### PR TITLE
Added support for new minifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "tobscure/json-api": "^0.2.0",
         "oyejorge/less.php": "~1.5",
         "intervention/image": "^2.3.0",
-        "s9e/text-formatter": "^0.4.4",
+        "s9e/text-formatter": "^0.4.8",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-stratigility": "^1.1",


### PR DESCRIPTION
https://discuss.flarum.org/d/1870-new-javascript-minifiers

New minifiers are available in s9e\TextFormatter 0.4.8. Two of them work with a web service that can be faster than the Closure Compiler service hosted by Google. The [web service's repository is here](https://github.com/s9e/WebService-Minifier). The default configuration is tuned for the library, Flarum needs different settings. Below is the code for the actual endpoint configured in Flarum. Going forward you may want to host the web service on your own server. The current instance acts as a caching proxy for the Closure Compiler service and only runs the Closure Compiler application locally if Google's service is unavailable.

```php
<?php

// That's the path to the WebService-Minifier repository
$root = $_ENV['OPENSHIFT_REPO_DIR'] . '/libs/webservice-minifier';
include $root . '/vendor/autoload.php';

$minifier = new s9e\WebServices\Minifier\Minifier;
// Path to the cache dir
$minifier->cacheDir = $_ENV['OPENSHIFT_REPO_DIR'] . '/misc/flarum-minifier-cache/';
// Max ~2MB of code, which is way overkill and should probably set lower
$minifier->maxPayload = 2000000;
$minifier->minifiers = [
	// Uses CCS first because it's probably faster than running the Java application locally
	'ClosureCompilerService' => [
		'compilationLevel' => 'SIMPLE_OPTIMIZATIONS',
		'timeout'          => 60
	],
	// Uses the Java application as a fallback
	'ClosureCompilerApplication' => [
		'closureCompilerBin' => $root . '/bin/compiler.jar'
	]
];
$minifier->handleRequest();
```