### PR TITLE
Extendable notification methods

### DIFF
--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -18,10 +18,7 @@ export default class NotificationGrid extends Component {
      *
      * @type {Array}
      */
-    this.methods = [
-      {name: 'alert', icon: 'bell', label: app.translator.trans('core.forum.settings.notify_by_web_heading')},
-      {name: 'email', icon: 'envelope-o', label: app.translator.trans('core.forum.settings.notify_by_email_heading')}
-    ];
+    this.methods = this.notificationMethods().toArray();
 
     /**
      * A map of notification type-method combinations to the checkbox instances
@@ -162,6 +159,35 @@ export default class NotificationGrid extends Component {
    */
   preferenceKey(type, method) {
     return 'notify_' + type + '_' + method;
+  }
+
+  /**
+   * Build an item list for the notification methods to display in the grid.
+   *
+   * Each notification method is an object which has the following properties:
+   *
+   * - `name` The name of the notification method.
+   * - `icon` The icon to display in the column header.
+   * - `label` The label to display in the column header.
+   *
+   * @return {ItemList}
+   */
+  notificationMethods() {
+    const items = new ItemList();
+
+    items.add('alert', {
+      name: 'alert',
+      icon: 'bell',
+      label: app.translator.trans('core.forum.settings.notify_by_web_heading'),
+    });
+
+    items.add('email', {
+      name: 'email',
+      icon: 'envelope-o',
+      label: app.translator.trans('core.forum.settings.notify_by_email_heading'),
+    });
+
+    return items;
   }
 
   /**

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -31,7 +31,7 @@ export default class NotificationGrid extends Component {
     /**
      * Information about the available notification types.
      *
-     * @type {Object}
+     * @type {Array}
      */
     this.types = this.notificationTypes().toArray();
 
@@ -196,6 +196,7 @@ export default class NotificationGrid extends Component {
    * Each notification type is an object which has the following properties:
    *
    * - `name` The name of the notification type.
+   * - `icon` The icon to display in the notification grid row.
    * - `label` The label to display in the notification grid row.
    *
    * @return {ItemList}


### PR DESCRIPTION
It's currently not easy to add new notifications methods in the settings grid (see what I had to do [here](https://github.com/flagrow/telegram/blob/master/js/forum/src/addNotificationMethod.js#L9) to achieve it in beta7). Simply using an ItemList makes it a lot easier.

While at it I also fixed the jsdoc for notification types that didn't exactly match the code anymore.