### PR TITLE
Always update Composer height on show

### DIFF
--- a/js/forum/src/components/Composer.js
+++ b/js/forum/src/components/Composer.js
@@ -354,6 +354,12 @@ class Composer extends Component {
    */
   show() {
     if (this.position === Composer.PositionEnum.NORMAL || this.position === Composer.PositionEnum.FULLSCREEN) {
+      // show() is often called just after load()
+      // Even if the position of the Composer didn't change,
+      // the flexible part of the new component needs to be resized to the correct height
+      m.redraw(true);
+      this.updateHeight();
+
       return;
     }
 


### PR DESCRIPTION
This prevents visual glitches when the Composer component was just replaced

The main issue that gets fixed with this happens when you click on "new discussion" while the composer is already open (many people must already have seen that one I guess):

![image](https://user-images.githubusercontent.com/5264300/34472085-6f8f605a-ef59-11e7-88fd-71d1372da5a5.png)
