### PR TITLE
#814 Better code style

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -116,6 +116,14 @@
     border-bottom: 2px dotted @body-bg;
     margin: 1em 0;
   }
+  code {
+    font-family: source-code-pro, Monaco, Consolas, "Courier New", monospace;
+    padding: 2px 6px;
+    background: #F2F7F9;
+    color: #256FC7;
+    font-size: 90%;
+    border-radius: 4px
+  }
   pre {
     border: 0;
     padding: 15px;
@@ -127,6 +135,13 @@
     .hljs {
       padding: 0;
       background: none;
+    }
+    code {
+      padding: 0;
+      background: transparent;
+      color: inherit;
+      font-size: 100%;
+      border-radius: 0;
     }
   }
   h1 {

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -119,7 +119,7 @@
   code {
     font-family: source-code-pro, Monaco, Consolas, "Courier New", monospace;
     padding: 2px 6px;
-    background: #F2F7F9;
+    background: #60646D;
     color: #256FC7;
     font-size: 90%;
     border-radius: 4px

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -119,8 +119,8 @@
   code {
     font-family: source-code-pro, Monaco, Consolas, "Courier New", monospace;
     padding: 2px 6px;
-    background: #60646D;
-    color: #256FC7;
+    background: @code-bg;
+    color: @code-color;
     font-size: 90%;
     border-radius: 4px
   }

--- a/less/lib/variables.less
+++ b/less/lib/variables.less
@@ -37,6 +37,9 @@
   @control-danger-color:           #d66;
 
   @overlay-bg:                     fade(@secondary-color, 90%);
+
+  @code-bg:                        #F2F7F9;
+  @code-color:                     #60646D;
 }
 .define-colors(true) {
   @primary-color:                  @config-primary-color;
@@ -56,6 +59,9 @@
   @control-danger-color:           #a88;
 
   @overlay-bg:                     fade(darken(@body-bg, 5%), 90%);
+
+  @code-bg:                        darken(#F2F7F9, 90%);
+  @code-color:                     lighten(#60646D, 90%);
 }
 
 @hero-bg:                          @control-bg;


### PR DESCRIPTION
This just makes the inline code look like Scoth.IO's.
It fixes #814 

I'll make any necessary changes.

CSS
```css
.Post-body code {
    font-family: source-code-pro, Monaco, Consolas, "Courier New", monospace;
    padding: 2px 6px;
    background: #F2F7F9;
    color: #256FC7;
    font-size: 90%;
    border-radius: 4px
  }
```

---
Screenshot:

![Flarum New Code Style](https://i.imgsafe.org/a3c428e.png)