### PR TITLE
Added search input types to 3 inputs total, closes #726

### DIFF
--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -17834,8 +17834,8 @@ System.register('flarum/components/AppearancePage', ['flarum/components/Page', '
                     m(
                       'div',
                       { className: 'AppearancePage-colors-input' },
-                      m('input', { className: 'FormControl', placeholder: '#aaaaaa', value: this.primaryColor(), onchange: m.withAttr('value', this.primaryColor) }),
-                      m('input', { className: 'FormControl', placeholder: '#aaaaaa', value: this.secondaryColor(), onchange: m.withAttr('value', this.secondaryColor) })
+                      m('input', { className: 'FormControl', type: 'color', placeholder: '#aaaaaa', value: this.primaryColor(), onchange: m.withAttr('value', this.primaryColor) }),
+                      m('input', { className: 'FormControl', type: 'color', placeholder: '#aaaaaa', value: this.secondaryColor(), onchange: m.withAttr('value', this.secondaryColor) })
                     ),
                     Switch.component({
                       state: this.darkMode(),

--- a/js/admin/src/components/AppearancePage.js
+++ b/js/admin/src/components/AppearancePage.js
@@ -28,8 +28,8 @@ export default class AppearancePage extends Page {
               </div>
 
               <div className="AppearancePage-colors-input">
-                <input className="FormControl" placeholder="#aaaaaa" value={this.primaryColor()} onchange={m.withAttr('value', this.primaryColor)}/>
-                <input className="FormControl" placeholder="#aaaaaa" value={this.secondaryColor()} onchange={m.withAttr('value', this.secondaryColor)}/>
+                <input className="FormControl" type="color" placeholder="#aaaaaa" value={this.primaryColor()} onchange={m.withAttr('value', this.primaryColor)}/>
+                <input className="FormControl" type="color" placeholder="#aaaaaa" value={this.secondaryColor()} onchange={m.withAttr('value', this.secondaryColor)}/>
               </div>
 
               {Switch.component({

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -26653,6 +26653,7 @@ System.register('flarum/components/Search', ['flarum/Component', 'flarum/compone
                 'div',
                 { className: 'Search-input' },
                 m('input', { className: 'FormControl',
+                  type: 'search',
                   placeholder: extractText(app.translator.trans('core.forum.header.search_placeholder')),
                   value: this.value(),
                   oninput: m.withAttr('value', this.value),

--- a/js/forum/src/components/Search.js
+++ b/js/forum/src/components/Search.js
@@ -83,6 +83,7 @@ export default class Search extends Component {
       })}>
         <div className="Search-input">
           <input className="FormControl"
+            type="search"
             placeholder={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
             value={this.value()}
             oninput={m.withAttr('value', this.value)}

--- a/less/lib/Search.less
+++ b/less/lib/Search.less
@@ -60,6 +60,7 @@
     padding-left: 32px;
     padding-right: 32px;
     .transition(all 0.4s);
+    box-sizing: inherit !important;
   }
   .Button {
     float: left;


### PR DESCRIPTION
Added input type to 3 inputs total, plus some css because bootstrap breaks Flarum. This fixes #726.

Changes:
* Added type search to search bar (forum)
* Added CSS `box-sizing: inherit` to search <input> because bootstrap styles mess up the search box
* Added type color to both color settings in appearance (admin)

If you find more inputs that are **not** type text (even if they don't have attribute) please comment.

---

_Original #1008 on July 24, 2016._