### PR TITLE
Add console configuration event

### DIFF
--- a/src/Console/Event/Configuring.php
+++ b/src/Console/Event/Configuring.php
@@ -15,9 +15,9 @@ use Flarum\Foundation\Application;
 use Symfony\Component\Console\Application as ConsoleApplication;
 
 /**
- * Configure the console application
+ * Configure the console application.
  *
- * This event is fired after the core commands are added to the application
+ * This event is fired after the core commands are added to the application.
  */
 class Configuring
 {

--- a/src/Console/Event/Configuring.php
+++ b/src/Console/Event/Configuring.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Console\Event;
+
+use Flarum\Foundation\Application;
+use Symfony\Component\Console\Application as ConsoleApplication;
+
+/**
+ * Configure the console application
+ *
+ * This event is fired after the core commands are added to the application
+ */
+class Configuring
+{
+    /**
+     * @var Application
+     */
+    public $app;
+
+    /**
+     * @var ConsoleApplication
+     */
+    public $console;
+
+    /**
+     * @param Application $app
+     * @param ConsoleApplication $console
+     */
+    public function __construct(Application $app, ConsoleApplication $console)
+    {
+        $this->app = $app;
+        $this->console = $console;
+    }
+}

--- a/src/Console/Server.php
+++ b/src/Console/Server.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Console;
 
+use Flarum\Console\Event\Configuring;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
 use Flarum\Foundation\Application;
@@ -19,6 +20,7 @@ use Flarum\Foundation\Console\InfoCommand;
 use Flarum\Foundation\Site;
 use Flarum\Install\Console\InstallCommand;
 use Flarum\Install\InstallServiceProvider;
+use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Application as ConsoleApplication;
 
 class Server
@@ -72,6 +74,9 @@ class Server
                 ['config' => $this->app->isInstalled() ? $this->app->make('flarum.config') : []]
             ));
         }
+
+        $events = $this->app->make(Dispatcher::class);
+        $events->fire(new Configuring($this->app, $console));
 
         return $console;
     }


### PR DESCRIPTION
This is based on the work previously done in https://github.com/flagrow/console

I'm not sure if having a reference to `Flarum\Foundation\Application` in the event is necessary. I remember there was no way to access it otherwise in beta7, but maybe this has changed in beta8 (use case: get the version or the path of the application when registering a command).

Adding this event will allow extensions to hook into the commands offered by `php flarum`