### PR TITLE
#200 Refresh doesn't update notifications

### DIFF
--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -18237,8 +18237,6 @@ $('#el').spin('flower', 'red');
 'use strict';
 
 System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', 'flarum/initializers/preload', 'flarum/initializers/routes', 'flarum/initializers/components', 'flarum/initializers/humanTime', 'flarum/initializers/boot', 'flarum/initializers/alertEmailConfirmation'], function (_export, _context) {
-  "use strict";
-
   var ForumApp, store, preload, routes, components, humanTime, boot, alertEmailConfirmation, app;
   return {
     setters: [function (_flarumForumApp) {
@@ -18278,8 +18276,6 @@ System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', '
 'use strict';
 
 System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/RequestErrorModal', 'flarum/components/ConfirmPasswordModal', 'flarum/Translator', 'flarum/utils/extract', 'flarum/utils/patchMithril', 'flarum/utils/RequestError', 'flarum/extend'], function (_export, _context) {
-  "use strict";
-
   var ItemList, Alert, Button, RequestErrorModal, ConfirmPasswordModal, Translator, extract, patchMithril, RequestError, extend, App;
   return {
     setters: [function (_flarumUtilsItemList) {
@@ -18608,8 +18604,6 @@ System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert
 'use strict';
 
 System.register('flarum/Component', [], function (_export, _context) {
-  "use strict";
-
   var Component;
   return {
     setters: [],
@@ -18778,8 +18772,6 @@ System.register('flarum/Component', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/components/Alert', ['flarum/Component', 'flarum/components/Button', 'flarum/helpers/listItems', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, listItems, extract, Alert;
   return {
     setters: [function (_flarumComponent) {
@@ -18851,8 +18843,6 @@ System.register('flarum/components/Alert', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/components/Alert'], function (_export, _context) {
-  "use strict";
-
   var Component, Alert, AlertManager;
   return {
     setters: [function (_flarumComponent) {
@@ -18942,8 +18932,6 @@ System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/listItems', 'flarum/utils/ItemList', 'flarum/components/Button', 'flarum/components/LoadingIndicator'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, icon, listItems, ItemList, Button, LoadingIndicator, AvatarEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -19107,8 +19095,6 @@ System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, extract, Badge;
   return {
     setters: [function (_flarumComponent) {
@@ -19161,8 +19147,6 @@ System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/
 'use strict';
 
 System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract', 'flarum/utils/extractText', 'flarum/components/LoadingIndicator'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, extract, extractText, LoadingIndicator, Button;
   return {
     setters: [function (_flarumComponent) {
@@ -19237,8 +19221,6 @@ System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, ChangeEmailModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19403,8 +19385,6 @@ System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal'
 'use strict';
 
 System.register('flarum/components/ChangePasswordModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, ChangePasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19482,8 +19462,6 @@ System.register('flarum/components/ChangePasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, icon, Checkbox;
   return {
     setters: [function (_flarumComponent) {
@@ -19556,8 +19534,6 @@ System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/CommentPost', ['flarum/components/Post', 'flarum/utils/classList', 'flarum/components/PostUser', 'flarum/components/PostMeta', 'flarum/components/PostEdited', 'flarum/components/EditPostComposer', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Post, classList, PostUser, PostMeta, PostEdited, EditPostComposer, ItemList, listItems, Button, CommentPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -19734,8 +19710,6 @@ System.register('flarum/components/CommentPost', ['flarum/components/Post', 'fla
 'use strict';
 
 System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/components/ComposerButton', 'flarum/helpers/listItems', 'flarum/utils/classList', 'flarum/utils/computed'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, ComposerButton, listItems, classList, computed, Composer;
   return {
     setters: [function (_flarumComponent) {
@@ -20178,8 +20152,6 @@ System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/components/TextEditor', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, TextEditor, avatar, listItems, ItemList, ComposerBody;
   return {
     setters: [function (_flarumComponent) {
@@ -20298,8 +20270,6 @@ System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/ComposerButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, ComposerButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -20332,8 +20302,6 @@ System.register('flarum/components/ComposerButton', ['flarum/components/Button']
 'use strict';
 
 System.register('flarum/components/DiscussionComposer', ['flarum/components/ComposerBody', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, extractText, DiscussionComposer;
   return {
     setters: [function (_flarumComponentsComposerBody) {
@@ -20445,8 +20413,6 @@ System.register('flarum/components/DiscussionComposer', ['flarum/components/Comp
 'use strict';
 
 System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, DiscussionHero;
   return {
     setters: [function (_flarumComponent) {
@@ -20516,8 +20482,6 @@ System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum/components/DiscussionListItem', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/components/Placeholder'], function (_export, _context) {
-  "use strict";
-
   var Component, DiscussionListItem, Button, LoadingIndicator, Placeholder, DiscussionList;
   return {
     setters: [function (_flarumComponent) {
@@ -20721,8 +20685,6 @@ System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/helpers/highlight', 'flarum/helpers/icon', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/abbreviateNumber', 'flarum/components/Dropdown', 'flarum/components/TerminalPost', 'flarum/components/PostPreview', 'flarum/utils/SubtreeRetainer', 'flarum/utils/DiscussionControls', 'flarum/utils/slidable', 'flarum/utils/extractText', 'flarum/utils/classList'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, listItems, highlight, icon, humanTime, ItemList, abbreviateNumber, Dropdown, TerminalPost, PostPreview, SubtreeRetainer, DiscussionControls, slidable, extractText, classList, DiscussionListItem;
   return {
     setters: [function (_flarumComponent) {
@@ -20950,8 +20912,6 @@ System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/DiscussionPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/components/DiscussionHero', 'flarum/components/PostStream', 'flarum/components/PostStreamScrubber', 'flarum/components/LoadingIndicator', 'flarum/components/SplitDropdown', 'flarum/helpers/listItems', 'flarum/utils/DiscussionControls'], function (_export, _context) {
-  "use strict";
-
   var Page, ItemList, DiscussionHero, PostStream, PostStreamScrubber, LoadingIndicator, SplitDropdown, listItems, DiscussionControls, DiscussionPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -21244,8 +21204,6 @@ System.register('flarum/components/DiscussionPage', ['flarum/components/Page', '
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedNotification', ['flarum/components/Notification'], function (_export, _context) {
-  "use strict";
-
   var Notification, DiscussionRenamedNotification;
   return {
     setters: [function (_flarumComponentsNotification) {
@@ -21288,8 +21246,6 @@ System.register('flarum/components/DiscussionRenamedNotification', ['flarum/comp
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/EventPost', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var EventPost, extractText, DiscussionRenamedPost;
   return {
     setters: [function (_flarumComponentsEventPost) {
@@ -21350,8 +21306,6 @@ System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/E
 'use strict';
 
 System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/highlight', 'flarum/components/LinkButton'], function (_export, _context) {
-  "use strict";
-
   var highlight, LinkButton, DiscussionsSearchSource;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -21436,8 +21390,6 @@ System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/hi
 'use strict';
 
 System.register('flarum/components/DiscussionsUserPage', ['flarum/components/UserPage', 'flarum/components/DiscussionList'], function (_export, _context) {
-  "use strict";
-
   var UserPage, DiscussionList, DiscussionsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -21485,8 +21437,6 @@ System.register('flarum/components/DiscussionsUserPage', ['flarum/components/Use
 'use strict';
 
 System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpers/icon', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, listItems, Dropdown;
   return {
     setters: [function (_flarumComponent) {
@@ -21613,8 +21563,6 @@ System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/EditPostComposer', ['flarum/components/ComposerBody', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, icon, EditPostComposer;
 
 
@@ -21731,8 +21679,6 @@ System.register('flarum/components/EditPostComposer', ['flarum/components/Compos
 'use strict';
 
 System.register('flarum/components/EditUserModal', ['flarum/components/Modal', 'flarum/components/Button', 'flarum/components/GroupBadge', 'flarum/models/Group', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, GroupBadge, Group, extractText, EditUserModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -21939,8 +21885,6 @@ System.register('flarum/components/EditUserModal', ['flarum/components/Modal', '
 'use strict';
 
 System.register('flarum/components/EventPost', ['flarum/components/Post', 'flarum/utils/string', 'flarum/helpers/username', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Post, ucfirst, usernameHelper, icon, EventPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -22021,8 +21965,6 @@ System.register('flarum/components/EventPost', ['flarum/components/Post', 'flaru
 'use strict';
 
 System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, listItems, FieldSet;
   return {
     setters: [function (_flarumComponent) {
@@ -22068,8 +22010,6 @@ System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Modal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, Alert, Button, extractText, ForgotPasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -22218,8 +22158,6 @@ System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], function (_export, _context) {
-  "use strict";
-
   var Badge, GroupBadge;
   return {
     setters: [function (_flarumComponentsBadge) {
@@ -22259,8 +22197,6 @@ System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], fun
 'use strict';
 
 System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, HeaderPrimary;
   return {
     setters: [function (_flarumComponent) {
@@ -22312,8 +22248,6 @@ System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/
 'use strict';
 
 System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LogInModal', 'flarum/components/SignUpModal', 'flarum/components/SessionDropdown', 'flarum/components/SelectDropdown', 'flarum/components/NotificationsDropdown', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, LogInModal, SignUpModal, SessionDropdown, SelectDropdown, NotificationsDropdown, ItemList, listItems, HeaderSecondary;
   return {
     setters: [function (_flarumComponent) {
@@ -22435,8 +22369,6 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 'use strict';
 
 System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/components/Page', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/helpers/icon', 'flarum/components/DiscussionList', 'flarum/components/WelcomeHero', 'flarum/components/DiscussionComposer', 'flarum/components/LogInModal', 'flarum/components/DiscussionPage', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/LinkButton', 'flarum/components/SelectDropdown'], function (_export, _context) {
-  "use strict";
-
   var extend, Page, ItemList, listItems, icon, DiscussionList, WelcomeHero, DiscussionComposer, LogInModal, DiscussionPage, Select, Button, LinkButton, SelectDropdown, IndexPage;
   return {
     setters: [function (_flarumExtend) {
@@ -22689,7 +22621,9 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
               icon: 'refresh',
               className: 'Button Button--icon',
               onclick: function onclick() {
-                return app.cache.discussionList.refresh();
+                app.cache.discussionList.refresh();
+                app.store.find('users', app.session.user.id());
+                m.redraw();
               }
             }));
 
@@ -22794,8 +22728,6 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
 'use strict';
 
 System.register('flarum/components/LinkButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, LinkButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22841,8 +22773,6 @@ System.register('flarum/components/LinkButton', ['flarum/components/Button'], fu
 'use strict';
 
 System.register('flarum/components/LoadingIndicator', ['flarum/Component'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator;
   return {
     setters: [function (_flarumComponent) {
@@ -22890,8 +22820,6 @@ System.register('flarum/components/LoadingIndicator', ['flarum/Component'], func
 'use strict';
 
 System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/helpers/avatar'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, LoadingPost;
   return {
     setters: [function (_flarumComponent) {
@@ -22940,8 +22868,6 @@ System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/LogInButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, LogInButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22982,8 +22908,6 @@ System.register('flarum/components/LogInButton', ['flarum/components/Button'], f
 'use strict';
 
 System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, LogInButtons;
   return {
     setters: [function (_flarumComponent) {
@@ -23025,8 +22949,6 @@ System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/u
 'use strict';
 
 System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'flarum/components/ForgotPasswordModal', 'flarum/components/SignUpModal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, ForgotPasswordModal, SignUpModal, Alert, Button, LogInButtons, extractText, LogInModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -23192,8 +23114,6 @@ System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'fla
 'use strict';
 
 System.register('flarum/components/Modal', ['flarum/Component', 'flarum/components/Alert', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, Alert, Button, Modal;
   return {
     setters: [function (_flarumComponent) {
@@ -23326,8 +23246,6 @@ System.register('flarum/components/Modal', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/components/Modal'], function (_export, _context) {
-  "use strict";
-
   var Component, Modal, ModalManager;
   return {
     setters: [function (_flarumComponent) {
@@ -23438,8 +23356,6 @@ System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LinkButton'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, LinkButton, Navigation;
   return {
     setters: [function (_flarumComponent) {
@@ -23548,8 +23464,6 @@ System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/com
 'use strict';
 
 System.register('flarum/components/Notification', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/humanTime'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, icon, humanTime, Notification;
   return {
     setters: [function (_flarumComponent) {
@@ -23632,8 +23546,6 @@ System.register('flarum/components/Notification', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flarum/components/Checkbox', 'flarum/helpers/icon', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, Checkbox, icon, ItemList, NotificationGrid;
   return {
     setters: [function (_flarumComponent) {
@@ -23845,8 +23757,6 @@ System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationList', ['flarum/Component', 'flarum/helpers/listItems', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/models/Discussion'], function (_export, _context) {
-  "use strict";
-
   var Component, listItems, Button, LoadingIndicator, Discussion, NotificationList;
   return {
     setters: [function (_flarumComponent) {
@@ -24031,8 +23941,6 @@ System.register('flarum/components/NotificationList', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationsDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon', 'flarum/components/NotificationList'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, icon, NotificationList, NotificationsDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -24148,8 +24056,6 @@ System.register('flarum/components/NotificationsDropdown', ['flarum/components/D
 'use strict';
 
 System.register('flarum/components/NotificationsPage', ['flarum/components/Page', 'flarum/components/NotificationList'], function (_export, _context) {
-  "use strict";
-
   var Page, NotificationList, NotificationsPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -24198,8 +24104,6 @@ System.register('flarum/components/NotificationsPage', ['flarum/components/Page'
 'use strict';
 
 System.register('flarum/components/Page', ['flarum/Component'], function (_export, _context) {
-  "use strict";
-
   var Component, Page;
   return {
     setters: [function (_flarumComponent) {
@@ -24256,8 +24160,6 @@ System.register('flarum/components/Page', ['flarum/Component'], function (_expor
 "use strict";
 
 System.register("flarum/components/Placeholder", ["flarum/Component"], function (_export, _context) {
-  "use strict";
-
   var Component, Placeholder;
   return {
     setters: [function (_flarumComponent) {
@@ -24296,8 +24198,6 @@ System.register("flarum/components/Placeholder", ["flarum/Component"], function 
 'use strict';
 
 System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/SubtreeRetainer', 'flarum/components/Dropdown', 'flarum/utils/PostControls', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, SubtreeRetainer, Dropdown, PostControls, listItems, ItemList, Post;
   return {
     setters: [function (_flarumComponent) {
@@ -24443,8 +24343,6 @@ System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/Sub
 'use strict';
 
 System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, extractText, PostEdited;
   return {
     setters: [function (_flarumComponent) {
@@ -24505,8 +24403,6 @@ System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/fullTime'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, fullTime, PostMeta;
   return {
     setters: [function (_flarumComponent) {
@@ -24599,8 +24495,6 @@ System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/highlight'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, username, highlight, PostPreview;
   return {
     setters: [function (_flarumComponent) {
@@ -24656,8 +24550,6 @@ System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/utils/ScrollListener', 'flarum/components/LoadingPost', 'flarum/utils/anchorScroll', 'flarum/utils/mixin', 'flarum/utils/evented', 'flarum/components/ReplyPlaceholder', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, ScrollListener, PostLoading, anchorScroll, mixin, evented, ReplyPlaceholder, Button, PostStream;
   return {
     setters: [function (_flarumComponent) {
@@ -25181,8 +25073,6 @@ System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/ScrollListener', 'flarum/utils/SubtreeRetainer', 'flarum/utils/computed', 'flarum/utils/formatNumber'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, ScrollListener, SubtreeRetainer, computed, formatNumber, PostStreamScrubber;
   return {
     setters: [function (_flarumComponent) {
@@ -25648,8 +25538,6 @@ System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage', 'flarum/components/LoadingIndicator', 'flarum/components/Button', 'flarum/components/CommentPost'], function (_export, _context) {
-  "use strict";
-
   var UserPage, LoadingIndicator, Button, CommentPost, PostsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -25808,8 +25696,6 @@ System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage'
 'use strict';
 
 System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/components/UserCard', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/userOnline', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, UserCard, avatar, username, userOnline, listItems, PostUser;
   return {
     setters: [function (_flarumComponent) {
@@ -25948,8 +25834,6 @@ System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerBody', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, Alert, Button, icon, extractText, ReplyComposer;
 
 
@@ -26098,8 +25982,6 @@ System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerB
 'use strict';
 
 System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/utils/DiscussionControls'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, username, DiscussionControls, ReplyPlaceholder;
   return {
     setters: [function (_flarumComponent) {
@@ -26207,8 +26089,6 @@ System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal'], function (_export, _context) {
-  "use strict";
-
   var Modal, RequestErrorModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -26270,8 +26150,6 @@ System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal
 'use strict';
 
 System.register('flarum/components/Search', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/ItemList', 'flarum/utils/classList', 'flarum/utils/extractText', 'flarum/utils/KeyboardNavigatable', 'flarum/helpers/icon', 'flarum/components/DiscussionsSearchSource', 'flarum/components/UsersSearchSource'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, ItemList, classList, extractText, KeyboardNavigatable, icon, DiscussionsSearchSource, UsersSearchSource, Search;
   return {
     setters: [function (_flarumComponent) {
@@ -26569,8 +26447,6 @@ System.register('flarum/components/Search', ['flarum/Component', 'flarum/compone
 "use strict";
 
 System.register("flarum/components/SearchSource", [], function (_export, _context) {
-  "use strict";
-
   var SearchSource;
   return {
     setters: [],
@@ -26597,8 +26473,6 @@ System.register("flarum/components/SearchSource", [], function (_export, _contex
 'use strict';
 
 System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, Select;
   return {
     setters: [function (_flarumComponent) {
@@ -26652,8 +26526,6 @@ System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, icon, SelectDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -26706,8 +26578,6 @@ System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown
 "use strict";
 
 System.register("flarum/components/Separator", ["flarum/Component"], function (_export, _context) {
-  "use strict";
-
   var Component, Separator;
   return {
     setters: [function (_flarumComponent) {
@@ -26740,8 +26610,6 @@ System.register("flarum/components/Separator", ["flarum/Component"], function (_
 'use strict';
 
 System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/components/Dropdown', 'flarum/components/LinkButton', 'flarum/components/Button', 'flarum/utils/ItemList', 'flarum/components/Separator', 'flarum/models/Group'], function (_export, _context) {
-  "use strict";
-
   var avatar, username, Dropdown, LinkButton, Button, ItemList, Separator, Group, SessionDropdown;
   return {
     setters: [function (_flarumHelpersAvatar) {
@@ -26848,8 +26716,6 @@ System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', '
 'use strict';
 
 System.register('flarum/components/SettingsPage', ['flarum/components/UserPage', 'flarum/utils/ItemList', 'flarum/components/Switch', 'flarum/components/Button', 'flarum/components/FieldSet', 'flarum/components/NotificationGrid', 'flarum/components/ChangePasswordModal', 'flarum/components/ChangeEmailModal', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var UserPage, ItemList, Switch, Button, FieldSet, NotificationGrid, ChangePasswordModal, ChangeEmailModal, listItems, SettingsPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -27002,8 +26868,6 @@ System.register('flarum/components/SettingsPage', ['flarum/components/UserPage',
 'use strict';
 
 System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'flarum/components/LogInModal', 'flarum/helpers/avatar', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, LogInModal, avatar, Button, LogInButtons, extractText, SignUpModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -27198,8 +27062,6 @@ System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'fl
 'use strict';
 
 System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, Button, icon, SplitDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -27265,8 +27127,6 @@ System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown'
 'use strict';
 
 System.register('flarum/components/Switch', ['flarum/components/Checkbox'], function (_export, _context) {
-  "use strict";
-
   var Checkbox, Switch;
   return {
     setters: [function (_flarumComponentsCheckbox) {
@@ -27304,8 +27164,6 @@ System.register('flarum/components/Switch', ['flarum/components/Checkbox'], func
 'use strict';
 
 System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, icon, TerminalPost;
   return {
     setters: [function (_flarumComponent) {
@@ -27355,8 +27213,6 @@ System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, Button, TextEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -27504,8 +27360,6 @@ System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/classList', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, classList, extractText, UserBio;
   return {
     setters: [function (_flarumComponent) {
@@ -27638,8 +27492,6 @@ System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/compon
 'use strict';
 
 System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/UserControls', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/icon', 'flarum/components/Dropdown', 'flarum/components/UserBio', 'flarum/components/AvatarEditor', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, ItemList, UserControls, avatar, username, icon, Dropdown, UserBio, AvatarEditor, listItems, UserCard;
   return {
     setters: [function (_flarumComponent) {
@@ -27769,8 +27621,6 @@ System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/utils/affixSidebar', 'flarum/components/UserCard', 'flarum/components/LoadingIndicator', 'flarum/components/SelectDropdown', 'flarum/components/LinkButton', 'flarum/components/Separator', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Page, ItemList, affixSidebar, UserCard, LoadingIndicator, SelectDropdown, LinkButton, Separator, listItems, UserPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -27940,8 +27790,6 @@ System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum
 'use strict';
 
 System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highlight', 'flarum/helpers/avatar', 'flarum/helpers/username'], function (_export, _context) {
-  "use strict";
-
   var highlight, avatar, username, UsersSearchResults;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -28005,8 +27853,6 @@ System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highligh
 'use strict';
 
 System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, WelcomeHero;
   return {
     setters: [function (_flarumComponent) {
@@ -28085,8 +27931,6 @@ System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/co
 "use strict";
 
 System.register("flarum/extend", [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -28174,8 +28018,6 @@ System.register("flarum/extend", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flarum/components/Search', 'flarum/components/Composer', 'flarum/components/ReplyComposer', 'flarum/components/DiscussionPage', 'flarum/components/SignUpModal'], function (_export, _context) {
-  "use strict";
-
   var History, App, Search, Composer, ReplyComposer, DiscussionPage, SignUpModal, ForumApp;
   return {
     setters: [function (_flarumUtilsHistory) {
@@ -28294,8 +28136,6 @@ System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flaru
 'use strict';
 
 System.register('flarum/helpers/avatar', [], function (_export, _context) {
-  "use strict";
-
   function avatar(user) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28342,8 +28182,6 @@ System.register('flarum/helpers/avatar', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/fullTime', [], function (_export, _context) {
-  "use strict";
-
   function fullTime(time) {
     var mo = moment(time);
 
@@ -28367,8 +28205,6 @@ System.register('flarum/helpers/fullTime', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_export, _context) {
-  "use strict";
-
   var truncate;
   function highlight(string, phrase, length) {
     if (!phrase && !length) return string;
@@ -28408,8 +28244,6 @@ System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_
 'use strict';
 
 System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
-  "use strict";
-
   var humanTimeUtil;
   function humanTime(time) {
     var mo = moment(time);
@@ -28437,8 +28271,6 @@ System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function
 'use strict';
 
 System.register('flarum/helpers/icon', [], function (_export, _context) {
-  "use strict";
-
   function icon(name) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28457,8 +28289,6 @@ System.register('flarum/helpers/icon', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'flarum/utils/classList'], function (_export, _context) {
-  "use strict";
-
   var Separator, classList;
 
 
@@ -28523,8 +28353,6 @@ System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'fla
 'use strict';
 
 System.register('flarum/helpers/punctuateSeries', [], function (_export, _context) {
-  "use strict";
-
   function punctuateSeries(items) {
     if (items.length === 2) {
       return app.translator.trans('core.lib.series.two_text', {
@@ -28559,8 +28387,6 @@ System.register('flarum/helpers/punctuateSeries', [], function (_export, _contex
 "use strict";
 
 System.register("flarum/helpers/username", [], function (_export, _context) {
-  "use strict";
-
   function username(user) {
     var name = user && user.username() || app.translator.trans('core.lib.username.deleted_text');
 
@@ -28581,8 +28407,6 @@ System.register("flarum/helpers/username", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (_export, _context) {
-    "use strict";
-
     var icon;
     function userOnline(user) {
         if (user.lastSeenTime() && user.isOnline()) {
@@ -28606,8 +28430,6 @@ System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (
 'use strict';
 
 System.register('flarum/initializers/alertEmailConfirmation', ['flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Alert, Button, icon;
   function alertEmailConfirmation(app) {
     var user = app.session.user;
@@ -28688,8 +28510,6 @@ System.register('flarum/initializers/alertEmailConfirmation', ['flarum/component
 'use strict';
 
 System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'flarum/utils/Pane', 'flarum/utils/Drawer', 'flarum/utils/mapRoutes', 'flarum/helpers/icon', 'flarum/components/Navigation', 'flarum/components/HeaderPrimary', 'flarum/components/HeaderSecondary', 'flarum/components/Composer', 'flarum/components/ModalManager', 'flarum/components/AlertManager'], function (_export, _context) {
-  "use strict";
-
   var ScrollListener, Pane, Drawer, mapRoutes, icon, Navigation, HeaderPrimary, HeaderSecondary, Composer, ModalManager, AlertManager;
   function boot(app) {
     // Get the configured default route and update that route's path to be '/'.
@@ -28730,6 +28550,7 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
     $('#home-link').click(function (e) {
       if (e.ctrlKey || e.metaKey || e.which === 2) return;
       e.preventDefault();
+      app.store.find('users', app.session.user.id());
       app.history.home();
     });
 
@@ -28785,8 +28606,6 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
 'use strict';
 
 System.register('flarum/initializers/components', ['flarum/components/CommentPost', 'flarum/components/DiscussionRenamedPost', 'flarum/components/DiscussionRenamedNotification'], function (_export, _context) {
-  "use strict";
-
   var CommentPost, DiscussionRenamedPost, DiscussionRenamedNotification;
   function components(app) {
     app.postComponents.comment = CommentPost;
@@ -28811,8 +28630,6 @@ System.register('flarum/initializers/components', ['flarum/components/CommentPos
 'use strict';
 
 System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
-  "use strict";
-
   var humanTimeUtil;
 
 
@@ -28845,8 +28662,6 @@ System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], fun
 'use strict';
 
 System.register('flarum/initializers/preload', ['flarum/Session'], function (_export, _context) {
-  "use strict";
-
   var Session;
   function preload(app) {
     app.store.pushPayload({ data: app.data.resources });
@@ -28868,8 +28683,6 @@ System.register('flarum/initializers/preload', ['flarum/Session'], function (_ex
 'use strict';
 
 System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'flarum/components/DiscussionPage', 'flarum/components/PostsUserPage', 'flarum/components/DiscussionsUserPage', 'flarum/components/SettingsPage', 'flarum/components/NotificationsPage'], function (_export, _context) {
-  "use strict";
-
   var IndexPage, DiscussionPage, PostsUserPage, DiscussionsUserPage, SettingsPage, NotificationsPage;
 
   _export('default', function (app) {
@@ -28945,8 +28758,6 @@ System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'f
 'use strict';
 
 System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/Forum', 'flarum/models/User', 'flarum/models/Discussion', 'flarum/models/Post', 'flarum/models/Group', 'flarum/models/Activity', 'flarum/models/Notification'], function (_export, _context) {
-  "use strict";
-
   var Store, Forum, User, Discussion, Post, Group, Activity, Notification;
   function store(app) {
     app.store = new Store({
@@ -28986,8 +28797,6 @@ System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/For
 'use strict';
 
 System.register('flarum/Model', [], function (_export, _context) {
-  "use strict";
-
   var Model;
   return {
     setters: [],
@@ -29246,8 +29055,6 @@ System.register('flarum/Model', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/ItemList', 'flarum/components/Badge'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, ItemList, Badge, Discussion;
   return {
     setters: [function (_flarumModel) {
@@ -29360,8 +29167,6 @@ System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/compu
 'use strict';
 
 System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _context) {
-  "use strict";
-
   var Model, Forum;
   return {
     setters: [function (_flarumModel) {
@@ -29392,8 +29197,6 @@ System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Group', ['flarum/Model'], function (_export, _context) {
-  "use strict";
-
   var Model, Group;
   return {
     setters: [function (_flarumModel) {
@@ -29429,8 +29232,6 @@ System.register('flarum/models/Group', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/computed'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, Notification;
   return {
     setters: [function (_flarumModel) {
@@ -29476,8 +29277,6 @@ System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/com
 'use strict';
 
 System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/string'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, getPlainContent, Post;
   return {
     setters: [function (_flarumModel) {
@@ -29535,8 +29334,6 @@ System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 
 'use strict';
 
 System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToColor', 'flarum/utils/ItemList', 'flarum/utils/computed', 'flarum/components/GroupBadge'], function (_export, _context) {
-  "use strict";
-
   var Model, stringToColor, ItemList, computed, GroupBadge, User;
   return {
     setters: [function (_flarumModel) {
@@ -29649,8 +29446,6 @@ System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToCol
 'use strict';
 
 System.register('flarum/Session', [], function (_export, _context) {
-  "use strict";
-
   var Session;
   return {
     setters: [],
@@ -29714,8 +29509,6 @@ System.register('flarum/Session', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Store', [], function (_export, _context) {
-  "use strict";
-
   var Store;
   return {
     setters: [],
@@ -29853,8 +29646,6 @@ System.register('flarum/Store', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/username', 'flarum/utils/extractText', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var User, username, extractText, extract, Translator;
   return {
     setters: [function (_flarumModelsUser) {
@@ -30162,8 +29953,6 @@ System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/user
 'use strict';
 
 System.register('flarum/utils/abbreviateNumber', [], function (_export, _context) {
-  "use strict";
-
   function abbreviateNumber(number) {
     // TODO: translation
     if (number >= 1000000) {
@@ -30185,8 +29974,6 @@ System.register('flarum/utils/abbreviateNumber', [], function (_export, _context
 'use strict';
 
 System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
-  "use strict";
-
   function affixSidebar(element, isInitialized) {
     var _this = this;
 
@@ -30222,8 +30009,6 @@ System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
-  "use strict";
-
   function anchorScroll(element, callback) {
     var $window = $(window);
     var relativeScroll = $(element).offset().top - $window.scrollTop();
@@ -30243,8 +30028,6 @@ System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/classList', [], function (_export, _context) {
-  "use strict";
-
   function classList(classes) {
     var classNames = void 0;
 
@@ -30273,8 +30056,6 @@ System.register('flarum/utils/classList', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/computed', [], function (_export, _context) {
-  "use strict";
-
   function computed() {
     for (var _len = arguments.length, dependentKeys = Array(_len), _key = 0; _key < _len; _key++) {
       dependentKeys[_key] = arguments[_key];
@@ -30322,8 +30103,6 @@ System.register('flarum/utils/computed', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/DiscussionControls', ['flarum/components/DiscussionPage', 'flarum/components/ReplyComposer', 'flarum/components/LogInModal', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var DiscussionPage, ReplyComposer, LogInModal, Button, Separator, ItemList, extractText;
   return {
     setters: [function (_flarumComponentsDiscussionPage) {
@@ -30508,8 +30287,6 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
 'use strict';
 
 System.register('flarum/utils/Drawer', [], function (_export, _context) {
-  "use strict";
-
   var Drawer;
   return {
     setters: [],
@@ -30576,8 +30353,6 @@ System.register('flarum/utils/Drawer', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/evented", [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -30635,8 +30410,6 @@ System.register("flarum/utils/evented", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/extract", [], function (_export, _context) {
-  "use strict";
-
   function extract(object, property) {
     var value = object[property];
 
@@ -30655,8 +30428,6 @@ System.register("flarum/utils/extract", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/extractText', [], function (_export, _context) {
-  "use strict";
-
   function extractText(vdom) {
     if (vdom instanceof Array) {
       return vdom.map(function (element) {
@@ -30679,8 +30450,6 @@ System.register('flarum/utils/extractText', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/formatNumber', [], function (_export, _context) {
-  "use strict";
-
   function formatNumber(number) {
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
@@ -30695,8 +30464,6 @@ System.register('flarum/utils/formatNumber', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/History', [], function (_export, _context) {
-  "use strict";
-
   var History;
   return {
     setters: [],
@@ -30793,8 +30560,6 @@ System.register('flarum/utils/History', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/humanTime', [], function (_export, _context) {
-  "use strict";
-
   function humanTime(time) {
     var m = moment(time);
     var now = moment();
@@ -30842,8 +30607,6 @@ System.register('flarum/utils/humanTime', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ItemList", [], function (_export, _context) {
-  "use strict";
-
   var Item, ItemList;
   return {
     setters: [],
@@ -30960,8 +30723,6 @@ System.register("flarum/utils/ItemList", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _context) {
-  "use strict";
-
   var KeyboardNavigatable;
   return {
     setters: [],
@@ -31077,8 +30838,6 @@ System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _cont
 'use strict';
 
 System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
-  "use strict";
-
   function mapRoutes(routes) {
     var basePath = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
 
@@ -31105,8 +30864,6 @@ System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/mixin", [], function (_export, _context) {
-  "use strict";
-
   function mixin(Parent) {
     var Mixed = function (_Parent) {
       babelHelpers.inherits(Mixed, _Parent);
@@ -31140,8 +30897,6 @@ System.register("flarum/utils/mixin", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/Pane', [], function (_export, _context) {
-  "use strict";
-
   var Pane;
   return {
     setters: [],
@@ -31257,8 +31012,6 @@ System.register('flarum/utils/Pane', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/patchMithril', ['../Component'], function (_export, _context) {
-  "use strict";
-
   var Component;
   function patchMithril(global) {
     var mo = global.m;
@@ -31317,8 +31070,6 @@ System.register('flarum/utils/patchMithril', ['../Component'], function (_export
 'use strict';
 
 System.register('flarum/utils/PostControls', ['flarum/components/EditPostComposer', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var EditPostComposer, Button, Separator, ItemList;
   return {
     setters: [function (_flarumComponentsEditPostComposer) {
@@ -31449,8 +31200,6 @@ System.register('flarum/utils/PostControls', ['flarum/components/EditPostCompose
 "use strict";
 
 System.register("flarum/utils/RequestError", [], function (_export, _context) {
-  "use strict";
-
   var RequestError;
   return {
     setters: [],
@@ -31479,8 +31228,6 @@ System.register("flarum/utils/RequestError", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ScrollListener", [], function (_export, _context) {
-  "use strict";
-
   var scroll, ScrollListener;
   return {
     setters: [],
@@ -31554,8 +31301,6 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
 'use strict';
 
 System.register('flarum/utils/slidable', [], function (_export, _context) {
-  "use strict";
-
   function slidable(element) {
     var $element = $(element);
     var threshold = 50;
@@ -31714,8 +31459,6 @@ System.register('flarum/utils/slidable', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/string', [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -31794,8 +31537,6 @@ System.register('flarum/utils/string', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/stringToColor', [], function (_export, _context) {
-  "use strict";
-
   function hsvToRgb(h, s, v) {
     var r = void 0;
     var g = void 0;
@@ -31862,8 +31603,6 @@ System.register('flarum/utils/stringToColor', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context) {
-  "use strict";
-
   var SubtreeRetainer;
   return {
     setters: [],
@@ -31936,8 +31675,6 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
 'use strict';
 
 System.register('flarum/utils/UserControls', ['flarum/components/Button', 'flarum/components/Separator', 'flarum/components/EditUserModal', 'flarum/components/UserPage', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Button, Separator, EditUserModal, UserPage, ItemList;
   return {
     setters: [function (_flarumComponentsButton) {

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -18237,6 +18237,8 @@ $('#el').spin('flower', 'red');
 'use strict';
 
 System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', 'flarum/initializers/preload', 'flarum/initializers/routes', 'flarum/initializers/components', 'flarum/initializers/humanTime', 'flarum/initializers/boot', 'flarum/initializers/alertEmailConfirmation'], function (_export, _context) {
+  "use strict";
+
   var ForumApp, store, preload, routes, components, humanTime, boot, alertEmailConfirmation, app;
   return {
     setters: [function (_flarumForumApp) {
@@ -18276,6 +18278,8 @@ System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', '
 'use strict';
 
 System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/RequestErrorModal', 'flarum/components/ConfirmPasswordModal', 'flarum/Translator', 'flarum/utils/extract', 'flarum/utils/patchMithril', 'flarum/utils/RequestError', 'flarum/extend'], function (_export, _context) {
+  "use strict";
+
   var ItemList, Alert, Button, RequestErrorModal, ConfirmPasswordModal, Translator, extract, patchMithril, RequestError, extend, App;
   return {
     setters: [function (_flarumUtilsItemList) {
@@ -18604,6 +18608,8 @@ System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert
 'use strict';
 
 System.register('flarum/Component', [], function (_export, _context) {
+  "use strict";
+
   var Component;
   return {
     setters: [],
@@ -18614,7 +18620,6 @@ System.register('flarum/Component', [], function (_export, _context) {
          * @param {Array|Object} children
          * @public
          */
-
         function Component() {
           var props = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
           var children = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
@@ -18772,6 +18777,8 @@ System.register('flarum/Component', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/components/Alert', ['flarum/Component', 'flarum/components/Button', 'flarum/helpers/listItems', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, listItems, extract, Alert;
   return {
     setters: [function (_flarumComponent) {
@@ -18843,6 +18850,8 @@ System.register('flarum/components/Alert', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/components/Alert'], function (_export, _context) {
+  "use strict";
+
   var Component, Alert, AlertManager;
   return {
     setters: [function (_flarumComponent) {
@@ -18932,6 +18941,8 @@ System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/listItems', 'flarum/utils/ItemList', 'flarum/components/Button', 'flarum/components/LoadingIndicator'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, icon, listItems, ItemList, Button, LoadingIndicator, AvatarEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -19095,6 +19106,8 @@ System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, extract, Badge;
   return {
     setters: [function (_flarumComponent) {
@@ -19147,6 +19160,8 @@ System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/
 'use strict';
 
 System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract', 'flarum/utils/extractText', 'flarum/components/LoadingIndicator'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, extract, extractText, LoadingIndicator, Button;
   return {
     setters: [function (_flarumComponent) {
@@ -19221,6 +19236,8 @@ System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, ChangeEmailModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19385,6 +19402,8 @@ System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal'
 'use strict';
 
 System.register('flarum/components/ChangePasswordModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, ChangePasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19462,6 +19481,8 @@ System.register('flarum/components/ChangePasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, icon, Checkbox;
   return {
     setters: [function (_flarumComponent) {
@@ -19534,6 +19555,8 @@ System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/CommentPost', ['flarum/components/Post', 'flarum/utils/classList', 'flarum/components/PostUser', 'flarum/components/PostMeta', 'flarum/components/PostEdited', 'flarum/components/EditPostComposer', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Post, classList, PostUser, PostMeta, PostEdited, EditPostComposer, ItemList, listItems, Button, CommentPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -19710,6 +19733,8 @@ System.register('flarum/components/CommentPost', ['flarum/components/Post', 'fla
 'use strict';
 
 System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/components/ComposerButton', 'flarum/helpers/listItems', 'flarum/utils/classList', 'flarum/utils/computed'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, ComposerButton, listItems, classList, computed, Composer;
   return {
     setters: [function (_flarumComponent) {
@@ -20152,6 +20177,8 @@ System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/components/TextEditor', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, TextEditor, avatar, listItems, ItemList, ComposerBody;
   return {
     setters: [function (_flarumComponent) {
@@ -20270,6 +20297,8 @@ System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/ComposerButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, ComposerButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -20302,6 +20331,8 @@ System.register('flarum/components/ComposerButton', ['flarum/components/Button']
 'use strict';
 
 System.register('flarum/components/DiscussionComposer', ['flarum/components/ComposerBody', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, extractText, DiscussionComposer;
   return {
     setters: [function (_flarumComponentsComposerBody) {
@@ -20413,6 +20444,8 @@ System.register('flarum/components/DiscussionComposer', ['flarum/components/Comp
 'use strict';
 
 System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, DiscussionHero;
   return {
     setters: [function (_flarumComponent) {
@@ -20482,6 +20515,8 @@ System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum/components/DiscussionListItem', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/components/Placeholder'], function (_export, _context) {
+  "use strict";
+
   var Component, DiscussionListItem, Button, LoadingIndicator, Placeholder, DiscussionList;
   return {
     setters: [function (_flarumComponent) {
@@ -20685,6 +20720,8 @@ System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/helpers/highlight', 'flarum/helpers/icon', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/abbreviateNumber', 'flarum/components/Dropdown', 'flarum/components/TerminalPost', 'flarum/components/PostPreview', 'flarum/utils/SubtreeRetainer', 'flarum/utils/DiscussionControls', 'flarum/utils/slidable', 'flarum/utils/extractText', 'flarum/utils/classList'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, listItems, highlight, icon, humanTime, ItemList, abbreviateNumber, Dropdown, TerminalPost, PostPreview, SubtreeRetainer, DiscussionControls, slidable, extractText, classList, DiscussionListItem;
   return {
     setters: [function (_flarumComponent) {
@@ -20912,6 +20949,8 @@ System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/DiscussionPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/components/DiscussionHero', 'flarum/components/PostStream', 'flarum/components/PostStreamScrubber', 'flarum/components/LoadingIndicator', 'flarum/components/SplitDropdown', 'flarum/helpers/listItems', 'flarum/utils/DiscussionControls'], function (_export, _context) {
+  "use strict";
+
   var Page, ItemList, DiscussionHero, PostStream, PostStreamScrubber, LoadingIndicator, SplitDropdown, listItems, DiscussionControls, DiscussionPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -21204,6 +21243,8 @@ System.register('flarum/components/DiscussionPage', ['flarum/components/Page', '
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedNotification', ['flarum/components/Notification'], function (_export, _context) {
+  "use strict";
+
   var Notification, DiscussionRenamedNotification;
   return {
     setters: [function (_flarumComponentsNotification) {
@@ -21246,6 +21287,8 @@ System.register('flarum/components/DiscussionRenamedNotification', ['flarum/comp
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/EventPost', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var EventPost, extractText, DiscussionRenamedPost;
   return {
     setters: [function (_flarumComponentsEventPost) {
@@ -21306,6 +21349,8 @@ System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/E
 'use strict';
 
 System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/highlight', 'flarum/components/LinkButton'], function (_export, _context) {
+  "use strict";
+
   var highlight, LinkButton, DiscussionsSearchSource;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -21390,6 +21435,8 @@ System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/hi
 'use strict';
 
 System.register('flarum/components/DiscussionsUserPage', ['flarum/components/UserPage', 'flarum/components/DiscussionList'], function (_export, _context) {
+  "use strict";
+
   var UserPage, DiscussionList, DiscussionsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -21437,6 +21484,8 @@ System.register('flarum/components/DiscussionsUserPage', ['flarum/components/Use
 'use strict';
 
 System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpers/icon', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, listItems, Dropdown;
   return {
     setters: [function (_flarumComponent) {
@@ -21563,6 +21612,8 @@ System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/EditPostComposer', ['flarum/components/ComposerBody', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, icon, EditPostComposer;
 
 
@@ -21679,6 +21730,8 @@ System.register('flarum/components/EditPostComposer', ['flarum/components/Compos
 'use strict';
 
 System.register('flarum/components/EditUserModal', ['flarum/components/Modal', 'flarum/components/Button', 'flarum/components/GroupBadge', 'flarum/models/Group', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, GroupBadge, Group, extractText, EditUserModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -21885,6 +21938,8 @@ System.register('flarum/components/EditUserModal', ['flarum/components/Modal', '
 'use strict';
 
 System.register('flarum/components/EventPost', ['flarum/components/Post', 'flarum/utils/string', 'flarum/helpers/username', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Post, ucfirst, usernameHelper, icon, EventPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -21965,6 +22020,8 @@ System.register('flarum/components/EventPost', ['flarum/components/Post', 'flaru
 'use strict';
 
 System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, listItems, FieldSet;
   return {
     setters: [function (_flarumComponent) {
@@ -22010,6 +22067,8 @@ System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Modal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, Alert, Button, extractText, ForgotPasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -22158,6 +22217,8 @@ System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], function (_export, _context) {
+  "use strict";
+
   var Badge, GroupBadge;
   return {
     setters: [function (_flarumComponentsBadge) {
@@ -22197,6 +22258,8 @@ System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], fun
 'use strict';
 
 System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, HeaderPrimary;
   return {
     setters: [function (_flarumComponent) {
@@ -22248,6 +22311,8 @@ System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/
 'use strict';
 
 System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LogInModal', 'flarum/components/SignUpModal', 'flarum/components/SessionDropdown', 'flarum/components/SelectDropdown', 'flarum/components/NotificationsDropdown', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, LogInModal, SignUpModal, SessionDropdown, SelectDropdown, NotificationsDropdown, ItemList, listItems, HeaderSecondary;
   return {
     setters: [function (_flarumComponent) {
@@ -22369,6 +22434,8 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 'use strict';
 
 System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/components/Page', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/helpers/icon', 'flarum/components/DiscussionList', 'flarum/components/WelcomeHero', 'flarum/components/DiscussionComposer', 'flarum/components/LogInModal', 'flarum/components/DiscussionPage', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/LinkButton', 'flarum/components/SelectDropdown'], function (_export, _context) {
+  "use strict";
+
   var extend, Page, ItemList, listItems, icon, DiscussionList, WelcomeHero, DiscussionComposer, LogInModal, DiscussionPage, Select, Button, LinkButton, SelectDropdown, IndexPage;
   return {
     setters: [function (_flarumExtend) {
@@ -22728,6 +22795,8 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
 'use strict';
 
 System.register('flarum/components/LinkButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, LinkButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22773,6 +22842,8 @@ System.register('flarum/components/LinkButton', ['flarum/components/Button'], fu
 'use strict';
 
 System.register('flarum/components/LoadingIndicator', ['flarum/Component'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator;
   return {
     setters: [function (_flarumComponent) {
@@ -22820,6 +22891,8 @@ System.register('flarum/components/LoadingIndicator', ['flarum/Component'], func
 'use strict';
 
 System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/helpers/avatar'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, LoadingPost;
   return {
     setters: [function (_flarumComponent) {
@@ -22868,6 +22941,8 @@ System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/LogInButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, LogInButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22908,6 +22983,8 @@ System.register('flarum/components/LogInButton', ['flarum/components/Button'], f
 'use strict';
 
 System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, LogInButtons;
   return {
     setters: [function (_flarumComponent) {
@@ -22949,6 +23026,8 @@ System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/u
 'use strict';
 
 System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'flarum/components/ForgotPasswordModal', 'flarum/components/SignUpModal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, ForgotPasswordModal, SignUpModal, Alert, Button, LogInButtons, extractText, LogInModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -23114,6 +23193,8 @@ System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'fla
 'use strict';
 
 System.register('flarum/components/Modal', ['flarum/Component', 'flarum/components/Alert', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, Alert, Button, Modal;
   return {
     setters: [function (_flarumComponent) {
@@ -23246,6 +23327,8 @@ System.register('flarum/components/Modal', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/components/Modal'], function (_export, _context) {
+  "use strict";
+
   var Component, Modal, ModalManager;
   return {
     setters: [function (_flarumComponent) {
@@ -23356,6 +23439,8 @@ System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LinkButton'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, LinkButton, Navigation;
   return {
     setters: [function (_flarumComponent) {
@@ -23464,6 +23549,8 @@ System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/com
 'use strict';
 
 System.register('flarum/components/Notification', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/humanTime'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, icon, humanTime, Notification;
   return {
     setters: [function (_flarumComponent) {
@@ -23546,6 +23633,8 @@ System.register('flarum/components/Notification', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flarum/components/Checkbox', 'flarum/helpers/icon', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, Checkbox, icon, ItemList, NotificationGrid;
   return {
     setters: [function (_flarumComponent) {
@@ -23757,6 +23846,8 @@ System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationList', ['flarum/Component', 'flarum/helpers/listItems', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/models/Discussion'], function (_export, _context) {
+  "use strict";
+
   var Component, listItems, Button, LoadingIndicator, Discussion, NotificationList;
   return {
     setters: [function (_flarumComponent) {
@@ -23941,6 +24032,8 @@ System.register('flarum/components/NotificationList', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationsDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon', 'flarum/components/NotificationList'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, icon, NotificationList, NotificationsDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -24056,6 +24149,8 @@ System.register('flarum/components/NotificationsDropdown', ['flarum/components/D
 'use strict';
 
 System.register('flarum/components/NotificationsPage', ['flarum/components/Page', 'flarum/components/NotificationList'], function (_export, _context) {
+  "use strict";
+
   var Page, NotificationList, NotificationsPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -24104,6 +24199,8 @@ System.register('flarum/components/NotificationsPage', ['flarum/components/Page'
 'use strict';
 
 System.register('flarum/components/Page', ['flarum/Component'], function (_export, _context) {
+  "use strict";
+
   var Component, Page;
   return {
     setters: [function (_flarumComponent) {
@@ -24160,6 +24257,8 @@ System.register('flarum/components/Page', ['flarum/Component'], function (_expor
 "use strict";
 
 System.register("flarum/components/Placeholder", ["flarum/Component"], function (_export, _context) {
+  "use strict";
+
   var Component, Placeholder;
   return {
     setters: [function (_flarumComponent) {
@@ -24198,6 +24297,8 @@ System.register("flarum/components/Placeholder", ["flarum/Component"], function 
 'use strict';
 
 System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/SubtreeRetainer', 'flarum/components/Dropdown', 'flarum/utils/PostControls', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, SubtreeRetainer, Dropdown, PostControls, listItems, ItemList, Post;
   return {
     setters: [function (_flarumComponent) {
@@ -24343,6 +24444,8 @@ System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/Sub
 'use strict';
 
 System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, extractText, PostEdited;
   return {
     setters: [function (_flarumComponent) {
@@ -24403,6 +24506,8 @@ System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/fullTime'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, fullTime, PostMeta;
   return {
     setters: [function (_flarumComponent) {
@@ -24495,6 +24600,8 @@ System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/highlight'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, username, highlight, PostPreview;
   return {
     setters: [function (_flarumComponent) {
@@ -24550,6 +24657,8 @@ System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/utils/ScrollListener', 'flarum/components/LoadingPost', 'flarum/utils/anchorScroll', 'flarum/utils/mixin', 'flarum/utils/evented', 'flarum/components/ReplyPlaceholder', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, ScrollListener, PostLoading, anchorScroll, mixin, evented, ReplyPlaceholder, Button, PostStream;
   return {
     setters: [function (_flarumComponent) {
@@ -25073,6 +25182,8 @@ System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/ScrollListener', 'flarum/utils/SubtreeRetainer', 'flarum/utils/computed', 'flarum/utils/formatNumber'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, ScrollListener, SubtreeRetainer, computed, formatNumber, PostStreamScrubber;
   return {
     setters: [function (_flarumComponent) {
@@ -25538,6 +25649,8 @@ System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage', 'flarum/components/LoadingIndicator', 'flarum/components/Button', 'flarum/components/CommentPost'], function (_export, _context) {
+  "use strict";
+
   var UserPage, LoadingIndicator, Button, CommentPost, PostsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -25696,6 +25809,8 @@ System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage'
 'use strict';
 
 System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/components/UserCard', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/userOnline', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, UserCard, avatar, username, userOnline, listItems, PostUser;
   return {
     setters: [function (_flarumComponent) {
@@ -25834,6 +25949,8 @@ System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerBody', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, Alert, Button, icon, extractText, ReplyComposer;
 
 
@@ -25982,6 +26099,8 @@ System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerB
 'use strict';
 
 System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/utils/DiscussionControls'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, username, DiscussionControls, ReplyPlaceholder;
   return {
     setters: [function (_flarumComponent) {
@@ -26089,6 +26208,8 @@ System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal'], function (_export, _context) {
+  "use strict";
+
   var Modal, RequestErrorModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -26150,6 +26271,8 @@ System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal
 'use strict';
 
 System.register('flarum/components/Search', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/ItemList', 'flarum/utils/classList', 'flarum/utils/extractText', 'flarum/utils/KeyboardNavigatable', 'flarum/helpers/icon', 'flarum/components/DiscussionsSearchSource', 'flarum/components/UsersSearchSource'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, ItemList, classList, extractText, KeyboardNavigatable, icon, DiscussionsSearchSource, UsersSearchSource, Search;
   return {
     setters: [function (_flarumComponent) {
@@ -26447,6 +26570,8 @@ System.register('flarum/components/Search', ['flarum/Component', 'flarum/compone
 "use strict";
 
 System.register("flarum/components/SearchSource", [], function (_export, _context) {
+  "use strict";
+
   var SearchSource;
   return {
     setters: [],
@@ -26473,6 +26598,8 @@ System.register("flarum/components/SearchSource", [], function (_export, _contex
 'use strict';
 
 System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, Select;
   return {
     setters: [function (_flarumComponent) {
@@ -26526,6 +26653,8 @@ System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, icon, SelectDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -26578,6 +26707,8 @@ System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown
 "use strict";
 
 System.register("flarum/components/Separator", ["flarum/Component"], function (_export, _context) {
+  "use strict";
+
   var Component, Separator;
   return {
     setters: [function (_flarumComponent) {
@@ -26610,6 +26741,8 @@ System.register("flarum/components/Separator", ["flarum/Component"], function (_
 'use strict';
 
 System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/components/Dropdown', 'flarum/components/LinkButton', 'flarum/components/Button', 'flarum/utils/ItemList', 'flarum/components/Separator', 'flarum/models/Group'], function (_export, _context) {
+  "use strict";
+
   var avatar, username, Dropdown, LinkButton, Button, ItemList, Separator, Group, SessionDropdown;
   return {
     setters: [function (_flarumHelpersAvatar) {
@@ -26716,6 +26849,8 @@ System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', '
 'use strict';
 
 System.register('flarum/components/SettingsPage', ['flarum/components/UserPage', 'flarum/utils/ItemList', 'flarum/components/Switch', 'flarum/components/Button', 'flarum/components/FieldSet', 'flarum/components/NotificationGrid', 'flarum/components/ChangePasswordModal', 'flarum/components/ChangeEmailModal', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var UserPage, ItemList, Switch, Button, FieldSet, NotificationGrid, ChangePasswordModal, ChangeEmailModal, listItems, SettingsPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -26868,6 +27003,8 @@ System.register('flarum/components/SettingsPage', ['flarum/components/UserPage',
 'use strict';
 
 System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'flarum/components/LogInModal', 'flarum/helpers/avatar', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, LogInModal, avatar, Button, LogInButtons, extractText, SignUpModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -27062,6 +27199,8 @@ System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'fl
 'use strict';
 
 System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, Button, icon, SplitDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -27127,6 +27266,8 @@ System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown'
 'use strict';
 
 System.register('flarum/components/Switch', ['flarum/components/Checkbox'], function (_export, _context) {
+  "use strict";
+
   var Checkbox, Switch;
   return {
     setters: [function (_flarumComponentsCheckbox) {
@@ -27164,6 +27305,8 @@ System.register('flarum/components/Switch', ['flarum/components/Checkbox'], func
 'use strict';
 
 System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, icon, TerminalPost;
   return {
     setters: [function (_flarumComponent) {
@@ -27213,6 +27356,8 @@ System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, Button, TextEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -27360,6 +27505,8 @@ System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/classList', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, classList, extractText, UserBio;
   return {
     setters: [function (_flarumComponent) {
@@ -27492,6 +27639,8 @@ System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/compon
 'use strict';
 
 System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/UserControls', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/icon', 'flarum/components/Dropdown', 'flarum/components/UserBio', 'flarum/components/AvatarEditor', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, ItemList, UserControls, avatar, username, icon, Dropdown, UserBio, AvatarEditor, listItems, UserCard;
   return {
     setters: [function (_flarumComponent) {
@@ -27621,6 +27770,8 @@ System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/utils/affixSidebar', 'flarum/components/UserCard', 'flarum/components/LoadingIndicator', 'flarum/components/SelectDropdown', 'flarum/components/LinkButton', 'flarum/components/Separator', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Page, ItemList, affixSidebar, UserCard, LoadingIndicator, SelectDropdown, LinkButton, Separator, listItems, UserPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -27790,6 +27941,8 @@ System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum
 'use strict';
 
 System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highlight', 'flarum/helpers/avatar', 'flarum/helpers/username'], function (_export, _context) {
+  "use strict";
+
   var highlight, avatar, username, UsersSearchResults;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -27853,6 +28006,8 @@ System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highligh
 'use strict';
 
 System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, WelcomeHero;
   return {
     setters: [function (_flarumComponent) {
@@ -27931,93 +28086,96 @@ System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/co
 "use strict";
 
 System.register("flarum/extend", [], function (_export, _context) {
+  "use strict";
+
+  /**
+   * Extend an object's method by running its output through a mutating callback
+   * every time it is called.
+   *
+   * The callback accepts the method's return value and should perform any
+   * mutations directly on this value. For this reason, this function will not be
+   * effective on methods which return scalar values (numbers, strings, booleans).
+   *
+   * Care should be taken to extend the correct object – in most cases, a class'
+   * prototype will be the desired target of extension, not the class itself.
+   *
+   * @example
+   * extend(Discussion.prototype, 'badges', function(badges) {
+   *   // do something with `badges`
+   * });
+   *
+   * @param {Object} object The object that owns the method
+   * @param {String} method The name of the method to extend
+   * @param {function} callback A callback which mutates the method's output
+   */
+  function extend(object, method, callback) {
+    var original = object[method];
+
+    object[method] = function () {
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      var value = original ? original.apply(this, args) : undefined;
+
+      callback.apply(this, [value].concat(args));
+
+      return value;
+    };
+
+    babelHelpers.extends(object[method], original);
+  }
+
+  /**
+   * Override an object's method by replacing it with a new function, so that the
+   * new function will be run every time the object's method is called.
+   *
+   * The replacement function accepts the original method as its first argument,
+   * which is like a call to 'super'. Any arguments passed to the original method
+   * are also passed to the replacement.
+   *
+   * Care should be taken to extend the correct object – in most cases, a class'
+   * prototype will be the desired target of extension, not the class itself.
+   *
+   * @example
+   * override(Discussion.prototype, 'badges', function(original) {
+   *   const badges = original();
+   *   // do something with badges
+   *   return badges;
+   * });
+   *
+   * @param {Object} object The object that owns the method
+   * @param {String} method The name of the method to override
+   * @param {function} newMethod The method to replace it with
+   */
+
+  _export("extend", extend);
+
+  function override(object, method, newMethod) {
+    var original = object[method];
+
+    object[method] = function () {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      return newMethod.apply(this, [original.bind(this)].concat(args));
+    };
+
+    babelHelpers.extends(object[method], original);
+  }
+  _export("override", override);
+
   return {
     setters: [],
-    execute: function () {
-      /**
-       * Extend an object's method by running its output through a mutating callback
-       * every time it is called.
-       *
-       * The callback accepts the method's return value and should perform any
-       * mutations directly on this value. For this reason, this function will not be
-       * effective on methods which return scalar values (numbers, strings, booleans).
-       *
-       * Care should be taken to extend the correct object – in most cases, a class'
-       * prototype will be the desired target of extension, not the class itself.
-       *
-       * @example
-       * extend(Discussion.prototype, 'badges', function(badges) {
-       *   // do something with `badges`
-       * });
-       *
-       * @param {Object} object The object that owns the method
-       * @param {String} method The name of the method to extend
-       * @param {function} callback A callback which mutates the method's output
-       */
-      function extend(object, method, callback) {
-        var original = object[method];
-
-        object[method] = function () {
-          for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-            args[_key] = arguments[_key];
-          }
-
-          var value = original ? original.apply(this, args) : undefined;
-
-          callback.apply(this, [value].concat(args));
-
-          return value;
-        };
-
-        babelHelpers.extends(object[method], original);
-      }
-
-      /**
-       * Override an object's method by replacing it with a new function, so that the
-       * new function will be run every time the object's method is called.
-       *
-       * The replacement function accepts the original method as its first argument,
-       * which is like a call to 'super'. Any arguments passed to the original method
-       * are also passed to the replacement.
-       *
-       * Care should be taken to extend the correct object – in most cases, a class'
-       * prototype will be the desired target of extension, not the class itself.
-       *
-       * @example
-       * override(Discussion.prototype, 'badges', function(original) {
-       *   const badges = original();
-       *   // do something with badges
-       *   return badges;
-       * });
-       *
-       * @param {Object} object The object that owns the method
-       * @param {String} method The name of the method to override
-       * @param {function} newMethod The method to replace it with
-       */
-
-      _export("extend", extend);
-
-      function override(object, method, newMethod) {
-        var original = object[method];
-
-        object[method] = function () {
-          for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-            args[_key2] = arguments[_key2];
-          }
-
-          return newMethod.apply(this, [original.bind(this)].concat(args));
-        };
-
-        babelHelpers.extends(object[method], original);
-      }
-
-      _export("override", override);
-    }
+    execute: function () {}
   };
 });;
 'use strict';
 
 System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flarum/components/Search', 'flarum/components/Composer', 'flarum/components/ReplyComposer', 'flarum/components/DiscussionPage', 'flarum/components/SignUpModal'], function (_export, _context) {
+  "use strict";
+
   var History, App, Search, Composer, ReplyComposer, DiscussionPage, SignUpModal, ForumApp;
   return {
     setters: [function (_flarumUtilsHistory) {
@@ -28136,6 +28294,8 @@ System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flaru
 'use strict';
 
 System.register('flarum/helpers/avatar', [], function (_export, _context) {
+  "use strict";
+
   function avatar(user) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28182,6 +28342,8 @@ System.register('flarum/helpers/avatar', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/fullTime', [], function (_export, _context) {
+  "use strict";
+
   function fullTime(time) {
     var mo = moment(time);
 
@@ -28205,6 +28367,8 @@ System.register('flarum/helpers/fullTime', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_export, _context) {
+  "use strict";
+
   var truncate;
   function highlight(string, phrase, length) {
     if (!phrase && !length) return string;
@@ -28244,6 +28408,8 @@ System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_
 'use strict';
 
 System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
+  "use strict";
+
   var humanTimeUtil;
   function humanTime(time) {
     var mo = moment(time);
@@ -28271,6 +28437,8 @@ System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function
 'use strict';
 
 System.register('flarum/helpers/icon', [], function (_export, _context) {
+  "use strict";
+
   function icon(name) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28289,6 +28457,8 @@ System.register('flarum/helpers/icon', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'flarum/utils/classList'], function (_export, _context) {
+  "use strict";
+
   var Separator, classList;
 
 
@@ -28353,6 +28523,8 @@ System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'fla
 'use strict';
 
 System.register('flarum/helpers/punctuateSeries', [], function (_export, _context) {
+  "use strict";
+
   function punctuateSeries(items) {
     if (items.length === 2) {
       return app.translator.trans('core.lib.series.two_text', {
@@ -28387,6 +28559,8 @@ System.register('flarum/helpers/punctuateSeries', [], function (_export, _contex
 "use strict";
 
 System.register("flarum/helpers/username", [], function (_export, _context) {
+  "use strict";
+
   function username(user) {
     var name = user && user.username() || app.translator.trans('core.lib.username.deleted_text');
 
@@ -28407,6 +28581,8 @@ System.register("flarum/helpers/username", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (_export, _context) {
+    "use strict";
+
     var icon;
     function userOnline(user) {
         if (user.lastSeenTime() && user.isOnline()) {
@@ -28430,6 +28606,8 @@ System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (
 'use strict';
 
 System.register('flarum/initializers/alertEmailConfirmation', ['flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Alert, Button, icon;
   function alertEmailConfirmation(app) {
     var user = app.session.user;
@@ -28510,6 +28688,8 @@ System.register('flarum/initializers/alertEmailConfirmation', ['flarum/component
 'use strict';
 
 System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'flarum/utils/Pane', 'flarum/utils/Drawer', 'flarum/utils/mapRoutes', 'flarum/helpers/icon', 'flarum/components/Navigation', 'flarum/components/HeaderPrimary', 'flarum/components/HeaderSecondary', 'flarum/components/Composer', 'flarum/components/ModalManager', 'flarum/components/AlertManager'], function (_export, _context) {
+  "use strict";
+
   var ScrollListener, Pane, Drawer, mapRoutes, icon, Navigation, HeaderPrimary, HeaderSecondary, Composer, ModalManager, AlertManager;
   function boot(app) {
     // Get the configured default route and update that route's path to be '/'.
@@ -28606,6 +28786,8 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
 'use strict';
 
 System.register('flarum/initializers/components', ['flarum/components/CommentPost', 'flarum/components/DiscussionRenamedPost', 'flarum/components/DiscussionRenamedNotification'], function (_export, _context) {
+  "use strict";
+
   var CommentPost, DiscussionRenamedPost, DiscussionRenamedNotification;
   function components(app) {
     app.postComponents.comment = CommentPost;
@@ -28630,6 +28812,8 @@ System.register('flarum/initializers/components', ['flarum/components/CommentPos
 'use strict';
 
 System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
+  "use strict";
+
   var humanTimeUtil;
 
 
@@ -28662,6 +28846,8 @@ System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], fun
 'use strict';
 
 System.register('flarum/initializers/preload', ['flarum/Session'], function (_export, _context) {
+  "use strict";
+
   var Session;
   function preload(app) {
     app.store.pushPayload({ data: app.data.resources });
@@ -28683,6 +28869,8 @@ System.register('flarum/initializers/preload', ['flarum/Session'], function (_ex
 'use strict';
 
 System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'flarum/components/DiscussionPage', 'flarum/components/PostsUserPage', 'flarum/components/DiscussionsUserPage', 'flarum/components/SettingsPage', 'flarum/components/NotificationsPage'], function (_export, _context) {
+  "use strict";
+
   var IndexPage, DiscussionPage, PostsUserPage, DiscussionsUserPage, SettingsPage, NotificationsPage;
 
   _export('default', function (app) {
@@ -28758,6 +28946,8 @@ System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'f
 'use strict';
 
 System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/Forum', 'flarum/models/User', 'flarum/models/Discussion', 'flarum/models/Post', 'flarum/models/Group', 'flarum/models/Activity', 'flarum/models/Notification'], function (_export, _context) {
+  "use strict";
+
   var Store, Forum, User, Discussion, Post, Group, Activity, Notification;
   function store(app) {
     app.store = new Store({
@@ -28797,6 +28987,8 @@ System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/For
 'use strict';
 
 System.register('flarum/Model', [], function (_export, _context) {
+  "use strict";
+
   var Model;
   return {
     setters: [],
@@ -28807,7 +28999,6 @@ System.register('flarum/Model', [], function (_export, _context) {
          * @param {Store} store The data store that this model should be persisted to.
          * @public
          */
-
         function Model() {
           var data = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
           var store = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
@@ -29055,6 +29246,8 @@ System.register('flarum/Model', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/ItemList', 'flarum/components/Badge'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, ItemList, Badge, Discussion;
   return {
     setters: [function (_flarumModel) {
@@ -29167,6 +29360,8 @@ System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/compu
 'use strict';
 
 System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _context) {
+  "use strict";
+
   var Model, Forum;
   return {
     setters: [function (_flarumModel) {
@@ -29197,6 +29392,8 @@ System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Group', ['flarum/Model'], function (_export, _context) {
+  "use strict";
+
   var Model, Group;
   return {
     setters: [function (_flarumModel) {
@@ -29232,6 +29429,8 @@ System.register('flarum/models/Group', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/computed'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, Notification;
   return {
     setters: [function (_flarumModel) {
@@ -29277,6 +29476,8 @@ System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/com
 'use strict';
 
 System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/string'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, getPlainContent, Post;
   return {
     setters: [function (_flarumModel) {
@@ -29334,6 +29535,8 @@ System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 
 'use strict';
 
 System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToColor', 'flarum/utils/ItemList', 'flarum/utils/computed', 'flarum/components/GroupBadge'], function (_export, _context) {
+  "use strict";
+
   var Model, stringToColor, ItemList, computed, GroupBadge, User;
   return {
     setters: [function (_flarumModel) {
@@ -29446,6 +29649,8 @@ System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToCol
 'use strict';
 
 System.register('flarum/Session', [], function (_export, _context) {
+  "use strict";
+
   var Session;
   return {
     setters: [],
@@ -29509,6 +29714,8 @@ System.register('flarum/Session', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Store', [], function (_export, _context) {
+  "use strict";
+
   var Store;
   return {
     setters: [],
@@ -29646,6 +29853,8 @@ System.register('flarum/Store', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/username', 'flarum/utils/extractText', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var User, username, extractText, extract, Translator;
   return {
     setters: [function (_flarumModelsUser) {
@@ -29953,6 +30162,8 @@ System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/user
 'use strict';
 
 System.register('flarum/utils/abbreviateNumber', [], function (_export, _context) {
+  "use strict";
+
   function abbreviateNumber(number) {
     // TODO: translation
     if (number >= 1000000) {
@@ -29974,6 +30185,8 @@ System.register('flarum/utils/abbreviateNumber', [], function (_export, _context
 'use strict';
 
 System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
+  "use strict";
+
   function affixSidebar(element, isInitialized) {
     var _this = this;
 
@@ -30009,6 +30222,8 @@ System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
+  "use strict";
+
   function anchorScroll(element, callback) {
     var $window = $(window);
     var relativeScroll = $(element).offset().top - $window.scrollTop();
@@ -30028,6 +30243,8 @@ System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/classList', [], function (_export, _context) {
+  "use strict";
+
   function classList(classes) {
     var classNames = void 0;
 
@@ -30056,6 +30273,8 @@ System.register('flarum/utils/classList', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/computed', [], function (_export, _context) {
+  "use strict";
+
   function computed() {
     for (var _len = arguments.length, dependentKeys = Array(_len), _key = 0; _key < _len; _key++) {
       dependentKeys[_key] = arguments[_key];
@@ -30103,6 +30322,8 @@ System.register('flarum/utils/computed', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/DiscussionControls', ['flarum/components/DiscussionPage', 'flarum/components/ReplyComposer', 'flarum/components/LogInModal', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var DiscussionPage, ReplyComposer, LogInModal, Button, Separator, ItemList, extractText;
   return {
     setters: [function (_flarumComponentsDiscussionPage) {
@@ -30287,6 +30508,8 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
 'use strict';
 
 System.register('flarum/utils/Drawer', [], function (_export, _context) {
+  "use strict";
+
   var Drawer;
   return {
     setters: [],
@@ -30353,6 +30576,8 @@ System.register('flarum/utils/Drawer', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/evented", [], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [],
     execute: function () {
@@ -30410,6 +30635,8 @@ System.register("flarum/utils/evented", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/extract", [], function (_export, _context) {
+  "use strict";
+
   function extract(object, property) {
     var value = object[property];
 
@@ -30428,6 +30655,8 @@ System.register("flarum/utils/extract", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/extractText', [], function (_export, _context) {
+  "use strict";
+
   function extractText(vdom) {
     if (vdom instanceof Array) {
       return vdom.map(function (element) {
@@ -30450,6 +30679,8 @@ System.register('flarum/utils/extractText', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/formatNumber', [], function (_export, _context) {
+  "use strict";
+
   function formatNumber(number) {
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
@@ -30464,6 +30695,8 @@ System.register('flarum/utils/formatNumber', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/History', [], function (_export, _context) {
+  "use strict";
+
   var History;
   return {
     setters: [],
@@ -30560,6 +30793,8 @@ System.register('flarum/utils/History', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/humanTime', [], function (_export, _context) {
+  "use strict";
+
   function humanTime(time) {
     var m = moment(time);
     var now = moment();
@@ -30607,6 +30842,8 @@ System.register('flarum/utils/humanTime', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ItemList", [], function (_export, _context) {
+  "use strict";
+
   var Item, ItemList;
   return {
     setters: [],
@@ -30723,6 +30960,8 @@ System.register("flarum/utils/ItemList", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _context) {
+  "use strict";
+
   var KeyboardNavigatable;
   return {
     setters: [],
@@ -30838,6 +31077,8 @@ System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _cont
 'use strict';
 
 System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
+  "use strict";
+
   function mapRoutes(routes) {
     var basePath = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
 
@@ -30864,6 +31105,8 @@ System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/mixin", [], function (_export, _context) {
+  "use strict";
+
   function mixin(Parent) {
     var Mixed = function (_Parent) {
       babelHelpers.inherits(Mixed, _Parent);
@@ -30897,6 +31140,8 @@ System.register("flarum/utils/mixin", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/Pane', [], function (_export, _context) {
+  "use strict";
+
   var Pane;
   return {
     setters: [],
@@ -31012,6 +31257,8 @@ System.register('flarum/utils/Pane', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/patchMithril', ['../Component'], function (_export, _context) {
+  "use strict";
+
   var Component;
   function patchMithril(global) {
     var mo = global.m;
@@ -31070,6 +31317,8 @@ System.register('flarum/utils/patchMithril', ['../Component'], function (_export
 'use strict';
 
 System.register('flarum/utils/PostControls', ['flarum/components/EditPostComposer', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var EditPostComposer, Button, Separator, ItemList;
   return {
     setters: [function (_flarumComponentsEditPostComposer) {
@@ -31200,6 +31449,8 @@ System.register('flarum/utils/PostControls', ['flarum/components/EditPostCompose
 "use strict";
 
 System.register("flarum/utils/RequestError", [], function (_export, _context) {
+  "use strict";
+
   var RequestError;
   return {
     setters: [],
@@ -31228,6 +31479,8 @@ System.register("flarum/utils/RequestError", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ScrollListener", [], function (_export, _context) {
+  "use strict";
+
   var scroll, ScrollListener;
   return {
     setters: [],
@@ -31242,7 +31495,6 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
          *     changes.
          * @public
          */
-
         function ScrollListener(callback) {
           babelHelpers.classCallCheck(this, ScrollListener);
 
@@ -31301,6 +31553,8 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
 'use strict';
 
 System.register('flarum/utils/slidable', [], function (_export, _context) {
+  "use strict";
+
   function slidable(element) {
     var $element = $(element);
     var threshold = 50;
@@ -31459,84 +31713,88 @@ System.register('flarum/utils/slidable', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/string', [], function (_export, _context) {
+  "use strict";
+
+  /**
+   * Truncate a string to the given length, appending ellipses if necessary.
+   *
+   * @param {String} string
+   * @param {Number} length
+   * @param {Number} [start=0]
+   * @return {String}
+   */
+  function truncate(string, length) {
+    var start = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
+
+    return (start > 0 ? '...' : '') + string.substring(start, start + length) + (string.length > start + length ? '...' : '');
+  }
+
+  /**
+   * Create a slug out of the given string. Non-alphanumeric characters are
+   * converted to hyphens.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+
+  _export('truncate', truncate);
+
+  function slug(string) {
+    return string.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-').replace(/-$|^-/g, '') || '-';
+  }
+
+  /**
+   * Strip HTML tags and quotes out of the given string, replacing them with
+   * meaningful punctuation.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+
+  _export('slug', slug);
+
+  function getPlainContent(string) {
+    var html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/ig, ' ');
+
+    var dom = $('<div/>').html(html);
+
+    dom.find(getPlainContent.removeSelectors.join(',')).remove();
+
+    return dom.text().replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * An array of DOM selectors to remove when getting plain content.
+   *
+   * @type {Array}
+   */
+
+  _export('getPlainContent', getPlainContent);
+
+  /**
+   * Make a string's first character uppercase.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+  function ucfirst(string) {
+    return string.substr(0, 1).toUpperCase() + string.substr(1);
+  }
+
+  _export('ucfirst', ucfirst);
+
   return {
     setters: [],
     execute: function () {
-      /**
-       * Truncate a string to the given length, appending ellipses if necessary.
-       *
-       * @param {String} string
-       * @param {Number} length
-       * @param {Number} [start=0]
-       * @return {String}
-       */
-      function truncate(string, length) {
-        var start = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
-
-        return (start > 0 ? '...' : '') + string.substring(start, start + length) + (string.length > start + length ? '...' : '');
-      }
-
-      /**
-       * Create a slug out of the given string. Non-alphanumeric characters are
-       * converted to hyphens.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-
-      _export('truncate', truncate);
-
-      function slug(string) {
-        return string.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-').replace(/-$|^-/g, '') || '-';
-      }
-
-      /**
-       * Strip HTML tags and quotes out of the given string, replacing them with
-       * meaningful punctuation.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-
-      _export('slug', slug);
-
-      function getPlainContent(string) {
-        var html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/ig, ' ');
-
-        var dom = $('<div/>').html(html);
-
-        dom.find(getPlainContent.removeSelectors.join(',')).remove();
-
-        return dom.text().replace(/\s+/g, ' ').trim();
-      }
-
-      /**
-       * An array of DOM selectors to remove when getting plain content.
-       *
-       * @type {Array}
-       */
-
-      _export('getPlainContent', getPlainContent);
-
       getPlainContent.removeSelectors = ['blockquote', 'script'];
-
-      /**
-       * Make a string's first character uppercase.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-      function ucfirst(string) {
-        return string.substr(0, 1).toUpperCase() + string.substr(1);
-      }
-
-      _export('ucfirst', ucfirst);
     }
   };
 });;
 'use strict';
 
 System.register('flarum/utils/stringToColor', [], function (_export, _context) {
+  "use strict";
+
   function hsvToRgb(h, s, v) {
     var r = void 0;
     var g = void 0;
@@ -31603,6 +31861,8 @@ System.register('flarum/utils/stringToColor', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context) {
+  "use strict";
+
   var SubtreeRetainer;
   return {
     setters: [],
@@ -31611,7 +31871,6 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
         /**
          * @param {...callbacks} callbacks Functions returning data to keep track of.
          */
-
         function SubtreeRetainer() {
           babelHelpers.classCallCheck(this, SubtreeRetainer);
 
@@ -31675,6 +31934,8 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
 'use strict';
 
 System.register('flarum/utils/UserControls', ['flarum/components/Button', 'flarum/components/Separator', 'flarum/components/EditUserModal', 'flarum/components/UserPage', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Button, Separator, EditUserModal, UserPage, ItemList;
   return {
     setters: [function (_flarumComponentsButton) {

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -22689,8 +22689,10 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
               className: 'Button Button--icon',
               onclick: function onclick() {
                 app.cache.discussionList.refresh();
-                app.store.find('users', app.session.user.id());
-                m.redraw();
+                if (app.session.user) {
+                  app.store.find('users', app.session.user.id());
+                  m.redraw();
+                }
               }
             }));
 
@@ -28730,8 +28732,11 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
     $('#home-link').click(function (e) {
       if (e.ctrlKey || e.metaKey || e.which === 2) return;
       e.preventDefault();
-      app.store.find('users', app.session.user.id());
       app.history.home();
+      if (app.session.user) {
+        app.store.find('users', app.session.user.id());
+        m.redraw();
+      }
     });
 
     // Add a class to the body which indicates that the page has been scrolled

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -238,8 +238,10 @@ export default class IndexPage extends Page {
         className: 'Button Button--icon',
         onclick: () => {
           app.cache.discussionList.refresh();
-          app.store.find('users', app.session.user.id());
-          m.redraw();
+          if (app.session.user) {
+            app.store.find('users', app.session.user.id());
+            m.redraw();
+          }
         }
       })
     );

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -236,7 +236,11 @@ export default class IndexPage extends Page {
         title: app.translator.trans('core.forum.index.refresh_tooltip'),
         icon: 'refresh',
         className: 'Button Button--icon',
-        onclick: () => app.cache.discussionList.refresh()
+        onclick: () => {
+          app.cache.discussionList.refresh();
+          app.store.find('users', app.session.user.id());
+          m.redraw();
+        }
       })
     );
 

--- a/js/forum/src/initializers/boot.js
+++ b/js/forum/src/initializers/boot.js
@@ -61,6 +61,7 @@ export default function boot(app) {
   $('#home-link').click(e => {
     if (e.ctrlKey || e.metaKey || e.which === 2) return;
     e.preventDefault();
+    app.store.find('users', app.session.user.id());
     app.history.home();
   });
 

--- a/js/forum/src/initializers/boot.js
+++ b/js/forum/src/initializers/boot.js
@@ -61,8 +61,11 @@ export default function boot(app) {
   $('#home-link').click(e => {
     if (e.ctrlKey || e.metaKey || e.which === 2) return;
     e.preventDefault();
-    app.store.find('users', app.session.user.id());
     app.history.home();
+    if (app.session.user) {
+      app.store.find('users', app.session.user.id());
+      m.redraw();
+    }
   });
 
   // Add a class to the body which indicates that the page has been scrolled


### PR DESCRIPTION
Refreshing discussion list (without Pusher) refreshes notifications as well. This fixes #200.
- When clicking "refresh" button for discussion list (on homepage) refresh notifications
- When clicking forum title (on homepage) refresh notifications

**TODO:** Have some way of updating the notifications when this events don't occur. Ideas:
1. The user is AFK with a page open, comes back, and the notification count is refreshed because it refreshes every _n_ minutes
2. Refresh notifications when clicking a discussion, a tag, clicking reply, like... (probably too much, though, maybe have a random chance of updating?)

_(I know this was marked for v1.0, but I think it should be ready ASAP)_
