### PR TITLE
Extension refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
   fast_finish: true
 
 before_script:
-  - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
+  - composer self-update
   - composer install
 
 script:

--- a/js/admin/src/components/ExtensionsPage.js
+++ b/js/admin/src/components/ExtensionsPage.js
@@ -11,7 +11,6 @@ import listItems from 'flarum/helpers/listItems';
 
 export default class ExtensionsPage extends Component {
   view() {
-    const extensions = Object.keys(app.extensions).map(id => app.extensions[id]);
 
     return (
       <div className="ExtensionsPage">
@@ -29,15 +28,15 @@ export default class ExtensionsPage extends Component {
         <div className="ExtensionsPage-list">
           <div className="container">
             <ul className="ExtensionList">
-              {extensions
-                .sort((a, b) => a.extra['flarum-extension'].title.localeCompare(b.extra['flarum-extension'].title))
-                .map(extension => {
+              {Object.keys(app.extensions)
+                .map(id => {
+                  const extension = app.extensions[id];
                   const controls = this.controlItems(extension.id).toArray();
 
                   return <li className={'ExtensionListItem ' + (!this.isEnabled(extension.id) ? 'disabled' : '')}>
                     <div className="ExtensionListItem-content">
-                      <span className="ExtensionListItem-icon ExtensionIcon" style={extension.extra['flarum-extension'].icon}>
-                        {extension.extra['flarum-extension'].icon ? icon(extension.extra['flarum-extension'].icon.name) : ''}
+                      <span className="ExtensionListItem-icon ExtensionIcon" style={extension.icon}>
+                        {extension.icon ? icon(extension.icon.name) : ''}
                       </span>
                       {controls.length ? (
                         <Dropdown

--- a/src/Admin/Controller/ClientController.php
+++ b/src/Admin/Controller/ClientController.php
@@ -72,7 +72,7 @@ class ClientController extends BaseClientController
 
         $view->setVariable('settings', $settings);
         $view->setVariable('permissions', Permission::map());
-        $view->setVariable('extensions', $this->extensions->getInfo());
+        $view->setVariable('extensions', $this->extensions->getExtensions()->toArray());
 
         return $view;
     }

--- a/src/Database/DatabaseMigrationRepository.php
+++ b/src/Database/DatabaseMigrationRepository.php
@@ -39,9 +39,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Create a new database migration repository instance.
      *
-     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-     * @param  string  $table
-     * @return void
+     * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
+     * @param  string                                           $table
      */
     public function __construct(Resolver $resolver, $table)
     {

--- a/src/Event/ExtensionWasDisabled.php
+++ b/src/Event/ExtensionWasDisabled.php
@@ -10,6 +10,8 @@
 
 namespace Flarum\Event;
 
+use Flarum\Extension\Extension;
+
 class ExtensionWasDisabled
 {
     /**
@@ -18,9 +20,9 @@ class ExtensionWasDisabled
     protected $extension;
 
     /**
-     * @param string $extension
+     * @param Extension $extension
      */
-    public function __construct($extension)
+    public function __construct(Extension $extension)
     {
         $this->extension = $extension;
     }

--- a/src/Event/ExtensionWasEnabled.php
+++ b/src/Event/ExtensionWasEnabled.php
@@ -10,6 +10,8 @@
 
 namespace Flarum\Event;
 
+use Flarum\Extension\Extension;
+
 class ExtensionWasEnabled
 {
     /**
@@ -18,9 +20,9 @@ class ExtensionWasEnabled
     protected $extension;
 
     /**
-     * @param string $extension
+     * @param Extension $extension
      */
-    public function __construct($extension)
+    public function __construct(Extension $extension)
     {
         $this->extension = $extension;
     }

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -1,0 +1,228 @@
+<?php
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension;
+
+use Illuminate\Support\Arr;
+
+/**
+ * @property string $name
+ * @property string $description
+ * @property string $type
+ * @property array  $keywords
+ * @property string $homepage
+ * @property string $time
+ * @property string $license
+ * @property array  $authors
+ * @property array  $support
+ * @property array  $require
+ * @property array  $requireDev
+ * @property array  $autoload
+ * @property array  $autoloadDev
+ * @property array  $conflict
+ * @property array  $replace
+ * @property array  $provide
+ * @property array  $suggest
+ * @property array  $extra
+ */
+class Extension
+{
+
+    /**
+     * Unique Id of the extension.
+     *
+     * @info Identical to the directory in the extensions directory.
+     * @example flarum_suspend
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * The directory of this extension.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Composer json of the package.
+     *
+     * @var array
+     */
+    protected $composerJson;
+
+    /**
+     * Whether the extension is installed.
+     *
+     * @var bool
+     */
+    protected $installed = false;
+
+    /**
+     * The installed version of the extension.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * Whether the extension is enabled.
+     *
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
+     * @param       $path
+     * @param array $composerJson
+     */
+    public function __construct($path, $composerJson)
+    {
+        $this->id           = end(explode('/', $path));
+        $this->path         = $path;
+        $this->composerJson = $composerJson;
+    }
+
+    /**
+     * Fallthrough for getting an attribute out of the composer.json.
+     *
+     * @param $name
+     * @return mixed|null
+     */
+    function __get($name)
+    {
+        return $this->composerJsonAttribute(camel_case($name));
+    }
+
+    /**
+     * Dot notation getter for composer.json attributes.
+     *
+     * @see https://laravel.com/docs/5.1/helpers#arrays
+     *
+     * @param $name
+     * @return mixed
+     */
+    public function composerJsonAttribute($name)
+    {
+        return Arr::get($this->composerJson, $name);
+    }
+
+    /**
+     * @param boolean $installed
+     * @return Extension
+     */
+    public function setInstalled($installed)
+    {
+        $this->installed = $installed;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isInstalled()
+    {
+        return $this->installed;
+    }
+
+    /**
+     * @param string $version
+     * @return Extension
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Loads the icon information from the composer.json.
+     *
+     * @return array|null
+     */
+    public function getIcon()
+    {
+        if (($icon = $this->composerJsonAttribute('extra.flarum-extension.icon'))) {
+            if ($file = Arr::get($icon, 'image')) {
+                $file = $this->path . '/' . $file;
+
+                if (file_exists($file)) {
+                    $mimetype = pathinfo($file, PATHINFO_EXTENSION) === 'svg'
+                        ? 'image/svg+xml'
+                        : finfo_file(finfo_open(FILEINFO_MIME_TYPE), $file);
+                    $data     = file_get_contents($file);
+
+                    $icon['backgroundImage'] = 'url(\'data:' . $mimetype . ';base64,' . base64_encode($data) . '\')';
+                }
+            }
+
+            return $icon;
+        }
+    }
+
+    /**
+     * @param boolean $enabled
+     * @return Extension
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * The raw path of the directory under extensions.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Tests whether the extension has assets.
+     *
+     * @return bool
+     */
+    public function hasAssets()
+    {
+        return realpath($this->path . '/assets/') !== false;
+    }
+
+    /**
+     * Tests whether the extension has migrations.
+     *
+     * @return bool
+     */
+    public function hasMigrations()
+    {
+        return realpath($this->path . '/migrations/') !== false;
+    }
+}

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -343,7 +343,7 @@ class InstallCommand extends AbstractCommand
             'flarum-pusher',
         ];
 
-        foreach ($extensions->getInfo() as $name => $extension) {
+        foreach ($extensions->getExtensions() as $name => $extension) {
             if (in_array($name, $disabled)) {
                 continue;
             }

--- a/src/Update/Console/MigrateCommand.php
+++ b/src/Update/Console/MigrateCommand.php
@@ -74,8 +74,8 @@ class MigrateCommand extends AbstractCommand
 
         $migrator = $extensions->getMigrator();
 
-        foreach ($extensions->getInfo() as $name => $extension) {
-            if (! $extensions->isEnabled($name)) {
+        foreach ($extensions->getExtensions() as $name => $extension) {
+            if (! $extension->isEnabled()) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #732 

This PR fixes the above issue as well as prepare for more things to happen with Extensions as a whole.

This pr does some stuff:

- ExtensionManager::getInfo is obsoleted.
- ExtensionManager::getExtensions and related methods added.
- Created an Extension class that does most of the "tough" work now.
- Rewrote any method that needs a whole Extension object to take it as argument.
- Related Extension events now take the whole object as argument.
- Refactor the admin ExtensionsPage to take the getExtensions results better.. Or create a filter before sending it to the view.
