### PR TITLE
Fixes enable extension in EntensionManager

### DIFF
--- a/src/Support/ExtensionManager.php
+++ b/src/Support/ExtensionManager.php
@@ -49,6 +49,8 @@ class ExtensionManager
     public function enable($extension)
     {
         if (! $this->isEnabled($extension)) {
+            $enabled = $this->getEnabled();
+
             $enabled[] = $extension;
 
             $class = $this->load($extension);


### PR DESCRIPTION
Enabling an extension was causing previously enabled extensions to get disabled 