### PR TITLE
typehint fix, opening for implementation

### DIFF
--- a/src/Foundation/AbstractServiceProvider.php
+++ b/src/Foundation/AbstractServiceProvider.php
@@ -11,6 +11,7 @@
 namespace Flarum\Foundation;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 abstract class AbstractServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
In order to use Laravel with Flarum, we need to open up the service providers to get the Laravel application injected. Currently only the `Flarum\Foundation\Application` is allowed, which implements the `Illuminate\Contracts\Foundation\Application`, in order to open up, the last should be imported in the AbstractServiceProvider.

I think the import was simply forgotten initially.