### PR TITLE
Add posts API filter for tags

### DIFF
--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -146,6 +146,15 @@ class ListPostsController extends AbstractCollectionController
             $query->where('type', $type);
         }
 
+        if ($tagId = array_get($filter, 'tag')) {
+            $query->join(
+                'discussions_tags',
+                'discussions_tags.discussion_id',
+                '=',
+                'posts.discussion_id'
+            )->where('discussions_tags.tag_id', $tagId);
+        }
+
         event(new ConfigurePostsQuery($query, $filter));
     }
 }


### PR DESCRIPTION
Adds another filter, `filter[tag]`, for the `/posts` API endpoint which filters posts based on the tag of the posts' parent discussion.

Addresses #990.