### PR TITLE
Correct image orientation according to Exif data

### DIFF
--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -101,7 +101,7 @@ class UploadAvatarHandler
             $manager = new ImageManager;
 
             // Explicitly tell Intervention to encode the image as JSON (instead of having to guess from the extension)
-            $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('jpg', 100);
+            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('jpg', 100);
             file_put_contents($tmpFile, $encodedImage);
 
             $this->events->fire(


### PR DESCRIPTION
When using mobile, take a photo and upload it as avatar, it's orientation is incorrect.
This commit will fix this problem.