### PR TITLE
Bug uploading PNG images as avatars with transparent backgrounds

### DIFF
--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -173,7 +173,7 @@ class RegisterUserHandler
             'target' => $this->uploadDir,
         ]);
 
-        $uploadName = Str::lower(Str::quickRandom()).'.jpg';
+        $uploadName = Str::lower(Str::quickRandom()).'.png';
 
         $user->changeAvatarPath($uploadName);
 


### PR DESCRIPTION
"PNG images with canvas size 100x100 pixels (avatars used on Flarum) usually are smaller than JPG images (even into PNG with transparency). So my advice is let users use JPG or PNG format, because the size reduction using JPG encoding with quality 100 don't exists, it simply increase final size of avatars. If i have to choose one format, i simply use PNG always and every simple problem disappear."

Part 2 of https://github.com/flarum/core/pull/1162