### PR TITLE
Set discussion page meta description same as first post

### DIFF
--- a/src/Forum/Controller/DiscussionController.php
+++ b/src/Forum/Controller/DiscussionController.php
@@ -85,6 +85,12 @@ class DiscussionController extends WebAppController
             }
         }
 
+        if ($posts) {
+            $description = substr(strip_tags($posts[0]->attributes->contentHtml), 0, 250).'...';
+
+            $view->setDescription($description);
+        }
+
         $view->setTitle($document->data->attributes->title);
         $view->setDocument($document);
         $view->setContent(app('view')->make('flarum.forum::discussion', compact('document', 'page', 'getResource', 'posts', 'url')));

--- a/src/Http/WebApp/WebAppView.php
+++ b/src/Http/WebApp/WebAppView.php
@@ -189,6 +189,16 @@ class WebAppView
     }
 
     /**
+     * The description of the document, to be displayed in the <meta name="description"> tag.
+     *
+     * @param null|string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
      * Set the SEO content of the page, to be displayed in <noscript> tags.
      *
      * @param null|string $content


### PR DESCRIPTION
As description is not set in discussion page, in our project, we decide to put first post as page description for better SEO. What do you think about it ?