### PR TITLE
Fixed partially showing discussions pane

### DIFF
--- a/ember/app/styles/flarum/discussions.less
+++ b/ember/app/styles/flarum/discussions.less
@@ -210,7 +210,7 @@
 	transition: left 0.2s;
 
 	&.showing {
-		left: 300px;
+		left: 325px;
 	}
 
 	& .page-header .pull-right {
@@ -219,7 +219,7 @@
 
 	& .discussions > li {
 		padding-right: 15px;
-		padding-left: 20px;
+		padding-left: 15px;
 
 		& .action {
 			padding-top: 15px;
@@ -295,7 +295,7 @@
 
 .pinned {
 	& .discussions-pane {
-		left: 300px;
+		left: 325px;
 		transition: left 0.2s, width 0.2s;
 	}
 	& .discussion-pane {
@@ -430,7 +430,7 @@
 				margin: 0;
 			}
 		}
-		
+
 		& .replies, & .action .unread {
 			width: auto;
 			float: none;


### PR DESCRIPTION
Referencing the discussions pane which slides out from the sidebar.
- Fixed styles for pinned and opened state of discussions pane
- Fixed padding in discussions pane
