### PR TITLE
Fix modal layout when width between 601px and 768px

### DIFF
--- a/less/lib/Modal.less
+++ b/less/lib/Modal.less
@@ -155,6 +155,7 @@
     }
   }
   .Modal {
+    max-width: 100%;
     margin: 0;
     -webkit-transform: none !important;
             transform: none !important;


### PR DESCRIPTION
This PR to resolve modal layout, there's a blank area when window width between 601px and 768px.

<img width="763" alt="flarum_community" src="https://cloud.githubusercontent.com/assets/2996108/23389673/93a8a390-fda4-11e6-8831-7afdbcde65e6.png">
