### PR TITLE
#616 Turn "Rename Discussion" dialog into a modal

### DIFF
--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -18237,6 +18237,8 @@ $('#el').spin('flower', 'red');
 'use strict';
 
 System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', 'flarum/initializers/preload', 'flarum/initializers/routes', 'flarum/initializers/components', 'flarum/initializers/humanTime', 'flarum/initializers/boot', 'flarum/initializers/alertEmailConfirmation'], function (_export, _context) {
+  "use strict";
+
   var ForumApp, store, preload, routes, components, humanTime, boot, alertEmailConfirmation, app;
   return {
     setters: [function (_flarumForumApp) {
@@ -18276,6 +18278,8 @@ System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', '
 'use strict';
 
 System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/RequestErrorModal', 'flarum/components/ConfirmPasswordModal', 'flarum/Translator', 'flarum/utils/extract', 'flarum/utils/patchMithril', 'flarum/utils/RequestError', 'flarum/extend'], function (_export, _context) {
+  "use strict";
+
   var ItemList, Alert, Button, RequestErrorModal, ConfirmPasswordModal, Translator, extract, patchMithril, RequestError, extend, App;
   return {
     setters: [function (_flarumUtilsItemList) {
@@ -18604,6 +18608,8 @@ System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert
 'use strict';
 
 System.register('flarum/Component', [], function (_export, _context) {
+  "use strict";
+
   var Component;
   return {
     setters: [],
@@ -18614,7 +18620,6 @@ System.register('flarum/Component', [], function (_export, _context) {
          * @param {Array|Object} children
          * @public
          */
-
         function Component() {
           var props = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
           var children = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
@@ -18772,6 +18777,8 @@ System.register('flarum/Component', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/components/Alert', ['flarum/Component', 'flarum/components/Button', 'flarum/helpers/listItems', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, listItems, extract, Alert;
   return {
     setters: [function (_flarumComponent) {
@@ -18843,6 +18850,8 @@ System.register('flarum/components/Alert', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/components/Alert'], function (_export, _context) {
+  "use strict";
+
   var Component, Alert, AlertManager;
   return {
     setters: [function (_flarumComponent) {
@@ -18932,6 +18941,8 @@ System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/listItems', 'flarum/utils/ItemList', 'flarum/components/Button', 'flarum/components/LoadingIndicator'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, icon, listItems, ItemList, Button, LoadingIndicator, AvatarEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -19095,6 +19106,8 @@ System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, extract, Badge;
   return {
     setters: [function (_flarumComponent) {
@@ -19147,6 +19160,8 @@ System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/
 'use strict';
 
 System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract', 'flarum/utils/extractText', 'flarum/components/LoadingIndicator'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, extract, extractText, LoadingIndicator, Button;
   return {
     setters: [function (_flarumComponent) {
@@ -19221,6 +19236,8 @@ System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, ChangeEmailModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19385,6 +19402,8 @@ System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal'
 'use strict';
 
 System.register('flarum/components/ChangePasswordModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, ChangePasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19462,6 +19481,8 @@ System.register('flarum/components/ChangePasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, icon, Checkbox;
   return {
     setters: [function (_flarumComponent) {
@@ -19534,6 +19555,8 @@ System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/CommentPost', ['flarum/components/Post', 'flarum/utils/classList', 'flarum/components/PostUser', 'flarum/components/PostMeta', 'flarum/components/PostEdited', 'flarum/components/EditPostComposer', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Post, classList, PostUser, PostMeta, PostEdited, EditPostComposer, ItemList, listItems, Button, CommentPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -19710,6 +19733,8 @@ System.register('flarum/components/CommentPost', ['flarum/components/Post', 'fla
 'use strict';
 
 System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/components/ComposerButton', 'flarum/helpers/listItems', 'flarum/utils/classList', 'flarum/utils/computed'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, ComposerButton, listItems, classList, computed, Composer;
   return {
     setters: [function (_flarumComponent) {
@@ -20152,6 +20177,8 @@ System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/components/TextEditor', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, TextEditor, avatar, listItems, ItemList, ComposerBody;
   return {
     setters: [function (_flarumComponent) {
@@ -20270,6 +20297,8 @@ System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/ComposerButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, ComposerButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -20302,6 +20331,8 @@ System.register('flarum/components/ComposerButton', ['flarum/components/Button']
 'use strict';
 
 System.register('flarum/components/DiscussionComposer', ['flarum/components/ComposerBody', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, extractText, DiscussionComposer;
   return {
     setters: [function (_flarumComponentsComposerBody) {
@@ -20413,6 +20444,8 @@ System.register('flarum/components/DiscussionComposer', ['flarum/components/Comp
 'use strict';
 
 System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, DiscussionHero;
   return {
     setters: [function (_flarumComponent) {
@@ -20482,6 +20515,8 @@ System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum/components/DiscussionListItem', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/components/Placeholder'], function (_export, _context) {
+  "use strict";
+
   var Component, DiscussionListItem, Button, LoadingIndicator, Placeholder, DiscussionList;
   return {
     setters: [function (_flarumComponent) {
@@ -20685,6 +20720,8 @@ System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/helpers/highlight', 'flarum/helpers/icon', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/abbreviateNumber', 'flarum/components/Dropdown', 'flarum/components/TerminalPost', 'flarum/components/PostPreview', 'flarum/utils/SubtreeRetainer', 'flarum/utils/DiscussionControls', 'flarum/utils/slidable', 'flarum/utils/extractText', 'flarum/utils/classList'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, listItems, highlight, icon, humanTime, ItemList, abbreviateNumber, Dropdown, TerminalPost, PostPreview, SubtreeRetainer, DiscussionControls, slidable, extractText, classList, DiscussionListItem;
   return {
     setters: [function (_flarumComponent) {
@@ -20912,6 +20949,8 @@ System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/DiscussionPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/components/DiscussionHero', 'flarum/components/PostStream', 'flarum/components/PostStreamScrubber', 'flarum/components/LoadingIndicator', 'flarum/components/SplitDropdown', 'flarum/helpers/listItems', 'flarum/utils/DiscussionControls'], function (_export, _context) {
+  "use strict";
+
   var Page, ItemList, DiscussionHero, PostStream, PostStreamScrubber, LoadingIndicator, SplitDropdown, listItems, DiscussionControls, DiscussionPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -21204,6 +21243,8 @@ System.register('flarum/components/DiscussionPage', ['flarum/components/Page', '
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedNotification', ['flarum/components/Notification'], function (_export, _context) {
+  "use strict";
+
   var Notification, DiscussionRenamedNotification;
   return {
     setters: [function (_flarumComponentsNotification) {
@@ -21246,6 +21287,8 @@ System.register('flarum/components/DiscussionRenamedNotification', ['flarum/comp
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/EventPost', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var EventPost, extractText, DiscussionRenamedPost;
   return {
     setters: [function (_flarumComponentsEventPost) {
@@ -21306,6 +21349,8 @@ System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/E
 'use strict';
 
 System.register('flarum/components/DiscussionRenameModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, DiscussionRenameModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -21408,6 +21453,8 @@ System.register('flarum/components/DiscussionRenameModal', ['flarum/components/M
 'use strict';
 
 System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/highlight', 'flarum/components/LinkButton'], function (_export, _context) {
+  "use strict";
+
   var highlight, LinkButton, DiscussionsSearchSource;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -21492,6 +21539,8 @@ System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/hi
 'use strict';
 
 System.register('flarum/components/DiscussionsUserPage', ['flarum/components/UserPage', 'flarum/components/DiscussionList'], function (_export, _context) {
+  "use strict";
+
   var UserPage, DiscussionList, DiscussionsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -21539,6 +21588,8 @@ System.register('flarum/components/DiscussionsUserPage', ['flarum/components/Use
 'use strict';
 
 System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpers/icon', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, listItems, Dropdown;
   return {
     setters: [function (_flarumComponent) {
@@ -21665,6 +21716,8 @@ System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/EditPostComposer', ['flarum/components/ComposerBody', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, icon, EditPostComposer;
 
 
@@ -21781,6 +21834,8 @@ System.register('flarum/components/EditPostComposer', ['flarum/components/Compos
 'use strict';
 
 System.register('flarum/components/EditUserModal', ['flarum/components/Modal', 'flarum/components/Button', 'flarum/components/GroupBadge', 'flarum/models/Group', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, Button, GroupBadge, Group, extractText, EditUserModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -21987,6 +22042,8 @@ System.register('flarum/components/EditUserModal', ['flarum/components/Modal', '
 'use strict';
 
 System.register('flarum/components/EventPost', ['flarum/components/Post', 'flarum/utils/string', 'flarum/helpers/username', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Post, ucfirst, usernameHelper, icon, EventPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -22067,6 +22124,8 @@ System.register('flarum/components/EventPost', ['flarum/components/Post', 'flaru
 'use strict';
 
 System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, listItems, FieldSet;
   return {
     setters: [function (_flarumComponent) {
@@ -22112,6 +22171,8 @@ System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Modal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, Alert, Button, extractText, ForgotPasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -22260,6 +22321,8 @@ System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], function (_export, _context) {
+  "use strict";
+
   var Badge, GroupBadge;
   return {
     setters: [function (_flarumComponentsBadge) {
@@ -22299,6 +22362,8 @@ System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], fun
 'use strict';
 
 System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, HeaderPrimary;
   return {
     setters: [function (_flarumComponent) {
@@ -22350,6 +22415,8 @@ System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/
 'use strict';
 
 System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LogInModal', 'flarum/components/SignUpModal', 'flarum/components/SessionDropdown', 'flarum/components/SelectDropdown', 'flarum/components/NotificationsDropdown', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, LogInModal, SignUpModal, SessionDropdown, SelectDropdown, NotificationsDropdown, ItemList, listItems, HeaderSecondary;
   return {
     setters: [function (_flarumComponent) {
@@ -22471,6 +22538,8 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 'use strict';
 
 System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/components/Page', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/helpers/icon', 'flarum/components/DiscussionList', 'flarum/components/WelcomeHero', 'flarum/components/DiscussionComposer', 'flarum/components/LogInModal', 'flarum/components/DiscussionPage', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/LinkButton', 'flarum/components/SelectDropdown'], function (_export, _context) {
+  "use strict";
+
   var extend, Page, ItemList, listItems, icon, DiscussionList, WelcomeHero, DiscussionComposer, LogInModal, DiscussionPage, Select, Button, LinkButton, SelectDropdown, IndexPage;
   return {
     setters: [function (_flarumExtend) {
@@ -22828,6 +22897,8 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
 'use strict';
 
 System.register('flarum/components/LinkButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, LinkButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22873,6 +22944,8 @@ System.register('flarum/components/LinkButton', ['flarum/components/Button'], fu
 'use strict';
 
 System.register('flarum/components/LoadingIndicator', ['flarum/Component'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator;
   return {
     setters: [function (_flarumComponent) {
@@ -22920,6 +22993,8 @@ System.register('flarum/components/LoadingIndicator', ['flarum/Component'], func
 'use strict';
 
 System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/helpers/avatar'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, LoadingPost;
   return {
     setters: [function (_flarumComponent) {
@@ -22968,6 +23043,8 @@ System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/LogInButton', ['flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Button, LogInButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -23008,6 +23085,8 @@ System.register('flarum/components/LogInButton', ['flarum/components/Button'], f
 'use strict';
 
 System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, LogInButtons;
   return {
     setters: [function (_flarumComponent) {
@@ -23049,6 +23128,8 @@ System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/u
 'use strict';
 
 System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'flarum/components/ForgotPasswordModal', 'flarum/components/SignUpModal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, ForgotPasswordModal, SignUpModal, Alert, Button, LogInButtons, extractText, LogInModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -23214,6 +23295,8 @@ System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'fla
 'use strict';
 
 System.register('flarum/components/Modal', ['flarum/Component', 'flarum/components/Alert', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, Alert, Button, Modal;
   return {
     setters: [function (_flarumComponent) {
@@ -23346,6 +23429,8 @@ System.register('flarum/components/Modal', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/components/Modal'], function (_export, _context) {
+  "use strict";
+
   var Component, Modal, ModalManager;
   return {
     setters: [function (_flarumComponent) {
@@ -23456,6 +23541,8 @@ System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LinkButton'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, LinkButton, Navigation;
   return {
     setters: [function (_flarumComponent) {
@@ -23564,6 +23651,8 @@ System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/com
 'use strict';
 
 System.register('flarum/components/Notification', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/humanTime'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, icon, humanTime, Notification;
   return {
     setters: [function (_flarumComponent) {
@@ -23646,6 +23735,8 @@ System.register('flarum/components/Notification', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flarum/components/Checkbox', 'flarum/helpers/icon', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, Checkbox, icon, ItemList, NotificationGrid;
   return {
     setters: [function (_flarumComponent) {
@@ -23857,6 +23948,8 @@ System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationList', ['flarum/Component', 'flarum/helpers/listItems', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/models/Discussion'], function (_export, _context) {
+  "use strict";
+
   var Component, listItems, Button, LoadingIndicator, Discussion, NotificationList;
   return {
     setters: [function (_flarumComponent) {
@@ -24041,6 +24134,8 @@ System.register('flarum/components/NotificationList', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationsDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon', 'flarum/components/NotificationList'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, icon, NotificationList, NotificationsDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -24156,6 +24251,8 @@ System.register('flarum/components/NotificationsDropdown', ['flarum/components/D
 'use strict';
 
 System.register('flarum/components/NotificationsPage', ['flarum/components/Page', 'flarum/components/NotificationList'], function (_export, _context) {
+  "use strict";
+
   var Page, NotificationList, NotificationsPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -24204,6 +24301,8 @@ System.register('flarum/components/NotificationsPage', ['flarum/components/Page'
 'use strict';
 
 System.register('flarum/components/Page', ['flarum/Component'], function (_export, _context) {
+  "use strict";
+
   var Component, Page;
   return {
     setters: [function (_flarumComponent) {
@@ -24260,6 +24359,8 @@ System.register('flarum/components/Page', ['flarum/Component'], function (_expor
 "use strict";
 
 System.register("flarum/components/Placeholder", ["flarum/Component"], function (_export, _context) {
+  "use strict";
+
   var Component, Placeholder;
   return {
     setters: [function (_flarumComponent) {
@@ -24298,6 +24399,8 @@ System.register("flarum/components/Placeholder", ["flarum/Component"], function 
 'use strict';
 
 System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/SubtreeRetainer', 'flarum/components/Dropdown', 'flarum/utils/PostControls', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Component, SubtreeRetainer, Dropdown, PostControls, listItems, ItemList, Post;
   return {
     setters: [function (_flarumComponent) {
@@ -24443,6 +24546,8 @@ System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/Sub
 'use strict';
 
 System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, extractText, PostEdited;
   return {
     setters: [function (_flarumComponent) {
@@ -24503,6 +24608,8 @@ System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/fullTime'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, fullTime, PostMeta;
   return {
     setters: [function (_flarumComponent) {
@@ -24595,6 +24702,8 @@ System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/highlight'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, username, highlight, PostPreview;
   return {
     setters: [function (_flarumComponent) {
@@ -24650,6 +24759,8 @@ System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/utils/ScrollListener', 'flarum/components/LoadingPost', 'flarum/utils/anchorScroll', 'flarum/utils/mixin', 'flarum/utils/evented', 'flarum/components/ReplyPlaceholder', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, ScrollListener, PostLoading, anchorScroll, mixin, evented, ReplyPlaceholder, Button, PostStream;
   return {
     setters: [function (_flarumComponent) {
@@ -25173,6 +25284,8 @@ System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/ScrollListener', 'flarum/utils/SubtreeRetainer', 'flarum/utils/computed', 'flarum/utils/formatNumber'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, ScrollListener, SubtreeRetainer, computed, formatNumber, PostStreamScrubber;
   return {
     setters: [function (_flarumComponent) {
@@ -25638,6 +25751,8 @@ System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage', 'flarum/components/LoadingIndicator', 'flarum/components/Button', 'flarum/components/CommentPost'], function (_export, _context) {
+  "use strict";
+
   var UserPage, LoadingIndicator, Button, CommentPost, PostsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -25796,6 +25911,8 @@ System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage'
 'use strict';
 
 System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/components/UserCard', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/userOnline', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, UserCard, avatar, username, userOnline, listItems, PostUser;
   return {
     setters: [function (_flarumComponent) {
@@ -25934,6 +26051,8 @@ System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerBody', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var ComposerBody, Alert, Button, icon, extractText, ReplyComposer;
 
 
@@ -26082,6 +26201,8 @@ System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerB
 'use strict';
 
 System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/utils/DiscussionControls'], function (_export, _context) {
+  "use strict";
+
   var Component, avatar, username, DiscussionControls, ReplyPlaceholder;
   return {
     setters: [function (_flarumComponent) {
@@ -26189,6 +26310,8 @@ System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal'], function (_export, _context) {
+  "use strict";
+
   var Modal, RequestErrorModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -26250,6 +26373,8 @@ System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal
 'use strict';
 
 System.register('flarum/components/Search', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/ItemList', 'flarum/utils/classList', 'flarum/utils/extractText', 'flarum/utils/KeyboardNavigatable', 'flarum/helpers/icon', 'flarum/components/DiscussionsSearchSource', 'flarum/components/UsersSearchSource'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, ItemList, classList, extractText, KeyboardNavigatable, icon, DiscussionsSearchSource, UsersSearchSource, Search;
   return {
     setters: [function (_flarumComponent) {
@@ -26547,6 +26672,8 @@ System.register('flarum/components/Search', ['flarum/Component', 'flarum/compone
 "use strict";
 
 System.register("flarum/components/SearchSource", [], function (_export, _context) {
+  "use strict";
+
   var SearchSource;
   return {
     setters: [],
@@ -26573,6 +26700,8 @@ System.register("flarum/components/SearchSource", [], function (_export, _contex
 'use strict';
 
 System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, icon, Select;
   return {
     setters: [function (_flarumComponent) {
@@ -26626,6 +26755,8 @@ System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, icon, SelectDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -26678,6 +26809,8 @@ System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown
 "use strict";
 
 System.register("flarum/components/Separator", ["flarum/Component"], function (_export, _context) {
+  "use strict";
+
   var Component, Separator;
   return {
     setters: [function (_flarumComponent) {
@@ -26710,6 +26843,8 @@ System.register("flarum/components/Separator", ["flarum/Component"], function (_
 'use strict';
 
 System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/components/Dropdown', 'flarum/components/LinkButton', 'flarum/components/Button', 'flarum/utils/ItemList', 'flarum/components/Separator', 'flarum/models/Group'], function (_export, _context) {
+  "use strict";
+
   var avatar, username, Dropdown, LinkButton, Button, ItemList, Separator, Group, SessionDropdown;
   return {
     setters: [function (_flarumHelpersAvatar) {
@@ -26816,6 +26951,8 @@ System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', '
 'use strict';
 
 System.register('flarum/components/SettingsPage', ['flarum/components/UserPage', 'flarum/utils/ItemList', 'flarum/components/Switch', 'flarum/components/Button', 'flarum/components/FieldSet', 'flarum/components/NotificationGrid', 'flarum/components/ChangePasswordModal', 'flarum/components/ChangeEmailModal', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var UserPage, ItemList, Switch, Button, FieldSet, NotificationGrid, ChangePasswordModal, ChangeEmailModal, listItems, SettingsPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -26968,6 +27105,8 @@ System.register('flarum/components/SettingsPage', ['flarum/components/UserPage',
 'use strict';
 
 System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'flarum/components/LogInModal', 'flarum/helpers/avatar', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Modal, LogInModal, avatar, Button, LogInButtons, extractText, SignUpModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -27162,6 +27301,8 @@ System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'fl
 'use strict';
 
 System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Dropdown, Button, icon, SplitDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -27227,6 +27368,8 @@ System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown'
 'use strict';
 
 System.register('flarum/components/Switch', ['flarum/components/Checkbox'], function (_export, _context) {
+  "use strict";
+
   var Checkbox, Switch;
   return {
     setters: [function (_flarumComponentsCheckbox) {
@@ -27264,6 +27407,8 @@ System.register('flarum/components/Switch', ['flarum/components/Checkbox'], func
 'use strict';
 
 System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, icon, TerminalPost;
   return {
     setters: [function (_flarumComponent) {
@@ -27313,6 +27458,8 @@ System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, ItemList, listItems, Button, TextEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -27460,6 +27607,8 @@ System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/classList', 'flarum/utils/extractText'], function (_export, _context) {
+  "use strict";
+
   var Component, LoadingIndicator, classList, extractText, UserBio;
   return {
     setters: [function (_flarumComponent) {
@@ -27592,6 +27741,8 @@ System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/compon
 'use strict';
 
 System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/UserControls', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/icon', 'flarum/components/Dropdown', 'flarum/components/UserBio', 'flarum/components/AvatarEditor', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Component, humanTime, ItemList, UserControls, avatar, username, icon, Dropdown, UserBio, AvatarEditor, listItems, UserCard;
   return {
     setters: [function (_flarumComponent) {
@@ -27721,6 +27872,8 @@ System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/utils/affixSidebar', 'flarum/components/UserCard', 'flarum/components/LoadingIndicator', 'flarum/components/SelectDropdown', 'flarum/components/LinkButton', 'flarum/components/Separator', 'flarum/helpers/listItems'], function (_export, _context) {
+  "use strict";
+
   var Page, ItemList, affixSidebar, UserCard, LoadingIndicator, SelectDropdown, LinkButton, Separator, listItems, UserPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -27890,6 +28043,8 @@ System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum
 'use strict';
 
 System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highlight', 'flarum/helpers/avatar', 'flarum/helpers/username'], function (_export, _context) {
+  "use strict";
+
   var highlight, avatar, username, UsersSearchResults;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -27953,6 +28108,8 @@ System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highligh
 'use strict';
 
 System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/components/Button'], function (_export, _context) {
+  "use strict";
+
   var Component, Button, WelcomeHero;
   return {
     setters: [function (_flarumComponent) {
@@ -28031,93 +28188,96 @@ System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/co
 "use strict";
 
 System.register("flarum/extend", [], function (_export, _context) {
+  "use strict";
+
+  /**
+   * Extend an object's method by running its output through a mutating callback
+   * every time it is called.
+   *
+   * The callback accepts the method's return value and should perform any
+   * mutations directly on this value. For this reason, this function will not be
+   * effective on methods which return scalar values (numbers, strings, booleans).
+   *
+   * Care should be taken to extend the correct object – in most cases, a class'
+   * prototype will be the desired target of extension, not the class itself.
+   *
+   * @example
+   * extend(Discussion.prototype, 'badges', function(badges) {
+   *   // do something with `badges`
+   * });
+   *
+   * @param {Object} object The object that owns the method
+   * @param {String} method The name of the method to extend
+   * @param {function} callback A callback which mutates the method's output
+   */
+  function extend(object, method, callback) {
+    var original = object[method];
+
+    object[method] = function () {
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      var value = original ? original.apply(this, args) : undefined;
+
+      callback.apply(this, [value].concat(args));
+
+      return value;
+    };
+
+    babelHelpers.extends(object[method], original);
+  }
+
+  /**
+   * Override an object's method by replacing it with a new function, so that the
+   * new function will be run every time the object's method is called.
+   *
+   * The replacement function accepts the original method as its first argument,
+   * which is like a call to 'super'. Any arguments passed to the original method
+   * are also passed to the replacement.
+   *
+   * Care should be taken to extend the correct object – in most cases, a class'
+   * prototype will be the desired target of extension, not the class itself.
+   *
+   * @example
+   * override(Discussion.prototype, 'badges', function(original) {
+   *   const badges = original();
+   *   // do something with badges
+   *   return badges;
+   * });
+   *
+   * @param {Object} object The object that owns the method
+   * @param {String} method The name of the method to override
+   * @param {function} newMethod The method to replace it with
+   */
+
+  _export("extend", extend);
+
+  function override(object, method, newMethod) {
+    var original = object[method];
+
+    object[method] = function () {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      return newMethod.apply(this, [original.bind(this)].concat(args));
+    };
+
+    babelHelpers.extends(object[method], original);
+  }
+  _export("override", override);
+
   return {
     setters: [],
-    execute: function () {
-      /**
-       * Extend an object's method by running its output through a mutating callback
-       * every time it is called.
-       *
-       * The callback accepts the method's return value and should perform any
-       * mutations directly on this value. For this reason, this function will not be
-       * effective on methods which return scalar values (numbers, strings, booleans).
-       *
-       * Care should be taken to extend the correct object – in most cases, a class'
-       * prototype will be the desired target of extension, not the class itself.
-       *
-       * @example
-       * extend(Discussion.prototype, 'badges', function(badges) {
-       *   // do something with `badges`
-       * });
-       *
-       * @param {Object} object The object that owns the method
-       * @param {String} method The name of the method to extend
-       * @param {function} callback A callback which mutates the method's output
-       */
-      function extend(object, method, callback) {
-        var original = object[method];
-
-        object[method] = function () {
-          for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-            args[_key] = arguments[_key];
-          }
-
-          var value = original ? original.apply(this, args) : undefined;
-
-          callback.apply(this, [value].concat(args));
-
-          return value;
-        };
-
-        babelHelpers.extends(object[method], original);
-      }
-
-      /**
-       * Override an object's method by replacing it with a new function, so that the
-       * new function will be run every time the object's method is called.
-       *
-       * The replacement function accepts the original method as its first argument,
-       * which is like a call to 'super'. Any arguments passed to the original method
-       * are also passed to the replacement.
-       *
-       * Care should be taken to extend the correct object – in most cases, a class'
-       * prototype will be the desired target of extension, not the class itself.
-       *
-       * @example
-       * override(Discussion.prototype, 'badges', function(original) {
-       *   const badges = original();
-       *   // do something with badges
-       *   return badges;
-       * });
-       *
-       * @param {Object} object The object that owns the method
-       * @param {String} method The name of the method to override
-       * @param {function} newMethod The method to replace it with
-       */
-
-      _export("extend", extend);
-
-      function override(object, method, newMethod) {
-        var original = object[method];
-
-        object[method] = function () {
-          for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-            args[_key2] = arguments[_key2];
-          }
-
-          return newMethod.apply(this, [original.bind(this)].concat(args));
-        };
-
-        babelHelpers.extends(object[method], original);
-      }
-
-      _export("override", override);
-    }
+    execute: function () {}
   };
 });;
 'use strict';
 
 System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flarum/components/Search', 'flarum/components/Composer', 'flarum/components/ReplyComposer', 'flarum/components/DiscussionPage', 'flarum/components/SignUpModal'], function (_export, _context) {
+  "use strict";
+
   var History, App, Search, Composer, ReplyComposer, DiscussionPage, SignUpModal, ForumApp;
   return {
     setters: [function (_flarumUtilsHistory) {
@@ -28236,6 +28396,8 @@ System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flaru
 'use strict';
 
 System.register('flarum/helpers/avatar', [], function (_export, _context) {
+  "use strict";
+
   function avatar(user) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28282,6 +28444,8 @@ System.register('flarum/helpers/avatar', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/fullTime', [], function (_export, _context) {
+  "use strict";
+
   function fullTime(time) {
     var mo = moment(time);
 
@@ -28305,6 +28469,8 @@ System.register('flarum/helpers/fullTime', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_export, _context) {
+  "use strict";
+
   var truncate;
   function highlight(string, phrase, length) {
     if (!phrase && !length) return string;
@@ -28344,6 +28510,8 @@ System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_
 'use strict';
 
 System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
+  "use strict";
+
   var humanTimeUtil;
   function humanTime(time) {
     var mo = moment(time);
@@ -28371,6 +28539,8 @@ System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function
 'use strict';
 
 System.register('flarum/helpers/icon', [], function (_export, _context) {
+  "use strict";
+
   function icon(name) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28389,6 +28559,8 @@ System.register('flarum/helpers/icon', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'flarum/utils/classList'], function (_export, _context) {
+  "use strict";
+
   var Separator, classList;
 
 
@@ -28453,6 +28625,8 @@ System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'fla
 'use strict';
 
 System.register('flarum/helpers/punctuateSeries', [], function (_export, _context) {
+  "use strict";
+
   function punctuateSeries(items) {
     if (items.length === 2) {
       return app.translator.trans('core.lib.series.two_text', {
@@ -28487,6 +28661,8 @@ System.register('flarum/helpers/punctuateSeries', [], function (_export, _contex
 "use strict";
 
 System.register("flarum/helpers/username", [], function (_export, _context) {
+  "use strict";
+
   function username(user) {
     var name = user && user.username() || app.translator.trans('core.lib.username.deleted_text');
 
@@ -28507,6 +28683,8 @@ System.register("flarum/helpers/username", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (_export, _context) {
+    "use strict";
+
     var icon;
     function userOnline(user) {
         if (user.lastSeenTime() && user.isOnline()) {
@@ -28530,6 +28708,8 @@ System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (
 'use strict';
 
 System.register('flarum/initializers/alertEmailConfirmation', ['flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
+  "use strict";
+
   var Alert, Button, icon;
   function alertEmailConfirmation(app) {
     var user = app.session.user;
@@ -28610,6 +28790,8 @@ System.register('flarum/initializers/alertEmailConfirmation', ['flarum/component
 'use strict';
 
 System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'flarum/utils/Pane', 'flarum/utils/Drawer', 'flarum/utils/mapRoutes', 'flarum/helpers/icon', 'flarum/components/Navigation', 'flarum/components/HeaderPrimary', 'flarum/components/HeaderSecondary', 'flarum/components/Composer', 'flarum/components/ModalManager', 'flarum/components/AlertManager'], function (_export, _context) {
+  "use strict";
+
   var ScrollListener, Pane, Drawer, mapRoutes, icon, Navigation, HeaderPrimary, HeaderSecondary, Composer, ModalManager, AlertManager;
   function boot(app) {
     // Get the configured default route and update that route's path to be '/'.
@@ -28705,6 +28887,8 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
 'use strict';
 
 System.register('flarum/initializers/components', ['flarum/components/CommentPost', 'flarum/components/DiscussionRenamedPost', 'flarum/components/DiscussionRenamedNotification'], function (_export, _context) {
+  "use strict";
+
   var CommentPost, DiscussionRenamedPost, DiscussionRenamedNotification;
   function components(app) {
     app.postComponents.comment = CommentPost;
@@ -28729,6 +28913,8 @@ System.register('flarum/initializers/components', ['flarum/components/CommentPos
 'use strict';
 
 System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
+  "use strict";
+
   var humanTimeUtil;
 
 
@@ -28761,6 +28947,8 @@ System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], fun
 'use strict';
 
 System.register('flarum/initializers/preload', ['flarum/Session'], function (_export, _context) {
+  "use strict";
+
   var Session;
   function preload(app) {
     app.store.pushPayload({ data: app.data.resources });
@@ -28782,6 +28970,8 @@ System.register('flarum/initializers/preload', ['flarum/Session'], function (_ex
 'use strict';
 
 System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'flarum/components/DiscussionPage', 'flarum/components/PostsUserPage', 'flarum/components/DiscussionsUserPage', 'flarum/components/SettingsPage', 'flarum/components/NotificationsPage'], function (_export, _context) {
+  "use strict";
+
   var IndexPage, DiscussionPage, PostsUserPage, DiscussionsUserPage, SettingsPage, NotificationsPage;
 
   _export('default', function (app) {
@@ -28857,6 +29047,8 @@ System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'f
 'use strict';
 
 System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/Forum', 'flarum/models/User', 'flarum/models/Discussion', 'flarum/models/Post', 'flarum/models/Group', 'flarum/models/Activity', 'flarum/models/Notification'], function (_export, _context) {
+  "use strict";
+
   var Store, Forum, User, Discussion, Post, Group, Activity, Notification;
   function store(app) {
     app.store = new Store({
@@ -28896,6 +29088,8 @@ System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/For
 'use strict';
 
 System.register('flarum/Model', [], function (_export, _context) {
+  "use strict";
+
   var Model;
   return {
     setters: [],
@@ -28906,7 +29100,6 @@ System.register('flarum/Model', [], function (_export, _context) {
          * @param {Store} store The data store that this model should be persisted to.
          * @public
          */
-
         function Model() {
           var data = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
           var store = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
@@ -29154,6 +29347,8 @@ System.register('flarum/Model', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/ItemList', 'flarum/components/Badge'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, ItemList, Badge, Discussion;
   return {
     setters: [function (_flarumModel) {
@@ -29266,6 +29461,8 @@ System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/compu
 'use strict';
 
 System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _context) {
+  "use strict";
+
   var Model, Forum;
   return {
     setters: [function (_flarumModel) {
@@ -29296,6 +29493,8 @@ System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Group', ['flarum/Model'], function (_export, _context) {
+  "use strict";
+
   var Model, Group;
   return {
     setters: [function (_flarumModel) {
@@ -29331,6 +29530,8 @@ System.register('flarum/models/Group', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/computed'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, Notification;
   return {
     setters: [function (_flarumModel) {
@@ -29376,6 +29577,8 @@ System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/com
 'use strict';
 
 System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/string'], function (_export, _context) {
+  "use strict";
+
   var Model, computed, getPlainContent, Post;
   return {
     setters: [function (_flarumModel) {
@@ -29433,6 +29636,8 @@ System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 
 'use strict';
 
 System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToColor', 'flarum/utils/ItemList', 'flarum/utils/computed', 'flarum/components/GroupBadge'], function (_export, _context) {
+  "use strict";
+
   var Model, stringToColor, ItemList, computed, GroupBadge, User;
   return {
     setters: [function (_flarumModel) {
@@ -29545,6 +29750,8 @@ System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToCol
 'use strict';
 
 System.register('flarum/Session', [], function (_export, _context) {
+  "use strict";
+
   var Session;
   return {
     setters: [],
@@ -29608,6 +29815,8 @@ System.register('flarum/Session', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Store', [], function (_export, _context) {
+  "use strict";
+
   var Store;
   return {
     setters: [],
@@ -29745,6 +29954,8 @@ System.register('flarum/Store', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/username', 'flarum/utils/extractText', 'flarum/utils/extract'], function (_export, _context) {
+  "use strict";
+
   var User, username, extractText, extract, Translator;
   return {
     setters: [function (_flarumModelsUser) {
@@ -30052,6 +30263,8 @@ System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/user
 'use strict';
 
 System.register('flarum/utils/abbreviateNumber', [], function (_export, _context) {
+  "use strict";
+
   function abbreviateNumber(number) {
     // TODO: translation
     if (number >= 1000000) {
@@ -30073,6 +30286,8 @@ System.register('flarum/utils/abbreviateNumber', [], function (_export, _context
 'use strict';
 
 System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
+  "use strict";
+
   function affixSidebar(element, isInitialized) {
     var _this = this;
 
@@ -30108,6 +30323,8 @@ System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
+  "use strict";
+
   function anchorScroll(element, callback) {
     var $window = $(window);
     var relativeScroll = $(element).offset().top - $window.scrollTop();
@@ -30127,6 +30344,8 @@ System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/classList', [], function (_export, _context) {
+  "use strict";
+
   function classList(classes) {
     var classNames = void 0;
 
@@ -30155,6 +30374,8 @@ System.register('flarum/utils/classList', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/computed', [], function (_export, _context) {
+  "use strict";
+
   function computed() {
     for (var _len = arguments.length, dependentKeys = Array(_len), _key = 0; _key < _len; _key++) {
       dependentKeys[_key] = arguments[_key];
@@ -30202,6 +30423,8 @@ System.register('flarum/utils/computed', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/DiscussionControls', ['flarum/components/DiscussionPage', 'flarum/components/ReplyComposer', 'flarum/components/LogInModal', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList', 'flarum/utils/extractText', 'flarum/components/DiscussionRenameModal'], function (_export, _context) {
+  "use strict";
+
   var DiscussionPage, ReplyComposer, LogInModal, Button, Separator, ItemList, extractText, DiscussionRenameModal;
   return {
     setters: [function (_flarumComponentsDiscussionPage) {
@@ -30377,6 +30600,8 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
 'use strict';
 
 System.register('flarum/utils/Drawer', [], function (_export, _context) {
+  "use strict";
+
   var Drawer;
   return {
     setters: [],
@@ -30443,6 +30668,8 @@ System.register('flarum/utils/Drawer', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/evented", [], function (_export, _context) {
+  "use strict";
+
   return {
     setters: [],
     execute: function () {
@@ -30500,6 +30727,8 @@ System.register("flarum/utils/evented", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/extract", [], function (_export, _context) {
+  "use strict";
+
   function extract(object, property) {
     var value = object[property];
 
@@ -30518,6 +30747,8 @@ System.register("flarum/utils/extract", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/extractText', [], function (_export, _context) {
+  "use strict";
+
   function extractText(vdom) {
     if (vdom instanceof Array) {
       return vdom.map(function (element) {
@@ -30540,6 +30771,8 @@ System.register('flarum/utils/extractText', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/formatNumber', [], function (_export, _context) {
+  "use strict";
+
   function formatNumber(number) {
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
@@ -30554,6 +30787,8 @@ System.register('flarum/utils/formatNumber', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/History', [], function (_export, _context) {
+  "use strict";
+
   var History;
   return {
     setters: [],
@@ -30650,6 +30885,8 @@ System.register('flarum/utils/History', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/humanTime', [], function (_export, _context) {
+  "use strict";
+
   function humanTime(time) {
     var m = moment(time);
     var now = moment();
@@ -30697,6 +30934,8 @@ System.register('flarum/utils/humanTime', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ItemList", [], function (_export, _context) {
+  "use strict";
+
   var Item, ItemList;
   return {
     setters: [],
@@ -30813,6 +31052,8 @@ System.register("flarum/utils/ItemList", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _context) {
+  "use strict";
+
   var KeyboardNavigatable;
   return {
     setters: [],
@@ -30928,6 +31169,8 @@ System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _cont
 'use strict';
 
 System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
+  "use strict";
+
   function mapRoutes(routes) {
     var basePath = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
 
@@ -30954,6 +31197,8 @@ System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/mixin", [], function (_export, _context) {
+  "use strict";
+
   function mixin(Parent) {
     var Mixed = function (_Parent) {
       babelHelpers.inherits(Mixed, _Parent);
@@ -30987,6 +31232,8 @@ System.register("flarum/utils/mixin", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/Pane', [], function (_export, _context) {
+  "use strict";
+
   var Pane;
   return {
     setters: [],
@@ -31102,6 +31349,8 @@ System.register('flarum/utils/Pane', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/patchMithril', ['../Component'], function (_export, _context) {
+  "use strict";
+
   var Component;
   function patchMithril(global) {
     var mo = global.m;
@@ -31160,6 +31409,8 @@ System.register('flarum/utils/patchMithril', ['../Component'], function (_export
 'use strict';
 
 System.register('flarum/utils/PostControls', ['flarum/components/EditPostComposer', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var EditPostComposer, Button, Separator, ItemList;
   return {
     setters: [function (_flarumComponentsEditPostComposer) {
@@ -31290,6 +31541,8 @@ System.register('flarum/utils/PostControls', ['flarum/components/EditPostCompose
 "use strict";
 
 System.register("flarum/utils/RequestError", [], function (_export, _context) {
+  "use strict";
+
   var RequestError;
   return {
     setters: [],
@@ -31318,6 +31571,8 @@ System.register("flarum/utils/RequestError", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ScrollListener", [], function (_export, _context) {
+  "use strict";
+
   var scroll, ScrollListener;
   return {
     setters: [],
@@ -31332,7 +31587,6 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
          *     changes.
          * @public
          */
-
         function ScrollListener(callback) {
           babelHelpers.classCallCheck(this, ScrollListener);
 
@@ -31391,6 +31645,8 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
 'use strict';
 
 System.register('flarum/utils/slidable', [], function (_export, _context) {
+  "use strict";
+
   function slidable(element) {
     var $element = $(element);
     var threshold = 50;
@@ -31549,84 +31805,88 @@ System.register('flarum/utils/slidable', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/string', [], function (_export, _context) {
+  "use strict";
+
+  /**
+   * Truncate a string to the given length, appending ellipses if necessary.
+   *
+   * @param {String} string
+   * @param {Number} length
+   * @param {Number} [start=0]
+   * @return {String}
+   */
+  function truncate(string, length) {
+    var start = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
+
+    return (start > 0 ? '...' : '') + string.substring(start, start + length) + (string.length > start + length ? '...' : '');
+  }
+
+  /**
+   * Create a slug out of the given string. Non-alphanumeric characters are
+   * converted to hyphens.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+
+  _export('truncate', truncate);
+
+  function slug(string) {
+    return string.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-').replace(/-$|^-/g, '') || '-';
+  }
+
+  /**
+   * Strip HTML tags and quotes out of the given string, replacing them with
+   * meaningful punctuation.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+
+  _export('slug', slug);
+
+  function getPlainContent(string) {
+    var html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/ig, ' ');
+
+    var dom = $('<div/>').html(html);
+
+    dom.find(getPlainContent.removeSelectors.join(',')).remove();
+
+    return dom.text().replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * An array of DOM selectors to remove when getting plain content.
+   *
+   * @type {Array}
+   */
+
+  _export('getPlainContent', getPlainContent);
+
+  /**
+   * Make a string's first character uppercase.
+   *
+   * @param {String} string
+   * @return {String}
+   */
+  function ucfirst(string) {
+    return string.substr(0, 1).toUpperCase() + string.substr(1);
+  }
+
+  _export('ucfirst', ucfirst);
+
   return {
     setters: [],
     execute: function () {
-      /**
-       * Truncate a string to the given length, appending ellipses if necessary.
-       *
-       * @param {String} string
-       * @param {Number} length
-       * @param {Number} [start=0]
-       * @return {String}
-       */
-      function truncate(string, length) {
-        var start = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
-
-        return (start > 0 ? '...' : '') + string.substring(start, start + length) + (string.length > start + length ? '...' : '');
-      }
-
-      /**
-       * Create a slug out of the given string. Non-alphanumeric characters are
-       * converted to hyphens.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-
-      _export('truncate', truncate);
-
-      function slug(string) {
-        return string.toLowerCase().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-').replace(/-$|^-/g, '') || '-';
-      }
-
-      /**
-       * Strip HTML tags and quotes out of the given string, replacing them with
-       * meaningful punctuation.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-
-      _export('slug', slug);
-
-      function getPlainContent(string) {
-        var html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/ig, ' ');
-
-        var dom = $('<div/>').html(html);
-
-        dom.find(getPlainContent.removeSelectors.join(',')).remove();
-
-        return dom.text().replace(/\s+/g, ' ').trim();
-      }
-
-      /**
-       * An array of DOM selectors to remove when getting plain content.
-       *
-       * @type {Array}
-       */
-
-      _export('getPlainContent', getPlainContent);
-
       getPlainContent.removeSelectors = ['blockquote', 'script'];
-
-      /**
-       * Make a string's first character uppercase.
-       *
-       * @param {String} string
-       * @return {String}
-       */
-      function ucfirst(string) {
-        return string.substr(0, 1).toUpperCase() + string.substr(1);
-      }
-
-      _export('ucfirst', ucfirst);
     }
   };
 });;
 'use strict';
 
 System.register('flarum/utils/stringToColor', [], function (_export, _context) {
+  "use strict";
+
   function hsvToRgb(h, s, v) {
     var r = void 0;
     var g = void 0;
@@ -31693,6 +31953,8 @@ System.register('flarum/utils/stringToColor', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context) {
+  "use strict";
+
   var SubtreeRetainer;
   return {
     setters: [],
@@ -31701,7 +31963,6 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
         /**
          * @param {...callbacks} callbacks Functions returning data to keep track of.
          */
-
         function SubtreeRetainer() {
           babelHelpers.classCallCheck(this, SubtreeRetainer);
 
@@ -31765,6 +32026,8 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
 'use strict';
 
 System.register('flarum/utils/UserControls', ['flarum/components/Button', 'flarum/components/Separator', 'flarum/components/EditUserModal', 'flarum/components/UserPage', 'flarum/utils/ItemList'], function (_export, _context) {
+  "use strict";
+
   var Button, Separator, EditUserModal, UserPage, ItemList;
   return {
     setters: [function (_flarumComponentsButton) {

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -18237,8 +18237,6 @@ $('#el').spin('flower', 'red');
 'use strict';
 
 System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', 'flarum/initializers/preload', 'flarum/initializers/routes', 'flarum/initializers/components', 'flarum/initializers/humanTime', 'flarum/initializers/boot', 'flarum/initializers/alertEmailConfirmation'], function (_export, _context) {
-  "use strict";
-
   var ForumApp, store, preload, routes, components, humanTime, boot, alertEmailConfirmation, app;
   return {
     setters: [function (_flarumForumApp) {
@@ -18278,8 +18276,6 @@ System.register('flarum/app', ['flarum/ForumApp', 'flarum/initializers/store', '
 'use strict';
 
 System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/RequestErrorModal', 'flarum/components/ConfirmPasswordModal', 'flarum/Translator', 'flarum/utils/extract', 'flarum/utils/patchMithril', 'flarum/utils/RequestError', 'flarum/extend'], function (_export, _context) {
-  "use strict";
-
   var ItemList, Alert, Button, RequestErrorModal, ConfirmPasswordModal, Translator, extract, patchMithril, RequestError, extend, App;
   return {
     setters: [function (_flarumUtilsItemList) {
@@ -18608,8 +18604,6 @@ System.register('flarum/App', ['flarum/utils/ItemList', 'flarum/components/Alert
 'use strict';
 
 System.register('flarum/Component', [], function (_export, _context) {
-  "use strict";
-
   var Component;
   return {
     setters: [],
@@ -18778,8 +18772,6 @@ System.register('flarum/Component', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/components/Alert', ['flarum/Component', 'flarum/components/Button', 'flarum/helpers/listItems', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, listItems, extract, Alert;
   return {
     setters: [function (_flarumComponent) {
@@ -18851,8 +18843,6 @@ System.register('flarum/components/Alert', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/components/Alert'], function (_export, _context) {
-  "use strict";
-
   var Component, Alert, AlertManager;
   return {
     setters: [function (_flarumComponent) {
@@ -18942,8 +18932,6 @@ System.register('flarum/components/AlertManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/listItems', 'flarum/utils/ItemList', 'flarum/components/Button', 'flarum/components/LoadingIndicator'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, icon, listItems, ItemList, Button, LoadingIndicator, AvatarEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -19107,8 +19095,6 @@ System.register('flarum/components/AvatarEditor', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, extract, Badge;
   return {
     setters: [function (_flarumComponent) {
@@ -19161,8 +19147,6 @@ System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/
 'use strict';
 
 System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/extract', 'flarum/utils/extractText', 'flarum/components/LoadingIndicator'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, extract, extractText, LoadingIndicator, Button;
   return {
     setters: [function (_flarumComponent) {
@@ -19237,8 +19221,6 @@ System.register('flarum/components/Button', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, ChangeEmailModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19403,8 +19385,6 @@ System.register('flarum/components/ChangeEmailModal', ['flarum/components/Modal'
 'use strict';
 
 System.register('flarum/components/ChangePasswordModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, ChangePasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -19482,8 +19462,6 @@ System.register('flarum/components/ChangePasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, icon, Checkbox;
   return {
     setters: [function (_flarumComponent) {
@@ -19556,8 +19534,6 @@ System.register('flarum/components/Checkbox', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/CommentPost', ['flarum/components/Post', 'flarum/utils/classList', 'flarum/components/PostUser', 'flarum/components/PostMeta', 'flarum/components/PostEdited', 'flarum/components/EditPostComposer', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Post, classList, PostUser, PostMeta, PostEdited, EditPostComposer, ItemList, listItems, Button, CommentPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -19734,8 +19710,6 @@ System.register('flarum/components/CommentPost', ['flarum/components/Post', 'fla
 'use strict';
 
 System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/components/ComposerButton', 'flarum/helpers/listItems', 'flarum/utils/classList', 'flarum/utils/computed'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, ComposerButton, listItems, classList, computed, Composer;
   return {
     setters: [function (_flarumComponent) {
@@ -20178,8 +20152,6 @@ System.register('flarum/components/Composer', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/components/TextEditor', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, TextEditor, avatar, listItems, ItemList, ComposerBody;
   return {
     setters: [function (_flarumComponent) {
@@ -20298,8 +20270,6 @@ System.register('flarum/components/ComposerBody', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/ComposerButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, ComposerButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -20332,8 +20302,6 @@ System.register('flarum/components/ComposerButton', ['flarum/components/Button']
 'use strict';
 
 System.register('flarum/components/DiscussionComposer', ['flarum/components/ComposerBody', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, extractText, DiscussionComposer;
   return {
     setters: [function (_flarumComponentsComposerBody) {
@@ -20445,8 +20413,6 @@ System.register('flarum/components/DiscussionComposer', ['flarum/components/Comp
 'use strict';
 
 System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, DiscussionHero;
   return {
     setters: [function (_flarumComponent) {
@@ -20516,8 +20482,6 @@ System.register('flarum/components/DiscussionHero', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum/components/DiscussionListItem', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/components/Placeholder'], function (_export, _context) {
-  "use strict";
-
   var Component, DiscussionListItem, Button, LoadingIndicator, Placeholder, DiscussionList;
   return {
     setters: [function (_flarumComponent) {
@@ -20721,8 +20685,6 @@ System.register('flarum/components/DiscussionList', ['flarum/Component', 'flarum
 'use strict';
 
 System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/listItems', 'flarum/helpers/highlight', 'flarum/helpers/icon', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/abbreviateNumber', 'flarum/components/Dropdown', 'flarum/components/TerminalPost', 'flarum/components/PostPreview', 'flarum/utils/SubtreeRetainer', 'flarum/utils/DiscussionControls', 'flarum/utils/slidable', 'flarum/utils/extractText', 'flarum/utils/classList'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, listItems, highlight, icon, humanTime, ItemList, abbreviateNumber, Dropdown, TerminalPost, PostPreview, SubtreeRetainer, DiscussionControls, slidable, extractText, classList, DiscussionListItem;
   return {
     setters: [function (_flarumComponent) {
@@ -20950,8 +20912,6 @@ System.register('flarum/components/DiscussionListItem', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/DiscussionPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/components/DiscussionHero', 'flarum/components/PostStream', 'flarum/components/PostStreamScrubber', 'flarum/components/LoadingIndicator', 'flarum/components/SplitDropdown', 'flarum/helpers/listItems', 'flarum/utils/DiscussionControls'], function (_export, _context) {
-  "use strict";
-
   var Page, ItemList, DiscussionHero, PostStream, PostStreamScrubber, LoadingIndicator, SplitDropdown, listItems, DiscussionControls, DiscussionPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -21244,8 +21204,6 @@ System.register('flarum/components/DiscussionPage', ['flarum/components/Page', '
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedNotification', ['flarum/components/Notification'], function (_export, _context) {
-  "use strict";
-
   var Notification, DiscussionRenamedNotification;
   return {
     setters: [function (_flarumComponentsNotification) {
@@ -21288,8 +21246,6 @@ System.register('flarum/components/DiscussionRenamedNotification', ['flarum/comp
 'use strict';
 
 System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/EventPost', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var EventPost, extractText, DiscussionRenamedPost;
   return {
     setters: [function (_flarumComponentsEventPost) {
@@ -21349,9 +21305,109 @@ System.register('flarum/components/DiscussionRenamedPost', ['flarum/components/E
 });;
 'use strict';
 
-System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/highlight', 'flarum/components/LinkButton'], function (_export, _context) {
-  "use strict";
+System.register('flarum/components/DiscussionRenameModal', ['flarum/components/Modal', 'flarum/components/Button'], function (_export, _context) {
+  var Modal, Button, DiscussionRenameModal;
+  return {
+    setters: [function (_flarumComponentsModal) {
+      Modal = _flarumComponentsModal.default;
+    }, function (_flarumComponentsButton) {
+      Button = _flarumComponentsButton.default;
+    }],
+    execute: function () {
+      DiscussionRenameModal = function (_Modal) {
+        babelHelpers.inherits(DiscussionRenameModal, _Modal);
 
+        function DiscussionRenameModal() {
+          babelHelpers.classCallCheck(this, DiscussionRenameModal);
+          return babelHelpers.possibleConstructorReturn(this, Object.getPrototypeOf(DiscussionRenameModal).apply(this, arguments));
+        }
+
+        babelHelpers.createClass(DiscussionRenameModal, [{
+          key: 'init',
+          value: function init() {
+            babelHelpers.get(Object.getPrototypeOf(DiscussionRenameModal.prototype), 'init', this).call(this);
+
+            this.discussion = this.props.discussion;
+            this.currentTitle = this.props.currentTitle;
+            this.newTitle = m.prop(this.currentTitle);
+          }
+        }, {
+          key: 'className',
+          value: function className() {
+            return 'DiscussionRenameModal Modal--small';
+          }
+        }, {
+          key: 'title',
+          value: function title() {
+            return app.translator.trans('core.forum.discussion_controls.rename_modal.title');
+          }
+        }, {
+          key: 'content',
+          value: function content() {
+
+            return m(
+              'div',
+              { className: 'Modal-body' },
+              m(
+                'div',
+                { className: 'Form' },
+                m(
+                  'div',
+                  { className: 'Form-group' },
+                  m('input', { className: 'FormControl title', placeholder: this.currentTitle, bidi: this.newTitle })
+                ),
+                m(
+                  'div',
+                  { className: 'Form-group' },
+                  Button.component({
+                    className: 'Button Button--primary',
+                    type: 'submit',
+                    loading: this.loading,
+                    children: app.translator.trans('core.forum.discussion_controls.rename_modal.submit_button')
+                  })
+                )
+              )
+            );
+          }
+        }, {
+          key: 'onsubmit',
+          value: function onsubmit(e) {
+            var _this2 = this;
+
+            e.preventDefault();
+
+            this.loading = true;
+
+            // const title = $('.DiscussionRenameModal input.title').val();
+            var title = this.newTitle;
+            var currentTitle = this.currentTitle;
+
+            // If the title is different to what it was before, then save it. After the
+            // save has completed, update the post stream as there will be a new post
+            // indicating that the discussion was renamed.
+            if (title && title !== currentTitle) {
+              return this.discussion.save({ title: title }).then(function () {
+                if (app.viewingDiscussion(_this2.discussion)) {
+                  app.current.stream.update();
+                }
+                m.redraw();
+                _this2.hide();
+              });
+            } else {
+              this.hide();
+            }
+          }
+        }]);
+        return DiscussionRenameModal;
+      }(Modal);
+
+      _export('default', DiscussionRenameModal);
+    }
+  };
+});;
+'use strict';
+
+System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/highlight', 'flarum/components/LinkButton'], function (_export, _context) {
   var highlight, LinkButton, DiscussionsSearchSource;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -21436,8 +21492,6 @@ System.register('flarum/components/DiscussionsSearchSource', ['flarum/helpers/hi
 'use strict';
 
 System.register('flarum/components/DiscussionsUserPage', ['flarum/components/UserPage', 'flarum/components/DiscussionList'], function (_export, _context) {
-  "use strict";
-
   var UserPage, DiscussionList, DiscussionsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -21485,8 +21539,6 @@ System.register('flarum/components/DiscussionsUserPage', ['flarum/components/Use
 'use strict';
 
 System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpers/icon', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, listItems, Dropdown;
   return {
     setters: [function (_flarumComponent) {
@@ -21613,8 +21665,6 @@ System.register('flarum/components/Dropdown', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/EditPostComposer', ['flarum/components/ComposerBody', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, icon, EditPostComposer;
 
 
@@ -21731,8 +21781,6 @@ System.register('flarum/components/EditPostComposer', ['flarum/components/Compos
 'use strict';
 
 System.register('flarum/components/EditUserModal', ['flarum/components/Modal', 'flarum/components/Button', 'flarum/components/GroupBadge', 'flarum/models/Group', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, Button, GroupBadge, Group, extractText, EditUserModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -21939,8 +21987,6 @@ System.register('flarum/components/EditUserModal', ['flarum/components/Modal', '
 'use strict';
 
 System.register('flarum/components/EventPost', ['flarum/components/Post', 'flarum/utils/string', 'flarum/helpers/username', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Post, ucfirst, usernameHelper, icon, EventPost;
   return {
     setters: [function (_flarumComponentsPost) {
@@ -22021,8 +22067,6 @@ System.register('flarum/components/EventPost', ['flarum/components/Post', 'flaru
 'use strict';
 
 System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, listItems, FieldSet;
   return {
     setters: [function (_flarumComponent) {
@@ -22068,8 +22112,6 @@ System.register('flarum/components/FieldSet', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Modal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, Alert, Button, extractText, ForgotPasswordModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -22218,8 +22260,6 @@ System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Mod
 'use strict';
 
 System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], function (_export, _context) {
-  "use strict";
-
   var Badge, GroupBadge;
   return {
     setters: [function (_flarumComponentsBadge) {
@@ -22259,8 +22299,6 @@ System.register('flarum/components/GroupBadge', ['flarum/components/Badge'], fun
 'use strict';
 
 System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, HeaderPrimary;
   return {
     setters: [function (_flarumComponent) {
@@ -22312,8 +22350,6 @@ System.register('flarum/components/HeaderPrimary', ['flarum/Component', 'flarum/
 'use strict';
 
 System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LogInModal', 'flarum/components/SignUpModal', 'flarum/components/SessionDropdown', 'flarum/components/SelectDropdown', 'flarum/components/NotificationsDropdown', 'flarum/utils/ItemList', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, LogInModal, SignUpModal, SessionDropdown, SelectDropdown, NotificationsDropdown, ItemList, listItems, HeaderSecondary;
   return {
     setters: [function (_flarumComponent) {
@@ -22435,8 +22471,6 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 'use strict';
 
 System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/components/Page', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/helpers/icon', 'flarum/components/DiscussionList', 'flarum/components/WelcomeHero', 'flarum/components/DiscussionComposer', 'flarum/components/LogInModal', 'flarum/components/DiscussionPage', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/LinkButton', 'flarum/components/SelectDropdown'], function (_export, _context) {
-  "use strict";
-
   var extend, Page, ItemList, listItems, icon, DiscussionList, WelcomeHero, DiscussionComposer, LogInModal, DiscussionPage, Select, Button, LinkButton, SelectDropdown, IndexPage;
   return {
     setters: [function (_flarumExtend) {
@@ -22794,8 +22828,6 @@ System.register('flarum/components/IndexPage', ['flarum/extend', 'flarum/compone
 'use strict';
 
 System.register('flarum/components/LinkButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, LinkButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22841,8 +22873,6 @@ System.register('flarum/components/LinkButton', ['flarum/components/Button'], fu
 'use strict';
 
 System.register('flarum/components/LoadingIndicator', ['flarum/Component'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator;
   return {
     setters: [function (_flarumComponent) {
@@ -22890,8 +22920,6 @@ System.register('flarum/components/LoadingIndicator', ['flarum/Component'], func
 'use strict';
 
 System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/helpers/avatar'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, LoadingPost;
   return {
     setters: [function (_flarumComponent) {
@@ -22940,8 +22968,6 @@ System.register('flarum/components/LoadingPost', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/LogInButton', ['flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Button, LogInButton;
   return {
     setters: [function (_flarumComponentsButton) {
@@ -22982,8 +23008,6 @@ System.register('flarum/components/LogInButton', ['flarum/components/Button'], f
 'use strict';
 
 System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, LogInButtons;
   return {
     setters: [function (_flarumComponent) {
@@ -23025,8 +23049,6 @@ System.register('flarum/components/LogInButtons', ['flarum/Component', 'flarum/u
 'use strict';
 
 System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'flarum/components/ForgotPasswordModal', 'flarum/components/SignUpModal', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, ForgotPasswordModal, SignUpModal, Alert, Button, LogInButtons, extractText, LogInModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -23192,8 +23214,6 @@ System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'fla
 'use strict';
 
 System.register('flarum/components/Modal', ['flarum/Component', 'flarum/components/Alert', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, Alert, Button, Modal;
   return {
     setters: [function (_flarumComponent) {
@@ -23326,8 +23346,6 @@ System.register('flarum/components/Modal', ['flarum/Component', 'flarum/componen
 'use strict';
 
 System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/components/Modal'], function (_export, _context) {
-  "use strict";
-
   var Component, Modal, ModalManager;
   return {
     setters: [function (_flarumComponent) {
@@ -23438,8 +23456,6 @@ System.register('flarum/components/ModalManager', ['flarum/Component', 'flarum/c
 'use strict';
 
 System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/components/Button', 'flarum/components/LinkButton'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, LinkButton, Navigation;
   return {
     setters: [function (_flarumComponent) {
@@ -23548,8 +23564,6 @@ System.register('flarum/components/Navigation', ['flarum/Component', 'flarum/com
 'use strict';
 
 System.register('flarum/components/Notification', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/icon', 'flarum/helpers/humanTime'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, icon, humanTime, Notification;
   return {
     setters: [function (_flarumComponent) {
@@ -23632,8 +23646,6 @@ System.register('flarum/components/Notification', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flarum/components/Checkbox', 'flarum/helpers/icon', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, Checkbox, icon, ItemList, NotificationGrid;
   return {
     setters: [function (_flarumComponent) {
@@ -23845,8 +23857,6 @@ System.register('flarum/components/NotificationGrid', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationList', ['flarum/Component', 'flarum/helpers/listItems', 'flarum/components/Button', 'flarum/components/LoadingIndicator', 'flarum/models/Discussion'], function (_export, _context) {
-  "use strict";
-
   var Component, listItems, Button, LoadingIndicator, Discussion, NotificationList;
   return {
     setters: [function (_flarumComponent) {
@@ -24031,8 +24041,6 @@ System.register('flarum/components/NotificationList', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/NotificationsDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon', 'flarum/components/NotificationList'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, icon, NotificationList, NotificationsDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -24148,8 +24156,6 @@ System.register('flarum/components/NotificationsDropdown', ['flarum/components/D
 'use strict';
 
 System.register('flarum/components/NotificationsPage', ['flarum/components/Page', 'flarum/components/NotificationList'], function (_export, _context) {
-  "use strict";
-
   var Page, NotificationList, NotificationsPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -24198,8 +24204,6 @@ System.register('flarum/components/NotificationsPage', ['flarum/components/Page'
 'use strict';
 
 System.register('flarum/components/Page', ['flarum/Component'], function (_export, _context) {
-  "use strict";
-
   var Component, Page;
   return {
     setters: [function (_flarumComponent) {
@@ -24256,8 +24260,6 @@ System.register('flarum/components/Page', ['flarum/Component'], function (_expor
 "use strict";
 
 System.register("flarum/components/Placeholder", ["flarum/Component"], function (_export, _context) {
-  "use strict";
-
   var Component, Placeholder;
   return {
     setters: [function (_flarumComponent) {
@@ -24296,8 +24298,6 @@ System.register("flarum/components/Placeholder", ["flarum/Component"], function 
 'use strict';
 
 System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/SubtreeRetainer', 'flarum/components/Dropdown', 'flarum/utils/PostControls', 'flarum/helpers/listItems', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Component, SubtreeRetainer, Dropdown, PostControls, listItems, ItemList, Post;
   return {
     setters: [function (_flarumComponent) {
@@ -24443,8 +24443,6 @@ System.register('flarum/components/Post', ['flarum/Component', 'flarum/utils/Sub
 'use strict';
 
 System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, extractText, PostEdited;
   return {
     setters: [function (_flarumComponent) {
@@ -24505,8 +24503,6 @@ System.register('flarum/components/PostEdited', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/fullTime'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, fullTime, PostMeta;
   return {
     setters: [function (_flarumComponent) {
@@ -24599,8 +24595,6 @@ System.register('flarum/components/PostMeta', ['flarum/Component', 'flarum/helpe
 'use strict';
 
 System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/highlight'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, username, highlight, PostPreview;
   return {
     setters: [function (_flarumComponent) {
@@ -24656,8 +24650,6 @@ System.register('flarum/components/PostPreview', ['flarum/Component', 'flarum/he
 'use strict';
 
 System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/utils/ScrollListener', 'flarum/components/LoadingPost', 'flarum/utils/anchorScroll', 'flarum/utils/mixin', 'flarum/utils/evented', 'flarum/components/ReplyPlaceholder', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, ScrollListener, PostLoading, anchorScroll, mixin, evented, ReplyPlaceholder, Button, PostStream;
   return {
     setters: [function (_flarumComponent) {
@@ -25181,8 +25173,6 @@ System.register('flarum/components/PostStream', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'flarum/helpers/icon', 'flarum/utils/ScrollListener', 'flarum/utils/SubtreeRetainer', 'flarum/utils/computed', 'flarum/utils/formatNumber'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, ScrollListener, SubtreeRetainer, computed, formatNumber, PostStreamScrubber;
   return {
     setters: [function (_flarumComponent) {
@@ -25648,8 +25638,6 @@ System.register('flarum/components/PostStreamScrubber', ['flarum/Component', 'fl
 'use strict';
 
 System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage', 'flarum/components/LoadingIndicator', 'flarum/components/Button', 'flarum/components/CommentPost'], function (_export, _context) {
-  "use strict";
-
   var UserPage, LoadingIndicator, Button, CommentPost, PostsUserPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -25808,8 +25796,6 @@ System.register('flarum/components/PostsUserPage', ['flarum/components/UserPage'
 'use strict';
 
 System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/components/UserCard', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/userOnline', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, UserCard, avatar, username, userOnline, listItems, PostUser;
   return {
     setters: [function (_flarumComponent) {
@@ -25948,8 +25934,6 @@ System.register('flarum/components/PostUser', ['flarum/Component', 'flarum/compo
 'use strict';
 
 System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerBody', 'flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var ComposerBody, Alert, Button, icon, extractText, ReplyComposer;
 
 
@@ -26098,8 +26082,6 @@ System.register('flarum/components/ReplyComposer', ['flarum/components/ComposerB
 'use strict';
 
 System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/utils/DiscussionControls'], function (_export, _context) {
-  "use strict";
-
   var Component, avatar, username, DiscussionControls, ReplyPlaceholder;
   return {
     setters: [function (_flarumComponent) {
@@ -26207,8 +26189,6 @@ System.register('flarum/components/ReplyPlaceholder', ['flarum/Component', 'flar
 'use strict';
 
 System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal'], function (_export, _context) {
-  "use strict";
-
   var Modal, RequestErrorModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -26270,8 +26250,6 @@ System.register('flarum/components/RequestErrorModal', ['flarum/components/Modal
 'use strict';
 
 System.register('flarum/components/Search', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/ItemList', 'flarum/utils/classList', 'flarum/utils/extractText', 'flarum/utils/KeyboardNavigatable', 'flarum/helpers/icon', 'flarum/components/DiscussionsSearchSource', 'flarum/components/UsersSearchSource'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, ItemList, classList, extractText, KeyboardNavigatable, icon, DiscussionsSearchSource, UsersSearchSource, Search;
   return {
     setters: [function (_flarumComponent) {
@@ -26569,8 +26547,6 @@ System.register('flarum/components/Search', ['flarum/Component', 'flarum/compone
 "use strict";
 
 System.register("flarum/components/SearchSource", [], function (_export, _context) {
-  "use strict";
-
   var SearchSource;
   return {
     setters: [],
@@ -26597,8 +26573,6 @@ System.register("flarum/components/SearchSource", [], function (_export, _contex
 'use strict';
 
 System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, icon, Select;
   return {
     setters: [function (_flarumComponent) {
@@ -26652,8 +26626,6 @@ System.register('flarum/components/Select', ['flarum/Component', 'flarum/helpers
 'use strict';
 
 System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, icon, SelectDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -26706,8 +26678,6 @@ System.register('flarum/components/SelectDropdown', ['flarum/components/Dropdown
 "use strict";
 
 System.register("flarum/components/Separator", ["flarum/Component"], function (_export, _context) {
-  "use strict";
-
   var Component, Separator;
   return {
     setters: [function (_flarumComponent) {
@@ -26740,8 +26710,6 @@ System.register("flarum/components/Separator", ["flarum/Component"], function (_
 'use strict';
 
 System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/components/Dropdown', 'flarum/components/LinkButton', 'flarum/components/Button', 'flarum/utils/ItemList', 'flarum/components/Separator', 'flarum/models/Group'], function (_export, _context) {
-  "use strict";
-
   var avatar, username, Dropdown, LinkButton, Button, ItemList, Separator, Group, SessionDropdown;
   return {
     setters: [function (_flarumHelpersAvatar) {
@@ -26848,8 +26816,6 @@ System.register('flarum/components/SessionDropdown', ['flarum/helpers/avatar', '
 'use strict';
 
 System.register('flarum/components/SettingsPage', ['flarum/components/UserPage', 'flarum/utils/ItemList', 'flarum/components/Switch', 'flarum/components/Button', 'flarum/components/FieldSet', 'flarum/components/NotificationGrid', 'flarum/components/ChangePasswordModal', 'flarum/components/ChangeEmailModal', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var UserPage, ItemList, Switch, Button, FieldSet, NotificationGrid, ChangePasswordModal, ChangeEmailModal, listItems, SettingsPage;
   return {
     setters: [function (_flarumComponentsUserPage) {
@@ -27002,8 +26968,6 @@ System.register('flarum/components/SettingsPage', ['flarum/components/UserPage',
 'use strict';
 
 System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'flarum/components/LogInModal', 'flarum/helpers/avatar', 'flarum/components/Button', 'flarum/components/LogInButtons', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Modal, LogInModal, avatar, Button, LogInButtons, extractText, SignUpModal;
   return {
     setters: [function (_flarumComponentsModal) {
@@ -27198,8 +27162,6 @@ System.register('flarum/components/SignUpModal', ['flarum/components/Modal', 'fl
 'use strict';
 
 System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Dropdown, Button, icon, SplitDropdown;
   return {
     setters: [function (_flarumComponentsDropdown) {
@@ -27265,8 +27227,6 @@ System.register('flarum/components/SplitDropdown', ['flarum/components/Dropdown'
 'use strict';
 
 System.register('flarum/components/Switch', ['flarum/components/Checkbox'], function (_export, _context) {
-  "use strict";
-
   var Checkbox, Switch;
   return {
     setters: [function (_flarumComponentsCheckbox) {
@@ -27304,8 +27264,6 @@ System.register('flarum/components/Switch', ['flarum/components/Checkbox'], func
 'use strict';
 
 System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/helpers/humanTime', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, icon, TerminalPost;
   return {
     setters: [function (_flarumComponent) {
@@ -27355,8 +27313,6 @@ System.register('flarum/components/TerminalPost', ['flarum/Component', 'flarum/h
 'use strict';
 
 System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/utils/ItemList', 'flarum/helpers/listItems', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, ItemList, listItems, Button, TextEditor;
   return {
     setters: [function (_flarumComponent) {
@@ -27504,8 +27460,6 @@ System.register('flarum/components/TextEditor', ['flarum/Component', 'flarum/uti
 'use strict';
 
 System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/components/LoadingIndicator', 'flarum/utils/classList', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
   var Component, LoadingIndicator, classList, extractText, UserBio;
   return {
     setters: [function (_flarumComponent) {
@@ -27638,8 +27592,6 @@ System.register('flarum/components/UserBio', ['flarum/Component', 'flarum/compon
 'use strict';
 
 System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils/humanTime', 'flarum/utils/ItemList', 'flarum/utils/UserControls', 'flarum/helpers/avatar', 'flarum/helpers/username', 'flarum/helpers/icon', 'flarum/components/Dropdown', 'flarum/components/UserBio', 'flarum/components/AvatarEditor', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Component, humanTime, ItemList, UserControls, avatar, username, icon, Dropdown, UserBio, AvatarEditor, listItems, UserCard;
   return {
     setters: [function (_flarumComponent) {
@@ -27769,8 +27721,6 @@ System.register('flarum/components/UserCard', ['flarum/Component', 'flarum/utils
 'use strict';
 
 System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum/utils/ItemList', 'flarum/utils/affixSidebar', 'flarum/components/UserCard', 'flarum/components/LoadingIndicator', 'flarum/components/SelectDropdown', 'flarum/components/LinkButton', 'flarum/components/Separator', 'flarum/helpers/listItems'], function (_export, _context) {
-  "use strict";
-
   var Page, ItemList, affixSidebar, UserCard, LoadingIndicator, SelectDropdown, LinkButton, Separator, listItems, UserPage;
   return {
     setters: [function (_flarumComponentsPage) {
@@ -27940,8 +27890,6 @@ System.register('flarum/components/UserPage', ['flarum/components/Page', 'flarum
 'use strict';
 
 System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highlight', 'flarum/helpers/avatar', 'flarum/helpers/username'], function (_export, _context) {
-  "use strict";
-
   var highlight, avatar, username, UsersSearchResults;
   return {
     setters: [function (_flarumHelpersHighlight) {
@@ -28005,8 +27953,6 @@ System.register('flarum/components/UsersSearchSource', ['flarum/helpers/highligh
 'use strict';
 
 System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/components/Button'], function (_export, _context) {
-  "use strict";
-
   var Component, Button, WelcomeHero;
   return {
     setters: [function (_flarumComponent) {
@@ -28085,8 +28031,6 @@ System.register('flarum/components/WelcomeHero', ['flarum/Component', 'flarum/co
 "use strict";
 
 System.register("flarum/extend", [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -28174,8 +28118,6 @@ System.register("flarum/extend", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flarum/components/Search', 'flarum/components/Composer', 'flarum/components/ReplyComposer', 'flarum/components/DiscussionPage', 'flarum/components/SignUpModal'], function (_export, _context) {
-  "use strict";
-
   var History, App, Search, Composer, ReplyComposer, DiscussionPage, SignUpModal, ForumApp;
   return {
     setters: [function (_flarumUtilsHistory) {
@@ -28294,8 +28236,6 @@ System.register('flarum/ForumApp', ['flarum/utils/History', 'flarum/App', 'flaru
 'use strict';
 
 System.register('flarum/helpers/avatar', [], function (_export, _context) {
-  "use strict";
-
   function avatar(user) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28342,8 +28282,6 @@ System.register('flarum/helpers/avatar', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/fullTime', [], function (_export, _context) {
-  "use strict";
-
   function fullTime(time) {
     var mo = moment(time);
 
@@ -28367,8 +28305,6 @@ System.register('flarum/helpers/fullTime', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_export, _context) {
-  "use strict";
-
   var truncate;
   function highlight(string, phrase, length) {
     if (!phrase && !length) return string;
@@ -28408,8 +28344,6 @@ System.register('flarum/helpers/highlight', ['flarum/utils/string'], function (_
 'use strict';
 
 System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
-  "use strict";
-
   var humanTimeUtil;
   function humanTime(time) {
     var mo = moment(time);
@@ -28437,8 +28371,6 @@ System.register('flarum/helpers/humanTime', ['flarum/utils/humanTime'], function
 'use strict';
 
 System.register('flarum/helpers/icon', [], function (_export, _context) {
-  "use strict";
-
   function icon(name) {
     var attrs = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -28457,8 +28389,6 @@ System.register('flarum/helpers/icon', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'flarum/utils/classList'], function (_export, _context) {
-  "use strict";
-
   var Separator, classList;
 
 
@@ -28523,8 +28453,6 @@ System.register('flarum/helpers/listItems', ['flarum/components/Separator', 'fla
 'use strict';
 
 System.register('flarum/helpers/punctuateSeries', [], function (_export, _context) {
-  "use strict";
-
   function punctuateSeries(items) {
     if (items.length === 2) {
       return app.translator.trans('core.lib.series.two_text', {
@@ -28559,8 +28487,6 @@ System.register('flarum/helpers/punctuateSeries', [], function (_export, _contex
 "use strict";
 
 System.register("flarum/helpers/username", [], function (_export, _context) {
-  "use strict";
-
   function username(user) {
     var name = user && user.username() || app.translator.trans('core.lib.username.deleted_text');
 
@@ -28581,8 +28507,6 @@ System.register("flarum/helpers/username", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (_export, _context) {
-    "use strict";
-
     var icon;
     function userOnline(user) {
         if (user.lastSeenTime() && user.isOnline()) {
@@ -28606,8 +28530,6 @@ System.register('flarum/helpers/userOnline', ['flarum/helpers/icon'], function (
 'use strict';
 
 System.register('flarum/initializers/alertEmailConfirmation', ['flarum/components/Alert', 'flarum/components/Button', 'flarum/helpers/icon'], function (_export, _context) {
-  "use strict";
-
   var Alert, Button, icon;
   function alertEmailConfirmation(app) {
     var user = app.session.user;
@@ -28688,8 +28610,6 @@ System.register('flarum/initializers/alertEmailConfirmation', ['flarum/component
 'use strict';
 
 System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'flarum/utils/Pane', 'flarum/utils/Drawer', 'flarum/utils/mapRoutes', 'flarum/helpers/icon', 'flarum/components/Navigation', 'flarum/components/HeaderPrimary', 'flarum/components/HeaderSecondary', 'flarum/components/Composer', 'flarum/components/ModalManager', 'flarum/components/AlertManager'], function (_export, _context) {
-  "use strict";
-
   var ScrollListener, Pane, Drawer, mapRoutes, icon, Navigation, HeaderPrimary, HeaderSecondary, Composer, ModalManager, AlertManager;
   function boot(app) {
     // Get the configured default route and update that route's path to be '/'.
@@ -28785,8 +28705,6 @@ System.register('flarum/initializers/boot', ['flarum/utils/ScrollListener', 'fla
 'use strict';
 
 System.register('flarum/initializers/components', ['flarum/components/CommentPost', 'flarum/components/DiscussionRenamedPost', 'flarum/components/DiscussionRenamedNotification'], function (_export, _context) {
-  "use strict";
-
   var CommentPost, DiscussionRenamedPost, DiscussionRenamedNotification;
   function components(app) {
     app.postComponents.comment = CommentPost;
@@ -28811,8 +28729,6 @@ System.register('flarum/initializers/components', ['flarum/components/CommentPos
 'use strict';
 
 System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], function (_export, _context) {
-  "use strict";
-
   var humanTimeUtil;
 
 
@@ -28845,8 +28761,6 @@ System.register('flarum/initializers/humanTime', ['flarum/utils/humanTime'], fun
 'use strict';
 
 System.register('flarum/initializers/preload', ['flarum/Session'], function (_export, _context) {
-  "use strict";
-
   var Session;
   function preload(app) {
     app.store.pushPayload({ data: app.data.resources });
@@ -28868,8 +28782,6 @@ System.register('flarum/initializers/preload', ['flarum/Session'], function (_ex
 'use strict';
 
 System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'flarum/components/DiscussionPage', 'flarum/components/PostsUserPage', 'flarum/components/DiscussionsUserPage', 'flarum/components/SettingsPage', 'flarum/components/NotificationsPage'], function (_export, _context) {
-  "use strict";
-
   var IndexPage, DiscussionPage, PostsUserPage, DiscussionsUserPage, SettingsPage, NotificationsPage;
 
   _export('default', function (app) {
@@ -28945,8 +28857,6 @@ System.register('flarum/initializers/routes', ['flarum/components/IndexPage', 'f
 'use strict';
 
 System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/Forum', 'flarum/models/User', 'flarum/models/Discussion', 'flarum/models/Post', 'flarum/models/Group', 'flarum/models/Activity', 'flarum/models/Notification'], function (_export, _context) {
-  "use strict";
-
   var Store, Forum, User, Discussion, Post, Group, Activity, Notification;
   function store(app) {
     app.store = new Store({
@@ -28986,8 +28896,6 @@ System.register('flarum/initializers/store', ['flarum/Store', 'flarum/models/For
 'use strict';
 
 System.register('flarum/Model', [], function (_export, _context) {
-  "use strict";
-
   var Model;
   return {
     setters: [],
@@ -29246,8 +29154,6 @@ System.register('flarum/Model', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/ItemList', 'flarum/components/Badge'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, ItemList, Badge, Discussion;
   return {
     setters: [function (_flarumModel) {
@@ -29360,8 +29266,6 @@ System.register('flarum/models/Discussion', ['flarum/Model', 'flarum/utils/compu
 'use strict';
 
 System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _context) {
-  "use strict";
-
   var Model, Forum;
   return {
     setters: [function (_flarumModel) {
@@ -29392,8 +29296,6 @@ System.register('flarum/models/Forum', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Group', ['flarum/Model'], function (_export, _context) {
-  "use strict";
-
   var Model, Group;
   return {
     setters: [function (_flarumModel) {
@@ -29429,8 +29331,6 @@ System.register('flarum/models/Group', ['flarum/Model'], function (_export, _con
 'use strict';
 
 System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/computed'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, Notification;
   return {
     setters: [function (_flarumModel) {
@@ -29476,8 +29376,6 @@ System.register('flarum/models/Notification', ['flarum/Model', 'flarum/utils/com
 'use strict';
 
 System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 'flarum/utils/string'], function (_export, _context) {
-  "use strict";
-
   var Model, computed, getPlainContent, Post;
   return {
     setters: [function (_flarumModel) {
@@ -29535,8 +29433,6 @@ System.register('flarum/models/Post', ['flarum/Model', 'flarum/utils/computed', 
 'use strict';
 
 System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToColor', 'flarum/utils/ItemList', 'flarum/utils/computed', 'flarum/components/GroupBadge'], function (_export, _context) {
-  "use strict";
-
   var Model, stringToColor, ItemList, computed, GroupBadge, User;
   return {
     setters: [function (_flarumModel) {
@@ -29649,8 +29545,6 @@ System.register('flarum/models/User', ['flarum/Model', 'flarum/utils/stringToCol
 'use strict';
 
 System.register('flarum/Session', [], function (_export, _context) {
-  "use strict";
-
   var Session;
   return {
     setters: [],
@@ -29714,8 +29608,6 @@ System.register('flarum/Session', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Store', [], function (_export, _context) {
-  "use strict";
-
   var Store;
   return {
     setters: [],
@@ -29853,8 +29745,6 @@ System.register('flarum/Store', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/username', 'flarum/utils/extractText', 'flarum/utils/extract'], function (_export, _context) {
-  "use strict";
-
   var User, username, extractText, extract, Translator;
   return {
     setters: [function (_flarumModelsUser) {
@@ -30162,8 +30052,6 @@ System.register('flarum/Translator', ['flarum/models/User', 'flarum/helpers/user
 'use strict';
 
 System.register('flarum/utils/abbreviateNumber', [], function (_export, _context) {
-  "use strict";
-
   function abbreviateNumber(number) {
     // TODO: translation
     if (number >= 1000000) {
@@ -30185,8 +30073,6 @@ System.register('flarum/utils/abbreviateNumber', [], function (_export, _context
 'use strict';
 
 System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
-  "use strict";
-
   function affixSidebar(element, isInitialized) {
     var _this = this;
 
@@ -30222,8 +30108,6 @@ System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
-  "use strict";
-
   function anchorScroll(element, callback) {
     var $window = $(window);
     var relativeScroll = $(element).offset().top - $window.scrollTop();
@@ -30243,8 +30127,6 @@ System.register("flarum/utils/anchorScroll", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/classList', [], function (_export, _context) {
-  "use strict";
-
   function classList(classes) {
     var classNames = void 0;
 
@@ -30273,8 +30155,6 @@ System.register('flarum/utils/classList', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/computed', [], function (_export, _context) {
-  "use strict";
-
   function computed() {
     for (var _len = arguments.length, dependentKeys = Array(_len), _key = 0; _key < _len; _key++) {
       dependentKeys[_key] = arguments[_key];
@@ -30321,10 +30201,8 @@ System.register('flarum/utils/computed', [], function (_export, _context) {
 });;
 'use strict';
 
-System.register('flarum/utils/DiscussionControls', ['flarum/components/DiscussionPage', 'flarum/components/ReplyComposer', 'flarum/components/LogInModal', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList', 'flarum/utils/extractText'], function (_export, _context) {
-  "use strict";
-
-  var DiscussionPage, ReplyComposer, LogInModal, Button, Separator, ItemList, extractText;
+System.register('flarum/utils/DiscussionControls', ['flarum/components/DiscussionPage', 'flarum/components/ReplyComposer', 'flarum/components/LogInModal', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList', 'flarum/utils/extractText', 'flarum/components/DiscussionRenameModal'], function (_export, _context) {
+  var DiscussionPage, ReplyComposer, LogInModal, Button, Separator, ItemList, extractText, DiscussionRenameModal;
   return {
     setters: [function (_flarumComponentsDiscussionPage) {
       DiscussionPage = _flarumComponentsDiscussionPage.default;
@@ -30340,6 +30218,8 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
       ItemList = _flarumUtilsItemList.default;
     }, function (_flarumUtilsExtractText) {
       extractText = _flarumUtilsExtractText.default;
+    }, function (_flarumComponentsDiscussionRenameModal) {
+      DiscussionRenameModal = _flarumComponentsDiscussionRenameModal.default;
     }],
     execute: function () {
       _export('default', {
@@ -30484,22 +30364,11 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
           }
         },
         renameAction: function renameAction() {
-          var _this3 = this;
-
-          var currentTitle = this.title();
-          var title = prompt(extractText(app.translator.trans('core.forum.discussion_controls.rename_text')), currentTitle);
-
-          // If the title is different to what it was before, then save it. After the
-          // save has completed, update the post stream as there will be a new post
-          // indicating that the discussion was renamed.
-          if (title && title !== currentTitle) {
-            return this.save({ title: title }).then(function () {
-              if (app.viewingDiscussion(_this3)) {
-                app.current.stream.update();
-              }
-              m.redraw();
-            });
-          }
+          var discussion = this;
+          return app.modal.show(new DiscussionRenameModal({
+            currentTitle: discussion.title(),
+            discussion: discussion
+          }));
         }
       });
     }
@@ -30508,8 +30377,6 @@ System.register('flarum/utils/DiscussionControls', ['flarum/components/Discussio
 'use strict';
 
 System.register('flarum/utils/Drawer', [], function (_export, _context) {
-  "use strict";
-
   var Drawer;
   return {
     setters: [],
@@ -30576,8 +30443,6 @@ System.register('flarum/utils/Drawer', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/evented", [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -30635,8 +30500,6 @@ System.register("flarum/utils/evented", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/extract", [], function (_export, _context) {
-  "use strict";
-
   function extract(object, property) {
     var value = object[property];
 
@@ -30655,8 +30518,6 @@ System.register("flarum/utils/extract", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/extractText', [], function (_export, _context) {
-  "use strict";
-
   function extractText(vdom) {
     if (vdom instanceof Array) {
       return vdom.map(function (element) {
@@ -30679,8 +30540,6 @@ System.register('flarum/utils/extractText', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/formatNumber', [], function (_export, _context) {
-  "use strict";
-
   function formatNumber(number) {
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
@@ -30695,8 +30554,6 @@ System.register('flarum/utils/formatNumber', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/History', [], function (_export, _context) {
-  "use strict";
-
   var History;
   return {
     setters: [],
@@ -30793,8 +30650,6 @@ System.register('flarum/utils/History', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/humanTime', [], function (_export, _context) {
-  "use strict";
-
   function humanTime(time) {
     var m = moment(time);
     var now = moment();
@@ -30842,8 +30697,6 @@ System.register('flarum/utils/humanTime', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ItemList", [], function (_export, _context) {
-  "use strict";
-
   var Item, ItemList;
   return {
     setters: [],
@@ -30960,8 +30813,6 @@ System.register("flarum/utils/ItemList", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _context) {
-  "use strict";
-
   var KeyboardNavigatable;
   return {
     setters: [],
@@ -31077,8 +30928,6 @@ System.register('flarum/utils/KeyboardNavigatable', [], function (_export, _cont
 'use strict';
 
 System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
-  "use strict";
-
   function mapRoutes(routes) {
     var basePath = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
 
@@ -31105,8 +30954,6 @@ System.register('flarum/utils/mapRoutes', [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/mixin", [], function (_export, _context) {
-  "use strict";
-
   function mixin(Parent) {
     var Mixed = function (_Parent) {
       babelHelpers.inherits(Mixed, _Parent);
@@ -31140,8 +30987,6 @@ System.register("flarum/utils/mixin", [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/Pane', [], function (_export, _context) {
-  "use strict";
-
   var Pane;
   return {
     setters: [],
@@ -31257,8 +31102,6 @@ System.register('flarum/utils/Pane', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/patchMithril', ['../Component'], function (_export, _context) {
-  "use strict";
-
   var Component;
   function patchMithril(global) {
     var mo = global.m;
@@ -31317,8 +31160,6 @@ System.register('flarum/utils/patchMithril', ['../Component'], function (_export
 'use strict';
 
 System.register('flarum/utils/PostControls', ['flarum/components/EditPostComposer', 'flarum/components/Button', 'flarum/components/Separator', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var EditPostComposer, Button, Separator, ItemList;
   return {
     setters: [function (_flarumComponentsEditPostComposer) {
@@ -31449,8 +31290,6 @@ System.register('flarum/utils/PostControls', ['flarum/components/EditPostCompose
 "use strict";
 
 System.register("flarum/utils/RequestError", [], function (_export, _context) {
-  "use strict";
-
   var RequestError;
   return {
     setters: [],
@@ -31479,8 +31318,6 @@ System.register("flarum/utils/RequestError", [], function (_export, _context) {
 "use strict";
 
 System.register("flarum/utils/ScrollListener", [], function (_export, _context) {
-  "use strict";
-
   var scroll, ScrollListener;
   return {
     setters: [],
@@ -31554,8 +31391,6 @@ System.register("flarum/utils/ScrollListener", [], function (_export, _context) 
 'use strict';
 
 System.register('flarum/utils/slidable', [], function (_export, _context) {
-  "use strict";
-
   function slidable(element) {
     var $element = $(element);
     var threshold = 50;
@@ -31714,8 +31549,6 @@ System.register('flarum/utils/slidable', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/string', [], function (_export, _context) {
-  "use strict";
-
   return {
     setters: [],
     execute: function () {
@@ -31794,8 +31627,6 @@ System.register('flarum/utils/string', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/stringToColor', [], function (_export, _context) {
-  "use strict";
-
   function hsvToRgb(h, s, v) {
     var r = void 0;
     var g = void 0;
@@ -31862,8 +31693,6 @@ System.register('flarum/utils/stringToColor', [], function (_export, _context) {
 'use strict';
 
 System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context) {
-  "use strict";
-
   var SubtreeRetainer;
   return {
     setters: [],
@@ -31936,8 +31765,6 @@ System.register('flarum/utils/SubtreeRetainer', [], function (_export, _context)
 'use strict';
 
 System.register('flarum/utils/UserControls', ['flarum/components/Button', 'flarum/components/Separator', 'flarum/components/EditUserModal', 'flarum/components/UserPage', 'flarum/utils/ItemList'], function (_export, _context) {
-  "use strict";
-
   var Button, Separator, EditUserModal, UserPage, ItemList;
   return {
     setters: [function (_flarumComponentsButton) {

--- a/js/forum/src/components/DiscussionRenameModal.js
+++ b/js/forum/src/components/DiscussionRenameModal.js
@@ -1,0 +1,70 @@
+import Modal from 'flarum/components/Modal';
+import Button from 'flarum/components/Button';
+
+/**
+ * The 'DiscussionRenameModal' displays a modal dialog with an input to rename a discussion
+ */
+export default class DiscussionRenameModal extends Modal {
+  init() {
+    super.init();
+
+    this.discussion = this.props.discussion;
+    this.currentTitle = this.props.currentTitle;
+    this.newTitle = m.prop(this.currentTitle);
+
+  }
+
+  className() {
+    return 'DiscussionRenameModal Modal--small';
+  }
+
+  title() {
+    return app.translator.trans('core.forum.discussion_controls.rename_modal.title');
+  }
+
+  content() {
+
+    return (
+      <div className="Modal-body">
+        <div className="Form">
+          <div className="Form-group">
+            <input className="FormControl title" placeholder={this.currentTitle} bidi={this.newTitle} />
+          </div>
+          <div className="Form-group">
+            {Button.component({
+              className: 'Button Button--primary',
+              type: 'submit',
+              loading: this.loading,
+              children: app.translator.trans('core.forum.discussion_controls.rename_modal.submit_button')
+            })}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  onsubmit(e) {
+    e.preventDefault();
+
+    this.loading = true;
+
+    // const title = $('.DiscussionRenameModal input.title').val();
+    const title = this.newTitle;
+    const currentTitle = this.currentTitle;
+
+    // If the title is different to what it was before, then save it. After the
+    // save has completed, update the post stream as there will be a new post
+    // indicating that the discussion was renamed.
+    if (title && title !== currentTitle) {
+      return this.discussion.save({title}).then(() => {
+        if (app.viewingDiscussion(this.discussion)) {
+          app.current.stream.update();
+        }
+        m.redraw();
+        this.hide();
+      });
+    } else {
+      this.hide();
+    }
+  }
+}

--- a/js/forum/src/utils/DiscussionControls.js
+++ b/js/forum/src/utils/DiscussionControls.js
@@ -5,6 +5,7 @@ import Button from 'flarum/components/Button';
 import Separator from 'flarum/components/Separator';
 import ItemList from 'flarum/utils/ItemList';
 import extractText from 'flarum/utils/extractText';
+import DiscussionRenameModal from 'flarum/components/DiscussionRenameModal';
 
 /**
  * The `DiscussionControls` utility constructs a list of buttons for a
@@ -227,19 +228,10 @@ export default {
    * @return {Promise}
    */
   renameAction() {
-    const currentTitle = this.title();
-    const title = prompt(extractText(app.translator.trans('core.forum.discussion_controls.rename_text')), currentTitle);
-
-    // If the title is different to what it was before, then save it. After the
-    // save has completed, update the post stream as there will be a new post
-    // indicating that the discussion was renamed.
-    if (title && title !== currentTitle) {
-      return this.save({title}).then(() => {
-        if (app.viewingDiscussion(this)) {
-          app.current.stream.update();
-        }
-        m.redraw();
-      });
-    }
+    const discussion = this;
+    return app.modal.show(new DiscussionRenameModal({
+      currentTitle: discussion.title(),
+      discussion: discussion
+    }));
   }
 };


### PR DESCRIPTION
Changed "Rename Discussion" dialog into a modal. This PR is for #616. No language files yet, just want to get your feedback.
- Added `DiscussionRenameModal` component (Modal)
- Changed `DiscussionControls.renameAction` to use the modal (I may have removed the ability to return a promise)

``` js
/**
 * Rename the discussion.
 *
 * @return {Promise}
 */
renameAction() {
  const discussion = this;
  return app.modal.show(new DiscussionRenameModal({
    currentTitle: discussion.title(),
    discussion: discussion
  }));
}
```

I still have the `return` in the `onsubmit` modal event, but I don't think there's any way to make `renameAction` return a Promise.

I chose `core.forum.discussion_controls.rename_modal.title` and `core.forum.discussion_controls.rename_modal.submit_button` because Dominion said to keep things organized, but we can probably still use `core.forum.discussion_controls.rename_text` and `core.ref.save_changes`.

---

<img width="1439" alt="captura de pantalla 2016-07-26 a las 5 44 26 pm" src="https://cloud.githubusercontent.com/assets/6401250/17156586/940e356c-5358-11e6-824c-bd62880ab75a.png">
