### PR TITLE
identifying migration namespace

### DIFF
--- a/src/Database/Migrator.php
+++ b/src/Database/Migrator.php
@@ -247,9 +247,8 @@ class Migrator
     {
         $file = implode('_', array_slice(explode('_', $file), 4));
 
-        // flagrow/image-upload
         if ($extension) {
-            $class = str_replace('/', '\\', $extension->name);
+            $class = $extension->getNamespace();
         } else {
             $class = 'Flarum\\Core';
         }

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -243,6 +243,17 @@ class Extension implements Arrayable
     }
 
     /**
+     * Identify the namespace of the extension from the composer file.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        $namespaces = array_keys($this->autoload);
+        return count($namespaces) ? head($namespaces) : null;
+    }
+
+    /**
      * Generates an array result for the object.
      *
      * @return array


### PR DESCRIPTION
Extension namespace is now identified by the extension class. This allows for both backward and forward compatible migration files, instead of wild guessing using a directory or package name.

This does require a "autoload" property set in the composer.json, which should be by default if you have a migration.