### PR TITLE
Fixed partially showing discussions pane

### DIFF
--- a/ember/app/styles/flarum/discussions.less
+++ b/ember/app/styles/flarum/discussions.less
@@ -295,7 +295,7 @@
 
 .pinned {
 	& .discussions-pane {
-		left: 300px;
+		left: 325px;
 		transition: left 0.2s, width 0.2s;
 	}
 	& .discussion-pane {


### PR DESCRIPTION
Referencing the discussions pane which slides out from the sidebar.
