### PR TITLE
Fixed #627

### DIFF
--- a/js/forum/src/components/DiscussionList.js
+++ b/js/forum/src/components/DiscussionList.js
@@ -115,7 +115,7 @@ export default class DiscussionList extends Component {
     map.latest = '-lastTime';
     map.top = '-commentsCount';
     map.newest = '-startTime';
-    map.oldest = '+startTime';
+    map.oldest = 'startTime';
 
     return map;
   }

--- a/src/Forum/Controller/IndexController.php
+++ b/src/Forum/Controller/IndexController.php
@@ -24,7 +24,7 @@ class IndexController extends ClientController
         'latest' => '-lastTime',
         'top' => '-commentsCount',
         'newest' => '-startTime',
-        'oldest' => '+startTime'
+        'oldest' => 'startTime'
     ];
 
     /**


### PR DESCRIPTION
In tobscure/json-api we use "startTime" not "+startTime" to represent asc.So this PR fixs the bug #627.