### PR TITLE
Domain based configuration file

### DIFF
--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -66,7 +66,7 @@ abstract class AbstractServer
                 $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
                 if ($host) {
-                    if (substr($host, 0, 4) == "www.") {
+                    if (substr($host, 0, 4) == 'www.') {
                         $host = substr($host, 4);
                     }
 

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -61,6 +61,17 @@ abstract class AbstractServer
 
         if (file_exists($file = $this->basePath.'/config.php')) {
             $this->config = include $file;
+        } else {
+            if (isset($_SERVER['SERVER_NAME'])) {
+                $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
+                if (!$host) $host = $_SERVER['SERVER_NAME'];
+
+                if (substr($host, 0, 4) == "www.") $host = substr($host, 4);
+
+                if (file_exists($file = $this->basePath.'/config.'.$host.'.php')) {
+                    $this->config = include $file;
+                }
+            }
         }
     }
 

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -65,7 +65,7 @@ abstract class AbstractServer
             if (isset($_SERVER['SERVER_NAME'])) {
                 $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
-                if (!$host) {
+                if (! $host) {
                     $host = $_SERVER['SERVER_NAME'];
                 }
 

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -64,12 +64,15 @@ abstract class AbstractServer
         } else {
             if (isset($_SERVER['SERVER_NAME'])) {
                 $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
-                if (!$host) $host = $_SERVER['SERVER_NAME'];
 
-                if (substr($host, 0, 4) == "www.") $host = substr($host, 4);
+                if ($host) {
+                    if (substr($host, 0, 4) == "www.") {
+                        $host = substr($host, 4);
+                    }
 
-                if (file_exists($file = $this->basePath.'/config.'.$host.'.php')) {
-                    $this->config = include $file;
+                    if (file_exists($file = $this->basePath.'/config.'.$host.'.php')) {
+                        $this->config = include $file;
+                    }
                 }
             }
         }

--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -65,14 +65,16 @@ abstract class AbstractServer
             if (isset($_SERVER['SERVER_NAME'])) {
                 $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
-                if ($host) {
-                    if (substr($host, 0, 4) == 'www.') {
-                        $host = substr($host, 4);
-                    }
+                if (!$host) {
+                    $host = $_SERVER['SERVER_NAME'];
+                }
 
-                    if (file_exists($file = $this->basePath.'/config.'.$host.'.php')) {
-                        $this->config = include $file;
-                    }
+                if (substr($host, 0, 4) == 'www.') {
+                    $host = substr($host, 4);
+                }
+
+                if (file_exists($file = $this->basePath.'/config.'.$host.'.php')) {
+                    $this->config = include $file;
                 }
             }
         }

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -367,7 +367,7 @@ class InstallCommand extends AbstractCommand
         if (isset($_SERVER['SERVER_NAME'])) {
             $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
-            if (!$host) {
+            if (! $host) {
                     $host = $_SERVER['SERVER_NAME'];
                 }
 

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -368,7 +368,7 @@ class InstallCommand extends AbstractCommand
             $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
             if ($host) {
-                if (substr($host, 0, 4) == "www.") {
+                if (substr($host, 0, 4) == 'www.') {
                     $host = substr($host, 4);
                 }
 

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -364,6 +364,15 @@ class InstallCommand extends AbstractCommand
 
     protected function getConfigFile()
     {
+        if (isset($_SERVER['SERVER_NAME'])) {
+            $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
+            if (!$host) $host = $_SERVER['SERVER_NAME'];
+
+            if (substr($host, 0, 4) == "www.") $host = substr($host, 4);
+
+            return base_path('config.'.$host.'.php');
+        }
+
         return base_path('config.php');
     }
 

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -366,11 +366,14 @@ class InstallCommand extends AbstractCommand
     {
         if (isset($_SERVER['SERVER_NAME'])) {
             $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
-            if (!$host) $host = $_SERVER['SERVER_NAME'];
 
-            if (substr($host, 0, 4) == "www.") $host = substr($host, 4);
+            if ($host) {
+                if (substr($host, 0, 4) == "www.") {
+                    $host = substr($host, 4);
+                }
 
-            return base_path('config.'.$host.'.php');
+                return base_path('config.'.$host.'.php');
+            }
         }
 
         return base_path('config.php');

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -367,13 +367,15 @@ class InstallCommand extends AbstractCommand
         if (isset($_SERVER['SERVER_NAME'])) {
             $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
-            if ($host) {
-                if (substr($host, 0, 4) == 'www.') {
-                    $host = substr($host, 4);
+            if (!$host) {
+                    $host = $_SERVER['SERVER_NAME'];
                 }
 
-                return base_path('config.'.$host.'.php');
+            if (substr($host, 0, 4) == 'www.') {
+                $host = substr($host, 4);
             }
+
+            return base_path('config.'.$host.'.php');
         }
 
         return base_path('config.php');

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -368,8 +368,8 @@ class InstallCommand extends AbstractCommand
             $host = @parse_url($_SERVER['SERVER_NAME'], PHP_URL_HOST);
 
             if (! $host) {
-                    $host = $_SERVER['SERVER_NAME'];
-                }
+                $host = $_SERVER['SERVER_NAME'];
+            }
 
             if (substr($host, 0, 4) == 'www.') {
                 $host = substr($host, 4);


### PR DESCRIPTION
A simple way of allowing multiple domains to use the same source but different configuration files (hence databases, enabled extensions, languages). Existing users will continue to use their default configuration file until next installation.
Generated configuration file will be named as _config.domain.tld.php_