### PR TITLE
Add viewUserList permission

### DIFF
--- a/js/admin/dist/app.js
+++ b/js/admin/dist/app.js
@@ -20294,6 +20294,13 @@ System.register('flarum/components/PermissionGrid', ['flarum/Component', 'flarum
               allowGuest: true
             }, 100);
 
+            items.add('viewUserList', {
+              icon: 'users',
+              label: app.translator.trans('core.admin.permissions.view_user_list_label'),
+              permission: 'viewUserList',
+              allowGuest: true
+            }, 100);
+
             items.add('signUp', {
               icon: 'user-plus',
               label: app.translator.trans('core.admin.permissions.sign_up_label'),

--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -91,6 +91,13 @@ export default class PermissionGrid extends Component {
       allowGuest: true
     }, 100);
 
+    items.add('viewUserList', {
+      icon: 'users',
+      label: app.translator.trans('core.admin.permissions.view_user_list_label'),
+      permission: 'viewUserList',
+      allowGuest: true
+    }, 100);
+
     items.add('signUp', {
       icon: 'user-plus',
       label: app.translator.trans('core.admin.permissions.sign_up_label'),

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -12,6 +12,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Api\UrlGenerator;
+use Flarum\Core\Exception\PermissionDeniedException;
 use Flarum\Core\Search\SearchCriteria;
 use Flarum\Core\Search\User\UserSearcher;
 use Psr\Http\Message\ServerRequestInterface;
@@ -66,6 +67,11 @@ class ListUsersController extends AbstractCollectionController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
+
+        if ($actor->cannot('viewUserList')) {
+            throw new PermissionDeniedException;
+        }
+
         $query = array_get($this->extractFilter($request), 'q');
         $sort = $this->extractSort($request);
 

--- a/src/Api/Serializer/ForumSerializer.php
+++ b/src/Api/Serializer/ForumSerializer.php
@@ -80,7 +80,8 @@ class ForumSerializer extends AbstractSerializer
             'allowSignUp' => (bool) $this->settings->get('allow_sign_up'),
             'defaultRoute'  => $this->settings->get('default_route'),
             'canViewDiscussions' => $this->actor->can('viewDiscussions'),
-            'canStartDiscussion' => $this->actor->can('startDiscussion')
+            'canStartDiscussion' => $this->actor->can('startDiscussion'),
+            'canViewUserList' => $this->actor->can('viewUserList')
         ];
 
         if ($this->actor->can('administrate')) {

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -291,9 +291,10 @@ class InstallCommand extends AbstractCommand
             // Guests can view the forum
             [Group::GUEST_ID, 'viewDiscussions'],
 
-            // Members can create and reply to discussions
+            // Members can create and reply to discussions, and view the user list
             [Group::MEMBER_ID, 'startDiscussion'],
             [Group::MEMBER_ID, 'discussion.reply'],
+            [Group::MEMBER_ID, 'viewUserList'],
 
             // Moderators can edit + delete stuff
             [static::MOD_GROUP_ID, 'discussion.delete'],


### PR DESCRIPTION
This adds a `viewUserList` permission that is needed to access the endpoint `/api/users`.
After installation, the permission defaults to Members only.
I wasn't sure if there was a way to make it default right after the owner updates Flarum.
I also wasn't sure if I should use `$actor->hasPermission` or `$actor->cannot`, because I see both `hasPermission` and `cannot` being used for the same purpose.
Closes #572.