### PR TITLE
Refactoring: PSR-7, decouple from Laravel, ...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "tobscure/permissible": "dev-master",
         "misd/linkify": "1.1.*",
         "oyejorge/less.php": "dev-master",
-        "intervention/image": "dev-master"
+        "intervention/image": "dev-master",
+        "psr/http-message": "^1.0@dev",
+        "nikic/fast-route": "dev-master"
     },
     "require-dev": {
         "fzaninotto/faker": "1.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2c72cfaf1f4ffecca91460d1e6f57f5d",
+    "hash": "8b517a2c5b1d000a443c5ad91c49b2c1",
     "packages": [
         {
             "name": "danielstjules/stringy",
@@ -224,7 +224,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/79ebeb4c169178a24c5eb7f17db94df01c7dd04d",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/79b6de7d8b76265d5e765ecd828d9e57c7844959",
                 "reference": "79ebeb4c169178a24c5eb7f17db94df01c7dd04d",
                 "shasum": ""
             },
@@ -480,6 +480,49 @@
             "time": "2015-05-09 03:23:44"
         },
         {
+            "name": "nikic/fast-route",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "ffb3b68a3ab0df7e60cf587d2de4937915670f16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/ffb3b68a3ab0df7e60cf587d2de4937915670f16",
+                "reference": "ffb3b68a3ab0df7e60cf587d2de4937915670f16",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "time": "2015-05-15 16:58:32"
+        },
+        {
             "name": "oyejorge/less.php",
             "version": "dev-master",
             "source": {
@@ -539,6 +582,55 @@
             "time": "2015-05-16 18:38:34"
         },
         {
+            "name": "psr/http-message",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
+        },
+        {
             "name": "symfony/translation",
             "version": "2.8.x-dev",
             "source": {
@@ -548,7 +640,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/a0735db452c5e592cb742333a32c6634a6d1ece1",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/ae980a18f73b88b3394510e07ed0f343f252ca4f",
                 "reference": "a0735db452c5e592cb742333a32c6634a6d1ece1",
                 "shasum": ""
             },
@@ -684,7 +776,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/325a6e747a3089a5ac51bb757ab6f195627a11b0",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/cdc3569fedb017eea204b40eae0c82cf726e0107",
                 "reference": "d3cf78c6053f3fdfa4025bfcdb713f91e3ccdbdf",
                 "shasum": ""
             },
@@ -1001,7 +1093,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/2498ee848cd01639aecdcf3d5a257bace8665b7c",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/9465032ac5d6beaa55f10923403e6e1c36018d9c",
                 "reference": "2498ee848cd01639aecdcf3d5a257bace8665b7c",
                 "shasum": ""
             },
@@ -1313,7 +1405,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3132b1f44c7bf2ec4c7eb2d3cb78fdeca760d373",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/5a355f91730c845301a9e28f91c8a5053353c496",
                 "reference": "3132b1f44c7bf2ec4c7eb2d3cb78fdeca760d373",
                 "shasum": ""
             },
@@ -2598,6 +2690,51 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2015-05-12 15:16:46"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "84e0c15195adfb3fe3efebb459defc65a1e0314d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/84e0c15195adfb3fe3efebb459defc65a1e0314d",
+                "reference": "84e0c15195adfb3fe3efebb459defc65a1e0314d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.23"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev",
+                    "dev-develop": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2015-05-04 16:35:14"
         }
     ],
     "aliases": [],
@@ -2606,7 +2743,9 @@
         "tobscure/json-api": 20,
         "tobscure/permissible": 20,
         "oyejorge/less.php": 20,
-        "intervention/image": 20
+        "intervention/image": 20,
+        "psr/http-message": 20,
+        "nikic/fast-route": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Admin/Actions/IndexAction.php
+++ b/src/Admin/Actions/IndexAction.php
@@ -1,18 +1,17 @@
 <?php namespace Flarum\Admin\Actions;
 
-use Flarum\Support\Action;
-use Illuminate\Http\Request;
+use Flarum\Support\HtmlAction;
 use Session;
 use Auth;
 use Cookie;
 use Config;
-use View;
 use DB;
 use Flarum\Api\Request as ApiRequest;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
-class IndexAction extends Action
+class IndexAction extends HtmlAction
 {
-    public function handle(Request $request, $params = [])
+    protected function render(Request $request, $routeParams = [])
     {
         $config = DB::table('config')->whereIn('key', ['base_url', 'api_url', 'forum_title', 'welcome_title', 'welcome_message'])->lists('value', 'key');
         $data = [];
@@ -35,7 +34,7 @@ class IndexAction extends Action
             }
         }
 
-        $view = View::make('flarum.admin::index')
+        $view = view('flarum.admin::index')
             ->with('title', 'Administration - '.Config::get('flarum::forum_title', 'Flarum Demo Forum'))
             ->with('config', $config)
             ->with('layout', 'flarum.admin::admin')

--- a/src/Admin/routes.php
+++ b/src/Admin/routes.php
@@ -1,19 +1,16 @@
 <?php
 
+use Psr\Http\Message\ServerRequestInterface;
+
 $action = function ($class) {
-    return function () use ($class) {
+    return function (ServerRequestInterface $httpRequest, $routeParams) use ($class) {
         $action = $this->app->make($class);
-        $request = $this->app['request']->instance();
-        $parameters = $this->app['router']->current()->parameters();
-        return $action->handle($request, $parameters);
+
+        return $action->handle($httpRequest, $routeParams);
     };
 };
 
-Route::group(['prefix' => 'admin', 'middleware' => 'Flarum\Admin\Middleware\LoginWithCookieAndCheckAdmin'], function () use ($action) {
+/** @var Flarum\Http\Router $router */
+$router = $this->app->make('Flarum\Http\Router');
 
-    Route::get('/', [
-        'as' => 'flarum.admin.index',
-        'uses' => $action('Flarum\Admin\Actions\IndexAction')
-    ]);
-
-});
+$router->get('/admin', 'flarum.admin.index', $action('Flarum\Admin\Actions\IndexAction'));

--- a/src/Api/Actions/ActionInterface.php
+++ b/src/Api/Actions/ActionInterface.php
@@ -8,7 +8,7 @@ interface ActionInterface
      * Handle a request to the API, returning an HTTP response.
      *
      * @param \Flarum\Api\Request $request
-     * @return \Illuminate\Http\Response
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function handle(Request $request);
 }

--- a/src/Api/Actions/Activity/IndexAction.php
+++ b/src/Api/Actions/Activity/IndexAction.php
@@ -4,7 +4,7 @@ use Flarum\Core\Repositories\UserRepositoryInterface;
 use Flarum\Core\Repositories\ActivityRepositoryInterface;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
@@ -61,10 +61,10 @@ class IndexAction extends SerializeCollectionAction
      * document response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $actor = $request->actor->getUser();
 

--- a/src/Api/Actions/CreateAction.php
+++ b/src/Api/Actions/CreateAction.php
@@ -1,29 +1,39 @@
 <?php namespace Flarum\Api\Actions;
 
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Flarum\Api\Request;
+use Tobscure\JsonApi\Document;
 
 abstract class CreateAction extends SerializeResourceAction
 {
     /**
-     * Delegate creation of the resource, and set a 201 Created status code on
-     * the response.
+     * Set a 201 Created status code on the response.
+     *
+     * @param \Flarum\Api\Request $request
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function respond(Request $request)
+    {
+        return parent::respond($request)->withStatus(201);
+    }
+
+    /**
+     * Get the newly created resource to be serialized and assigned to the response document.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Model
+     * @param \Tobscure\JsonApi\Document $document
+     * @return array
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
-        $response->setStatusCode(201);
-
-        return $this->create($request, $response);
+        return $this->create($request);
     }
 
     /**
      * Create the resource.
      *
+     * @param JsonApiRequest $request
      * @return \Flarum\Core\Models\Model
      */
-    abstract protected function create(JsonApiRequest $request, JsonApiResponse $response);
+    abstract protected function create(JsonApiRequest $request);
 }

--- a/src/Api/Actions/DeleteAction.php
+++ b/src/Api/Actions/DeleteAction.php
@@ -1,7 +1,7 @@
 <?php namespace Flarum\Api\Actions;
 
 use Flarum\Api\Request;
-use Illuminate\Http\Response;
+use Zend\Diactoros\Response;
 
 abstract class DeleteAction extends JsonApiAction
 {
@@ -10,21 +10,20 @@ abstract class DeleteAction extends JsonApiAction
      * response.
      *
      * @param \Flarum\Api\Request $request
-     * @return \Flarum\Api\Response
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function respond(Request $request)
     {
-        $this->delete($request, $response = new Response('', 204));
+        $this->delete($request);
 
-        return $response;
+        return new Response('', 204);
     }
 
     /**
      * Delete the resource.
      *
      * @param \Flarum\Api\Request $request
-     * @param \Flarum\Api\Response $response
      * @return void
      */
-    abstract protected function delete(Request $request, Response $response);
+    abstract protected function delete(Request $request);
 }

--- a/src/Api/Actions/Discussions/CreateAction.php
+++ b/src/Api/Actions/Discussions/CreateAction.php
@@ -5,7 +5,6 @@ use Flarum\Core\Commands\ReadDiscussionCommand;
 use Flarum\Core\Models\Forum;
 use Flarum\Api\Actions\CreateAction as BaseCreateAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class CreateAction extends BaseCreateAction
@@ -60,11 +59,10 @@ class CreateAction extends BaseCreateAction
     /**
      * Create a discussion according to input from the API request.
      *
-     * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Discussion
+     * @param JsonApiRequest $request
+     * @return \Flarum\Core\Models\Model
      */
-    protected function create(JsonApiRequest $request, JsonApiResponse $response)
+    protected function create(JsonApiRequest $request)
     {
         $user = $request->actor->getUser();
 

--- a/src/Api/Actions/Discussions/DeleteAction.php
+++ b/src/Api/Actions/Discussions/DeleteAction.php
@@ -3,7 +3,6 @@
 use Flarum\Core\Commands\DeleteDiscussionCommand;
 use Flarum\Api\Actions\DeleteAction as BaseDeleteAction;
 use Flarum\Api\Request;
-use Illuminate\Http\Response;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class DeleteAction extends BaseDeleteAction
@@ -29,10 +28,9 @@ class DeleteAction extends BaseDeleteAction
      * Delete a discussion.
      *
      * @param \Flarum\Api\Request $request
-     * @param \Illuminate\Http\Response $response
      * @return void
      */
-    protected function delete(Request $request, Response $response)
+    protected function delete(Request $request)
     {
         $this->bus->dispatch(
             new DeleteDiscussionCommand($request->get('id'), $request->actor->getUser())

--- a/src/Api/Actions/Discussions/IndexAction.php
+++ b/src/Api/Actions/Discussions/IndexAction.php
@@ -4,7 +4,7 @@ use Flarum\Core\Search\Discussions\DiscussionSearchCriteria;
 use Flarum\Core\Search\Discussions\DiscussionSearcher;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
@@ -58,10 +58,10 @@ class IndexAction extends SerializeCollectionAction
      * document response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $criteria = new DiscussionSearchCriteria(
             $request->actor->getUser(),
@@ -73,10 +73,15 @@ class IndexAction extends SerializeCollectionAction
         $results = $this->searcher->search($criteria, $request->limit, $request->offset, $load);
 
         if (($total = $results->getTotal()) !== null) {
-            $response->content->addMeta('total', $total);
+            $document->addMeta('total', $total);
         }
 
-        static::addPaginationLinks($response, $request, route('flarum.api.discussions.index'), $total ?: $results->areMoreResults());
+        static::addPaginationLinks(
+            $document,
+            $request,
+            route('flarum.api.discussions.index'),
+            $total ?: $results->areMoreResults()
+        );
 
         return $results->getDiscussions();
     }

--- a/src/Api/Actions/Discussions/ShowAction.php
+++ b/src/Api/Actions/Discussions/ShowAction.php
@@ -5,7 +5,7 @@ use Flarum\Core\Repositories\PostRepositoryInterface;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\Actions\Posts\GetsPosts;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class ShowAction extends SerializeResourceAction
 {
@@ -84,10 +84,10 @@ class ShowAction extends SerializeResourceAction
      * JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Discussion
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $user = $request->actor->getUser();
 

--- a/src/Api/Actions/Discussions/UpdateAction.php
+++ b/src/Api/Actions/Discussions/UpdateAction.php
@@ -3,10 +3,9 @@
 use Flarum\Core\Commands\EditDiscussionCommand;
 use Flarum\Core\Commands\ReadDiscussionCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
-use Flarum\Api\Actions\Posts\GetsPosts;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class UpdateAction extends SerializeResourceAction
 {
@@ -47,10 +46,10 @@ class UpdateAction extends SerializeResourceAction
      * it ready to be serialized and assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Discussion
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $user = $request->actor->getUser();
         $discussionId = $request->get('id');

--- a/src/Api/Actions/Groups/IndexAction.php
+++ b/src/Api/Actions/Groups/IndexAction.php
@@ -3,7 +3,7 @@
 use Flarum\Core\Models\Group;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
@@ -19,10 +19,10 @@ class IndexAction extends SerializeCollectionAction
      * response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return Group::get();
     }

--- a/src/Api/Actions/JsonApiAction.php
+++ b/src/Api/Actions/JsonApiAction.php
@@ -37,7 +37,9 @@ abstract class JsonApiAction implements ActionInterface
 
     protected function json($data = null, $status = 200)
     {
-        if ($data === null) $data = new \ArrayObject();
+        if ($data === null) {
+            $data = new \ArrayObject();
+        }
 
         $data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 

--- a/src/Api/Actions/JsonApiAction.php
+++ b/src/Api/Actions/JsonApiAction.php
@@ -35,7 +35,7 @@ abstract class JsonApiAction implements ActionInterface
         }
     }
 
-    protected function json($data, $status = 200)
+    protected function json($data = null, $status = 200)
     {
         if ($data === null) $data = new \ArrayObject();
 

--- a/src/Api/Actions/Notifications/IndexAction.php
+++ b/src/Api/Actions/Notifications/IndexAction.php
@@ -4,7 +4,7 @@ use Flarum\Core\Repositories\NotificationRepositoryInterface;
 use Flarum\Core\Exceptions\PermissionDeniedException;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
@@ -60,10 +60,11 @@ class IndexAction extends SerializeCollectionAction
      * document response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
+     * @throws PermissionDeniedException
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         if (! $request->actor->isAuthenticated()) {
             throw new PermissionDeniedException;

--- a/src/Api/Actions/Notifications/UpdateAction.php
+++ b/src/Api/Actions/Notifications/UpdateAction.php
@@ -3,8 +3,8 @@
 use Flarum\Core\Commands\ReadNotificationCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class UpdateAction extends SerializeResourceAction
 {
@@ -35,10 +35,10 @@ class UpdateAction extends SerializeResourceAction
      * assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Notification
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->bus->dispatch(
             new ReadNotificationCommand($request->get('id'), $request->actor->getUser())

--- a/src/Api/Actions/Posts/CreateAction.php
+++ b/src/Api/Actions/Posts/CreateAction.php
@@ -4,7 +4,6 @@ use Flarum\Core\Commands\PostReplyCommand;
 use Flarum\Core\Commands\ReadDiscussionCommand;
 use Flarum\Api\Actions\CreateAction as BaseCreateAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class CreateAction extends BaseCreateAction
@@ -38,11 +37,10 @@ class CreateAction extends BaseCreateAction
     /**
      * Reply to a discussion according to input from the API request.
      *
-     * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Post
+     * @param JsonApiRequest $request
+     * @return \Flarum\Core\Models\Model
      */
-    protected function create(JsonApiRequest $request, JsonApiResponse $response)
+    protected function create(JsonApiRequest $request)
     {
         $user = $request->actor->getUser();
 

--- a/src/Api/Actions/Posts/DeleteAction.php
+++ b/src/Api/Actions/Posts/DeleteAction.php
@@ -3,7 +3,6 @@
 use Flarum\Core\Commands\DeletePostCommand;
 use Flarum\Api\Actions\DeleteAction as BaseDeleteAction;
 use Flarum\Api\Request;
-use Illuminate\Http\Response;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class DeleteAction extends BaseDeleteAction
@@ -27,10 +26,9 @@ class DeleteAction extends BaseDeleteAction
      * Delete a post.
      *
      * @param \Flarum\Api\Request $request
-     * @param \Illuminate\Http\Response $response
      * @return void
      */
-    protected function delete(Request $request, Response $response)
+    protected function delete(Request $request)
     {
         $this->bus->dispatch(
             new DeletePostCommand($request->get('id'), $request->actor->getUser())

--- a/src/Api/Actions/Posts/IndexAction.php
+++ b/src/Api/Actions/Posts/IndexAction.php
@@ -3,7 +3,7 @@
 use Flarum\Core\Repositories\PostRepositoryInterface;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
@@ -50,10 +50,10 @@ class IndexAction extends SerializeCollectionAction
      * document response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $postIds = (array) $request->get('ids');
         $user = $request->actor->getUser();

--- a/src/Api/Actions/Posts/ShowAction.php
+++ b/src/Api/Actions/Posts/ShowAction.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Flarum\Core\Repositories\PostRepositoryInterface;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class ShowAction extends SerializeResourceAction
 {
@@ -49,10 +49,10 @@ class ShowAction extends SerializeResourceAction
      * response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Discussion
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->posts->findOrFail($request->get('id'), $request->actor->getUser());
     }

--- a/src/Api/Actions/Posts/UpdateAction.php
+++ b/src/Api/Actions/Posts/UpdateAction.php
@@ -3,8 +3,8 @@
 use Flarum\Core\Commands\EditPostCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class UpdateAction extends SerializeResourceAction
 {
@@ -35,10 +35,10 @@ class UpdateAction extends SerializeResourceAction
      * ready to be serialized and assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Post
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->bus->dispatch(
             new EditPostCommand($request->get('id'), $request->actor->getUser(), $request->get('data'))

--- a/src/Api/Actions/TokenAction.php
+++ b/src/Api/Actions/TokenAction.php
@@ -4,7 +4,6 @@ use Flarum\Api\Request;
 use Flarum\Core\Commands\GenerateAccessTokenCommand;
 use Flarum\Core\Repositories\UserRepositoryInterface;
 use Flarum\Core\Exceptions\PermissionDeniedException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class TokenAction extends JsonApiAction
@@ -23,7 +22,8 @@ class TokenAction extends JsonApiAction
      * Log in and return a token.
      *
      * @param \Flarum\Api\Request $request
-     * @return \Flarum\Api\Response
+     * @return \Psr\Http\Message\ResponseInterface
+     * @throws PermissionDeniedException
      */
     public function respond(Request $request)
     {
@@ -40,7 +40,7 @@ class TokenAction extends JsonApiAction
             new GenerateAccessTokenCommand($user->id)
         );
 
-        return new JsonResponse([
+        return $this->json([
             'token' => $token->id,
             'userId' => $user->id
         ]);

--- a/src/Api/Actions/Users/CreateAction.php
+++ b/src/Api/Actions/Users/CreateAction.php
@@ -4,7 +4,6 @@ use Flarum\Core\Models\Forum;
 use Flarum\Core\Commands\RegisterUserCommand;
 use Flarum\Api\Actions\CreateAction as BaseCreateAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class CreateAction extends BaseCreateAction
@@ -45,11 +44,10 @@ class CreateAction extends BaseCreateAction
     /**
      * Register a user according to input from the API request.
      *
-     * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\User
+     * @param JsonApiRequest $request
+     * @return \Flarum\Core\Models\Model
      */
-    protected function create(JsonApiRequest $request, JsonApiResponse $response)
+    protected function create(JsonApiRequest $request)
     {
         return $this->bus->dispatch(
             new RegisterUserCommand($request->actor->getUser(), $this->forum, $request->get('data'))

--- a/src/Api/Actions/Users/DeleteAction.php
+++ b/src/Api/Actions/Users/DeleteAction.php
@@ -3,7 +3,6 @@
 use Flarum\Core\Commands\DeleteUserCommand;
 use Flarum\Api\Actions\DeleteAction as BaseDeleteAction;
 use Flarum\Api\Request;
-use Illuminate\Http\Response;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class DeleteAction extends BaseDeleteAction
@@ -29,10 +28,9 @@ class DeleteAction extends BaseDeleteAction
      * Delete a user.
      *
      * @param \Flarum\Api\Request $request
-     * @param \Illuminate\Http\Response $response
      * @return void
      */
-    protected function delete(Request $request, Response $response)
+    protected function delete(Request $request)
     {
         $this->bus->dispatch(
             new DeleteUserCommand($request->get('id'), $request->actor->getUser())

--- a/src/Api/Actions/Users/DeleteAvatarAction.php
+++ b/src/Api/Actions/Users/DeleteAvatarAction.php
@@ -3,8 +3,8 @@
 use Flarum\Core\Commands\DeleteAvatarCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class DeleteAvatarAction extends SerializeResourceAction
 {
@@ -35,10 +35,10 @@ class DeleteAvatarAction extends SerializeResourceAction
      * assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\User
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Flarum\Core\Models\Discussion
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->bus->dispatch(
             new DeleteAvatarCommand($request->get('id'), $request->actor->getUser())

--- a/src/Api/Actions/Users/ForgotAction.php
+++ b/src/Api/Actions/Users/ForgotAction.php
@@ -4,7 +4,6 @@ use Flarum\Api\Request;
 use Flarum\Api\Actions\JsonApiAction;
 use Flarum\Core\Repositories\UserRepositoryInterface;
 use Flarum\Core\Commands\RequestPasswordResetCommand;
-use Illuminate\Http\Response;
 use Illuminate\Contracts\Bus\Dispatcher;
 
 class ForgotAction extends JsonApiAction
@@ -23,7 +22,7 @@ class ForgotAction extends JsonApiAction
      * Log in and return a token.
      *
      * @param \Flarum\Api\Request $request
-     * @return \Flarum\Api\Response
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function respond(Request $request)
     {
@@ -33,6 +32,6 @@ class ForgotAction extends JsonApiAction
             new RequestPasswordResetCommand($email)
         );
 
-        return new Response;
+        return $this->json();
     }
 }

--- a/src/Api/Actions/Users/IndexAction.php
+++ b/src/Api/Actions/Users/IndexAction.php
@@ -4,21 +4,21 @@ use Flarum\Core\Search\Users\UserSearchCriteria;
 use Flarum\Core\Search\Users\UserSearcher;
 use Flarum\Api\Actions\SerializeCollectionAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class IndexAction extends SerializeCollectionAction
 {
     /**
      * The user searcher.
      *
-     * @var \Flarum\Core\Search\Discussions\UserSearcher
+     * @var \Flarum\Core\Search\Users\UserSearcher
      */
     protected $searcher;
 
     /**
      * Instantiate the action.
      *
-     * @param  \Flarum\Core\Search\Discussions\UserSearcher  $searcher
+     * @param  \Flarum\Core\Search\Users\UserSearcher  $searcher
      */
     public function __construct(UserSearcher $searcher)
     {
@@ -54,10 +54,10 @@ class IndexAction extends SerializeCollectionAction
      * document response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $criteria = new UserSearchCriteria(
             $request->actor->getUser(),
@@ -68,10 +68,11 @@ class IndexAction extends SerializeCollectionAction
         $results = $this->searcher->search($criteria, $request->limit, $request->offset, $request->include);
 
         if (($total = $results->getTotal()) !== null) {
-            $response->content->addMeta('total', $total);
+            $document->addMeta('total', $total);
         }
 
-        static::addPaginationLinks($response, $request, route('flarum.api.users.index'), $total ?: $results->areMoreResults());
+        // TODO: Add route() method!
+        static::addPaginationLinks($document, $request, 'flarum.api.users.index', $total ?: $results->areMoreResults());
 
         return $results->getUsers();
     }

--- a/src/Api/Actions/Users/ShowAction.php
+++ b/src/Api/Actions/Users/ShowAction.php
@@ -3,7 +3,7 @@
 use Flarum\Core\Repositories\UserRepositoryInterface;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
+use Tobscure\JsonApi\Document;
 
 class ShowAction extends SerializeResourceAction
 {
@@ -44,10 +44,10 @@ class ShowAction extends SerializeResourceAction
      * response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
+     * @param \Tobscure\JsonApi\Document $document
      * @return \Flarum\Core\Models\Discussion
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         $id = $request->get('id');
 

--- a/src/Api/Actions/Users/UpdateAction.php
+++ b/src/Api/Actions/Users/UpdateAction.php
@@ -3,8 +3,8 @@
 use Flarum\Core\Commands\EditUserCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class UpdateAction extends SerializeResourceAction
 {
@@ -35,10 +35,10 @@ class UpdateAction extends SerializeResourceAction
      * ready to be serialized and assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\Post
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Flarum\Core\Models\Discussion
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->bus->dispatch(
             new EditUserCommand($request->get('id'), $request->actor->getUser(), $request->get('data'))

--- a/src/Api/Actions/Users/UploadAvatarAction.php
+++ b/src/Api/Actions/Users/UploadAvatarAction.php
@@ -3,8 +3,8 @@
 use Flarum\Core\Commands\UploadAvatarCommand;
 use Flarum\Api\Actions\SerializeResourceAction;
 use Flarum\Api\JsonApiRequest;
-use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Tobscure\JsonApi\Document;
 
 class UploadAvatarAction extends SerializeResourceAction
 {
@@ -35,13 +35,17 @@ class UploadAvatarAction extends SerializeResourceAction
      * and assigned to the JsonApi response.
      *
      * @param \Flarum\Api\JsonApiRequest $request
-     * @param \Flarum\Api\JsonApiResponse $response
-     * @return \Flarum\Core\Models\User
+     * @param \Tobscure\JsonApi\Document $document
+     * @return \Flarum\Core\Models\Discussion
      */
-    protected function data(JsonApiRequest $request, JsonApiResponse $response)
+    protected function data(JsonApiRequest $request, Document $document)
     {
         return $this->bus->dispatch(
-            new UploadAvatarCommand($request->get('id'), $request->http->file('avatar'), $request->actor->getUser())
+            new UploadAvatarCommand(
+                $request->get('id'),
+                $request->http->getUploadedFiles()['avatar'],
+                $request->actor->getUser()
+            )
         );
     }
 }

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -17,7 +17,7 @@ class ApiServiceProvider extends ServiceProvider
             'Flarum\Api\ExceptionHandler'
         );
 
-        $this->app->singleton('Flarum\Http\Router', function() { return new Router(); });
+        $this->app->singleton('Flarum\Http\Router');
 
         include __DIR__.'/routes.php';
     }

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -1,7 +1,7 @@
 <?php namespace Flarum\Api;
 
+use Flarum\Http\Router;
 use Illuminate\Support\ServiceProvider;
-use Flarum\Api\Serializers\BaseSerializer;
 
 class ApiServiceProvider extends ServiceProvider
 {
@@ -16,6 +16,8 @@ class ApiServiceProvider extends ServiceProvider
             'Illuminate\Contracts\Debug\ExceptionHandler',
             'Flarum\Api\ExceptionHandler'
         );
+
+        $this->app->singleton('Flarum\Http\Router', function() { return new Router(); });
 
         include __DIR__.'/routes.php';
     }

--- a/src/Api/JsonApiResponse.php
+++ b/src/Api/JsonApiResponse.php
@@ -1,19 +1,14 @@
 <?php namespace Flarum\Api;
 
-use Illuminate\Http\Response;
 use Tobscure\JsonApi\Document;
+use Zend\Diactoros\Response;
 
 class JsonApiResponse extends Response
 {
-    public $content;
-
-    public function __construct($data = null, $status = 200, array $headers = [])
+    public function __construct(Document $document)
     {
-        parent::__construct('', $status, $headers);
+        parent::__construct('php://memory', 200, ['content-type' => 'application/vnd.api+json']);
 
-        $this->headers->set('Content-Type', 'application/vnd.api+json');
-
-        $this->content = new Document;
-        $this->content->setData($data);
+        $this->getBody()->write($document);
     }
 }

--- a/src/Api/Middleware/LoginWithHeader.php
+++ b/src/Api/Middleware/LoginWithHeader.php
@@ -2,12 +2,20 @@
 
 use Flarum\Core\Models\AccessToken;
 use Flarum\Support\Actor;
-use Closure;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Stratigility\MiddlewareInterface;
 
-class LoginWithHeader
+class LoginWithHeader implements MiddlewareInterface
 {
+    /**
+     * @var Actor
+     */
     protected $actor;
 
+    /**
+     * @var string
+     */
     protected $prefix = 'Token ';
 
     // @todo rather than using a singleton, we should have our own HTTP
@@ -17,17 +25,21 @@ class LoginWithHeader
         $this->actor = $actor;
     }
 
-    public function handle($request, Closure $next)
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(Request $request, Response $response, callable $out = null)
     {
-        $header = $request->headers->get('authorization');
+        $header = $request->getHeaderLine('authorization');
         if (starts_with($header, $this->prefix) &&
             ($token = substr($header, strlen($this->prefix))) &&
-            ($accessToken = AccessToken::where('id', $token)->first())) {
+            ($accessToken = AccessToken::where('id', $token)->first())
+        ) {
             $this->actor->setUser($user = $accessToken->user);
 
             $user->updateLastSeen()->save();
         }
 
-        return $next($request);
+        return $out ? $out($request, $response) : $response;
     }
 }

--- a/src/Api/Middleware/ReadJsonParameters.php
+++ b/src/Api/Middleware/ReadJsonParameters.php
@@ -1,0 +1,24 @@
+<?php namespace Flarum\Api\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Stratigility\MiddlewareInterface;
+
+class ReadJsonParameters implements MiddlewareInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(Request $request, Response $response, callable $out = null)
+    {
+        if (str_contains($request->getHeaderLine('content-type'), 'application/vnd.api+json')) {
+            $input = json_decode($request->getBody(), true);
+
+            foreach ($input as $name => $value) {
+                $request = $request->withAttribute($name, $value);
+            }
+        }
+
+        return $out ? $out($request, $response) : $response;
+    }
+}

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -1,7 +1,7 @@
 <?php namespace Flarum\Api;
 
 use Flarum\Support\Actor;
-use Illuminate\Http\Request as IlluminateRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 class Request
 {
@@ -9,9 +9,12 @@ class Request
 
     public $actor;
 
+    /**
+     * @var ServerRequestInterface
+     */
     public $http;
 
-    public function __construct(array $input, Actor $actor = null, IlluminateRequest $http = null)
+    public function __construct(array $input, Actor $actor = null, ServerRequestInterface $http = null)
     {
         $this->input = $input;
         $this->actor = $actor;

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-use Flarum\Api\Request as ApiRequest;
+use Flarum\Api\Request;
 use Psr\Http\Message\ServerRequestInterface;
 
 $action = function ($class) {
@@ -8,14 +8,8 @@ $action = function ($class) {
         $action = $this->app->make($class);
         $actor = $this->app->make('Flarum\Support\Actor');
 
-        if (str_contains($httpRequest->getHeaderLine('content-type'), 'application/vnd.api+json')) {
-            $input = json_decode($httpRequest->getBody(), true);
-        } else {
-            $input = $httpRequest->getAttributes();
-        }
-        $input = array_merge($input, $routeParams);
-
-        $request = new ApiRequest($input, $actor, $httpRequest);
+        $input = array_merge($httpRequest->getAttributes(), $routeParams);
+        $request = new Request($input, $actor, $httpRequest);
 
         return $action->handle($request);
     };

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -1,227 +1,140 @@
 <?php
 
-use Flarum\Api\Request;
+use Flarum\Api\Request as ApiRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 $action = function ($class) {
-    return function () use ($class) {
+    return function (ServerRequestInterface $httpRequest, $routeParams) use ($class) {
         $action = $this->app->make($class);
+        $actor = $this->app->make('Flarum\Support\Actor');
 
-        $httpRequest = $this->app['request']->instance();
-        $routeParams = $this->app['router']->current()->parameters();
-        $actor = $this->app['Flarum\Support\Actor'];
-
-        if (str_contains($httpRequest->header('CONTENT_TYPE'), 'application/vnd.api+json')) {
-            $input = $httpRequest->json();
+        if (str_contains($httpRequest->getHeaderLine('content-type'), 'application/vnd.api+json')) {
+            $input = json_decode($httpRequest->getBody(), true);
         } else {
-            $input = $httpRequest->all();
+            $input = $httpRequest->getAttributes();
         }
         $input = array_merge($input, $routeParams);
 
-        $request = new Request($input, $actor, $httpRequest);
+        $request = new ApiRequest($input, $actor, $httpRequest);
 
         return $action->handle($request);
     };
 };
 
-Route::group(['prefix' => 'api', 'middleware' => 'Flarum\Api\Middleware\LoginWithHeader'], function () use ($action) {
+/** @var Flarum\Http\Router $router */
+$router = $this->app->make('Flarum\Http\Router');
 
-    // Get forum information
-    Route::get('forum', [
-        'as' => 'flarum.api.forum.show',
-        'uses' => $action('Flarum\Api\Actions\Forum\ShowAction')
-    ]);
+// Get forum information
+$router->get('/api/forum', 'flarum.api.forum.show', $action('Flarum\Api\Actions\Forum\ShowAction'));
 
-    // Retrieve authentication token
-    Route::post('token', [
-        'as' => 'flarum.api.token',
-        'uses' => $action('Flarum\Api\Actions\TokenAction')
-    ]);
+// Retrieve authentication token
+$router->post('/api/token', 'flarum.api.token', $action('Flarum\Api\Actions\TokenAction'));
 
-    // Send forgot password email
-    Route::post('forgot', [
-        'as' => 'flarum.api.forgot',
-        'uses' => $action('Flarum\Api\Actions\Users\ForgotAction')
-    ]);
+// Send forgot password email
+$router->post('/forgot', 'flarum.api.forgot', $action('Flarum\Api\Actions\ForgotAction'));
 
-    /*
-    |--------------------------------------------------------------------------
-    | Users
-    |--------------------------------------------------------------------------
-    */
+/*
+|--------------------------------------------------------------------------
+| Users
+|--------------------------------------------------------------------------
+*/
 
-    // List users
-    Route::get('users', [
-        'as' => 'flarum.api.users.index',
-        'uses' => $action('Flarum\Api\Actions\Users\IndexAction')
-    ]);
+// List users
+$router->get('/api/users', 'flarum.api.users.index', $action('Flarum\Api\Actions\Users\IndexAction'));
 
-    // Register a user
-    Route::post('users', [
-        'as' => 'flarum.api.users.create',
-        'uses' => $action('Flarum\Api\Actions\Users\CreateAction')
-    ]);
+// Register a user
+$router->post('/api/users', 'flarum.api.users.create', $action('Flarum\Api\Actions\Users\CreateAction'));
 
-    // Get a single user
-    Route::get('users/{id}', [
-        'as' => 'flarum.api.users.show',
-        'uses' => $action('Flarum\Api\Actions\Users\ShowAction')
-    ]);
+// Get a single user
+$router->get('/api/users/{id}', 'flarum.api.users.show', $action('Flarum\Api\Actions\Users\ShowAction'));
 
-    // Edit a user
-    Route::put('users/{id}', [
-        'as' => 'flarum.api.users.update',
-        'uses' => $action('Flarum\Api\Actions\Users\UpdateAction')
-    ]);
+// Edit a user
+$router->put('/api/users/{id}', 'flarum.api.users.update', $action('Flarum\Api\Actions\Users\UpdateAction'));
 
-    // Delete a user
-    Route::delete('users/{id}', [
-        'as' => 'flarum.api.users.delete',
-        'uses' => $action('Flarum\Api\Actions\Users\DeleteAction')
-    ]);
+// Delete a user
+$router->delete('/api/users/{id}', 'flarum.api.users.delete', $action('Flarum\Api\Actions\Users\DeleteAction'));
 
-    // Upload avatar
-    Route::post('users/{id}/avatar', [
-        'as' => 'flarum.api.users.avatar.upload',
-        'uses' => $action('Flarum\Api\Actions\Users\UploadAvatarAction')
-    ]);
+// Upload avatar
+$router->post('/api/users/{id}/avatar', 'flarum.api.users.avatar.upload', $action('Flarum\Api\Actions\Users\UploadAvatarAction'));
 
-    // Remove avatar
-    Route::delete('users/{id}/avatar', [
-        'as' => 'flarum.api.users.avatar.delete',
-        'uses' => $action('Flarum\Api\Actions\Users\DeleteAvatarAction')
-    ]);
+// Remove avatar
+$router->delete('/api/users/{id}/avatar', 'flarum.api.users.avatar.delete', $action('Flarum\Api\Actions\Users\DeleteAvatarAction'));
 
-    /*
-    |--------------------------------------------------------------------------
-    | Activity
-    |--------------------------------------------------------------------------
-    */
+/*
+|--------------------------------------------------------------------------
+| Activity
+|--------------------------------------------------------------------------
+*/
 
-    // List activity
-    Route::get('activity', [
-        'as' => 'flarum.api.activity.index',
-        'uses' => $action('Flarum\Api\Actions\Activity\IndexAction')
-    ]);
+// List activity
+$router->get('/api/activity', 'flarum.api.activity.index', $action('Flarum\Api\Actions\Activity\IndexAction'));
 
-    // List notifications for the current user
-    Route::get('notifications', [
-        'as' => 'flarum.api.notifications.index',
-        'uses' => $action('Flarum\Api\Actions\Notifications\IndexAction')
-    ]);
+// List notifications for the current user
+$router->get('/api/notifications', 'flarum.api.notifications.index', $action('Flarum\Api\Actions\Notifications\IndexAction'));
 
-    // Mark a single notification as read
-    Route::put('notifications/{id}', [
-        'as' => 'flarum.api.notifications.update',
-        'uses' => $action('Flarum\Api\Actions\Notifications\UpdateAction')
-    ]);
+// Mark a single notification as read
+$router->put('/api/notifications/{id}', 'flarum.api.notifications.update', $action('Flarum\Api\Actions\Notifications\UpdateAction'));
 
-    /*
-    |--------------------------------------------------------------------------
-    | Discussions
-    |--------------------------------------------------------------------------
-    */
+/*
+|--------------------------------------------------------------------------
+| Discussions
+|--------------------------------------------------------------------------
+*/
 
-    // List discussions
-    Route::get('discussions', [
-        'as' => 'flarum.api.discussions.index',
-        'uses' => $action('Flarum\Api\Actions\Discussions\IndexAction')
-    ]);
+// List discussions
+$router->get('/api/discussions', 'flarum.api.discussions.index', $action('Flarum\Api\Actions\Discussions\IndexAction'));
 
-    // Create a discussion
-    Route::post('discussions', [
-        'as' => 'flarum.api.discussions.create',
-        'uses' => $action('Flarum\Api\Actions\Discussions\CreateAction')
-    ]);
+// Create a discussion
+$router->post('/api/discussions', 'flarum.api.discussions.create', $action('Flarum\Api\Actions\Discussions\CreateAction'));
 
-    // Show a single discussion
-    Route::get('discussions/{id}', [
-        'as' => 'flarum.api.discussions.show',
-        'uses' => $action('Flarum\Api\Actions\Discussions\ShowAction')
-    ]);
+// Show a single discussion
+$router->get('/api/discussions/{id}', 'flarum.api.discussions.show', $action('Flarum\Api\Actions\Discussions\ShowAction'));
 
-    // Edit a discussion
-    Route::put('discussions/{id}', [
-        'as' => 'flarum.api.discussions.update',
-        'uses' => $action('Flarum\Api\Actions\Discussions\UpdateAction')
-    ]);
+// Edit a discussion
+$router->put('/api/discussions/{id}', 'flarum.api.discussions.update', $action('Flarum\Api\Actions\Discussions\UpdateAction'));
 
-    // Delete a discussion
-    Route::delete('discussions/{id}', [
-        'as' => 'flarum.api.discussions.delete',
-        'uses' => $action('Flarum\Api\Actions\Discussions\DeleteAction')
-    ]);
+// Delete a discussion
+$router->delete('/api/discussions/{id}', 'flarum.api.discussions.delete', $action('Flarum\Api\Actions\Discussions\DeleteAction'));
 
-    /*
-    |--------------------------------------------------------------------------
-    | Posts
-    |--------------------------------------------------------------------------
-    */
+/*
+|--------------------------------------------------------------------------
+| Posts
+|--------------------------------------------------------------------------
+*/
 
-    // List posts, usually for a discussion
-    Route::get('posts', [
-        'as' => 'flarum.api.posts.index',
-        'uses' => $action('Flarum\Api\Actions\Posts\IndexAction')
-    ]);
+// List posts, usually for a discussion
+$router->get('/api/posts', 'flarum.api.posts.index', $action('Flarum\Api\Actions\Posts\IndexAction'));
 
-    // Create a post
-    // @todo consider 'discussions/{id}/links/posts'?
-    Route::post('posts', [
-        'as' => 'flarum.api.posts.create',
-        'uses' => $action('Flarum\Api\Actions\Posts\CreateAction')
-    ]);
+// Create a post
+// @todo consider 'discussions/{id}/links/posts'?
+$router->post('/api/posts', 'flarum.api.posts.create', $action('Flarum\Api\Actions\Posts\CreateAction'));
 
-    // Show a single or multiple posts by ID
-    Route::get('posts/{id}', [
-        'as' => 'flarum.api.posts.show',
-        'uses' => $action('Flarum\Api\Actions\Posts\ShowAction')
-    ]);
+// Show a single or multiple posts by ID
+$router->get('/api/posts/{id}', 'flarum.api.posts.show', $action('Flarum\Api\Actions\Posts\ShowAction'));
 
-    // Edit a post
-    Route::put('posts/{id}', [
-        'as' => 'flarum.api.posts.update',
-        'uses' => $action('Flarum\Api\Actions\Posts\UpdateAction')
-    ]);
+// Edit a post
+$router->put('/api/posts/{id}', 'flarum.api.posts.update', $action('Flarum\Api\Actions\Posts\UpdateAction'));
 
-    // Delete a post
-    Route::delete('posts/{id}', [
-        'as' => 'flarum.api.posts.delete',
-        'uses' => $action('Flarum\Api\Actions\Posts\DeleteAction')
-    ]);
+// Delete a post
+$router->delete('/api/posts/{id}', 'flarum.api.posts.delete', $action('Flarum\Api\Actions\Posts\DeleteAction'));
 
-    /*
-    |--------------------------------------------------------------------------
-    | Groups
-    |--------------------------------------------------------------------------
-    */
+/*
+|--------------------------------------------------------------------------
+| Groups
+|--------------------------------------------------------------------------
+*/
 
-    // List groups
-    Route::get('groups', [
-        'as' => 'flarum.api.groups.index',
-        'uses' => $action('Flarum\Api\Actions\Groups\IndexAction')
-    ]);
+// List groups
+$router->get('/api/groups', 'flarum.api.groups.index', $action('Flarum\Api\Actions\Groups\IndexAction'));
 
-    // Create a group
-    Route::post('groups', [
-        'as' => 'flarum.api.groups.create',
-        'uses' => $action('Flarum\Api\Actions\Groups\CreateAction')
-    ]);
+// Create a group
+$router->post('/api/groups', 'flarum.api.groups.create', $action('Flarum\Api\Actions\Groups\CreateAction'));
 
-    // Show a single group
-    Route::get('groups/{id}', [
-        'as' => 'flarum.api.groups.show',
-        'uses' => $action('Flarum\Api\Actions\Groups\ShowAction')
-    ]);
+// Show a single group
+$router->get('/api/groups/{id}', 'flarum.api.groups.show', $action('Flarum\Api\Actions\Groups\ShowAction'));
 
-    // Edit a group
-    Route::put('groups/{id}', [
-        'as' => 'flarum.api.groups.update',
-        'uses' => $action('Flarum\Api\Actions\Groups\UpdateAction')
-    ]);
+// Edit a group
+$router->put('/api/groups/{id}', 'flarum.api.groups.update', $action('Flarum\Api\Actions\Groups\UpdateAction'));
 
-    // Delete a group
-    Route::delete('groups/{id}', [
-        'as' => 'flarum.api.groups.delete',
-        'uses' => $action('Flarum\Api\Actions\Groups\DeleteAction')
-    ]);
-
-});
+// Delete a group
+$router->delete('/api/groups/{id}', 'flarum.api.groups.delete', $action('Flarum\Api\Actions\Groups\DeleteAction'));

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Flarum\Http;
+
+use FastRoute\Dispatcher;
+use FastRoute\RouteParser;
+use FastRoute\DataGenerator;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class Router
+{
+    /**
+     * @var \FastRoute\DataGenerator
+     */
+    protected $dataGenerator;
+
+    /**
+     * @var \FastRoute\RouteParser
+     */
+    protected $routeParser;
+
+    /**
+     * @var string
+     */
+    protected $currentRequestName;
+
+    /**
+     * @var array
+     */
+    protected $currentRequestParameters;
+
+    /**
+     * @var array
+     */
+    protected $reverse = [];
+
+    /**
+     * @var \FastRoute\Dispatcher
+     */
+    protected $dispatcher;
+
+
+    public function __construct()
+    {
+        $this->routeParser = new RouteParser\Std;
+        $this->dataGenerator = new DataGenerator\GroupCountBased;
+    }
+
+    public function get($path, $name, $handler)
+    {
+        return $this->addRoute('GET', $path, $name, $handler);
+    }
+
+    public function post($path, $name, $handler)
+    {
+        return $this->addRoute('POST', $path, $name, $handler);
+    }
+
+    public function put($path, $name, $handler)
+    {
+        return $this->addRoute('PUT', $path, $name, $handler);
+    }
+
+    public function delete($path, $name, $handler)
+    {
+        return $this->addRoute('DELETE', $path, $name, $handler);
+    }
+
+    public function addRoute($method, $path, $name, $handler)
+    {
+        $routeData = $this->routeParser->parse($path);
+        $this->dataGenerator->addRoute($method, $routeData, $handler);
+
+        $routeDate['method'] = $method;
+        $this->reverse[$name] = $routeData;
+
+        return $this;
+    }
+
+    public function getPath($name, $parameters = [])
+    {
+        $parts = $this->reverse[$name];
+
+        $path = implode('', array_map(function ($part) use ($parameters) {
+            if (is_array($part)) {
+                $part = $parameters[$part[0]];
+            }
+            return $part;
+        }, $parts));
+
+        $path = '/' . ltrim($path, '/');
+        return $path;
+    }
+
+    public function getCurrentPath()
+    {
+        $name = $this->currentRequestName;
+        $parameters = $this->currentRequestParameters;
+
+        return $this->getPath($name, $parameters);
+    }
+
+    public function getMethod($handler)
+    {
+        return array_get($this->reverse, $handler . '.method', '');
+    }
+
+    public function dispatch(Request $request)
+    {
+        $method = $request->getMethod();
+        $uri = $request->getUri()->getPath();
+
+        $routeInfo = $this->getDispatcher()->dispatch($method, $uri);
+
+        switch ($routeInfo[0]) {
+            case Dispatcher::NOT_FOUND:
+                throw new \Exception('404 Not Found');
+            case Dispatcher::METHOD_NOT_ALLOWED:
+                throw new \Exception('405 Method Not Allowed');
+            case Dispatcher::FOUND:
+                $handler = $routeInfo[1];
+                $parameters = $routeInfo[2];
+
+                return $handler($request, $parameters);
+        }
+    }
+
+    protected function getDispatcher()
+    {
+        if (! isset($this->dispatcher)) {
+            $this->dispatcher = new Dispatcher\GroupCountBased($this->dataGenerator->getData());
+        }
+
+        return $this->dispatcher;
+    }
+}

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -71,7 +71,7 @@ class Router
         $routeData = $this->routeParser->parse($path);
         $this->dataGenerator->addRoute($method, $routeData, $handler);
 
-        $routeDate['method'] = $method;
+        $routeData['method'] = $method;
         $this->reverse[$name] = $routeData;
 
         return $this;

--- a/src/Support/Action.php
+++ b/src/Support/Action.php
@@ -1,7 +1,8 @@
 <?php namespace Flarum\Support;
 
-use Illuminate\Http\Request;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response;
 
 abstract class Action
 {
@@ -17,5 +18,27 @@ abstract class Action
     {
         $action = app($class);
         return $action->call($params);
+    }
+
+    /**
+     * @param string $url
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function redirectTo($url)
+    {
+        $content = sprintf('<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="refresh" content="1;url=%1$s" />
+
+        <title>Redirecting to %1$s</title>
+    </head>
+    <body>
+        Redirecting to <a href="%1$s">%1$s</a>.
+    </body>
+</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8'));
+
+        return new Response($content, 302, ['location' => $url]);
     }
 }

--- a/src/Support/HtmlAction.php
+++ b/src/Support/HtmlAction.php
@@ -1,0 +1,24 @@
+<?php namespace Flarum\Support;
+
+use Illuminate\Contracts\Bus\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response;
+
+abstract class HtmlAction extends Action
+{
+    public function handle(Request $request, $routeParams = [])
+    {
+        $view = $this->render($request, $routeParams);
+
+        $response = new Response();
+        $response->getBody()->write($view->render());
+        return $response;
+    }
+
+    /**
+     * @param Request $request
+     * @param array $routeParams
+     * @return \Illuminate\Contracts\View\View
+     */
+    abstract protected function render(Request $request, $routeParams = []);
+}


### PR DESCRIPTION
An ongoing effort to decouple from Laravel. Currently WIP.

Here's the plan:
- [x] Implement a custom [router](https://github.com/nikic/FastRoute)
- [ ] Explicitly pull in only the Illuminate components that we need
- [x] Pull in a PSR-7 implementation (probably the one by @phly, which has now moved to Zend)
- [x] Pull in a PSR-7 middleware stack ([zend-stratigility](https://github.com/zendframework/zend-stratigility)) to the skeleton repository. This will replace Laravel's HTTP kernel.
- [ ] Convert the different parts (frontend, admin and API) of the app to separate middlewares that can be mounted independently. This should also speed up routing because only the routes for the proper middleware need to be parsed. (Special attention to route generation, because we do need all routes there.)
- [ ] Hook this up with a container instance (an application class?) and load our service providers
- [ ] Implement a config system: `config.php` for database details, everything else in a ConfigRepository (database)
- [ ] Provide integration with Laravel (possibly via a separate package), basically bridging the Symfony HTTP kernel to PSR-7.

This will fix #75.