### PR TITLE
Update to Zend Stratigility 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "s9e/text-formatter": "^0.8.1",
         "tobscure/json-api": "^0.3.0",
         "zendframework/zend-diactoros": "^1.1",
-        "zendframework/zend-stratigility": "1.2.*"
+        "zendframework/zend-stratigility": "^1.3"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "docs": "http://flarum.org/docs"
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6.0",
         "dflydev/fig-cookies": "^1.0.2",
         "doctrine/dbal": "^2.5",
         "components/font-awesome": "^4.6",

--- a/src/Api/Middleware/HandleErrors.php
+++ b/src/Api/Middleware/HandleErrors.php
@@ -11,12 +11,12 @@
 
 namespace Flarum\Api\Middleware;
 
+use Exception;
 use Flarum\Api\ErrorHandler;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Zend\Stratigility\ErrorMiddlewareInterface;
 
-class HandleErrors implements ErrorMiddlewareInterface
+class HandleErrors
 {
     /**
      * @var ErrorHandler
@@ -32,10 +32,19 @@ class HandleErrors implements ErrorMiddlewareInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Catch all errors that happen during further middleware execution.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param callable $out
+     * @return Response
      */
-    public function __invoke($e, Request $request, Response $response, callable $out = null)
+    public function __invoke(Request $request, Response $response, callable $out = null)
     {
-        return $this->errorHandler->handle($e);
+        try {
+            return $out($request, $response);
+        } catch (Exception $e) {
+            return $this->errorHandler->handle($e);
+        }
     }
 }

--- a/src/Api/Server.php
+++ b/src/Api/Server.php
@@ -25,10 +25,13 @@ class Server extends AbstractServer
     protected function getMiddleware(Application $app)
     {
         $pipe = new MiddlewarePipe;
+        $pipe->raiseThrowables();
 
         $path = parse_url($app->url('api'), PHP_URL_PATH);
 
         if ($app->isInstalled() && $app->isUpToDate()) {
+            $pipe->pipe($path, $app->make('Flarum\Api\Middleware\HandleErrors'));
+
             $pipe->pipe($path, $app->make('Flarum\Http\Middleware\ParseJsonBody'));
             $pipe->pipe($path, $app->make('Flarum\Api\Middleware\FakeHttpMethods'));
             $pipe->pipe($path, $app->make('Flarum\Http\Middleware\StartSession'));
@@ -40,7 +43,6 @@ class Server extends AbstractServer
             event(new ConfigureMiddleware($pipe, $path, $this));
 
             $pipe->pipe($path, $app->make('Flarum\Http\Middleware\DispatchRoute', ['routes' => $app->make('flarum.api.routes')]));
-            $pipe->pipe($path, $app->make('Flarum\Api\Middleware\HandleErrors'));
         } else {
             $pipe->pipe($path, function () {
                 $document = new Document;

--- a/src/Http/FullStackServer.php
+++ b/src/Http/FullStackServer.php
@@ -26,6 +26,7 @@ class FullStackServer extends AbstractServer
     protected function getMiddleware(Application $app)
     {
         $pipe = new MiddlewarePipe;
+        $pipe->raiseThrowables();
 
         $pipe->pipe(new ApiServer);
         $pipe->pipe(new AdminServer);

--- a/src/Http/Middleware/HandleErrors.php
+++ b/src/Http/Middleware/HandleErrors.php
@@ -11,14 +11,14 @@
 
 namespace Flarum\Http\Middleware;
 
+use Exception;
 use Franzl\Middleware\Whoops\ErrorMiddleware as WhoopsMiddleware;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
 use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Stratigility\ErrorMiddlewareInterface;
 
-class HandleErrors implements ErrorMiddlewareInterface
+class HandleErrors
 {
     /**
      * @var string
@@ -48,9 +48,23 @@ class HandleErrors implements ErrorMiddlewareInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Catch all errors that happen during further middleware execution.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param callable $out
+     * @return Response
      */
-    public function __invoke($error, Request $request, Response $response, callable $out = null)
+    public function __invoke(Request $request, Response $response, callable $out = null)
+    {
+        try {
+            return $out($request, $response);
+        } catch (Exception $e) {
+            return $this->formatException($e);
+        }
+    }
+
+    protected function formatException(Exception $error)
     {
         $status = 500;
         $errorCode = $error->getCode();


### PR DESCRIPTION
* Fix dependency version constraint. (Reverts #1066.)
* Allow exceptions to be raised when dispatching middleware.
* Fix our error handler middleware (do not implement Stratigility's
  error handler interface, catch exceptions instead).

See https://docs.zendframework.com/zend-stratigility/migration/to-v2/.

Closes #1069.