### PR TITLE
"Specified key was too long" fix.

### DIFF
--- a/src/migrations/2014_01_14_231343_create_permissions_table.php
+++ b/src/migrations/2014_01_14_231343_create_permissions_table.php
@@ -14,9 +14,9 @@ class CreatePermissionsTable extends Migration {
 	{
 		Schema::create('permissions', function($table)
 		{
-			$table->string('grantee');
-			$table->string('entity');
-			$table->string('permission');
+			$table->string('grantee', 100);
+			$table->string('entity', 100);
+			$table->string('permission', 100);
 			$table->primary(['grantee', 'entity', 'permission']);
 		});
 	}


### PR DESCRIPTION
```
[Illuminate\Database\QueryException]
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000 bytes (SQL: alter table `permissions` add primary key perm
  issions_grantee_entity_permission_primary(`grantee`, `entity`, `permission`))
```