### PR TITLE
Fix text overlap in search result with long content

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -262,6 +262,10 @@
   padding-left: 50px;
   line-height: 1.7em;
 
+  .PostPreview-excerpt {
+    word-wrap: break-word;
+  }
+
   .Avatar {
     float: left;
     margin-left: -50px;


### PR DESCRIPTION
When text content in search result has a very long single line, it makes the text overlap the page, as in the below image:

![](https://i.imgur.com/WqxaMxc.png)

Just add word-wrap property to `PostPreview-excerpt` class to make it force wrap the words