### PR TITLE
Support PNG avatars with transparent backgrounds and fix EXIF rotation

### DIFF
--- a/src/Core/Command/RegisterUserHandler.php
+++ b/src/Core/Command/RegisterUserHandler.php
@@ -173,7 +173,7 @@ class RegisterUserHandler
             'target' => $this->uploadDir,
         ]);
 
-        $uploadName = Str::lower(Str::quickRandom()).'.jpg';
+        $uploadName = Str::lower(Str::quickRandom()).'.png';
 
         $user->changeAvatarPath($uploadName);
 

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -101,7 +101,13 @@ class UploadAvatarHandler
             $manager = new ImageManager;
 
             // Explicitly tell Intervention to encode the image as PNG (instead of having to guess from the extension)
-            $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('png', 100);
+            // Read exif data to orientate avatar only if EXIF extension is enabled
+            if (extension_loaded('exif')) {
+                $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('png', 100);
+            }
+            else {
+                $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('png', 100);
+            }
             file_put_contents($tmpFile, $encodedImage);
 
             $this->events->fire(

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -101,7 +101,7 @@ class UploadAvatarHandler
             $manager = new ImageManager;
 
             // Explicitly tell Intervention to encode the image as JSON (instead of having to guess from the extension)
-            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('png', 100);
+            $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('png', 100);
             file_put_contents($tmpFile, $encodedImage);
 
             $this->events->fire(

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -100,7 +100,7 @@ class UploadAvatarHandler
 
             $manager = new ImageManager;
 
-            // Explicitly tell Intervention to encode the image as JSON (instead of having to guess from the extension)
+            // Explicitly tell Intervention to encode the image as PNG (instead of having to guess from the extension)
             $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('png', 100);
             file_put_contents($tmpFile, $encodedImage);
 

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -101,7 +101,7 @@ class UploadAvatarHandler
             $manager = new ImageManager;
 
             // Explicitly tell Intervention to encode the image as JSON (instead of having to guess from the extension)
-            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('jpg', 100);
+            $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('png', 100);
             file_put_contents($tmpFile, $encodedImage);
 
             $this->events->fire(
@@ -117,7 +117,7 @@ class UploadAvatarHandler
                 $mount->delete($file);
             }
 
-            $uploadName = Str::lower(Str::quickRandom()).'.jpg';
+            $uploadName = Str::lower(Str::quickRandom()).'.png';
 
             $user->changeAvatarPath($uploadName);
 

--- a/src/Core/Command/UploadAvatarHandler.php
+++ b/src/Core/Command/UploadAvatarHandler.php
@@ -104,8 +104,7 @@ class UploadAvatarHandler
             // Read exif data to orientate avatar only if EXIF extension is enabled
             if (extension_loaded('exif')) {
                 $encodedImage = $manager->make($tmpFile)->orientate()->fit(100, 100)->encode('png', 100);
-            }
-            else {
+            } else {
                 $encodedImage = $manager->make($tmpFile)->fit(100, 100)->encode('png', 100);
             }
             file_put_contents($tmpFile, $encodedImage);

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -2,7 +2,7 @@
 $url = app('Flarum\Forum\UrlGenerator');
 ?>
 <div class="container">
-    <h3>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h3>
+    <h2>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h2>
 
     <ul>
         @foreach ($document->data as $discussion)

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -2,7 +2,7 @@
 $url = app('Flarum\Forum\UrlGenerator');
 ?>
 <div class="container">
-    <h2>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h2>
+    <h3>{{ $translator->trans('core.views.index.all_discussions_heading') }}</h3>
 
     <ul>
         @foreach ($document->data as $discussion)


### PR DESCRIPTION
With this PR i try to solve the issues:

+ [1161](https://github.com/flarum/core/issues/1161): Upload profile image error - php exif extension
+ [1163](https://github.com/flarum/core/issues/1163): Problems uploading PNG images as avatars with transparent backgrounds

I decided to solve both issues with one PR, because both are related.