### PR TITLE
fixed namespace guessing for extension

### DIFF
--- a/src/Database/Migrator.php
+++ b/src/Database/Migrator.php
@@ -247,9 +247,8 @@ class Migrator
     {
         $file = implode('_', array_slice(explode('_', $file), 4));
 
-        // flagrow/image-upload
         if ($extension) {
-            $class = str_replace('/', '\\', $extension->name);
+            $class = $extension->getNamespace();
         } else {
             $class = 'Flarum\\Core';
         }

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -237,9 +237,10 @@ class Extension implements Arrayable
      *
      * @return bool
      */
-    public function hasMigrations()
+    public function getNamespace()
     {
-        return realpath($this->path . '/migrations/') !== false;
+        $namespaces = array_keys($this->autoload);
+        return count($namespaces) ? head($namespaces) : null;
     }
 
     /**


### PR DESCRIPTION
Fixes namespace guessing in migration files by loading composer autoloading definition. In cases where migration files are used, this will be set. This is a good way of providing extension migration support and is forward an backward compatible. Also works with lowercase namespacing.