### PR TITLE
Add Icon Dropdown Component

### DIFF
--- a/js/admin/src/components/EditGroupModal.js
+++ b/js/admin/src/components/EditGroupModal.js
@@ -2,6 +2,7 @@ import Modal from 'flarum/components/Modal';
 import Button from 'flarum/components/Button';
 import Badge from 'flarum/components/Badge';
 import Group from 'flarum/models/Group';
+import IconDropdown from 'flarum/components/IconDropdown';
 
 /**
  * The `EditGroupModal` component shows a modal dialog which allows the user
@@ -54,7 +55,7 @@ export default class EditGroupModal extends Modal {
             <div className="helpText">
               {app.translator.trans('core.admin.edit_group.icon_text', {a: <a href="http://fortawesome.github.io/Font-Awesome/icons/" tabindex="-1"/>}, {em: <em/>}, {code: <code/>})}
             </div>
-            <input className="FormControl" placeholder="bolt" value={this.icon()} oninput={m.withAttr('value', this.icon)}/>
+            {IconDropdown.component({selection: this.icon})}
           </div>
 
           <div className="Form-group">

--- a/js/lib/components/IconDropdown.js
+++ b/js/lib/components/IconDropdown.js
@@ -1,0 +1,65 @@
+import Dropdown from 'flarum/components/Dropdown';
+import ItemList from 'flarum/utils/ItemList';
+import icon from 'flarum/helpers/icon';
+
+/**
+ * The `IconDropdown` component is the same as a `Dropdown`, except the it
+ * houses font awesome icons for selection.
+ *
+ * ### Props
+ *
+ * - `selection` - The icon currently selected, required as m.prop
+ * - `icons` - The set of icons to display as an option, set as 'all', 'social', or custom array of fa-icons
+ */
+export default class IconDropdown extends Dropdown {
+  static initProps(props) {
+    super.initProps(props);
+    
+    props.className = 'Dropdown--iconselector';
+    props.buttonClassName = 'Button Button--iconselector';
+    props.menuClassName = 'Dropdown-menu--below';
+  }
+  
+  view() {
+    this.props.children = this.items().toArray();
+
+    return super.view();
+  }
+
+  getButtonContent() {
+    return [
+        icon(this.props.selection()),
+        this.props.caretIcon ? icon(this.props.caretIcon, {className: 'Button-caret'}) : ''
+    ];
+  }
+  
+  items() {
+    //Set Defaults
+    if (typeof this.props.selection == 'undefined') {this.props.selection = m.prop('question');}
+    if (typeof this.props.icons == 'undefined') {this.props.icons = 'all';}
+
+    const items = new ItemList();
+    //Preset icon list
+    const iconlist = {
+        'all':
+            ["500px", "adjust", "adn", "amazon", "ambulance", "anchor", "android", "angellist", "apple", "archive", "arrows", "asterisk", "at", "automobile", "backward", "ban", "bank", "barcode", "bars", "bed", "beer", "behance", "bell", "bicycle", "binoculars", "bitbucket", "bitcoin", "bold", "bolt", "bomb", "book", "bookmark", "briefcase", "btc", "bug", "building", "bullhorn", "bullseye", "bus", "buysellads", "cab", "calculator", "calendar", "camera", "car", "cc", "certificate", "chain", "check", "child", "chrome", "circle", "clipboard", "clone", "close", "cloud", "cny", "code", "codepen", "coffee", "cog", "cogs", "columns", "comment", "commenting", "comments", "compass", "compress", "connectdevelop", "contao", "copy", "copyright", "crop", "crosshairs", "css3", "cube", "cubes", "cut", "cutlery", "dashboard", "dashcube", "database", "dedent", "delicious", "desktop", "deviantart", "diamond", "digg", "dollar", "download", "dribbble", "dropbox", "drupal", "edit", "eject", "empire", "envelope", "eraser", "eur", "euro", "exchange", "exclamation", "expand", "expeditedssl", "eye", "eyedropper", "facebook", "fax", "feed", "female", "file", "film", "filter", "fire", "firefox", "flag", "flash", "flask", "flickr", "folder", "font", "fonticons", "forumbee", "forward", "foursquare", "gamepad", "gavel", "gbp", "ge", "gear", "gears", "genderless", "gg", "gift", "git", "github", "gittip", "glass", "globe", "google", "gratipay", "group", "header", "headphones", "heart", "heartbeat", "history", "home", "hotel", "hourglass", "houzz", "html5", "ils", "image", "inbox", "indent", "industry", "info", "inr", "instagram", "institution", "intersex", "ioxhost", "italic", "joomla", "jpy", "jsfiddle", "key", "krw", "language", "laptop", "lastfm", "leaf", "leanpub", "legal", "link", "linkedin", "linux", "list", "lock", "magic", "magnet", "male", "map", "mars", "maxcdn", "meanpath", "medium", "medkit", "mercury", "microphone", "minus", "mobile", "money", "motorcycle", "music", "navicon", "neuter", "odnoklassniki", "opencart", "openid", "opera", "outdent", "pagelines", "paperclip", "paragraph", "paste", "pause", "paw", "paypal", "pencil", "phone", "photo", "pinterest", "plane", "play", "plug", "plus", "print", "qq", "qrcode", "question", "ra", "random", "rebel", "recycle", "reddit", "refresh", "registered", "remove", "renren", "reorder", "repeat", "reply", "retweet", "rmb", "road", "rocket", "rouble", "rss", "rub", "ruble", "rupee", "safari", "save", "scissors", "search", "sellsy", "send", "server", "share", "shekel", "sheqel", "shield", "ship", "shirtsinbulk", "signal", "simplybuilt", "sitemap", "skyatlas", "skype", "slack", "sliders", "slideshare", "sort", "soundcloud", "spinner", "spoon", "spotify", "square", "star", "steam", "stethoscope", "stop", "strikethrough", "stumbleupon", "subscript", "subway", "suitcase", "superscript", "support", "table", "tablet", "tachometer", "tag", "tags", "tasks", "taxi", "television", "terminal", "th", "ticket", "times", "tint", "trademark", "train", "transgender", "trash", "tree", "trello", "tripadvisor", "trophy", "truck", "try", "tty", "tumblr", "tv", "twitch", "twitter", "umbrella", "underline", "undo", "university", "unlink", "unlock", "unsorted", "upload", "usb", "usd", "user", "users", "venus", "viacoin", "vimeo", "vine", "vk", "warning", "wechat", "weibo", "weixin", "whatsapp", "wheelchair", "wifi", "windows", "won", "wordpress", "wrench", "xing", "yahoo", "yc", "yelp", "yen", "youtube"],
+        'social':
+            ["globe", 'amazon', 'angellist', 'apple', 'behance', 'bitbucket', 'codepen', 'connectdevelop', 'dashcube', 'delicious', 'deviantart', 'digg', 'dribbble', 'dropbox', 'drupal', 'facebook', 'flickr', 'foursquare', 'get-pocket', 'git', 'github', 'github-alt', 'gittip', 'google', 'google-plus', 'google-wallet', 'gratipay', 'hacker-news', 'instagram', 'ioxhost', 'joomla', 'jsfiddle', 'lastfm', 'leanpub', 'linkedin', 'meanpath', 'medium', 'odnoklassniki', 'opencart', 'pagelines', 'paypal', 'pied-piper-alt', 'pinterest-p', 'qq', 'reddit', 'renren', 'sellsy', 'share-alt', 'shirtsinbulk', 'simplybuilt', 'skyatlas', 'skype', 'slack', 'slideshare', 'soundcloud', 'spotify', 'stack-exchange', 'stack-overflow', 'steam', 'stumbleupon', 'tencent-weibo', 'trello', 'tripadvisor', 'tumblr', 'twitch', 'twitter', 'viacoin', 'vimeo', 'vine', 'vk', 'wechat', 'weibo', 'weixin', 'whatsapp', 'wordpress', 'xing', 'y-combinator', 'yelp', 'youtube-play' ],
+    };
+    //If using custom icon list
+    if (typeof iconlist[this.props.icons] == 'undefined') {
+      iconlist['custom'] = this.props.icons;
+      this.props.icons = 'custom';
+    }
+    //Add icons to dropdown
+    for(const k in iconlist[this.props.icons]) {
+      //Highlight Selected
+      const highlighted = m.prop(this.props.selection() == iconlist[this.props.icons][k] ? 'highlighted' : '');
+      items.add(iconlist[this.props.icons][k],(
+        m('div', {onclick: () => {this.props.selection(iconlist[this.props.icons][k]); m.redraw();}, role: "button", href: "#", class: highlighted(), title: iconlist[this.props.icons][k]}, [icon(iconlist[this.props.icons][k])])),
+        100
+      );
+    }
+    return items;
+  }
+}

--- a/js/lib/components/IconDropdown.js
+++ b/js/lib/components/IconDropdown.js
@@ -35,8 +35,14 @@ export default class IconDropdown extends Dropdown {
   
   items() {
     //Set Defaults
-    if (typeof this.props.selection == 'undefined') {this.props.selection = m.prop('question');}
-    if (typeof this.props.icons == 'undefined') {this.props.icons = 'all';}
+    if (typeof this.props.selection == 'undefined') {
+      this.props.selection = m.prop('question');
+    } else if (this.props.selection() == '') {
+      this.props.selection('question');
+    }
+    if (typeof this.props.icons == 'undefined') {
+      this.props.icons = 'all';
+    }
 
     const items = new ItemList();
     //Preset icon list

--- a/less/lib/Button.less
+++ b/less/lib/Button.less
@@ -215,6 +215,21 @@
     margin: 0;
   }
 }
+
+.Button--iconselector {
+  width: 52px;
+  text-align: center;
+  padding: 8px 0;
+
+  .Button-label {
+    display: none;
+  }
+  .Button-icon {
+    font-size: 16px;
+    vertical-align: -1px;
+    margin: 0;
+  }
+}
 .SessionDropdown .Dropdown-toggle {
   border-radius: 18px;
 

--- a/less/lib/Dropdown.less
+++ b/less/lib/Dropdown.less
@@ -79,6 +79,49 @@
   left: auto;
   right: 0;
 }
+.Dropdown-menu--below {
+    padding-left: 10px !important;
+    padding-top: 10px !important;
+    bottom: inherit !important;
+    position: absolute !important;
+    top: 100% !important;
+    overflow: auto;
+    max-height: 45vh !important;
+    min-width: 189px !important;
+    z-index: 1000;
+    float: left;
+    background-color: #fff;
+    -webkit-background-clip: padding-box;
+    background-clip: padding-box;
+    border: 1px solid rgba(0,0,0,.15);
+    -webkit-transform: none !important;
+    transform: none !important;
+    -webkit-transition: none !important;
+    -moz-transition: none !important;
+    -o-transition: none !important;
+    transition: none !important;
+    > li > div {
+      float: left;
+      padding: 12px;
+      margin: 0 12px 12px 0;
+      text-align: center;
+      cursor: pointer;
+      border-radius: 3px;
+      font-size: 14px;
+      box-shadow: 0 0 0 1px #ddd;
+      color: #7c7c7c;
+      &:hover {
+        background-color: #e8ecf3;
+      }
+    }
+    > li > .highlighted {
+      background-color: #4D698E;
+      color: white;
+      &:hover {
+        background-color: #364A65;
+      }
+    }
+}
 .Dropdown-header {
   padding: 10px 15px;
   color: @heading-color;

--- a/less/lib/Modal.less
+++ b/less/lib/Modal.less
@@ -63,7 +63,6 @@
   background-color: @body-bg;
   background-clip: padding-box;
   margin: 0 auto;
-  overflow: hidden;
 }
 
 // Measure scrollbar width for padding body during modal show/hide


### PR DESCRIPTION
The `IconDropdown` component is the same as a `Dropdown`, except the it houses font awesome icons for selection. This adds a cleaner way for users to select a font awesome icon. I noticed in groups
# Usage:

`selection` the icon that is currently selected. Default value of `question`
`icons` the set of icons to display for selection. Possible values: "all", "social", or an array of icon names. Default value of `all`.

```
IconDropdown.component({selection: this.selection, icons: 'social'})
```
# Screenshot:

![screenshot](http://i.imgur.com/LzyVLtR.png)
