### PR TITLE
Manifest.json flush

### DIFF
--- a/src/Asset/RevisionCompiler.php
+++ b/src/Asset/RevisionCompiler.php
@@ -200,7 +200,7 @@ class RevisionCompiler implements CompilerInterface
      */
     public function flush()
     {
-        if (!($this instanceof self)) {
+        if (is_subclass_of($this, self::class)) {
             $revision = $this->getRevision();
 
             $ext = pathinfo($this->filename, PATHINFO_EXTENSION);

--- a/src/Asset/RevisionCompiler.php
+++ b/src/Asset/RevisionCompiler.php
@@ -29,6 +29,16 @@ class RevisionCompiler implements CompilerInterface
     protected $watch;
 
     /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var string
+     */
+    protected $filename;
+
+    /**
      * @param string $path
      * @param string $filename
      * @param bool $watch
@@ -190,11 +200,15 @@ class RevisionCompiler implements CompilerInterface
      */
     public function flush()
     {
-        $revision = $this->getRevision();
+        if (!($this instanceof self)) {
+            $revision = $this->getRevision();
 
-        $ext = pathinfo($this->filename, PATHINFO_EXTENSION);
+            $ext = pathinfo($this->filename, PATHINFO_EXTENSION);
 
-        $file = $this->path.'/'.substr_replace($this->filename, '-'.$revision, -strlen($ext) - 1, 0);
+            $file = $this->path . '/' . substr_replace($this->filename, '-' . $revision, -strlen($ext) - 1, 0);
+        } else {
+            $file = $this->getRevisionFile();
+        }
 
         if (file_exists($file)) {
             unlink($file);

--- a/src/Http/WebApp/WebAppAssets.php
+++ b/src/Http/WebApp/WebAppAssets.php
@@ -13,6 +13,7 @@ namespace Flarum\Http\WebApp;
 
 use Flarum\Asset\JsCompiler;
 use Flarum\Asset\LessCompiler;
+use Flarum\Asset\RevisionCompiler;
 use Flarum\Foundation\Application;
 use Flarum\Locale\JsCompiler as LocaleJsCompiler;
 use Flarum\Locale\LocaleManager;
@@ -58,6 +59,12 @@ class WebAppAssets
     {
         $this->flushJs();
         $this->flushCss();
+        $this->flushManifest();
+    }
+
+    public function flushManifest()
+    {
+        $this->getRevision()->flush();
     }
 
     public function flushJs()
@@ -109,6 +116,18 @@ class WebAppAssets
             "$this->name.css",
             $this->shouldWatch(),
             $this->getLessStorage()
+        );
+    }
+
+    /**
+     * @return RevisionCompiler
+     */
+    public function getRevision()
+    {
+        return new RevisionCompiler(
+            $this->getDestination(),
+            '',
+            $this->shouldWatch()
         );
     }
 


### PR DESCRIPTION
#837 

- deletes rev-manifest.json

I know it's part of the solution needed, but at least it solves a lot of complications people have with flushing the cache and files not updating.