### PR TITLE
#249 AvatarEditor should show an upload icon instead of a user's default avatar

### DIFF
--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -18995,10 +18995,10 @@ System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/h
               avatar(user),
               m(
                 'a',
-                { className: 'Dropdown-toggle',
+                { className: user.avatarUrl() ? "Dropdown-toggle" : "Dropdown-toggle AvatarEditor--noAvatar",
                   'data-toggle': 'dropdown',
                   onclick: this.quickUpload.bind(this) },
-                this.loading ? LoadingIndicator.component() : icon('pencil')
+                this.loading ? LoadingIndicator.component() : user.avatarUrl() ? icon('pencil') : icon('upload')
               ),
               m(
                 'ul',

--- a/js/forum/src/components/AvatarEditor.js
+++ b/js/forum/src/components/AvatarEditor.js
@@ -37,10 +37,10 @@ export default class AvatarEditor extends Component {
     return (
       <div className={'AvatarEditor Dropdown ' + this.props.className + (this.loading ? ' loading' : '')}>
         {avatar(user)}
-        <a className="Dropdown-toggle"
-          data-toggle="dropdown"
-          onclick={this.quickUpload.bind(this)}>
-          {this.loading ? LoadingIndicator.component() : icon('pencil')}
+        <a className={ user.avatarUrl() ? "Dropdown-toggle" : "Dropdown-toggle AvatarEditor--noAvatar" }
+           data-toggle="dropdown"
+           onclick={this.quickUpload.bind(this)}>
+          {this.loading ? LoadingIndicator.component() : (user.avatarUrl() ? icon('pencil') : icon('upload'))}
         </a>
         <ul className="Dropdown-menu Menu">
           {listItems(this.controlItems().toArray())}

--- a/less/forum/AvatarEditor.less
+++ b/less/forum/AvatarEditor.less
@@ -14,6 +14,9 @@
     text-decoration: none;
     border: 0;
   }
+  .AvatarEditor--noAvatar {
+    opacity: 0.7;
+  }
   &:hover .Dropdown-toggle, &.open .Dropdown-toggle, &.loading .Dropdown-toggle {
     opacity: 1;
   }


### PR DESCRIPTION
This kind of fixes #249
When a user doesn't have an avatar, over their "avatar" it will show an upload button with opacity of 70%.
It isn't very clear, but the users hopefully sees that something is up with the avatar :wink:
When you click it it directly calls the `upload` function

Screenshot:

![Flarum User Profile: No avatar and shows upload button](https://i.imgsafe.org/7d19327.png)