### PR TITLE
Affix sidebar when window is resized

### DIFF
--- a/js/forum/dist/app.js
+++ b/js/forum/dist/app.js
@@ -31146,29 +31146,42 @@ System.register('flarum/utils/abbreviateNumber', [], function (_export, _context
 System.register('flarum/utils/affixSidebar', [], function (_export, _context) {
   "use strict";
 
-  function affixSidebar(element, isInitialized) {
+  function affixSidebar(element, isInitialized, context) {
     var _this = this;
 
     if (isInitialized) return;
 
-    var $sidebar = $(element);
-    var $header = $('#header');
-    var $footer = $('#footer');
+    var onresize = function onresize() {
+      var $sidebar = $(element);
+      var $header = $('#header');
+      var $footer = $('#footer');
+      var $affixElement = $sidebar.find('> ul');
 
-    // Don't affix the sidebar if it is taller than the viewport (otherwise
-    // there would be no way to scroll through its content).
-    if ($sidebar.outerHeight(true) > $(window).height() - $header.outerHeight(true)) return;
+      $(window).off('.affix');
+      $affixElement.removeClass('affix affix-top affix-bottom').removeData('bs.affix');
 
-    $sidebar.find('> ul').affix({
-      offset: {
-        top: function top() {
-          return $sidebar.offset().top - $header.outerHeight(true) - parseInt($sidebar.css('margin-top'), 10);
-        },
-        bottom: function bottom() {
-          return _this.bottom = $footer.outerHeight(true);
+      // Don't affix the sidebar if it is taller than the viewport (otherwise
+      // there would be no way to scroll through its content).
+      if ($sidebar.outerHeight(true) > $(window).height() - $header.outerHeight(true)) return;
+
+      $affixElement.affix({
+        offset: {
+          top: function top() {
+            return $sidebar.offset().top - $header.outerHeight(true) - parseInt($sidebar.css('margin-top'), 10);
+          },
+          bottom: function bottom() {
+            return _this.bottom = $footer.outerHeight(true);
+          }
         }
-      }
-    });
+      });
+    };
+
+    // Register the affix plugin to execute on every window resize (and trigger)
+    $(window).on('resize', onresize).resize();
+
+    context.onunload = function () {
+      $(window).off('resize', onresize);
+    };
   }
 
   _export('default', affixSidebar);

--- a/js/forum/src/utils/affixSidebar.js
+++ b/js/forum/src/utils/affixSidebar.js
@@ -4,22 +4,38 @@
  *
  * @param {DOMElement} element
  * @param {Boolean} isInitialized
+ * @param {Object} context
  */
-export default function affixSidebar(element, isInitialized) {
+export default function affixSidebar(element, isInitialized, context) {
   if (isInitialized) return;
 
-  const $sidebar = $(element);
-  const $header = $('#header');
-  const $footer = $('#footer');
+  const onresize = () => {
+    const $sidebar = $(element);
+    const $header = $('#header');
+    const $footer = $('#footer');
+    const $affixElement = $sidebar.find('> ul');
 
-  // Don't affix the sidebar if it is taller than the viewport (otherwise
-  // there would be no way to scroll through its content).
-  if ($sidebar.outerHeight(true) > $(window).height() - $header.outerHeight(true)) return;
+    $(window).off('.affix');
+    $affixElement
+      .removeClass('affix affix-top affix-bottom')
+      .removeData('bs.affix');
 
-  $sidebar.find('> ul').affix({
-    offset: {
-      top: () => $sidebar.offset().top - $header.outerHeight(true) - parseInt($sidebar.css('margin-top'), 10),
-      bottom: () => this.bottom = $footer.outerHeight(true)
-    }
-  });
+    // Don't affix the sidebar if it is taller than the viewport (otherwise
+    // there would be no way to scroll through its content).
+    if ($sidebar.outerHeight(true) > $(window).height() - $header.outerHeight(true)) return;
+
+    $affixElement.affix({
+      offset: {
+        top: () => $sidebar.offset().top - $header.outerHeight(true) - parseInt($sidebar.css('margin-top'), 10),
+        bottom: () => this.bottom = $footer.outerHeight(true)
+      }
+    });
+  };
+
+  // Register the affix plugin to execute on every window resize (and trigger)
+  $(window).on('resize', onresize).resize();
+
+  context.onunload = () => {
+    $(window).off('resize', onresize);
+  }
 }


### PR DESCRIPTION
Fixes #866.

Phew... that was harder than I thought.

#### Implementation
- Bind an event handler for window resize events.
- Execute this handler exactly once to get the initial setup working.
- Tweak the handler a little bit (in contrast to the current implementation that is only executed once): Always remove the affix plugin first (see below for why) and then apply it again, if appropriate given the current dimensions.

The challenging part was realizing that the height/offset calculation did not work once the affix was applied. This was due to the surrounding `$sidebar` element essentially having zero height, because its content - the affixed `$affixElement` - had received fixed positioning. Thus, the calculation broke down. To fix this, I had to remove the affix plugin calculation.

#### Downsides
- Because there is no easy way (that I found) to remove the affix from an element, I had to remove it globally, following [this StackOverflow answer](https://stackoverflow.com/questions/15366519/how-do-i-remove-bootstrap-affix-from-an-element-under-certain-conditions#15372789). This means that having multiple affixed regions on one page would probably break down.

#### Questions
To @tobscure mostly...

1. Can we live with this downside of only supporting one affixed region per page?
2. Is my implementation okay? It's a little unnecessary overhead, but in the real world, resizing should not happen as often as it did during my testing (where the impact seemed fine).