### PR TITLE
Allow JSON to be used for Install Command

### DIFF
--- a/src/Install/Console/FileDataProvider.php
+++ b/src/Install/Console/FileDataProvider.php
@@ -33,8 +33,15 @@ class FileDataProvider implements DataProviderInterface
 
         // Check if file exists before parsing content
         if (file_exists($configurationFile)) {
-            // Parse YAML
-            $configuration = Yaml::parse(file_get_contents($configurationFile));
+            $configurationFileContents = file_get_contents($configurationFile);
+            // Try parsing JSON
+            if (($json = json_decode($configurationFileContents)) !== null) {
+                //Use JSON if Valid
+                $configuration = $json;
+            } else {
+                //Else use YAML
+                $configuration = Yaml::parse($configurationFileContents);
+            }
 
             // Define configuration variables
             $this->baseUrl = isset($configuration['baseUrl']) ? rtrim($configuration['baseUrl'], '/') : null;

--- a/src/Install/Console/FileDataProvider.php
+++ b/src/Install/Console/FileDataProvider.php
@@ -35,7 +35,7 @@ class FileDataProvider implements DataProviderInterface
         if (file_exists($configurationFile)) {
             $configurationFileContents = file_get_contents($configurationFile);
             // Try parsing JSON
-            if (($json = json_decode($configurationFileContents)) !== null) {
+            if (($json = json_decode($configurationFileContents, true)) !== null) {
                 //Use JSON if Valid
                 $configuration = $json;
             } else {

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -69,7 +69,7 @@ class InstallCommand extends AbstractCommand
                 'file',
                 'f',
                 InputOption::VALUE_REQUIRED,
-                'Use external configuration file in YAML format'
+                'Use external configuration file in JSON or YAML format'
             )
             ->addOption(
                 'config',


### PR DESCRIPTION
This will check if valid JSON is provided and if so, use JSON, otherwise it will try to parse as a YAML file.