### PR TITLE
Align select input properly

### DIFF
--- a/less/lib/Select.less
+++ b/less/lib/Select.less
@@ -9,6 +9,7 @@
     -moz-appearance: none;
     padding-right: 30px;
     cursor: pointer;
+    line-height: 1;
   }
 }
 .Select-caret {


### PR DESCRIPTION
I was annoyed by the select input on the index not being aligned properly.
Set the line-height to 1 for select inputs only.