### PR TITLE
make cookie name configurable

### DIFF
--- a/src/Forum/Actions/WritesRememberCookie.php
+++ b/src/Forum/Actions/WritesRememberCookie.php
@@ -21,7 +21,7 @@ trait WritesRememberCookie
         // Set a long-living cookie (two weeks) with the remember token
         return FigResponseCookies::set(
             $response,
-            SetCookie::create('flarum_remember', $token)
+            SetCookie::create(app('config')->get('session.cookie'), $token)
                 ->withMaxAge(14 * 24 * 60 * 60)
                 ->withPath('/')
                 ->withHttpOnly(true)
@@ -33,7 +33,7 @@ trait WritesRememberCookie
         // Delete the cookie by setting it to an expiration date in the past
         return FigResponseCookies::set(
             $response,
-            SetCookie::create('flarum_remember')
+            SetCookie::create(app('config')->get('session.cookie'))
                 ->withMaxAge(-2628000)
                 ->withPath('/')
                 ->withHttpOnly(true)

--- a/src/Forum/Middleware/LoginWithCookie.php
+++ b/src/Forum/Middleware/LoginWithCookie.php
@@ -72,7 +72,7 @@ class LoginWithCookie implements MiddlewareInterface
      */
     protected function getToken(Request $request)
     {
-        $token = array_get($request->getCookieParams(), 'flarum_remember');
+        $token = array_get($request->getCookieParams(), app('config')->get('session.cookie'));
 
         if ($token) {
             return AccessToken::find($token);

--- a/src/Support/ClientView.php
+++ b/src/Support/ClientView.php
@@ -337,7 +337,7 @@ class ClientView implements Renderable
     {
         return [
             'userId' => $this->actor->id,
-            'token' => array_get($this->request->getCookieParams(), 'flarum_remember'),
+            'token' => array_get($this->request->getCookieParams(), app('config')->get('session.cookie')),
         ];
     }
 }


### PR DESCRIPTION
The current cookie set for remembering and restoring session is called `flarum_remember`. On domains that have multiple installations this will conflict and users are automatically logged out from another installation if logging in elsewhere on the domain.

This requires also a change in the `config` ioc binding in `flarum/bootstrap.php`, see the references PR: https://github.com/flarum/flarum/issues/17

> Side info, these pr's allow me to stay logged in on all flarum.today installations.