### PR TITLE
#1002 Handle word wrapping properly in posts

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -92,6 +92,7 @@
   line-height: 1.7;
   position: relative;
   overflow: auto;
+  overflow-wrap: break-word;
 
   p, ul, ol, blockquote {
     margin-bottom: 1em;
@@ -134,6 +135,7 @@
     color: #666;
     font-size: 90%;
     border-radius: @border-radius;
+    overflow-wrap: normal;
 
     code {
       padding: 0;


### PR DESCRIPTION
This PR fixes #1002.

- Added `overflow-wrap: break-word` to .Post-body
- Added `overflow-wrap: normal` to pre in .Post-body for code blocks so there is no wrap (easier to identify different lines, unless we want to add that enter icon to indicate it's the same line)

Screenshot (if needed):

<img width="1261" alt="captura de pantalla 2016-07-24 a las 12 18 40 pm" src="https://cloud.githubusercontent.com/assets/6401250/17084927/be2aa2ac-5198-11e6-9bc3-b2e76fd9ed0f.png">