### PR TITLE
Add option to hide the language selector

### DIFF
--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -18109,7 +18109,7 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
                   Switch.component({
                     state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
                     onchange: this.values.show_language_selector,
-                    children: app.translator.trans('core.admin.basics.show_language_selector_heading')
+                    children: app.translator.trans('core.admin.basics.show_language_selector_label')
                   }),
                   m('br', null),
                   FieldSet.component({

--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -18057,7 +18057,7 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
 
             this.loading = false;
 
-            this.fields = ['forum_title', 'forum_description', 'default_locale', 'hide_language_selector', 'default_route', 'welcome_title', 'welcome_message'];
+            this.fields = ['forum_title', 'forum_description', 'default_locale', 'show_language_selector', 'default_route', 'welcome_title', 'welcome_message'];
             this.values = {};
 
             var settings = app.data.settings;
@@ -18070,6 +18070,8 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
             for (var i in locales) {
               this.localeOptions[i] = locales[i] + ' (' + i + ')';
             }
+
+            if (typeof this.values.show_language_selector() != "number") this.values.show_language_selector(1);
           }
         }, {
           key: 'view',
@@ -18105,9 +18107,9 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
                     })]
                   }) : '',
                   Switch.component({
-                    state: this.values.hide_language_selector(),
-                    onchange: this.values.hide_language_selector,
-                    children: app.translator.trans('core.admin.basics.hide_language_selector_heading')
+                    state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
+                    onchange: this.values.show_language_selector,
+                    children: app.translator.trans('core.admin.basics.show_language_selector_heading')
                   }),
                   m('br', null),
                   FieldSet.component({

--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -17437,7 +17437,7 @@ System.register('flarum/components/AddExtensionModal', ['flarum/components/Modal
         }, {
           key: 'title',
           value: function title() {
-            return 'Add Extension';
+            return app.translator.trans('core.admin.add_extension.title');
           }
         }, {
           key: 'content',
@@ -18017,10 +18017,10 @@ System.register('flarum/components/Badge', ['flarum/Component', 'flarum/helpers/
 });;
 'use strict';
 
-System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flarum/components/FieldSet', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/Alert', 'flarum/utils/saveSettings', 'flarum/utils/ItemList'], function (_export, _context) {
+System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flarum/components/FieldSet', 'flarum/components/Select', 'flarum/components/Button', 'flarum/components/Alert', 'flarum/utils/saveSettings', 'flarum/utils/ItemList', 'flarum/components/Switch'], function (_export, _context) {
   "use strict";
 
-  var Page, FieldSet, Select, Button, Alert, saveSettings, ItemList, BasicsPage;
+  var Page, FieldSet, Select, Button, Alert, saveSettings, ItemList, Switch, BasicsPage;
   return {
     setters: [function (_flarumComponentsPage) {
       Page = _flarumComponentsPage.default;
@@ -18036,6 +18036,8 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
       saveSettings = _flarumUtilsSaveSettings.default;
     }, function (_flarumUtilsItemList) {
       ItemList = _flarumUtilsItemList.default;
+    }, function (_flarumComponentsSwitch) {
+      Switch = _flarumComponentsSwitch.default;
     }],
     execute: function () {
       BasicsPage = function (_Page) {
@@ -18055,12 +18057,12 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
 
             this.loading = false;
 
-            this.fields = ['forum_title', 'forum_description', 'default_locale', 'default_route', 'welcome_title', 'welcome_message'];
+            this.fields = ['forum_title', 'forum_description', 'default_locale', 'hide_language_selector', 'default_route', 'welcome_title', 'welcome_message'];
             this.values = {};
 
             var settings = app.data.settings;
             this.fields.forEach(function (key) {
-              return _this2.values[key] = m.prop(settings[key]);
+              return _this2.values[key] = m.prop(settings[key] || false);
             });
 
             this.localeOptions = {};
@@ -18102,6 +18104,12 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
                       onchange: this.values.default_locale
                     })]
                   }) : '',
+                  Switch.component({
+                    state: this.values.hide_language_selector(),
+                    onchange: this.values.hide_language_selector,
+                    children: app.translator.trans('core.admin.basics.hide_language_selector_heading')
+                  }),
+                  m('br', null),
                   FieldSet.component({
                     label: app.translator.trans('core.admin.basics.home_page_heading'),
                     className: 'BasicsPage-homePage',

--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -18072,8 +18072,6 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
             }
 
             if (typeof this.values.show_language_selector() !== "number") this.values.show_language_selector(1);
-
-            console.log(this.values.show_language_selector());
           }
         }, {
           key: 'view',

--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -18071,7 +18071,9 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
               this.localeOptions[i] = locales[i] + ' (' + i + ')';
             }
 
-            if (typeof this.values.show_language_selector() != "number") this.values.show_language_selector(1);
+            if (typeof this.values.show_language_selector() !== "number") this.values.show_language_selector(1);
+
+            console.log(this.values.show_language_selector());
           }
         }, {
           key: 'view',
@@ -18107,7 +18109,7 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
                     })]
                   }) : '',
                   Switch.component({
-                    state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
+                    state: this.values.show_language_selector(),
                     onchange: this.values.show_language_selector,
                     children: app.translator.trans('core.admin.basics.show_language_selector_label')
                   }),

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -73,7 +73,7 @@ export default class BasicsPage extends Page {
              {Switch.component({
                  state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
                  onchange: this.values.show_language_selector,
-                 children: app.translator.trans('core.admin.basics.show_language_selector_heading'),
+                 children: app.translator.trans('core.admin.basics.show_language_selector_label'),
              })}
 
             <br/>

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -5,6 +5,7 @@ import Button from 'flarum/components/Button';
 import Alert from 'flarum/components/Alert';
 import saveSettings from 'flarum/utils/saveSettings';
 import ItemList from 'flarum/utils/ItemList';
+import Switch from 'flarum/components/Switch';
 
 export default class BasicsPage extends Page {
   init() {
@@ -16,6 +17,7 @@ export default class BasicsPage extends Page {
       'forum_title',
       'forum_description',
       'default_locale',
+      'hide_language_selector',
       'default_route',
       'welcome_title',
       'welcome_message'
@@ -23,7 +25,7 @@ export default class BasicsPage extends Page {
     this.values = {};
 
     const settings = app.data.settings;
-    this.fields.forEach(key => this.values[key] = m.prop(settings[key]));
+    this.fields.forEach(key => this.values[key] = m.prop(settings[key] || false));
 
     this.localeOptions = {};
     const locales = app.data.locales;
@@ -65,6 +67,14 @@ export default class BasicsPage extends Page {
                 ]
               })
               : ''}
+
+             {Switch.component({
+                 state: this.values.hide_language_selector(),
+                 onchange: this.values.hide_language_selector,
+                 children: app.translator.trans('core.admin.basics.hide_language_selector_heading'),
+             })}
+
+            <br/>
 
             {FieldSet.component({
               label: app.translator.trans('core.admin.basics.home_page_heading'),

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -33,7 +33,9 @@ export default class BasicsPage extends Page {
       this.localeOptions[i] = `${locales[i]} (${i})`;
     }
 
-    if (typeof this.values.show_language_selector() != "number") this.values.show_language_selector(1);
+    if (typeof this.values.show_language_selector() !== "number") this.values.show_language_selector(1);
+
+    console.log(this.values.show_language_selector());
   }
 
   view() {
@@ -71,7 +73,7 @@ export default class BasicsPage extends Page {
               : ''}
 
              {Switch.component({
-                 state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
+                 state: this.values.show_language_selector(),
                  onchange: this.values.show_language_selector,
                  children: app.translator.trans('core.admin.basics.show_language_selector_label'),
              })}

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -34,8 +34,6 @@ export default class BasicsPage extends Page {
     }
 
     if (typeof this.values.show_language_selector() !== "number") this.values.show_language_selector(1);
-
-    console.log(this.values.show_language_selector());
   }
 
   view() {

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -17,7 +17,7 @@ export default class BasicsPage extends Page {
       'forum_title',
       'forum_description',
       'default_locale',
-      'hide_language_selector',
+      'show_language_selector',
       'default_route',
       'welcome_title',
       'welcome_message'
@@ -32,6 +32,8 @@ export default class BasicsPage extends Page {
     for (const i in locales) {
       this.localeOptions[i] = `${locales[i]} (${i})`;
     }
+
+    if (typeof this.values.show_language_selector() != "number") this.values.show_language_selector(1);
   }
 
   view() {
@@ -69,9 +71,9 @@ export default class BasicsPage extends Page {
               : ''}
 
              {Switch.component({
-                 state: this.values.hide_language_selector(),
-                 onchange: this.values.hide_language_selector,
-                 children: app.translator.trans('core.admin.basics.hide_language_selector_heading'),
+                 state: this.values.show_language_selector() == undefined ? this.values.show_language_selector() : 1,
+                 onchange: this.values.show_language_selector,
+                 children: app.translator.trans('core.admin.basics.show_language_selector_heading'),
              })}
 
             <br/>

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -23185,7 +23185,7 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 
             items.add('search', app.search.render(), 30);
 
-            if (app.forum.attribute("showLanguageSelector") != 0 && Object.keys(app.data.locales).length > 1) {
+            if (app.forum.attribute("showLanguageSelector") && Object.keys(app.data.locales).length > 1) {
               var locales = [];
 
               var _loop = function _loop(locale) {

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -23185,7 +23185,7 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 
             items.add('search', app.search.render(), 30);
 
-            if (app.forum.attribute("hideLanguageSelector") != 1 && Object.keys(app.data.locales).length > 1) {
+            if (app.forum.attribute("showLanguageSelector") != 0 && Object.keys(app.data.locales).length > 1) {
               var locales = [];
 
               var _loop = function _loop(locale) {

--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -22984,12 +22984,6 @@ System.register('flarum/components/ForgotPasswordModal', ['flarum/components/Mod
                     disabled: this.loading })
                 ),
                 m(
-                  'label',
-                  { className: 'checkbox' },
-                  m('input', { name: 'remember', type: 'checkbox', bidi: this.remember, disabled: this.loading }),
-                  app.translator.trans('core.forum.log_in.remember_me_text')
-                ),
-                m(
                   'div',
                   { className: 'Form-group' },
                   Button.component({
@@ -23191,7 +23185,7 @@ System.register('flarum/components/HeaderSecondary', ['flarum/Component', 'flaru
 
             items.add('search', app.search.render(), 30);
 
-            if (Object.keys(app.data.locales).length > 1) {
+            if (app.forum.attribute("hideLanguageSelector") != 1 && Object.keys(app.data.locales).length > 1) {
               var locales = [];
 
               var _loop = function _loop(locale) {
@@ -23935,6 +23929,12 @@ System.register('flarum/components/LogInModal', ['flarum/components/Modal', 'fla
                   m('input', { className: 'FormControl', name: 'password', type: 'password', placeholder: extractText(app.translator.trans('core.forum.log_in.password_placeholder')),
                     bidi: this.password,
                     disabled: this.loading })
+                ),
+                m(
+                  'label',
+                  { className: 'checkbox' },
+                  m('input', { name: 'remember', type: 'checkbox', bidi: this.remember, disabled: this.loading }),
+                  app.translator.trans('core.forum.log_in.remember_me_label')
                 ),
                 m(
                   'div',

--- a/js/forum/src/components/HeaderSecondary.js
+++ b/js/forum/src/components/HeaderSecondary.js
@@ -39,7 +39,7 @@ export default class HeaderSecondary extends Component {
 
     items.add('search', app.search.render(), 30);
 
-    if (app.forum.attribute("showLanguageSelector") != 0 && Object.keys(app.data.locales).length > 1) {
+    if (app.forum.attribute("showLanguageSelector") && Object.keys(app.data.locales).length > 1) {
       const locales = [];
 
       for (const locale in app.data.locales) {

--- a/js/forum/src/components/HeaderSecondary.js
+++ b/js/forum/src/components/HeaderSecondary.js
@@ -39,7 +39,7 @@ export default class HeaderSecondary extends Component {
 
     items.add('search', app.search.render(), 30);
 
-    if (app.forum.attribute("hideLanguageSelector") != 1 && Object.keys(app.data.locales).length > 1) {
+    if (app.forum.attribute("showLanguageSelector") != 0 && Object.keys(app.data.locales).length > 1) {
       const locales = [];
 
       for (const locale in app.data.locales) {

--- a/js/forum/src/components/HeaderSecondary.js
+++ b/js/forum/src/components/HeaderSecondary.js
@@ -39,28 +39,28 @@ export default class HeaderSecondary extends Component {
 
     items.add('search', app.search.render(), 30);
 
-    if (Object.keys(app.data.locales).length > 1) {
+    if (app.forum.attribute("hideLanguageSelector") != 1 && Object.keys(app.data.locales).length > 1) {
       const locales = [];
 
       for (const locale in app.data.locales) {
         locales.push(Button.component({
-          active: app.data.locale === locale,
-          children: app.data.locales[locale],
-          icon: app.data.locale === locale ? 'check' : true,
-          onclick: () => {
-            if (app.session.user) {
-              app.session.user.savePreferences({locale}).then(() => window.location.reload());
-            } else {
-              document.cookie = `locale=${locale}; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT`;
-              window.location.reload();
+            active: app.data.locale === locale,
+            children: app.data.locales[locale],
+            icon: app.data.locale === locale ? 'check' : true,
+            onclick: () => {
+              if (app.session.user) {
+                app.session.user.savePreferences({locale}).then(() => window.location.reload());
+              } else {
+                document.cookie = `locale=${locale}; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT`;
+                window.location.reload();
+              }
             }
-          }
         }));
       }
 
       items.add('locale', SelectDropdown.component({
-        children: locales,
-        buttonClassName: 'Button Button--link'
+          children: locales,
+          buttonClassName: 'Button Button--link'
       }), 20);
     }
 

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -65,6 +65,7 @@ class ForumSerializer extends AbstractSerializer
         $attributes = [
             'title' => $this->settings->get('forum_title'),
             'description' => $this->settings->get('forum_description'),
+            'hideLanguageSelector' => $this->settings->get('hide_language_selector'),
             'baseUrl' => $url = $this->app->url(),
             'basePath' => parse_url($url, PHP_URL_PATH) ?: '',
             'debug' => $this->app->inDebugMode(),

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -65,7 +65,7 @@ class ForumSerializer extends AbstractSerializer
         $attributes = [
             'title' => $this->settings->get('forum_title'),
             'description' => $this->settings->get('forum_description'),
-            'hideLanguageSelector' => $this->settings->get('hide_language_selector'),
+            'showLanguageSelector' => $this->settings->get('show_language_selector'),
             'baseUrl' => $url = $this->app->url(),
             'basePath' => parse_url($url, PHP_URL_PATH) ?: '',
             'debug' => $this->app->inDebugMode(),

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -65,7 +65,7 @@ class ForumSerializer extends AbstractSerializer
         $attributes = [
             'title' => $this->settings->get('forum_title'),
             'description' => $this->settings->get('forum_description'),
-            'showLanguageSelector' => $this->settings->get('show_language_selector'),
+            'showLanguageSelector' => (bool) $this->settings->get('show_language_selector', true),
             'baseUrl' => $url = $this->app->url(),
             'basePath' => parse_url($url, PHP_URL_PATH) ?: '',
             'debug' => $this->app->inDebugMode(),


### PR DESCRIPTION
Related to #539, but doesn't close it.

* Added `hide_language_selector` Switch to BasicsPage
* Added `hideLanguageSelector` property to ForumSerializer
* Changed: Language selector shows only if `hideLanguageSelector != 1` (default `undefined`, and off `"0"`)
* Other: Apparently fixed the "Add Extension" button locale.... someone must not have compiled their changes 😛 

Please feel free to correct the attribute name... I couldn't figure out what would be a good name.
I chose `hide` instead of `show` because, by default, the setting is undefined, so the switch would be off (hide) instead of on (show). Now the switch is off (show) by default.