### PR TITLE
Add third-level namespacing to deleted_user_text

### DIFF
--- a/js/lib/helpers/username.js
+++ b/js/lib/helpers/username.js
@@ -6,7 +6,7 @@
  * @return {Object}
  */
 export default function username(user) {
-  const name = (user && user.username()) || app.translator.trans('core.lib.deleted_user_text');
+  const name = (user && user.username()) || app.translator.trans('core.lib.username.deleted_text');
 
   return <span className="username">{name}</span>;
 }


### PR DESCRIPTION
Just a quick fix for consistent namespacing in `lib`.