### PR TITLE
Updated s9e\TextFormatter to 0.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/http-foundation": "^2.7",
         "symfony/translation": "^2.7",
         "symfony/yaml": "^2.7",
-        "s9e/text-formatter": "^0.5.1",
+        "s9e/text-formatter": "^0.6.1",
         "tobscure/json-api": "^0.3.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-stratigility": "^1.1"


### PR DESCRIPTION
You can check out the release notes for [v0.6.0](https://github.com/s9e/TextFormatter/releases/tag/0.6.0) and [v0.6.1](https://github.com/s9e/TextFormatter/releases/tag/0.6.1).

Relevant to Flarum:

 * Google's Closure Compiler service has been updated and older versions of the library may not work with their current service. The service I host is unaffected.
 * There's been some internal changes to how the JavaScript is generated. All tests pass but new bugs are always a possibility so don't update flarum.org before leaving for a camping trip. :)
 * The Litedown syntax has evolved slightly:
    * Added support for link titles in parentheses: `[x](/y (z))` [(try it)](http://johnmacfarlane.net/babelmark2/?normalize=1&text=%5Bx%5D%28%2Fy+%28z%29%29)
    * Added experimental support for two blank lines as a delimiter for quotes and lists. [(try quotes)](http://johnmacfarlane.net/babelmark2/?normalize=1&text=%3E+foo%0A%0A%0A%3E+bar) [(try lists)](http://johnmacfarlane.net/babelmark2/?normalize=1&text=*+foo%0A%0A%0A*+bar)
    * Improved handling of BBCodes/Litedown interaction mentioned [in the forums](https://discuss.flarum.org/d/271-text-formatting-in-flarum/69).