### PR TITLE
Bug uploading PNG images as avatars with transparent backgrounds

### DIFF
--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -101,7 +101,7 @@ class UploadAvatarHandler
             $manager = new ImageManager;
 
             // Explicitly tell Intervention to encode the image as JSON (instead of having to guess from the extension)
-            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('jpg', 100);
+            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('png', 100);
             file_put_contents($tmpFile, $encodedImage);
 
             $this->events->fire(
@@ -117,7 +117,7 @@ class UploadAvatarHandler
                 $mount->delete($file);
             }
 
-            $uploadName = Str::lower(Str::quickRandom()).'.jpg';
+            $uploadName = Str::lower(Str::quickRandom()).'.png';
 
             $user->changeAvatarPath($uploadName);
 


### PR DESCRIPTION
"PNG images with canvas size 100x100 pixels (avatars used on Flarum) usually are smaller than JPG images (even into PNG with transparency). So my advice is let users use JPG or PNG format, because the size reduction using JPG encoding with quality 100 don't exists, it simply increase final size of avatars. If i have to choose one format, i simply use PNG always and every simple problem disappear."

["Bug uploading PNG images as avatars with transparent backgrounds" On Flarum](https://discuss.flarum.org/d/5522-bug-uploading-png-images-as-avatars-with-transparent-backgrounds/23)