### PR TITLE
Admin: fix default language selector

### DIFF
--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -18103,6 +18103,7 @@ System.register('flarum/components/BasicsPage', ['flarum/components/Page', 'flar
                     label: app.translator.trans('core.admin.basics.default_language_heading'),
                     children: [Select.component({
                       options: this.localeOptions,
+                      value: this.values.default_locale(),
                       onchange: this.values.default_locale
                     })]
                   }) : '',

--- a/js/admin/src/components/BasicsPage.js
+++ b/js/admin/src/components/BasicsPage.js
@@ -64,6 +64,7 @@ export default class BasicsPage extends Page {
                 children: [
                   Select.component({
                     options: this.localeOptions,
+                    value: this.values.default_locale(),
                     onchange: this.values.default_locale
                   })
                 ]


### PR DESCRIPTION
the binding of the control to the value was missing
fixes #1164