### PR TITLE
Changed default Admin password

### DIFF
--- a/src/Install/Console/DefaultData.php
+++ b/src/Install/Console/DefaultData.php
@@ -25,8 +25,8 @@ class DefaultData implements ProvidesData
 
     protected $adminUser = [
         'username'              => 'admin',
-        'password'              => 'admin',
-        'password_confirmation' => 'admin',
+        'password'              => 'password',
+        'password_confirmation' => 'password',
         'email'                 => 'admin@example.com',
     ];
 


### PR DESCRIPTION
Default Admin password doesn't pass the new validation rule (min 8 chars)

See: https://github.com/flarum/core/commit/cbcad27679faaaeb10206d7c25e21952231b5542#diff-2e6d4ed85cd06d3e11f7f8428746214eR126