### PR TITLE
Make Add Extension modal's title translatable (#1094 for next-front)

### DIFF
--- a/js/admin/src/components/AddExtensionModal.js
+++ b/js/admin/src/components/AddExtensionModal.js
@@ -15,7 +15,7 @@ export default class AddExtensionModal extends Modal {
   }
 
   title() {
-    return 'Add Extension';
+    return app.translator.trans('core.admin.add_extension.title');
   }
 
   content() {


### PR DESCRIPTION
This is just the `next-front` branch version of the #1094 PR.