### PR TITLE
#446 Replace Post Edit Icon into Text

### DIFF
--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -24381,8 +24381,8 @@ System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/hel
 
             return m(
               'span',
-              { className: 'PostEdited', title: title },
-              icon('pencil')
+              { className: 'PostEdited' },
+              title
             );
           }
         }, {

--- a/js/forum/src/components/PostEdited.js
+++ b/js/forum/src/components/PostEdited.js
@@ -18,7 +18,7 @@ export default class PostEdited extends Component {
     const title = extractText(app.translator.trans('core.forum.post.edited_tooltip', {user: editUser, ago: humanTime(post.editTime())}));
 
     return (
-      <span className="PostEdited" title={title}>{icon('pencil')}</span>
+      <span className="PostEdited">{title}</span>
     );
   }
 


### PR DESCRIPTION
---
##### COMMITED: This pull replaces the pencil icon with the tooltip with just the text that was previously on the tooltip.
<img width="1429" alt="captura de pantalla 2016-05-08 a las 8 11 38 pm" src="https://cloud.githubusercontent.com/assets/6401250/15101259/206c57ca-1559-11e6-86c9-859d978fbc74.png">

---
##### SUGGESTION: We could probably also still use the pencil button + the text, like this:
<img width="1422" alt="captura de pantalla 2016-05-08 a las 8 13 44 pm" src="https://cloud.githubusercontent.com/assets/6401250/15101265/65ebc7d6-1559-11e6-9c12-1c784af3de5e.png">

---

What do you guys think?

_PS: GitHub, this fixes #446 :wink:_ 
_I also figured out how to sign commits... had the wrong email :cry: :smiley:_