### PR TITLE
Add extension rollback command

### DIFF
--- a/src/Console/Server.php
+++ b/src/Console/Server.php
@@ -14,6 +14,7 @@ namespace Flarum\Console;
 use Flarum\Console\Event\Configuring;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
+use Flarum\Database\Console\RollbackCommand;
 use Flarum\Foundation\Application;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
@@ -58,6 +59,7 @@ class Server
         $commands = [
             InstallCommand::class,
             MigrateCommand::class,
+            RollbackCommand::class,
             GenerateMigrationCommand::class,
         ];
 

--- a/src/Console/Server.php
+++ b/src/Console/Server.php
@@ -14,7 +14,7 @@ namespace Flarum\Console;
 use Flarum\Console\Event\Configuring;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
-use Flarum\Database\Console\RollbackCommand;
+use Flarum\Database\Console\ResetCommand;
 use Flarum\Foundation\Application;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
@@ -59,7 +59,7 @@ class Server
         $commands = [
             InstallCommand::class,
             MigrateCommand::class,
-            RollbackCommand::class,
+            ResetCommand::class,
             GenerateMigrationCommand::class,
         ];
 

--- a/src/Database/Console/ResetCommand.php
+++ b/src/Database/Console/ResetCommand.php
@@ -13,9 +13,9 @@ namespace Flarum\Database\Console;
 
 use Flarum\Console\AbstractCommand;
 use Flarum\Extension\ExtensionManager;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
-class RollbackCommand extends AbstractCommand
+class ResetCommand extends AbstractCommand
 {
     /**
      * @var ExtensionManager
@@ -38,12 +38,13 @@ class RollbackCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('migrate:rollback')
-            ->setDescription('Run rollback migrations for an extension')
-            ->addArgument(
+            ->setName('migrate:reset')
+            ->setDescription('Run all migrations down for an extension')
+            ->addOption(
                 'extension',
-                InputArgument::REQUIRED,
-                'The name of the extension.'
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The extension to reset migrations for.'
             );
     }
 
@@ -52,7 +53,14 @@ class RollbackCommand extends AbstractCommand
      */
     protected function fire()
     {
-        $extensionName = $this->input->getArgument('extension');
+        $extensionName = $this->input->getOption('extension');
+
+        if (! $extensionName) {
+            $this->info('No extension specified. Please check command syntax.');
+
+            return;
+        }
+
         $extension = $this->manager->getExtension($extensionName);
 
         if (! $extension) {

--- a/src/Database/Console/RollbackCommand.php
+++ b/src/Database/Console/RollbackCommand.php
@@ -55,7 +55,7 @@ class RollbackCommand extends AbstractCommand
         $extensionName = $this->input->getArgument('extension');
         $extension = $this->manager->getExtension($extensionName);
 
-        if (!$extension) {
+        if (! $extension) {
             $this->info('Could not find extension '.$extensionName);
 
             return;

--- a/src/Database/Console/RollbackCommand.php
+++ b/src/Database/Console/RollbackCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Database\Console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\Extension\ExtensionManager;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RollbackCommand extends AbstractCommand
+{
+    /**
+     * @var ExtensionManager
+     */
+    protected $manager;
+
+    /**
+     * @param ExtensionManager $manager
+     */
+    public function __construct(ExtensionManager $manager)
+    {
+        $this->manager = $manager;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('migrate:rollback')
+            ->setDescription('Run rollback migrations for an extension')
+            ->addArgument(
+                'extension',
+                InputArgument::REQUIRED,
+                'The name of the extension.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $extensionName = $this->input->getArgument('extension');
+        $extension = $this->manager->getExtension($extensionName);
+
+        if (!$extension) {
+            $this->info('Could not find extension ' . $extensionName);
+
+            return;
+        }
+
+        $this->info('Rolling back extension: ' . $extensionName);
+
+        $notes = $this->manager->migrateDown($extension);
+
+        foreach ($notes as $note) {
+            $this->info($note);
+        }
+
+        $this->info('DONE.');
+    }
+}

--- a/src/Database/Console/RollbackCommand.php
+++ b/src/Database/Console/RollbackCommand.php
@@ -56,12 +56,12 @@ class RollbackCommand extends AbstractCommand
         $extension = $this->manager->getExtension($extensionName);
 
         if (!$extension) {
-            $this->info('Could not find extension ' . $extensionName);
+            $this->info('Could not find extension '.$extensionName);
 
             return;
         }
 
-        $this->info('Rolling back extension: ' . $extensionName);
+        $this->info('Rolling back extension: '.$extensionName);
 
         $notes = $this->manager->migrateDown($extension);
 

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -247,10 +247,11 @@ class ExtensionManager
      * Runs the database migrations to reset the database to its old state.
      *
      * @param Extension $extension
+     * @return array Notes from the migrator.
      */
     public function migrateDown(Extension $extension)
     {
-        $this->migrate($extension, false);
+        return $this->migrate($extension, false);
     }
 
     /**


### PR DESCRIPTION
I'm not sure this adds any end-user benefit but this would really help extension developers when they're trying to run your migrations over and over again.

This also fixes `migrateDown` not returning the list of notes.

This PR adds a command that is used like this:

    $ php flarum migrate:rollback flarum-auth-twitter
    Rolling back extension: flarum-auth-twitter
    Rolled back: 2015_09_15_000000_add_twitter_id_to_users_table
    DONE.

Given that command will probably only be used by developer or when troubleshooting, I'm not sure it's worth checking if the extension is enabled or not. Or maybe rollback could be forbidden for enabled extensions and we could add a `--force` flag to do it even if the extension is enabled ?

Maybe you'd prefer having the extension name parameter as an option instead of an argument to keep backwards compatibility if you add more options (core or migration-file-specific) to `migrate:rollback` in the future ?
