### PR TITLE
Add HTTP2 Push Headers

### DIFF
--- a/src/Http/WebApp/WebAppView.php
+++ b/src/Http/WebApp/WebAppView.php
@@ -300,7 +300,7 @@ class WebAppView
 
         return $view->render();
     }
-    
+
     protected function addLinkHeaders()
     {
         $css = [

--- a/src/Http/WebApp/WebAppView.php
+++ b/src/Http/WebApp/WebAppView.php
@@ -313,13 +313,13 @@ class WebAppView
         ];
         foreach ($css as $cssUrl) {
             if ($cssUrl != null) {
-                header('Link: <' . $cssUrl . '>; rel=preload, as=style', false);
+                header('Link: <'.$cssUrl.'>; rel=preload, as=style', false);
             }
         }
 
         foreach ($js as $jsUrl) {
             if ($jsUrl != null) {
-                header('Link: <' . $jsUrl . '>; rel=preload, as=script', false);
+                header('Link: <'.$jsUrl.'>; rel=preload, as=script', false);
             }
         }
     }

--- a/src/Http/WebApp/WebAppView.php
+++ b/src/Http/WebApp/WebAppView.php
@@ -293,11 +293,35 @@ class WebAppView
         $baseUrl = array_get($forum, 'data.attributes.baseUrl');
         $view->cssUrls = $this->buildCssUrls($baseUrl);
         $view->jsUrls = $this->buildJsUrls($baseUrl);
+        $this->addLinkHeaders();
 
         $view->head = implode("\n", $this->head);
         $view->foot = implode("\n", $this->foot);
 
         return $view->render();
+    }
+    
+    protected function addLinkHeaders()
+    {
+        $css = [
+            str_replace(public_path(), '', $this->getCss()->getFile()),
+            str_replace(public_path(), '', $this->localeCss->getFile())
+        ];
+        $js = [
+            str_replace(public_path(), '', $this->getJs()->getFile()),
+            str_replace(public_path(), '', $this->localeJs->getFile())
+        ];
+        foreach ($css as $cssUrl) {
+            if ($cssUrl != null) {
+                header('Link: <' . $cssUrl . '>; rel=preload, as=style', false);
+            }
+        }
+
+        foreach ($js as $jsUrl) {
+            if ($jsUrl != null) {
+                header('Link: <' . $jsUrl . '>; rel=preload, as=script', false);
+            }
+        }
     }
 
     protected function buildTitle($forumTitle)


### PR DESCRIPTION
This code adds the HTTP2 Push headers that allow Nginx and some CDN's with HTTP2 enabled to push the JS and CSS assets decreasing overall load time. See https://discuss.flarum.org/d/4768-http2-server-push/ for details.