### PR TITLE
added integration with codecov to track coverage of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,7 @@ notifications:
     on_failure: always
     on_start: false
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 sudo: false


### PR DESCRIPTION
Would like to propose tracking code coverage. We can do this automatically by using codecov.io (just use your account to set it up @flarum/core ). The entry below sends the stats over to codecov.