### PR TITLE
Fix oauth controller wrong session method call

### DIFF
--- a/src/Forum/Controller/AbstractOAuth2Controller.php
+++ b/src/Forum/Controller/AbstractOAuth2Controller.php
@@ -66,7 +66,7 @@ abstract class AbstractOAuth2Controller implements ControllerInterface
 
             return new RedirectResponse($authUrl.'&display=popup');
         } elseif (! $state || $state !== $session->get('oauth2state')) {
-            $session->forget('oauth2state');
+            $session->remove('oauth2state');
             echo 'Invalid state. Please close the window and try again.';
             exit;
         }


### PR DESCRIPTION
This rare error emerges when wrong oauth2state passed to AbstractOAuth2Controller:
Call to undefined method Symfony\Component\HttpFoundation\Session\Session::forget()
Obviously method "remove" meant. It works well after the correction inside my custom extension.