### PR TITLE
Fix UI for iOS while replying to a post

### DIFF
--- a/js/forum/src/components/ReplyPlaceholder.js
+++ b/js/forum/src/components/ReplyPlaceholder.js
@@ -31,17 +31,15 @@ export default class ReplyPlaceholder extends Component {
       );
     }
 
-    function triggerClick(e) {
-      $(this).trigger('click');
-      e.preventDefault();
-    }
 
     const reply = () => {
-      DiscussionControls.replyAction.call(this.props.discussion, true);
+      DiscussionControls.replyAction.call(this.props.discussion,false).then(function (newComponent) {
+        newComponent.focus();
+      });
     };
 
     return (
-      <article className="Post ReplyPlaceholder" onclick={reply} onmousedown={triggerClick}>
+      <article className="Post ReplyPlaceholder" onclick={reply}>
         <header className="Post-header">
           {avatar(app.session.user, {className: 'PostUser-avatar'})}{' '}
           {app.translator.trans('core.forum.post_stream.reply_placeholder')}


### PR DESCRIPTION
In reference to :
https://discuss.flarum.org/d/3347-no-cursor-while-replying-to-a-post-in-mobile-view-on-ios/9

 - Removed the triggerClick
 - Changed the DiscussionControls.replayAction.call method