### PR TITLE
Fix comment count update in seed.

### DIFF
--- a/src/Core/Seeders/DiscussionsTableSeeder.php
+++ b/src/Core/Seeders/DiscussionsTableSeeder.php
@@ -131,7 +131,7 @@ class DiscussionsTableSeeder extends Seeder
         $prefix = DB::getTablePrefix();
         DB::table('users')->update([
             'discussions_count' => DB::raw('(SELECT COUNT(id) FROM '.$prefix.'discussions WHERE start_user_id = '.$prefix.'users.id)'),
-            'comments_count' => DB::raw('(SELECT COUNT(id) FROM '.$prefix.'posts WHERE user_id = '.$prefix.'users.id and type = "comment")'),
+            'comments_count' => DB::raw('(SELECT COUNT(id) FROM '.$prefix.'posts WHERE user_id = '.$prefix.'users.id and type = \'comment\')'),
         ]);
     }
 }


### PR DESCRIPTION
Addresses the following error when using pqsql.

[PDOException]
  SQLSTATE[42703]: Undefined column: 7 ERROR:  column "comment" does not exist
  LINE 1: ...d) FROM posts WHERE user_id = users.id and type = "comment")