### PR TITLE
UrlGenerator prefix fix.

### DIFF
--- a/src/Admin/UrlGenerator.php
+++ b/src/Admin/UrlGenerator.php
@@ -14,5 +14,8 @@ use Flarum\Http\AbstractUrlGenerator;
 
 class UrlGenerator extends AbstractUrlGenerator
 {
+    /**
+     * {@inheritdoc}
+     */
     protected $path = 'admin';
 }

--- a/src/Api/UrlGenerator.php
+++ b/src/Api/UrlGenerator.php
@@ -17,5 +17,5 @@ class UrlGenerator extends AbstractUrlGenerator
     /**
      * {@inheritdoc}
      */
-    protected $prefix = 'api';
+    protected $path = 'api';
 }

--- a/src/Http/AbstractUrlGenerator.php
+++ b/src/Http/AbstractUrlGenerator.php
@@ -31,11 +31,6 @@ class AbstractUrlGenerator
     protected $path;
 
     /**
-     * @var string
-     */
-    protected $prefix = '';
-
-    /**
      * @param Application $app
      * @param RouteCollection $routes
      */
@@ -78,12 +73,6 @@ class AbstractUrlGenerator
      */
     public function toBase()
     {
-        $base = $this->app->url($this->path);
-
-        if (empty($this->prefix)) {
-            return $base;
-        } else {
-            return $base . '/' . $this->prefix;
-        }
+        return $this->app->url($this->path);
     }
 }


### PR DESCRIPTION
I've just seen that `$path` and `$prefix` are doing the same thing, fixed that.

BTW how can I squash these 3 commits? When I'm rebasing them, these two merge commits does not show up.