### PR TITLE
Make Google Web Font work on both HTTP and HTTPS

### DIFF
--- a/less/lib/lib.less
+++ b/less/lib/lib.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,600);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,600);
 
 @import "font-awesome.less";
 @fa-font-path: "../../assets/fonts";
@@ -27,4 +27,3 @@
 @import "Tooltip.less";
 
 @import "variables.less";
-

--- a/views/install/app.blade.php
+++ b/views/install/app.blade.php
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
 
     <style>
-      @import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,600);
+      @import url(//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,600);
 
       body {
         background: #fff;


### PR DESCRIPTION
Just a little hack to make the Google Web Font work on both HTTP and HTTPS
The solution is to remove `http:` in Google Web Font import, see change log for more detail.