### PR TITLE
Updated s9e\TextFormatter to 0.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/http-foundation": "^2.7",
         "symfony/translation": "^2.7",
         "symfony/yaml": "^2.7",
-        "s9e/text-formatter": "^0.6.1",
+        "s9e/text-formatter": "^0.8.1",
         "tobscure/json-api": "^0.3.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-stratigility": "^1.1"


### PR DESCRIPTION
Changelog's there: https://github.com/s9e/TextFormatter/blob/master/CHANGELOG.md
Some small API changes, shouldn't affect Flarum's core but may affect some extensions: http://s9etextformatter.readthedocs.io/Internals/API_changes/#080

This release supports the latest released version of Unicode emoji (3.0) and contains a fix for [a JavaScript error](https://github.com/s9e/TextFormatter/issues/40) that can happen with internationalized domain names in preview if punycode.js 1.x isn't available. On that note, you may want to bundle [punycode 1.4.1](https://cdnjs.com/libraries/punycode/1.4.1) with Flarum because the library needs it to validate IDNs in the JavaScript preview.
