### PR TITLE
Update .gitignore to exclude files for distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,10 @@
 .gitignore export-ignore
 .gitmodules export-ignore
 .travis.yml export-ignore
+.editorconfig export-ignore
+.styleci.yml export-ignore
+
+phpunit.xml export-ignore
+tests export-ignore
 
 js/*/dist/*.js -diff


### PR DESCRIPTION
This adds some files that are only needed for contributing and the `tests` folder to `.gitattributes` to be ignored on Composer's ZIP distribution.
I added these because I don't think there's any reason to install Flarum via ZIP with composer if you are going to contribute. I wasn't sure if I should include `stubs`.
Happy to discuss, tho :)
Closes #762.