### PR TITLE
Always show vertical scrollbar

### DIFF
--- a/ember/app/styles/flarum/layout.less
+++ b/ember/app/styles/flarum/layout.less
@@ -1,6 +1,7 @@
 body {
   background: @fl-body-bg;
   color: @fl-body-color;
+  overflow-y: scroll;
 }
 .container-narrow {
   max-width: 500px;


### PR DESCRIPTION
Show the vertical scrollbar as inactive when content of the site
don't require any scrolling, instead of not showing anything.
This avoids the annoying "jumps" when you switch between
pages that require scrolling vs don't require scrolling.