### PR TITLE
fixed issues with $extension visibility and typehinting

### DIFF
--- a/src/Event/ExtensionWasDisabled.php
+++ b/src/Event/ExtensionWasDisabled.php
@@ -16,9 +16,9 @@ use Flarum\Extension\Extension;
 class ExtensionWasDisabled
 {
     /**
-     * @var string
+     * @var Extension
      */
-    protected $extension;
+    public $extension;
 
     /**
      * @param Extension $extension

--- a/src/Event/ExtensionWasEnabled.php
+++ b/src/Event/ExtensionWasEnabled.php
@@ -16,9 +16,9 @@ use Flarum\Extension\Extension;
 class ExtensionWasEnabled
 {
     /**
-     * @var string
+     * @var Extension
      */
-    protected $extension;
+    public $extension;
 
     /**
      * @param Extension $extension

--- a/src/Event/ExtensionWasUninstalled.php
+++ b/src/Event/ExtensionWasUninstalled.php
@@ -11,17 +11,19 @@
 
 namespace Flarum\Event;
 
+use Flarum\Extension\Extension;
+
 class ExtensionWasUninstalled
 {
     /**
-     * @var string
+     * @var Extension
      */
-    protected $extension;
+    public $extension;
 
     /**
-     * @param string $extension
+     * @param Extension $extension
      */
-    public function __construct($extension)
+    public function __construct(Extension $extension)
     {
         $this->extension = $extension;
     }

--- a/src/Event/ExtensionWillBeDisabled.php
+++ b/src/Event/ExtensionWillBeDisabled.php
@@ -16,7 +16,7 @@ use Flarum\Extension\Extension;
 class ExtensionWillBeDisabled
 {
     /**
-     * @var string
+     * @var Extension
      */
     public $extension;
 

--- a/src/Event/ExtensionWillBeEnabled.php
+++ b/src/Event/ExtensionWillBeEnabled.php
@@ -16,7 +16,7 @@ use Flarum\Extension\Extension;
 class ExtensionWillBeEnabled
 {
     /**
-     * @var string
+     * @var Extension
      */
     public $extension;
 


### PR DESCRIPTION
Fixes three things:

- Visibility of the `extension` property, which cannot be used from the outside now.
- Updated php doc, which I forgot during the extension rewrite.
- Added one more typehint for Extension

The first one is very important to take along in the next version.