### PR TITLE
Improve forgot password modal error handling

### DIFF
--- a/src/Core/Command/RequestPasswordResetHandler.php
+++ b/src/Core/Command/RequestPasswordResetHandler.php
@@ -15,6 +15,8 @@ use Flarum\Core\PasswordToken;
 use Flarum\Core\Repository\UserRepository;
 use Flarum\Forum\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Core\Exception\ValidationException;
+use Flarum\Core\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Mail\Message;
@@ -70,6 +72,11 @@ class RequestPasswordResetHandler
      */
     public function handle(RequestPasswordReset $command)
     {
+
+        if (! $command->email) {
+            throw new ValidationException(['The email field is required']);
+        }
+
         $user = $this->users->findByEmail($command->email);
 
         if (! $user) {

--- a/src/Core/Command/RequestPasswordResetHandler.php
+++ b/src/Core/Command/RequestPasswordResetHandler.php
@@ -16,7 +16,6 @@ use Flarum\Core\Repository\UserRepository;
 use Flarum\Forum\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Core\Exception\ValidationException;
-use Flarum\Core\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Mail\Message;

--- a/src/Core/Command/RequestPasswordResetHandler.php
+++ b/src/Core/Command/RequestPasswordResetHandler.php
@@ -75,7 +75,7 @@ class RequestPasswordResetHandler
         $this->url = $url;
         $this->translator = $translator;
         $this->validator = $validator;
-        $this->validatorFactory = $validatorFactory
+        $this->validatorFactory = $validatorFactory;
     }
 
     /**

--- a/src/Core/Command/RequestPasswordResetHandler.php
+++ b/src/Core/Command/RequestPasswordResetHandler.php
@@ -11,7 +11,6 @@
 namespace Flarum\Core\Command;
 
 use Flarum\Core;
-use Flarum\Core\Exception\ValidationException;
 use Flarum\Core\PasswordToken;
 use Flarum\Core\Repository\UserRepository;
 use Flarum\Forum\UrlGenerator;


### PR DESCRIPTION
This solves #776 (I think)
All I did was add a
```php 
$validation = $this->validatorFactory->make(['email' => $command->email], ['email' => 'required|email']);
 
 if ($validation->fails()) {
     throw new ValidationException($validation);
}
```
before Flarum looks in the database for any user with the email to reset password in `RequestPasswordResetHandler.php`.

Any improvements you might want me to make, I'll try :smiley: 
This is my very first code contribution, so I don't really know much of Flarum's core :wink: