### PR TITLE
SQL Performance tuning

### DIFF
--- a/src/Core/Repository/PostRepository.php
+++ b/src/Core/Repository/PostRepository.php
@@ -146,7 +146,7 @@ class PostRepository
 
     protected function getDiscussionsForPosts($postIds, User $actor)
     {
-	    return Discussion::query()
+        return Discussion::query()
             ->select('discussions.*')
             ->join('posts', 'posts.discussion_id', '=', 'discussions.id')
             ->whereIn('posts.id', $postIds)

--- a/src/Core/Repository/PostRepository.php
+++ b/src/Core/Repository/PostRepository.php
@@ -146,9 +146,9 @@ class PostRepository
 
     protected function getDiscussionsForPosts($postIds, User $actor)
     {
-        return Discussion::whereIn('id', function ($query) use ($postIds) {
-            $query->select('discussion_id')->from('posts')->whereIn('id', $postIds);
-        })
+        $posts = Post::whereIn('id', $postIds)->lists('discussion_id');
+
+        return Discussion::whereIn('id', $posts->toArray())
             ->whereVisibleTo($actor)
             ->get();
     }

--- a/src/Core/Repository/PostRepository.php
+++ b/src/Core/Repository/PostRepository.php
@@ -146,9 +146,11 @@ class PostRepository
 
     protected function getDiscussionsForPosts($postIds, User $actor)
     {
-        return Discussion::query()
-            ->whereIn('posts.id', $postIds)
+	    return Discussion::query()
+            ->select('discussions.*')
             ->join('posts', 'posts.discussion_id', '=', 'discussions.id')
+            ->whereIn('posts.id', $postIds)
+            ->groupBy('discussions.id')
             ->whereVisibleTo($actor)
             ->get();
     }

--- a/src/Core/Repository/PostRepository.php
+++ b/src/Core/Repository/PostRepository.php
@@ -146,9 +146,9 @@ class PostRepository
 
     protected function getDiscussionsForPosts($postIds, User $actor)
     {
-        $posts = Post::whereIn('id', $postIds)->lists('discussion_id');
-
-        return Discussion::whereIn('id', $posts->toArray())
+        return Discussion::query()
+            ->whereIn('posts.id', $postIds)
+            ->join('posts', 'posts.discussion_id', '=', 'discussions.id')
             ->whereVisibleTo($actor)
             ->get();
     }


### PR DESCRIPTION
I found bad query:

select * from `flarum_discussions` where `id` in (select `discussion_id` from `flarum_posts` where `id` in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) and not exists (select 1 from `flarum_discussions_tags` where 0 = 1 and `flarum_discussions`.`id` = discussion_id)

One complex nested query take more time than 2 simple query. MySQL engine doesn't like nested queries.
So I reduce execution time on my VPS from ~3.1 seconds to 360 milliseconds just switching from one complex nested query to 2 small queries.


MySQL EXPLAIN for one big query:

MySQL> explain select * from `flarum_discussions` where `id` in (select `discussion_id` from `flarum_posts` where `id` in (1 ,2, 4, 5)) and not exists (select 1 from `flarum_discussions_tags` where 0 = 1 and `flarum_discussions`.`id` = discussion_id);
+----+--------------------+--------------------+-------+-------------------------------------------+---------+---------+------+-------+------------------+
| id | select_type        | table              | type  | possible_keys                             | key     | key_len | ref  | rows  | Extra            |
+----+--------------------+--------------------+-------+-------------------------------------------+---------+---------+------+-------+------------------+
|  1 | PRIMARY            | flarum_discussions | ALL   | NULL                                      | NULL    | NULL    | NULL | 39022 | Using where      |
|  3 | DEPENDENT SUBQUERY | NULL               | NULL  | NULL                                      | NULL    | NULL    | NULL |  NULL | Impossible WHERE |
|  2 | DEPENDENT SUBQUERY | flarum_posts       | range | PRIMARY,posts_discussion_id_number_unique | PRIMARY | 4       | NULL |     4 | Using where      |
+----+--------------------+--------------------+-------+-------------------------------------------+---------+---------+------+-------+------------------+



MySQL EXPLAIN for 2 small queries:

explain select `discussion_id` from `flarum_posts` where `id` in (1 ,2, 4, 5);
+----+-------------+--------------+-------+---------------+---------+---------+------+------+-------------+
| id | select_type | table        | type  | possible_keys | key     | key_len | ref  | rows | Extra       |
+----+-------------+--------------+-------+---------------+---------+---------+------+------+-------------+
|  1 | SIMPLE      | flarum_posts | range | PRIMARY       | PRIMARY | 4       | NULL |    4 | Using where |
+----+-------------+--------------+-------+---------------+---------+---------+------+------+-------------+


MySQL > explain select * from `flarum_discussions` where `id` in (2, 3, 4) and not exists (select 1 from `flarum_discussions_tags` where 0 = 1 and `flarum_discussions`.`id` = discussion_id);
+----+--------------------+--------------------+-------+---------------+---------+---------+------+------+------------------+
| id | select_type        | table              | type  | possible_keys | key     | key_len | ref  | rows | Extra            |
+----+--------------------+--------------------+-------+---------------+---------+---------+------+------+------------------+
|  1 | PRIMARY            | flarum_discussions | range | PRIMARY       | PRIMARY | 4       | NULL |    3 | Using where      |
|  2 | DEPENDENT SUBQUERY | NULL               | NULL  | NULL          | NULL    | NULL    | NULL | NULL | Impossible WHERE |
+----+--------------------+--------------------+-------+---------------+---------+---------+------+------+------------------+