### PR TITLE
Add namespacing for badges

### DIFF
--- a/js/lib/models/Discussion.js
+++ b/js/lib/models/Discussion.js
@@ -86,7 +86,7 @@ Object.assign(Discussion.prototype, {
     const items = new ItemList();
 
     if (this.isHidden()) {
-      items.add('hidden', <Badge type="hidden" icon="trash" label={app.translator.trans('core.lib.hidden_discussion_tooltip')}/>);
+      items.add('hidden', <Badge type="hidden" icon="trash" label={app.translator.trans('core.lib.badge.hidden_discussion_tooltip')}/>);
     }
 
     return items;


### PR DESCRIPTION
- Adds a `lib.badge` namespace to match extension handling.