### PR TITLE
#1184 Fix /api/posts returning 500

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -186,7 +186,7 @@ abstract class AbstractSerializeController implements ControllerInterface
      */
     protected function extractFilter(ServerRequestInterface $request)
     {
-        return $this->buildParameters($request)->getFilter();
+        return $this->buildParameters($request)->getFilter() ?: [];
     }
 
     /**

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -107,7 +107,7 @@ class ListPostsController extends AbstractCollectionController
      */
     private function getPostIds(ServerRequestInterface $request)
     {
-        $filter = $this->extractFilter($request);
+        $filter = $this->extractFilter($request) ?: array();
         $sort = $this->extractSort($request);
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -107,7 +107,7 @@ class ListPostsController extends AbstractCollectionController
      */
     private function getPostIds(ServerRequestInterface $request)
     {
-        $filter = $this->extractFilter($request) ?: array();
+        $filter = $this->extractFilter($request) ?: [];
         $sort = $this->extractSort($request);
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -107,7 +107,7 @@ class ListPostsController extends AbstractCollectionController
      */
     private function getPostIds(ServerRequestInterface $request)
     {
-        $filter = $this->extractFilter($request) ?: [];
+        $filter = $this->extractFilter($request);
         $sort = $this->extractSort($request);
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);


### PR DESCRIPTION
This makes sure `$filter` is an array even if there is no `filter` property in the url query.
Not sure if we want to use a different solution.
Fixes #1184 

### Changelog
- [Fixed] ListPostsController::applyFilters not receiving array if  `$filter` argument is null

---

_PS: Franz, I somehow remembered `?:` is a thing [after all this time](https://github.com/flarum/core/pull/1105#discussion_r96127460) 😛_