### PR TITLE
No slug? Then no '-' separator!

### DIFF
--- a/js/forum/src/initializers/routes.js
+++ b/js/forum/src/initializers/routes.js
@@ -35,7 +35,7 @@ export default function(app) {
    */
   app.route.discussion = (discussion, near) => {
     return app.route(near && near !== 1 ? 'discussion.near' : 'discussion', {
-      id: discussion.id() + '-' + discussion.slug(),
+      id: discussion.id() + (discussion.slug().trim() ? '-' + discussion.slug() : ''),
       near: near && near !== 1 ? near : undefined
     });
   };

--- a/js/forum/src/initializers/routes.js
+++ b/js/forum/src/initializers/routes.js
@@ -34,8 +34,9 @@ export default function(app) {
    * @return {String}
    */
   app.route.discussion = (discussion, near) => {
+    const slug = discussion.slug();
     return app.route(near && near !== 1 ? 'discussion.near' : 'discussion', {
-      id: discussion.id() + (discussion.slug().trim() ? '-' + discussion.slug() : ''),
+      id: discussion.id() + (slug.trim() ? '-' + slug : ''),
       near: near && near !== 1 ? near : undefined
     });
   };

--- a/js/lib/utils/string.js
+++ b/js/lib/utils/string.js
@@ -23,7 +23,7 @@ export function slug(string) {
   return string.toLowerCase()
     .replace(/[^a-z0-9]/gi, '-')
     .replace(/-+/g, '-')
-    .replace(/-$|^-/g, '') || '-';
+    .replace(/-$|^-/g, '');
 }
 
 /**

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -28,6 +28,6 @@ class Str
         $str = preg_replace('/-+/', '-', $str);
         $str = preg_replace('/-$|^-/', '', $str);
 
-        return $str ?: '-';
+        return $str;
     }
 }

--- a/views/frontend/content/index.blade.php
+++ b/views/frontend/content/index.blade.php
@@ -7,7 +7,7 @@
         @foreach ($document->data as $discussion)
             <li>
                 <a href="{{ $url->to('forum')->route('discussion', [
-                    'id' => $discussion->id . '-' . $discussion->attributes->slug
+                    'id' => $discussion->id . (trim($discussion->attributes->slug) ? '-' . $discussion->attributes->slug : '')
                 ]) }}">
                     {{ $discussion->attributes->title }}
                 </a>


### PR DESCRIPTION
If there is no slug for the discussion then the '-' separator between the discussion id and the discussion slug is redundant and should not be used.

This would allow to have numeric only permalinks for discussions if slugs are empty.