### PR TITLE
Change content column from TEXT to MEDIUMTEXT

### DIFF
--- a/migrations/2017_04_09_152230_change_posts_content_column_to_mediumtext.php
+++ b/migrations/2017_04_09_152230_change_posts_content_column_to_mediumtext.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('posts', function (Blueprint $table) {
+            $table->mediumText('content')->change();
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('posts', function (Blueprint $table) {
+            $table->text('content')->change();
+        });
+    }
+];


### PR DESCRIPTION
Fixes #1044 by addressing the following:

- A new migration to change the type of the content column in the posts table from TEXT to MEDIUMTEXT.
- Confirmed that `doctrine/dbal` already exists in the core composer.json, so that we can modify existing columns.