### PR TITLE
Add base OAuth2 controller API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "illuminate/validation": "5.1.*",
         "illuminate/view": "5.1.*",
         "league/flysystem": "^1.0.11",
+        "league/oauth2-client": "~1.0",
         "tobscure/json-api": "^0.2.0",
         "oyejorge/less.php": "~1.5",
         "intervention/image": "^2.3.0",

--- a/src/Forum/Controller/AbstractOAuth2Controller.php
+++ b/src/Forum/Controller/AbstractOAuth2Controller.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Forum\Controller;
+
+use Flarum\Forum\AuthenticationResponseFactory;
+use Flarum\Http\Controller\ControllerInterface;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Diactoros\Response\RedirectResponse;
+
+abstract class AbstractOAuth2Controller implements ControllerInterface
+{
+    /**
+     * @var AuthenticationResponseFactory
+     */
+    protected $authResponse;
+
+    /**
+     * @param AuthenticationResponseFactory $authResponse
+     */
+    public function __construct(AuthenticationResponseFactory $authResponse)
+    {
+        $this->authResponse = $authResponse;
+    }
+
+    /**
+     * @param Request $request
+     * @return \Psr\Http\Message\ResponseInterface|RedirectResponse
+     */
+    public function handle(Request $request)
+    {
+        $redirectUri = (string) $request->getUri()->withQuery('');
+
+        $provider = $this->getProvider($redirectUri);
+
+        $session = $request->getAttribute('session');
+
+        $queryParams = $request->getQueryParams();
+        $code = array_get($queryParams, 'code');
+        $state = array_get($queryParams, 'state');
+
+        if (! $code) {
+            $authUrl = $provider->getAuthorizationUrl($this->getAuthorizationUrlOptions());
+            $session->set('oauth2state', $provider->getState());
+
+            return new RedirectResponse($authUrl.'&display=popup');
+        } elseif (! $state || $state !== $session->get('oauth2state')) {
+            $session->forget('oauth2state');
+            echo 'Invalid state. Please close the window and try again.';
+            exit;
+        }
+
+        $token = $provider->getAccessToken('authorization_code', compact('code'));
+
+        $owner = $provider->getResourceOwner($token);
+
+        $identification = $this->getIdentification($owner);
+        $suggestions = $this->getSuggestions($owner);
+
+        return $this->authResponse->make($request, $identification, $suggestions);
+    }
+
+    /**
+     * @param string $redirectUri
+     * @return \League\OAuth2\Client\Provider\AbstractProvider
+     */
+    abstract protected function getProvider($redirectUri);
+
+    /**
+     * @return array
+     */
+    abstract protected function getAuthorizationUrlOptions();
+
+    /**
+     * @param ResourceOwnerInterface $resourceOwner
+     * @return array
+     */
+    abstract protected function getIdentification(ResourceOwnerInterface $resourceOwner);
+
+    /**
+     * @param ResourceOwnerInterface $resourceOwner
+     * @return array
+     */
+    abstract protected function getSuggestions(ResourceOwnerInterface $resourceOwner);
+}


### PR DESCRIPTION
This PR adds an abstract controller which makes it much simpler for extensions to implement external authentication using the league/oauth2-client package. Previously all of this code has been duplicated between the Facebook/GitHub extensions.

Technically this doesn't belong in core, because it's only useful for pretty specific cases – Twitter auth can't use it, for example, because that uses league/oauth1-client. In that respect it's more like a utility than an API, and should be in its own package (flarum/oauth2-controller) which extensions could then require.

My hesitation in doing this is that as we start adding "utility" packages like these to the flarum organisation, they become mixed in with our extension repos. So I'm wondering if it'd be best to prefix our extension repos with `flarum-`, just like we recommend other vendors do. We'd end up with repos like:

* flarum/core
* flarum/gulp
* flarum/oauth2-controller
* flarum/flarum-tags
* flarum/flarum-sticky
* flarum/flarum-auth-facebook

This might also be good because it's consistent with what we recommend for other vendors in terms of naming Flarum extensions. 

Any thoughts about all of this?