### PR TITLE
Fix asset path when unpublishing

### DIFF
--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -199,7 +199,7 @@ class ExtensionManager
      */
     protected function unpublishAssets(Extension $extension)
     {
-        $this->filesystem->deleteDirectory($this->app->publicPath().'/assets/extensions/'.$extension);
+        $this->filesystem->deleteDirectory($this->app->publicPath().'/assets/extensions/'.$extension->getId());
     }
 
     /**


### PR DESCRIPTION
There is probably a missing method call when building assets path in the `unpublishAssets` method. I get a 500 error each time I uninstall a package with assets:

    Object of class Flarum\Extension\Extension could not be converted to string in [...]/vendor/flarum/core/src/Extension/ExtensionManager.php on line 195

Given there is no object to string conversion in place for the Extension class I believe this is not intended.

I used the same method that is used to build the path to access assets. Now paths are identical when installing, accessing and removing.