### PR TITLE
Fixed fontawesome relative path

### DIFF
--- a/less/lib/lib.less
+++ b/less/lib/lib.less
@@ -1,5 +1,5 @@
 @import "font-awesome.less";
-@fa-font-path: "../assets/fonts";
+@fa-font-path: "./fonts";
 
 @import "normalize.less";
 @import "print.less";

--- a/less/lib/lib.less
+++ b/less/lib/lib.less
@@ -1,5 +1,5 @@
 @import "font-awesome.less";
-@fa-font-path: "../../assets/fonts";
+@fa-font-path: "../assets/fonts";
 
 @import "normalize.less";
 @import "print.less";


### PR DESCRIPTION
If install flarum in the site's root directory, it seems nothing
is wrong because the server software will trim the path, but if
install flarum in a sub directory, the font file of fontawesome
will not load correctly.