### PR TITLE
Fix Permission Name for Viewing Ips

### DIFF
--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -173,10 +173,10 @@ export default class PermissionGrid extends Component {
   moderateItems() {
     const items = new ItemList();
 
-    items.add('viewPostIps', {
+    items.add('viewIpsPosts', {
       icon: 'bullseye',
       label: app.translator.trans('core.admin.permissions.view_post_ips_label'),
-      permission: 'discussion.viewPostIps'
+      permission: 'discussion.viewIpsPosts'
     }, 110);
 
     items.add('renameDiscussions', {

--- a/src/Api/Serializer/PostSerializer.php
+++ b/src/Api/Serializer/PostSerializer.php
@@ -47,7 +47,7 @@ class PostSerializer extends PostBasicSerializer
             if ($canEdit) {
                 $attributes['content'] = $post->content;
             }
-            if ($gate->allows('viewPostIps', $post)) {
+            if ($gate->allows('viewIps', $post)) {
                 $attributes['ipAddress'] = $post->ip_address;
             }
         } else {


### PR DESCRIPTION
Apparently permissions must end in 'Posts' if they are about a post. This is something I wasn't aware of when creating my previous PR to add the ability to view post Ips. This fixes the bug preventing mods from seeing IPs.