### PR TITLE
Refactoring to drop extensions dir, see #774

### DIFF
--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -96,8 +96,9 @@ class Extension implements Arrayable
      */
     protected function assignId()
     {
-        $segments = explode('/', $this->path);
-        $this->id = end($segments);
+        list($vendor, $package) = explode('/', $this->name);
+        $package = str_replace(['flarum-ext-', 'flarum-'], '', $package);
+        $this->id = "$vendor-$package";
     }
 
     /**

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -21,15 +21,12 @@ class ExtensionServiceProvider extends AbstractServiceProvider
     {
         $this->app->bind('flarum.extensions', 'Flarum\Extension\ExtensionManager');
 
-        $config = $this->app->make('flarum.settings')->get('extensions_enabled');
-        $extensions = json_decode($config, true);
+        $bootstrappers = $this->app->make('flarum.extensions')->getEnabledBootstrappers();
 
-        foreach ($extensions as $extension) {
-            if (file_exists($file = public_path().'/extensions/'.$extension.'/bootstrap.php')) {
-                $bootstrapper = require $file;
+        foreach ($bootstrappers as $file) {
+            $bootstrapper = require $file;
 
-                $this->app->call($bootstrapper);
-            }
+            $this->app->call($bootstrapper);
         }
     }
 }


### PR DESCRIPTION
- See #774 & https://github.com/flarum/flarum/pull/35
- No longer loading the composer.json in the extension directory, but fully utilizing the installed.json of composer.

### tested:

- with dev-master of all core extensions and dev-master of flarum/flarum dropping flarum/composer-installer
- loading flarum
- loading admin
- en-/disabling extensions
- re-running migrations