### PR TITLE
Public and base directory can be separated

### DIFF
--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -63,11 +63,11 @@ class ExtensionManager
      */
     public function getExtensions()
     {
-        if (is_null($this->extensions) && $this->filesystem->exists(base_path('vendor/composer/installed.json'))) {
+        if (is_null($this->extensions) && $this->filesystem->exists($this->app->basePath().'/vendor/composer/installed.json')) {
             $extensions = new Collection();
 
             // Load all packages installed by composer.
-            $installed = json_decode($this->filesystem->get(base_path('vendor/composer/installed.json')), true);
+            $installed = json_decode($this->filesystem->get($this->app->basePath().'/vendor/composer/installed.json'), true);
 
             foreach ($installed as $package) {
                 if (Arr::get($package, 'type') != 'flarum-extension' || empty(Arr::get($package, 'name'))) {
@@ -318,6 +318,6 @@ class ExtensionManager
      */
     protected function getExtensionsDir()
     {
-        return base_path('vendor');
+        return $this->app->basePath().'/vendor';
     }
 }

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -63,11 +63,11 @@ class ExtensionManager
      */
     public function getExtensions()
     {
-        if (is_null($this->extensions) && $this->filesystem->exists(public_path('vendor/composer/installed.json'))) {
+        if (is_null($this->extensions) && $this->filesystem->exists(base_path('vendor/composer/installed.json'))) {
             $extensions = new Collection();
 
             // Load all packages installed by composer.
-            $installed = json_decode($this->filesystem->get(public_path('vendor/composer/installed.json')), true);
+            $installed = json_decode($this->filesystem->get(base_path('vendor/composer/installed.json')), true);
 
             foreach ($installed as $package) {
                 if (Arr::get($package, 'type') != 'flarum-extension' || empty(Arr::get($package, 'name'))) {
@@ -180,7 +180,7 @@ class ExtensionManager
         if ($extension->hasAssets()) {
             $this->filesystem->copyDirectory(
                 $extension->getPath().'/assets',
-                $this->app->basePath().'/assets/extensions/'.$extension->getId()
+                $this->app->publicPath().'/assets/extensions/'.$extension->getId()
             );
         }
     }
@@ -192,7 +192,7 @@ class ExtensionManager
      */
     protected function unpublishAssets(Extension $extension)
     {
-        $this->filesystem->deleteDirectory($this->app->basePath().'/assets/extensions/'.$extension);
+        $this->filesystem->deleteDirectory($this->app->publicPath().'/assets/extensions/'.$extension);
     }
 
     /**
@@ -204,7 +204,7 @@ class ExtensionManager
      */
     public function getAsset(Extension $extension, $path)
     {
-        return $this->app->basePath().'/assets/extensions/'.$extension->getId().$path;
+        return $this->app->publicPath().'/assets/extensions/'.$extension->getId().$path;
     }
 
     /**
@@ -318,6 +318,6 @@ class ExtensionManager
      */
     protected function getExtensionsDir()
     {
-        return public_path('vendor');
+        return base_path('vendor');
     }
 }

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -25,12 +25,12 @@ abstract class AbstractServer
     /**
      * @var string
      */
-    protected $base_path;
+    protected $basePath;
 
     /**
      * @var string
      */
-    protected $public_path;
+    protected $publicPath;
 
     /**
      * @var array
@@ -40,20 +40,20 @@ abstract class AbstractServer
     /**
      * @param string $path
      */
-    public function __construct($base_path = null, $public_path = null)
+    public function __construct($basePath = null, $publicPath = null)
     {
-        if ($base_path === null) {
-            $base_path = getcwd();
+        if ($basePath === null) {
+            $basePath = getcwd();
         }
 
-        if ($public_path === null) {
-            $public_path = $base_path;
+        if ($publicPath === null) {
+            $publicPath = $basePath;
         }
 
-        $this->base_path = $base_path;
-        $this->public_path = $public_path;
+        $this->basePath = $basePath;
+        $this->publicPath = $publicPath;
 
-        if (file_exists($file = $this->base_path.'/config.php')) {
+        if (file_exists($file = $this->basePath.'/config.php')) {
             $this->config = include $file;
         }
 
@@ -65,7 +65,7 @@ abstract class AbstractServer
      */
     public function getBasePath()
     {
-        return $this->base_path;
+        return $this->basePath;
     }
 
     /**
@@ -73,23 +73,23 @@ abstract class AbstractServer
      */
     public function getPublicPath()
     {
-        return $this->public_path;
+        return $this->publicPath;
     }
 
     /**
      * @param string $base_path
      */
-    public function setBasePath($base_path)
+    public function setBasePath($basePath)
     {
-        $this->base_path = $base_path;
+        $this->basePath = $basePath;
     }
 
     /**
      * @param string $public_path
      */
-    public function setPublicPath($public_path)
+    public function setPublicPath($publicPath)
     {
-        $this->public_path = $public_path;
+        $this->publicPath = $publicPath;
     }
 
     /**
@@ -115,7 +115,7 @@ abstract class AbstractServer
     {
         date_default_timezone_set('UTC');
 
-        $app = new Application($this->base_path, $this->public_path);
+        $app = new Application($this->basePath, $this->publicPath);
 
         $app->instance('env', 'production');
         $app->instance('flarum.config', $this->config);

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -25,7 +25,12 @@ abstract class AbstractServer
     /**
      * @var string
      */
-    protected $path;
+    protected $base_path;
+
+    /**
+     * @var string
+     */
+    protected $public_path;
 
     /**
      * @var array
@@ -35,15 +40,20 @@ abstract class AbstractServer
     /**
      * @param string $path
      */
-    public function __construct($path = null)
+    public function __construct($base_path = null, $public_path = null)
     {
-        if ($path === null) {
-            $path = getcwd();
+        if ($base_path === null) {
+            $base_path = getcwd();
         }
 
-        $this->path = $path;
+        if ($public_path === null) {
+            $public_path = $base_path;
+        }
 
-        if (file_exists($file = $this->path.'/config.php')) {
+        $this->base_path = $base_path;
+        $this->public_path = $public_path;
+
+        if (file_exists($file = $this->base_path.'/config.php')) {
             $this->config = include $file;
         }
 
@@ -53,17 +63,33 @@ abstract class AbstractServer
     /**
      * @return string
      */
-    public function getPath()
+    public function getBasePath()
     {
-        return $this->path;
+        return $this->base_path;
     }
 
     /**
-     * @param string $path
+     * @return string
      */
-    public function setPath($path)
+    public function getPublicPath()
     {
-        $this->path = $path;
+        return $this->public_path;
+    }
+
+    /**
+     * @param string $base_path
+     */
+    public function setBasePath($base_path)
+    {
+        $this->base_path = $base_path;
+    }
+
+    /**
+     * @param string $public_path
+     */
+    public function setPublicPath($public_path)
+    {
+        $this->public_path = $public_path;
     }
 
     /**
@@ -89,7 +115,7 @@ abstract class AbstractServer
     {
         date_default_timezone_set('UTC');
 
-        $app = new Application($this->path);
+        $app = new Application($this->base_path, $this->public_path);
 
         $app->instance('env', 'production');
         $app->instance('flarum.config', $this->config);

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -102,8 +102,12 @@ class Application extends Container implements ApplicationContract
 
         $this->registerCoreContainerAliases();
 
-        if ($basePath && $publicPath) {
-            $this->setPaths($basePath, $publicPath);
+        if ($basePath) {
+            $this->setBasePath($basePath);
+        }
+
+        if ($publicPath) {
+            $this->setPublicPath($publicPath);
         }
     }
 
@@ -213,10 +217,24 @@ class Application extends Container implements ApplicationContract
      * @param string $publicPath
      * @return $this
      */
-    public function setPaths($basePath, $publicPath)
+    public function setBasePath($basePath)
     {
         $this->basePath = rtrim($basePath, '\/');
 
+        $this->bindPathsInContainer();
+
+        return $this;
+    }
+
+    /**
+     * Set the public path for the application.
+     *
+     * @param string $basePath
+     * @param string $publicPath
+     * @return $this
+     */
+    public function setPublicPath($publicPath)
+    {
         $this->publicPath = rtrim($publicPath, '\/');
 
         $this->bindPathsInContainer();

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -34,6 +34,13 @@ class Application extends Container implements ApplicationContract
     protected $basePath;
 
     /**
+     * The public path for the Flarum installation.
+     *
+     * @var string
+     */
+    protected $publicPath;
+
+    /**
      * Indicates if the application has "booted".
      *
      * @var bool
@@ -87,7 +94,7 @@ class Application extends Container implements ApplicationContract
      *
      * @param string|null $basePath
      */
-    public function __construct($basePath = null)
+    public function __construct($basePath = null, $publicPath = null)
     {
         $this->registerBaseBindings();
 
@@ -95,8 +102,8 @@ class Application extends Container implements ApplicationContract
 
         $this->registerCoreContainerAliases();
 
-        if ($basePath) {
-            $this->setBasePath($basePath);
+        if ($basePath && $publicPath) {
+            $this->setPaths($basePath, $publicPath);
         }
     }
 
@@ -203,11 +210,14 @@ class Application extends Container implements ApplicationContract
      * Set the base path for the application.
      *
      * @param string $basePath
+     * @param string $publicPath
      * @return $this
      */
-    public function setBasePath($basePath)
+    public function setPaths($basePath, $publicPath)
     {
         $this->basePath = rtrim($basePath, '\/');
+
+        $this->publicPath = rtrim($publicPath, '\/');
 
         $this->bindPathsInContainer();
 
@@ -243,7 +253,7 @@ class Application extends Container implements ApplicationContract
      */
     public function publicPath()
     {
-        return $this->basePath;
+        return $this->publicPath;
     }
 
     /**

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -358,7 +358,7 @@ class InstallCommand extends AbstractCommand
     {
         $this->filesystem->copyDirectory(
             __DIR__.'/../../../assets',
-            $this->application->basePath().'/assets'
+            $this->application->publicPath().'/assets'
         );
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -64,7 +64,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->publicPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 


### PR DESCRIPTION
Existing users don't have to make any change. In their case, the base and public path will be the same. In order to use separated base and public path, **before installing Flarum**, you need to specify them as arguments of the `Server` object constructor, in _index.php, api.php_ and _admin.php_ respectively:

`$server = new Flarum\Forum\Server(BASE_PATH, PUBLIC_PATH);`

If `PUBLIC_PATH` is not specified, it will be the taken from `BASE_PATH`. Extensions assets will be copied to the public path, with all the assets (CSS, JS, avatars)