### PR TITLE
Fixes #945 - Incorrect Scrubber count value

### DIFF
--- a/js/forum/src/components/PostStreamScrubber.js
+++ b/js/forum/src/components/PostStreamScrubber.js
@@ -61,7 +61,7 @@ export default class PostStreamScrubber extends Component {
     const unreadPercent = count ? Math.min(count - this.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {
-      index: <span className="Scrubber-index">{retain || formatNumber((Math.ceil(this.index + this.visible) < count) ? Math.ceil(this.index + this.visible) : count)}</span>,
+      index: <span className="Scrubber-index">{retain || formatNumber(Math.min(Math.ceil(this.index + this.visible), count))}</span>,
       count: <span className="Scrubber-count">{formatNumber(count)}</span>
     });
 

--- a/js/forum/src/components/PostStreamScrubber.js
+++ b/js/forum/src/components/PostStreamScrubber.js
@@ -61,7 +61,7 @@ export default class PostStreamScrubber extends Component {
     const unreadPercent = count ? Math.min(count - this.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {
-      index: <span className="Scrubber-index">{retain || formatNumber(Math.ceil(this.index + this.visible))}</span>,
+      index: <span className="Scrubber-index">{retain || formatNumber((Math.ceil(this.index + this.visible) < count) ? Math.ceil(this.index + this.visible) : count)}</span>,
       count: <span className="Scrubber-count">{formatNumber(count)}</span>
     });
 


### PR DESCRIPTION
Clicking and dragging the Scrubber beyond the final post causes the counter to exceed the total post count. This commit fixes that issue. 

Please review code.