### PR TITLE
Updated s9e\TextFormatter to 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "symfony/http-foundation": "^2.7",
         "symfony/translation": "^2.7",
         "symfony/yaml": "^2.7",
-        "s9e/text-formatter": "^0.4.12",
+        "s9e/text-formatter": "^0.5.0",
         "tobscure/json-api": "^0.3.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-stratigility": "^1.1"

--- a/src/Asset/JsCompiler.php
+++ b/src/Asset/JsCompiler.php
@@ -93,11 +93,11 @@ class JsCompiler extends RevisionCompiler
 
         $hostedMinifer = $minifier->add('HostedMinifier');
         $hostedMinifer->url = 'http://s9e-textformatter.rhcloud.com/flarum-minifier/';
-        $hostedMinifer->timeout = 30;
+        $hostedMinifer->httpClient->timeout = 30;
 
         $ccs = $minifier->add('ClosureCompilerService');
         $ccs->compilationLevel = 'SIMPLE_OPTIMIZATIONS';
-        $ccs->timeout = 30;
+        $ccs->httpClient->timeout = 30;
 
         $minifier->add('MatthiasMullieMinify');
 


### PR DESCRIPTION
The `timeout` property has been removed from the JavaScript minifiers. You need to set it on the HTTP client instead.