### PR TITLE
Fix avatar upload on Windows servers - Issue #893

### DIFF
--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -99,7 +99,7 @@ class UploadAvatarHandler
 
         $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('jpg', 100);
 
-        @file_put_contents($tmpFile, $encodedImage);
+        file_put_contents($tmpFile, $encodedImage);
 
         $this->events->fire(
             new AvatarWillBeSaved($user, $actor, $tmpFile)

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -96,7 +96,10 @@ class UploadAvatarHandler
         $this->validator->assertValid(['avatar' => $file]);
 
         $manager = new ImageManager;
-        $manager->make($tmpFile)->fit(100, 100)->save();
+
+        $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('jpg', 100);
+
+        @file_put_contents($tmpFile, $encodedImage);
 
         $this->events->fire(
             new AvatarWillBeSaved($user, $actor, $tmpFile)


### PR DESCRIPTION
As said in Intervention Image docs on save api: The image type will be defined by the file extension. For example if you pass foo.jpg the image will be saved as a JPG file.

Windows servers will generate temporary name and include .tmp extension.

So instead of using the save api. It will first encode the image to JPG format then save it using the native file_put_contents.