### PR TITLE
fix the number_index is null

### DIFF
--- a/src/Flarum/Core/Support/Seeders/DiscussionTableSeeder.php
+++ b/src/Flarum/Core/Support/Seeders/DiscussionTableSeeder.php
@@ -61,6 +61,7 @@ class DiscussionTableSeeder extends Seeder
 
                     $post = Post::create([
                         'discussion_id' => $discussion->id,
+                        'number'        => $j + 2 + $numberOffset,
                         'time'          => $startTime = date_add($startTime, date_interval_create_from_date_string('1 second')),
                         'user_id'       => rand(1, $users),
                         'type'          => 'title',


### PR DESCRIPTION
Pls, PR it.

```
[Illuminate\Database\QueryException]
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'number_index' cannot be null (SQL: upda
  te `discussions` set `posts_count` = 38, `start_post_id` = 1404, `last_time` = 2014-05-14 19:49:12, `
  last_user_id` = 12, `last_post_id` = 1442, `last_post_number` = , `number_index` =  where `id` = 72)


  [PDOException]
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'number_index' cannot be null
```
