### PR TITLE
Use JSON for Install Command Instead of Yaml

### DIFF
--- a/src/Install/Console/FileDataProvider.php
+++ b/src/Install/Console/FileDataProvider.php
@@ -13,7 +13,6 @@ namespace Flarum\Install\Console;
 
 use Exception;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Yaml\Yaml;
 
 class FileDataProvider implements DataProviderInterface
 {
@@ -33,8 +32,8 @@ class FileDataProvider implements DataProviderInterface
 
         // Check if file exists before parsing content
         if (file_exists($configurationFile)) {
-            // Parse YAML
-            $configuration = Yaml::parse(file_get_contents($configurationFile));
+            // Parse JSON
+            $configuration = json_decode(file_get_contents($configurationFile), true);
 
             // Define configuration variables
             $this->baseUrl = isset($configuration['baseUrl']) ? rtrim($configuration['baseUrl'], '/') : null;

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -69,7 +69,7 @@ class InstallCommand extends AbstractCommand
                 'file',
                 'f',
                 InputOption::VALUE_REQUIRED,
-                'Use external configuration file in YAML format'
+                'Use external configuration file in JSON format'
             )
             ->addOption(
                 'config',


### PR DESCRIPTION
Yaml is a pain to escape things. Currently, we can only safely pass alpha numeric characters into the yaml file safely. When passing the discussion title, something like "Davis' Forum" won't work because of the apostrophe. JSON can be encoded using `json_encode()` and will automatically escape special characters. It's much safer for automated use (which is probably all that would use the artisan commands).