### PR TITLE
Clean up translation keys

### DIFF
--- a/js/forum/src/components/ChangeEmailModal.js
+++ b/js/forum/src/components/ChangeEmailModal.js
@@ -66,7 +66,7 @@ export default class ChangeEmailModal extends Modal {
           </div>
           <div className="Form-group">
             <input type="password" name="password" className="FormControl"
-              placeholder={app.translator.trans('core.forum.change_email.confirm_password_label')}
+              placeholder={app.translator.trans('core.forum.change_email.confirm_password_placeholder')}
               bidi={this.password}
               disabled={this.loading}/>
           </div>

--- a/js/forum/src/components/EditUserModal.js
+++ b/js/forum/src/components/EditUserModal.js
@@ -29,7 +29,7 @@ export default class EditUserModal extends Modal {
   }
 
   title() {
-    return 'Edit User';
+    return app.translator.trans('core.forum.edit_user.title');
   }
 
   content() {


### PR DESCRIPTION
- Corrects the suffix on a key in the Change Email modal.
- Extracts the title of the Edit User modal.