### PR TITLE
Prevent crawlers to index nojs pages

### DIFF
--- a/views/app.blade.php
+++ b/views/app.blade.php
@@ -6,6 +6,9 @@
     <meta name="description" content="{{ $description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
     <meta name="theme-color" content="{{ array_get($forum, 'attributes.themePrimaryColor') }}">
+    @if (! $allowJs)
+      <meta name="robots" content="noindex" />
+    @endif
 
     @foreach ($cssUrls as $url)
       <link rel="stylesheet" href="{{ $url }}">


### PR DESCRIPTION
this resolves #912 

as it's mentioned in [this document](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag#using-the-robots-meta-tag) by using `robots` meta tag it's possible to prevent crawlers to index specific pages.

maybe content value should be [none](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag#valid-indexing--serving-directives)? instead of `noindex`