### PR TITLE
Fix #834

### DIFF
--- a/js/lib/utils/string.js
+++ b/js/lib/utils/string.js
@@ -34,11 +34,11 @@ export function slug(string) {
  * @return {String}
  */
 export function getPlainContent(string) {
-  const dom = $('<div/>').html(string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;'));
+  const dom = $('<div/>').html(string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img/g, '<eximg'));
 
   dom.find(getPlainContent.removeSelectors.join(',')).remove();
 
-  return dom.text();
+  return dom.text().replace(/([\S^\s])[\s]+([\S$\s])/g, '$1 $2');
 }
 
 /**


### PR DESCRIPTION
This fixes #834 

First, I change all <img tags to <eximg to prevent loading them as images.

Then, I added something to remove extra spaces. It replaces groups of spaces between non space characters with a single space. I also replaces spaces between the first (or last) space and a non space character. This effectively allows only one space between characters.