### PR TITLE
Add drag and drop avatar uploading

### DIFF
--- a/less/forum/AvatarEditor.less
+++ b/less/forum/AvatarEditor.less
@@ -17,7 +17,10 @@
   .AvatarEditor--noAvatar {
     opacity: 0.7;
   }
-  &:hover .Dropdown-toggle, &.open .Dropdown-toggle, &.loading .Dropdown-toggle {
+  &:hover .Dropdown-toggle,
+  &.open .Dropdown-toggle,
+  &.loading .Dropdown-toggle,
+  &.dragover .Dropdown-toggle {
     opacity: 1;
   }
   .LoadingIndicator {


### PR DESCRIPTION
- Turned the avatar into a dropzone which takes uploads. Used native APIs.
- Refactor uploading a bit to allow both the file picker and drag & drop method to use the same upload code
- Used the same styling as loading/open/hover when user drags their avatar into the dropzone.

Closes #107 