### PR TITLE
FontAwesome v5.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.0",
         "dflydev/fig-cookies": "^1.0.2",
         "doctrine/dbal": "^2.5",
-        "components/font-awesome": "^4.6",
+        "components/font-awesome": "^5.0.6",
         "franzl/whoops-middleware": "^0.4.0",
         "illuminate/bus": "5.5.*",
         "illuminate/cache": "5.5.*",

--- a/js/admin/src/components/AdminNav.js
+++ b/js/admin/src/components/AdminNav.js
@@ -41,7 +41,7 @@ export default class AdminNav extends Component {
 
     items.add('basics', AdminLinkButton.component({
       href: app.route('basics'),
-      icon: 'pencil',
+      icon: 'pencil-alt',
       children: app.translator.trans('core.admin.nav.basics_button'),
       description: app.translator.trans('core.admin.nav.basics_text')
     }));

--- a/js/admin/src/components/AdminNav.js
+++ b/js/admin/src/components/AdminNav.js
@@ -34,43 +34,42 @@ export default class AdminNav extends Component {
 
     items.add('dashboard', AdminLinkButton.component({
       href: app.route('dashboard'),
-      icon: 'chart-bar',
-      iconPrefix: 'far',
+      icon: 'far fa-chart-bar',
       children: app.translator.trans('core.admin.nav.dashboard_button'),
       description: app.translator.trans('core.admin.nav.dashboard_text')
     }));
 
     items.add('basics', AdminLinkButton.component({
       href: app.route('basics'),
-      icon: 'pencil-alt',
+      icon: 'fa fa-pencil-alt',
       children: app.translator.trans('core.admin.nav.basics_button'),
       description: app.translator.trans('core.admin.nav.basics_text')
     }));
 
     items.add('mail', AdminLinkButton.component({
       href: app.route('mail'),
-      icon: 'envelope',
+      icon: 'fa fa-envelope',
       children: app.translator.trans('core.admin.nav.email_button'),
       description: app.translator.trans('core.admin.nav.email_text')
     }));
 
     items.add('permissions', AdminLinkButton.component({
       href: app.route('permissions'),
-      icon: 'key',
+      icon: 'fa fa-key',
       children: app.translator.trans('core.admin.nav.permissions_button'),
       description: app.translator.trans('core.admin.nav.permissions_text')
     }));
 
     items.add('appearance', AdminLinkButton.component({
       href: app.route('appearance'),
-      icon: 'paint-brush',
+      icon: 'fa fa-paint-brush',
       children: app.translator.trans('core.admin.nav.appearance_button'),
       description: app.translator.trans('core.admin.nav.appearance_text')
     }));
 
     items.add('extensions', AdminLinkButton.component({
       href: app.route('extensions'),
-      icon: 'puzzle-piece',
+      icon: 'fa fa-puzzle-piece',
       children: app.translator.trans('core.admin.nav.extensions_button'),
       description: app.translator.trans('core.admin.nav.extensions_text')
     }));

--- a/js/admin/src/components/AdminNav.js
+++ b/js/admin/src/components/AdminNav.js
@@ -34,7 +34,8 @@ export default class AdminNav extends Component {
 
     items.add('dashboard', AdminLinkButton.component({
       href: app.route('dashboard'),
-      icon: 'bar-chart',
+      icon: 'chart-bar',
+      iconPrefix: 'far',
       children: app.translator.trans('core.admin.nav.dashboard_button'),
       description: app.translator.trans('core.admin.nav.dashboard_text')
     }));

--- a/js/admin/src/components/ExtensionsPage.js
+++ b/js/admin/src/components/ExtensionsPage.js
@@ -42,7 +42,7 @@ export default class ExtensionsPage extends Page {
                           className="ExtensionListItem-controls"
                           buttonClassName="Button Button--icon Button--flat"
                           menuClassName="Dropdown-menu--right"
-                          icon="ellipsis-h">
+                          icon="fa fa-ellipsis-h">
                           {controls}
                         </Dropdown>
                       ) : ''}

--- a/js/admin/src/components/ExtensionsPage.js
+++ b/js/admin/src/components/ExtensionsPage.js
@@ -35,7 +35,7 @@ export default class ExtensionsPage extends Page {
                   return <li className={'ExtensionListItem ' + (!this.isEnabled(extension.id) ? 'disabled' : '')}>
                     <div className="ExtensionListItem-content">
                       <span className="ExtensionListItem-icon ExtensionIcon" style={extension.icon}>
-                        {extension.icon ? icon(extension.icon.name) : ''}
+                        {extension.icon ? icon(extension.icon.name, undefined, extension.icon.prefix) : ''}
                       </span>
                       {controls.length ? (
                         <Dropdown

--- a/js/admin/src/components/ExtensionsPage.js
+++ b/js/admin/src/components/ExtensionsPage.js
@@ -17,7 +17,7 @@ export default class ExtensionsPage extends Page {
           <div className="container">
             {Button.component({
               children: app.translator.trans('core.admin.extensions.add_button'),
-              icon: 'plus',
+              icon: 'fa fa-plus',
               className: 'Button Button--primary',
               onclick: () => app.modal.show(new AddExtensionModal())
             })}
@@ -35,7 +35,7 @@ export default class ExtensionsPage extends Page {
                   return <li className={'ExtensionListItem ' + (!this.isEnabled(extension.id) ? 'disabled' : '')}>
                     <div className="ExtensionListItem-content">
                       <span className="ExtensionListItem-icon ExtensionIcon" style={extension.icon}>
-                        {extension.icon ? icon(extension.icon.name, undefined, extension.icon.prefix) : ''}
+                        {extension.icon ? icon(extension.icon.name) : ''}
                       </span>
                       {controls.length ? (
                         <Dropdown
@@ -67,7 +67,7 @@ export default class ExtensionsPage extends Page {
 
     if (app.extensionSettings[name]) {
       items.add('settings', Button.component({
-        icon: 'cog',
+        icon: 'fa fa-cog',
         children: app.translator.trans('core.admin.extensions.settings_button'),
         onclick: app.extensionSettings[name]
       }));
@@ -75,8 +75,7 @@ export default class ExtensionsPage extends Page {
 
     if (!enabled) {
       items.add('uninstall', Button.component({
-        icon: 'trash-alt',
-        iconPrefix: 'far',
+        icon: 'far fa-trash-alt',
         children: app.translator.trans('core.admin.extensions.uninstall_button'),
         onclick: () => {
           app.request({

--- a/js/admin/src/components/ExtensionsPage.js
+++ b/js/admin/src/components/ExtensionsPage.js
@@ -75,7 +75,8 @@ export default class ExtensionsPage extends Page {
 
     if (!enabled) {
       items.add('uninstall', Button.component({
-        icon: 'trash-o',
+        icon: 'trash-alt',
+        iconPrefix: 'far',
         children: app.translator.trans('core.admin.extensions.uninstall_button'),
         onclick: () => {
           app.request({

--- a/js/admin/src/components/PermissionDropdown.js
+++ b/js/admin/src/components/PermissionDropdown.js
@@ -52,9 +52,9 @@ export default class PermissionDropdown extends Dropdown {
     const adminGroup = app.store.getById('groups', Group.ADMINISTRATOR_ID);
 
     if (everyone) {
-      this.props.label = Badge.component({icon: 'globe'});
+      this.props.label = Badge.component({icon: 'fa fa-globe'});
     } else if (members) {
-      this.props.label = Badge.component({icon: 'user'});
+      this.props.label = Badge.component({icon: 'fa fa-user'});
     } else {
       this.props.label = [
         badgeForId(Group.ADMINISTRATOR_ID),
@@ -66,8 +66,8 @@ export default class PermissionDropdown extends Dropdown {
       if (this.props.allowGuest) {
         this.props.children.push(
           Button.component({
-            children: [Badge.component({icon: 'globe'}), ' ', app.translator.trans('core.admin.permissions_controls.everyone_button')],
-            icon: everyone ? 'check' : true,
+            children: [Badge.component({icon: 'fa fa-globe'}), ' ', app.translator.trans('core.admin.permissions_controls.everyone_button')],
+            icon: everyone ? 'fa fa-check' : true,
             onclick: () => this.save([Group.GUEST_ID]),
             disabled: this.isGroupDisabled(Group.GUEST_ID)
           })
@@ -76,8 +76,8 @@ export default class PermissionDropdown extends Dropdown {
 
       this.props.children.push(
         Button.component({
-          children: [Badge.component({icon: 'user'}), ' ', app.translator.trans('core.admin.permissions_controls.members_button')],
-          icon: members ? 'check' : true,
+          children: [Badge.component({icon: 'fa fa-user'}), ' ', app.translator.trans('core.admin.permissions_controls.members_button')],
+          icon: members ? 'fa fa-check' : true,
           onclick: () => this.save([Group.MEMBER_ID]),
           disabled: this.isGroupDisabled(Group.MEMBER_ID)
         }),
@@ -86,7 +86,7 @@ export default class PermissionDropdown extends Dropdown {
 
         Button.component({
           children: [badgeForId(adminGroup.id()), ' ', adminGroup.namePlural()],
-          icon: !everyone && !members ? 'check' : true,
+          icon: !everyone && !members ? 'fa fa-check' : true,
           disabled: !everyone && !members,
           onclick: e => {
             if (e.shiftKey) e.stopPropagation();
@@ -101,7 +101,7 @@ export default class PermissionDropdown extends Dropdown {
           .filter(group => [Group.ADMINISTRATOR_ID, Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()) === -1)
           .map(group => Button.component({
             children: [badgeForId(group.id()), ' ', group.namePlural()],
-            icon: groupIds.indexOf(group.id()) !== -1 ? 'check' : true,
+            icon: groupIds.indexOf(group.id()) !== -1 ? 'fa fa-check' : true,
             onclick: (e) => {
               if (e.shiftKey) e.stopPropagation();
               this.toggle(group.id());

--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -29,7 +29,7 @@ export default class PermissionGrid extends Component {
             {scopes.map(scope => (
               <th>
                 {scope.label}{' '}
-                {scope.onremove ? Button.component({icon: 'times', className: 'Button Button--text PermissionGrid-removeScope', onclick: scope.onremove}) : ''}
+                {scope.onremove ? Button.component({icon: 'fa fa-times', className: 'Button Button--text PermissionGrid-removeScope', onclick: scope.onremove}) : ''}
               </th>
             ))}
             <th>{this.scopeControlItems().toArray()}</th>
@@ -44,7 +44,7 @@ export default class PermissionGrid extends Component {
             </tr>
             {section.children.map(child => (
               <tr className="PermissionGrid-child">
-                <th>{icon(child.icon, undefined, child.iconPrefix)}{child.label}</th>
+                <th>{icon(child.icon)}{child.label}</th>
                 {permissionCells(child)}
                 <td/>
               </tr>
@@ -85,21 +85,21 @@ export default class PermissionGrid extends Component {
     const items = new ItemList();
 
     items.add('viewDiscussions', {
-      icon: 'eye',
+      icon: 'fa fa-eye',
       label: app.translator.trans('core.admin.permissions.view_discussions_label'),
       permission: 'viewDiscussions',
       allowGuest: true
     }, 100);
 
     items.add('viewUserList', {
-      icon: 'users',
+      icon: 'fa fa-users',
       label: app.translator.trans('core.admin.permissions.view_user_list_label'),
       permission: 'viewUserList',
       allowGuest: true
     }, 100);
 
     items.add('signUp', {
-      icon: 'user-plus',
+      icon: 'fa fa-user-plus',
       label: app.translator.trans('core.admin.permissions.sign_up_label'),
       setting: () => SettingDropdown.component({
         key: 'allow_sign_up',
@@ -117,13 +117,13 @@ export default class PermissionGrid extends Component {
     const items = new ItemList();
 
     items.add('start', {
-      icon: 'edit',
+      icon: 'fa fa-edit',
       label: app.translator.trans('core.admin.permissions.start_discussions_label'),
       permission: 'startDiscussion'
     }, 100);
 
     items.add('allowRenaming', {
-      icon: 'i-cursor',
+      icon: 'fa fa-i-cursor',
       label: app.translator.trans('core.admin.permissions.allow_renaming_label'),
       setting: () => {
         const minutes = parseInt(app.data.settings.allow_renaming, 10);
@@ -149,13 +149,13 @@ export default class PermissionGrid extends Component {
     const items = new ItemList();
 
     items.add('reply', {
-      icon: 'reply',
+      icon: 'fa fa-reply',
       label: app.translator.trans('core.admin.permissions.reply_to_discussions_label'),
       permission: 'discussion.reply'
     }, 100);
 
     items.add('allowPostEditing', {
-      icon: 'pencil-alt',
+      icon: 'fa fa-pencil-alt',
       label: app.translator.trans('core.admin.permissions.allow_post_editing_label'),
       setting: () => {
         const minutes = parseInt(app.data.settings.allow_post_editing, 10);
@@ -181,38 +181,37 @@ export default class PermissionGrid extends Component {
     const items = new ItemList();
 
     items.add('viewIpsPosts', {
-      icon: 'bullseye',
+      icon: 'fa fa-bullseye',
       label: app.translator.trans('core.admin.permissions.view_post_ips_label'),
       permission: 'discussion.viewIpsPosts'
     }, 110);
 
     items.add('renameDiscussions', {
-      icon: 'i-cursor',
+      icon: 'fa fa-i-cursor',
       label: app.translator.trans('core.admin.permissions.rename_discussions_label'),
       permission: 'discussion.rename'
     }, 100);
 
     items.add('hideDiscussions', {
-      icon: 'trash-alt',
-      iconPrefix: 'far',
+      icon: 'far fa-trash-alt',
       label: app.translator.trans('core.admin.permissions.delete_discussions_label'),
       permission: 'discussion.hide'
     }, 90);
 
     items.add('deleteDiscussions', {
-      icon: 'times',
+      icon: 'fa fa-times',
       label: app.translator.trans('core.admin.permissions.delete_discussions_forever_label'),
       permission: 'discussion.delete'
     }, 80);
 
     items.add('editPosts', {
-      icon: 'pencil-alt',
+      icon: 'fa fa-pencil-alt',
       label: app.translator.trans('core.admin.permissions.edit_and_delete_posts_label'),
       permission: 'discussion.editPosts'
     }, 70);
 
     items.add('deletePosts', {
-      icon: 'times',
+      icon: 'fa fa-times',
       label: app.translator.trans('core.admin.permissions.delete_posts_forever_label'),
       permission: 'discussion.deletePosts'
     }, 60);

--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -44,7 +44,7 @@ export default class PermissionGrid extends Component {
             </tr>
             {section.children.map(child => (
               <tr className="PermissionGrid-child">
-                <th>{icon(child.icon)}{child.label}</th>
+                <th>{icon(child.icon, undefined, child.iconPrefix)}{child.label}</th>
                 {permissionCells(child)}
                 <td/>
               </tr>

--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -193,7 +193,8 @@ export default class PermissionGrid extends Component {
     }, 100);
 
     items.add('hideDiscussions', {
-      icon: 'trash-o',
+      icon: 'trash-alt',
+      iconPrefix: 'far',
       label: app.translator.trans('core.admin.permissions.delete_discussions_label'),
       permission: 'discussion.hide'
     }, 90);

--- a/js/admin/src/components/PermissionGrid.js
+++ b/js/admin/src/components/PermissionGrid.js
@@ -155,7 +155,7 @@ export default class PermissionGrid extends Component {
     }, 100);
 
     items.add('allowPostEditing', {
-      icon: 'pencil',
+      icon: 'pencil-alt',
       label: app.translator.trans('core.admin.permissions.allow_post_editing_label'),
       setting: () => {
         const minutes = parseInt(app.data.settings.allow_post_editing, 10);
@@ -205,7 +205,7 @@ export default class PermissionGrid extends Component {
     }, 80);
 
     items.add('editPosts', {
-      icon: 'pencil',
+      icon: 'pencil-alt',
       label: app.translator.trans('core.admin.permissions.edit_and_delete_posts_label'),
       permission: 'discussion.editPosts'
     }, 70);

--- a/js/admin/src/components/PermissionsPage.js
+++ b/js/admin/src/components/PermissionsPage.js
@@ -24,7 +24,7 @@ export default class PermissionsPage extends Page {
                 </button>
               ))}
             <button className="Button Group Group--add" onclick={() => app.modal.show(new EditGroupModal())}>
-              {icon('plus', {className: 'Group-icon'})}
+              {icon('fa fa-plus', {className: 'Group-icon'})}
               <span className="Group-name">{app.translator.trans('core.admin.permissions.new_group_button')}</span>
             </button>
           </div>

--- a/js/admin/src/components/SessionDropdown.js
+++ b/js/admin/src/components/SessionDropdown.js
@@ -42,7 +42,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('logOut',
       Button.component({
-        icon: 'sign-out',
+        icon: 'sign-out-alt',
         children: app.translator.trans('core.admin.header.log_out_button'),
         onclick: app.session.logout.bind(app.session)
       }),

--- a/js/admin/src/components/SessionDropdown.js
+++ b/js/admin/src/components/SessionDropdown.js
@@ -42,7 +42,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('logOut',
       Button.component({
-        icon: 'sign-out-alt',
+        icon: 'fa fa-sign-out-alt',
         children: app.translator.trans('core.admin.header.log_out_button'),
         onclick: app.session.logout.bind(app.session)
       }),

--- a/js/admin/src/components/SettingDropdown.js
+++ b/js/admin/src/components/SettingDropdown.js
@@ -8,7 +8,7 @@ export default class SettingDropdown extends SelectDropdown {
 
     props.className = 'SettingDropdown';
     props.buttonClassName = 'Button Button--text';
-    props.caretIcon = 'caret-down';
+    props.caretIcon = 'fa fa-caret-down';
     props.defaultLabel = 'Custom';
 
     props.children = props.options.map(({value, label}) => {
@@ -16,7 +16,7 @@ export default class SettingDropdown extends SelectDropdown {
 
       return Button.component({
         children: label,
-        icon: active ? 'check' : true,
+        icon: active ? 'fa fa-check' : true,
         onclick: saveSettings.bind(this, {[props.key]: value}),
         active
       });

--- a/js/admin/src/components/StatusWidget.js
+++ b/js/admin/src/components/StatusWidget.js
@@ -28,7 +28,7 @@ export default class StatusWidget extends DashboardWidget {
 
     items.add('help', (
       <a href="http://flarum.org/docs/troubleshooting" target="_blank">
-        {icon('question-circle')} {app.translator.trans('core.admin.dashboard.help_link')}
+        {icon('fa fa-question-circle')} {app.translator.trans('core.admin.dashboard.help_link')}
       </a>
     ));
 

--- a/js/forum/src/components/AvatarEditor.js
+++ b/js/forum/src/components/AvatarEditor.js
@@ -53,7 +53,7 @@ export default class AvatarEditor extends Component {
           ondragleave={this.disableDragover.bind(this)}
           ondragend={this.disableDragover.bind(this)}
           ondrop={this.dropUpload.bind(this)}>
-          {this.loading ? LoadingIndicator.component() : (user.avatarUrl() ? icon('pencil-alt') : icon('plus-circle'))}
+          {this.loading ? LoadingIndicator.component() : (user.avatarUrl() ? icon('fa fa-pencil-alt') : icon('fa fa-plus-circle'))}
         </a>
         <ul className="Dropdown-menu Menu">
           {listItems(this.controlItems().toArray())}
@@ -72,7 +72,7 @@ export default class AvatarEditor extends Component {
 
     items.add('upload',
       Button.component({
-        icon: 'upload',
+        icon: 'fa fa-upload',
         children: app.translator.trans('core.forum.user.avatar_upload_button'),
         onclick: this.openPicker.bind(this)
       })
@@ -80,7 +80,7 @@ export default class AvatarEditor extends Component {
 
     items.add('remove',
       Button.component({
-        icon: 'times',
+        icon: 'fa fa-times',
         children: app.translator.trans('core.forum.user.avatar_remove_button'),
         onclick: this.remove.bind(this)
       })

--- a/js/forum/src/components/AvatarEditor.js
+++ b/js/forum/src/components/AvatarEditor.js
@@ -53,7 +53,7 @@ export default class AvatarEditor extends Component {
           ondragleave={this.disableDragover.bind(this)}
           ondragend={this.disableDragover.bind(this)}
           ondrop={this.dropUpload.bind(this)}>
-          {this.loading ? LoadingIndicator.component() : (user.avatarUrl() ? icon('pencil') : icon('plus-circle'))}
+          {this.loading ? LoadingIndicator.component() : (user.avatarUrl() ? icon('pencil-alt') : icon('plus-circle'))}
         </a>
         <ul className="Dropdown-menu Menu">
           {listItems(this.controlItems().toArray())}

--- a/js/forum/src/components/CommentPost.js
+++ b/js/forum/src/components/CommentPost.js
@@ -142,7 +142,7 @@ export default class CommentPost extends Post {
       items.add('toggle', (
         Button.component({
           className: 'Button Button--default Button--more',
-          icon: 'ellipsis-h',
+          icon: 'fa fa-ellipsis-h',
           onclick: this.toggleContent.bind(this)
         })
       ));

--- a/js/forum/src/components/Composer.js
+++ b/js/forum/src/components/Composer.js
@@ -422,28 +422,28 @@ class Composer extends Component {
 
     if (this.position === Composer.PositionEnum.FULLSCREEN) {
       items.add('exitFullScreen', ComposerButton.component({
-        icon: 'compress',
+        icon: 'fa fa-compress',
         title: app.translator.trans('core.forum.composer.exit_full_screen_tooltip'),
         onclick: this.exitFullScreen.bind(this)
       }));
     } else {
       if (this.position !== Composer.PositionEnum.MINIMIZED) {
         items.add('minimize', ComposerButton.component({
-          icon: 'minus minimize',
+          icon: 'fa fa-minus minimize',
           title: app.translator.trans('core.forum.composer.minimize_tooltip'),
           onclick: this.minimize.bind(this),
           itemClassName: 'App-backControl'
         }));
 
         items.add('fullScreen', ComposerButton.component({
-          icon: 'expand',
+          icon: 'fa fa-expand',
           title: app.translator.trans('core.forum.composer.full_screen_tooltip'),
           onclick: this.fullScreen.bind(this)
         }));
       }
 
       items.add('close', ComposerButton.component({
-        icon: 'times',
+        icon: 'fa fa-times',
         title: app.translator.trans('core.forum.composer.close_tooltip'),
         onclick: this.close.bind(this)
       }));

--- a/js/forum/src/components/DiscussionListItem.js
+++ b/js/forum/src/components/DiscussionListItem.js
@@ -81,7 +81,7 @@ export default class DiscussionListItem extends Component {
     return (
       <div {...attrs}>
         {controls.length ? Dropdown.component({
-          icon: 'ellipsis-v',
+          icon: 'fa fa-ellipsis-v',
           children: controls,
           className: 'DiscussionListItem-controls',
           buttonClassName: 'Button Button--icon Button--flat Slidable-underneath Slidable-underneath--right'
@@ -89,7 +89,7 @@ export default class DiscussionListItem extends Component {
 
         <a className={'Slidable-underneath Slidable-underneath--left Slidable-underneath--elastic' + (isUnread ? '' : ' disabled')}
           onclick={this.markAsRead.bind(this)}>
-          {icon('check')}
+          {icon('fa fa-check')}
         </a>
 
         <div className={'DiscussionListItem-content Slidable-content' + (isUnread ? ' unread' : '') + (isRead ? ' read' : '')}>

--- a/js/forum/src/components/DiscussionPage.js
+++ b/js/forum/src/components/DiscussionPage.js
@@ -240,7 +240,7 @@ export default class DiscussionPage extends Page {
     items.add('controls',
       SplitDropdown.component({
         children: DiscussionControls.controls(this.discussion, this).toArray(),
-        icon: 'ellipsis-v',
+        icon: 'fa fa-ellipsis-v',
         className: 'App-primaryControl',
         buttonClassName: 'Button--primary'
       })

--- a/js/forum/src/components/DiscussionRenamedNotification.js
+++ b/js/forum/src/components/DiscussionRenamedNotification.js
@@ -10,7 +10,7 @@ import Notification from 'flarum/components/Notification';
  */
 export default class DiscussionRenamedNotification extends Notification {
   icon() {
-    return 'pencil';
+    return 'pencil-alt';
   }
 
   href() {

--- a/js/forum/src/components/DiscussionRenamedNotification.js
+++ b/js/forum/src/components/DiscussionRenamedNotification.js
@@ -10,7 +10,7 @@ import Notification from 'flarum/components/Notification';
  */
 export default class DiscussionRenamedNotification extends Notification {
   icon() {
-    return 'pencil-alt';
+    return 'fa fa-pencil-alt';
   }
 
   href() {

--- a/js/forum/src/components/DiscussionRenamedPost.js
+++ b/js/forum/src/components/DiscussionRenamedPost.js
@@ -11,7 +11,7 @@ import extractText from 'flarum/utils/extractText';
  */
 export default class DiscussionRenamedPost extends EventPost {
   icon() {
-    return 'pencil';
+    return 'pencil-alt';
   }
 
   description(data) {

--- a/js/forum/src/components/DiscussionRenamedPost.js
+++ b/js/forum/src/components/DiscussionRenamedPost.js
@@ -11,7 +11,7 @@ import extractText from 'flarum/utils/extractText';
  */
 export default class DiscussionRenamedPost extends EventPost {
   icon() {
-    return 'pencil-alt';
+    return 'fa fa-pencil-alt';
   }
 
   description(data) {

--- a/js/forum/src/components/DiscussionsSearchSource.js
+++ b/js/forum/src/components/DiscussionsSearchSource.js
@@ -35,7 +35,7 @@ export default class DiscussionsSearchSource {
       <li className="Dropdown-header">{app.translator.trans('core.forum.search.discussions_heading')}</li>,
       <li>
         {LinkButton.component({
-          icon: 'search',
+          icon: 'fa fa-search',
           children: app.translator.trans('core.forum.search.all_discussions_button', {query}),
           href: app.route('index', {q: query})
         })}

--- a/js/forum/src/components/EditPostComposer.js
+++ b/js/forum/src/components/EditPostComposer.js
@@ -52,7 +52,7 @@ export default class EditPostComposer extends ComposerBody {
 
     items.add('title', (
       <h3>
-        {icon('pencil')} {' '}
+        {icon('pencil-alt')} {' '}
         <a href={app.route.discussion(post.discussion(), post.number())} config={routeAndMinimize}>
           {app.translator.trans('core.forum.composer_edit.post_link', {number: post.number(), discussion: post.discussion().title()})}
         </a>

--- a/js/forum/src/components/EditPostComposer.js
+++ b/js/forum/src/components/EditPostComposer.js
@@ -52,7 +52,7 @@ export default class EditPostComposer extends ComposerBody {
 
     items.add('title', (
       <h3>
-        {icon('pencil-alt')} {' '}
+        {icon('fa fa-pencil-alt')} {' '}
         <a href={app.route.discussion(post.discussion(), post.number())} config={routeAndMinimize}>
           {app.translator.trans('core.forum.composer_edit.post_link', {number: post.number(), discussion: post.discussion().title()})}
         </a>

--- a/js/forum/src/components/HeaderSecondary.js
+++ b/js/forum/src/components/HeaderSecondary.js
@@ -46,7 +46,7 @@ export default class HeaderSecondary extends Component {
         locales.push(Button.component({
           active: app.data.locale === locale,
           children: app.data.locales[locale],
-          icon: app.data.locale === locale ? 'check' : true,
+          icon: app.data.locale === locale ? 'fa fa-check' : true,
           onclick: () => {
             if (app.session.user) {
               app.session.user.savePreferences({locale}).then(() => window.location.reload());

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -187,7 +187,8 @@ export default class IndexPage extends Page {
       LinkButton.component({
         href: app.route('index', params),
         children: app.translator.trans('core.forum.index.all_discussions_link'),
-        icon: 'comments-o'
+        icon: 'comments',
+        iconPrefix: 'far'
       }),
       100
     );

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -154,7 +154,7 @@ export default class IndexPage extends Page {
     items.add('newDiscussion',
       Button.component({
         children: app.translator.trans(canStartDiscussion ? 'core.forum.index.start_discussion_button' : 'core.forum.index.cannot_start_discussion_button'),
-        icon: 'edit',
+        icon: 'fa fa-edit',
         className: 'Button Button--primary IndexPage-newDiscussion',
         itemClassName: 'App-primaryControl',
         onclick: this.newDiscussion.bind(this),
@@ -187,8 +187,7 @@ export default class IndexPage extends Page {
       LinkButton.component({
         href: app.route('index', params),
         children: app.translator.trans('core.forum.index.all_discussions_link'),
-        icon: 'comments',
-        iconPrefix: 'far'
+        icon: 'far fa-comments'
       }),
       100
     );
@@ -222,7 +221,7 @@ export default class IndexPage extends Page {
 
           return Button.component({
             children: label,
-            icon: active ? 'check' : true,
+            icon: active ? 'fa fa-check' : true,
             onclick: this.changeSort.bind(this, value),
             active: active,
           })
@@ -245,7 +244,7 @@ export default class IndexPage extends Page {
     items.add('refresh',
       Button.component({
         title: app.translator.trans('core.forum.index.refresh_tooltip'),
-        icon: 'sync',
+        icon: 'fa fa-sync',
         className: 'Button Button--icon',
         onclick: () => {
           app.cache.discussionList.refresh();
@@ -261,7 +260,7 @@ export default class IndexPage extends Page {
       items.add('markAllAsRead',
         Button.component({
           title: app.translator.trans('core.forum.index.mark_all_as_read_tooltip'),
-          icon: 'check',
+          icon: 'fa fa-check',
           className: 'Button Button--icon',
           onclick: this.markAllAsRead.bind(this)
         })

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -244,7 +244,7 @@ export default class IndexPage extends Page {
     items.add('refresh',
       Button.component({
         title: app.translator.trans('core.forum.index.refresh_tooltip'),
-        icon: 'refresh',
+        icon: 'sync',
         className: 'Button Button--icon',
         onclick: () => {
           app.cache.discussionList.refresh();

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -183,7 +183,8 @@ export default class NotificationGrid extends Component {
 
     items.add('email', {
       name: 'email',
-      icon: 'envelope-o',
+      icon: 'envelope',
+      iconPrefix: 'far',
       label: app.translator.trans('core.forum.settings.notify_by_email_heading'),
     });
 

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -206,7 +206,7 @@ export default class NotificationGrid extends Component {
 
     items.add('discussionRenamed', {
       name: 'discussionRenamed',
-      icon: 'pencil',
+      icon: 'pencil-alt',
       label: app.translator.trans('core.forum.settings.notify_discussion_renamed_label')
     });
 

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -59,7 +59,7 @@ export default class NotificationGrid extends Component {
             <td/>
             {this.methods.map(method => (
               <th className="NotificationGrid-groupToggle" onclick={this.toggleMethod.bind(this, method.name)}>
-                {icon(method.icon, undefined, method.iconPrefix)} {method.label}
+                {icon(method.icon)} {method.label}
               </th>
             ))}
           </tr>
@@ -69,7 +69,7 @@ export default class NotificationGrid extends Component {
           {this.types.map(type => (
             <tr>
               <td className="NotificationGrid-groupToggle" onclick={this.toggleType.bind(this, type.name)}>
-                {icon(type.icon, undefined, type.iconPrefix)} {type.label}
+                {icon(type.icon)} {type.label}
               </td>
               {this.methods.map(method => (
                 <td className="NotificationGrid-checkbox">
@@ -177,14 +177,13 @@ export default class NotificationGrid extends Component {
 
     items.add('alert', {
       name: 'alert',
-      icon: 'bell',
+      icon: 'fa fa-bell',
       label: app.translator.trans('core.forum.settings.notify_by_web_heading'),
     });
 
     items.add('email', {
       name: 'email',
-      icon: 'envelope',
-      iconPrefix: 'far',
+      icon: 'far fa-envelope',
       label: app.translator.trans('core.forum.settings.notify_by_email_heading'),
     });
 
@@ -207,7 +206,7 @@ export default class NotificationGrid extends Component {
 
     items.add('discussionRenamed', {
       name: 'discussionRenamed',
-      icon: 'pencil-alt',
+      icon: 'fa fa-pencil-alt',
       label: app.translator.trans('core.forum.settings.notify_discussion_renamed_label')
     });
 

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -59,7 +59,7 @@ export default class NotificationGrid extends Component {
             <td/>
             {this.methods.map(method => (
               <th className="NotificationGrid-groupToggle" onclick={this.toggleMethod.bind(this, method.name)}>
-                {icon(method.icon)} {method.label}
+                {icon(method.icon, undefined, method.iconPrefix)} {method.label}
               </th>
             ))}
           </tr>
@@ -69,7 +69,7 @@ export default class NotificationGrid extends Component {
           {this.types.map(type => (
             <tr>
               <td className="NotificationGrid-groupToggle" onclick={this.toggleType.bind(this, type.name)}>
-                {icon(type.icon)} {type.label}
+                {icon(type.icon, undefined, type.iconPrefix)} {type.label}
               </td>
               {this.methods.map(method => (
                 <td className="NotificationGrid-checkbox">

--- a/js/forum/src/components/NotificationList.js
+++ b/js/forum/src/components/NotificationList.js
@@ -34,7 +34,7 @@ export default class NotificationList extends Component {
           <div className="App-primaryControl">
             {Button.component({
               className: 'Button Button--icon Button--link',
-              icon: 'check',
+              icon: 'fa fa-check',
               title: app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip'),
               onclick: this.markAllAsRead.bind(this)
             })}

--- a/js/forum/src/components/NotificationsDropdown.js
+++ b/js/forum/src/components/NotificationsDropdown.js
@@ -8,7 +8,7 @@ export default class NotificationsDropdown extends Dropdown {
     props.buttonClassName = props.buttonClassName || 'Button Button--flat';
     props.menuClassName = props.menuClassName || 'Dropdown-menu--right';
     props.label = props.label || app.translator.trans('core.forum.notifications.tooltip');
-    props.icon = props.icon || 'bell';
+    props.icon = props.icon || 'fa fa-bell';
 
     super.initProps(props);
   }

--- a/js/forum/src/components/Post.js
+++ b/js/forum/src/components/Post.js
@@ -57,7 +57,7 @@ export default class Post extends Component {
                       className="Post-controls"
                       buttonClassName="Button Button--icon Button--flat"
                       menuClassName="Dropdown-menu--right"
-                      icon="ellipsis-h"
+                      icon="fa fa-ellipsis-h"
                       onshow={() => this.$('.Post-actions').addClass('open')}
                       onhide={() => this.$('.Post-actions').removeClass('open')}>
                       {controls}

--- a/js/forum/src/components/PostStreamScrubber.js
+++ b/js/forum/src/components/PostStreamScrubber.js
@@ -84,13 +84,13 @@ export default class PostStreamScrubber extends Component {
     return (
       <div className={'PostStreamScrubber Dropdown ' + (this.disabled() ? 'disabled ' : '') + (this.props.className || '')}>
         <button className="Button Dropdown-toggle" data-toggle="dropdown">
-          {viewing} {icon('sort')}
+          {viewing} {icon('fa fa-sort')}
         </button>
 
         <div className="Dropdown-menu dropdown-menu">
           <div className="Scrubber">
             <a className="Scrubber-first" onclick={this.goToFirst.bind(this)}>
-              {icon('angle-double-up')} {app.translator.trans('core.forum.post_scrubber.original_post_link')}
+              {icon('fa fa-angle-double-up')} {app.translator.trans('core.forum.post_scrubber.original_post_link')}
             </a>
 
             <div className="Scrubber-scrollbar">
@@ -110,7 +110,7 @@ export default class PostStreamScrubber extends Component {
             </div>
 
             <a className="Scrubber-last" onclick={this.goToLast.bind(this)}>
-              {icon('angle-double-down')} {app.translator.trans('core.forum.post_scrubber.now_link')}
+              {icon('fa fa-angle-double-down')} {app.translator.trans('core.forum.post_scrubber.now_link')}
             </a>
           </div>
         </div>

--- a/js/forum/src/components/ReplyComposer.js
+++ b/js/forum/src/components/ReplyComposer.js
@@ -51,7 +51,7 @@ export default class ReplyComposer extends ComposerBody {
 
     items.add('title', (
       <h3>
-        {icon('reply')} {' '}
+        {icon('fa fa-reply')} {' '}
         <a href={app.route.discussion(discussion)} config={routeAndMinimize}>{discussion.title()}</a>
       </h3>
     ));

--- a/js/forum/src/components/Search.js
+++ b/js/forum/src/components/Search.js
@@ -92,7 +92,7 @@ export default class Search extends Component {
           {this.loadingSources
             ? LoadingIndicator.component({size: 'tiny', className: 'Button Button--icon Button--link'})
             : currentSearch
-              ? <button className="Search-clear Button Button--icon Button--link" onclick={this.clear.bind(this)}>{icon('times-circle')}</button>
+              ? <button className="Search-clear Button Button--icon Button--link" onclick={this.clear.bind(this)}>{icon('fa fa-times-circle')}</button>
               : ''}
         </div>
         <ul className="Dropdown-menu Search-results">

--- a/js/forum/src/components/SessionDropdown.js
+++ b/js/forum/src/components/SessionDropdown.js
@@ -46,7 +46,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('profile',
       LinkButton.component({
-        icon: 'user',
+        icon: 'fa fa-user',
         children: app.translator.trans('core.forum.header.profile_button'),
         href: app.route.user(user)
       }),
@@ -55,7 +55,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('settings',
       LinkButton.component({
-        icon: 'cog',
+        icon: 'fa fa-cog',
         children: app.translator.trans('core.forum.header.settings_button'),
         href: app.route('settings')
       }),
@@ -65,7 +65,7 @@ export default class SessionDropdown extends Dropdown {
     if (app.forum.attribute('adminUrl')) {
       items.add('administration',
         LinkButton.component({
-          icon: 'wrench',
+          icon: 'fa fa-wrench',
           children: app.translator.trans('core.forum.header.admin_button'),
           href: app.forum.attribute('adminUrl'),
           target: '_blank',
@@ -79,7 +79,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('logOut',
       Button.component({
-        icon: 'sign-out-alt',
+        icon: 'fa fa-sign-out-alt',
         children: app.translator.trans('core.forum.header.log_out_button'),
         onclick: app.session.logout.bind(app.session)
       }),

--- a/js/forum/src/components/SessionDropdown.js
+++ b/js/forum/src/components/SessionDropdown.js
@@ -79,7 +79,7 @@ export default class SessionDropdown extends Dropdown {
 
     items.add('logOut',
       Button.component({
-        icon: 'sign-out',
+        icon: 'sign-out-alt',
         children: app.translator.trans('core.forum.header.log_out_button'),
         onclick: app.session.logout.bind(app.session)
       }),

--- a/js/forum/src/components/TerminalPost.js
+++ b/js/forum/src/components/TerminalPost.js
@@ -20,7 +20,7 @@ export default class TerminalPost extends Component {
 
     return (
       <span>
-        {lastPost ? icon('reply') : ''}{' '}
+        {lastPost ? icon('fa fa-reply') : ''}{' '}
         {app.translator.trans('core.forum.discussion_list.' + (lastPost ? 'replied' : 'started') + '_text', {
           user,
           ago: humanTime(time)

--- a/js/forum/src/components/TextEditor.js
+++ b/js/forum/src/components/TextEditor.js
@@ -70,7 +70,7 @@ export default class TextEditor extends Component {
     items.add('submit',
       Button.component({
         children: this.props.submitLabel,
-        icon: 'check',
+        icon: 'fa fa-check',
         className: 'Button Button--primary',
         itemClassName: 'App-primaryControl',
         onclick: this.onsubmit.bind(this)
@@ -80,7 +80,7 @@ export default class TextEditor extends Component {
     if (this.props.preview) {
       items.add('preview',
         Button.component({
-          icon: 'eye',
+          icon: 'fa fa-eye',
           className: 'Button Button--icon',
           onclick: this.props.preview,
           title: app.translator.trans('core.forum.composer.preview_tooltip')

--- a/js/forum/src/components/UserCard.js
+++ b/js/forum/src/components/UserCard.js
@@ -40,7 +40,7 @@ export default class UserCard extends Component {
               menuClassName: 'Dropdown-menu--right',
               buttonClassName: this.props.controlsButtonClassName,
               label: app.translator.trans('core.forum.user_controls.button'),
-              icon: 'ellipsis-v'
+              icon: 'fa fa-ellipsis-v'
             }) : ''}
 
             <div className="UserCard-profile">
@@ -87,8 +87,8 @@ export default class UserCard extends Component {
       items.add('lastSeen', (
         <span className={'UserCard-lastSeen' + (online ? ' online' : '')}>
           {online
-            ? [icon('circle'), ' ', app.translator.trans('core.forum.user.online_text')]
-            : [icon('clock-o'), ' ', humanTime(lastSeenTime)]}
+            ? [icon('fa fa-circle'), ' ', app.translator.trans('core.forum.user.online_text')]
+            : [icon('far fa-clock'), ' ', humanTime(lastSeenTime)]}
         </span>
       ));
     }

--- a/js/forum/src/components/UserPage.js
+++ b/js/forum/src/components/UserPage.js
@@ -130,8 +130,7 @@ export default class UserPage extends Page {
       LinkButton.component({
         href: app.route('user.posts', {username: user.username()}),
         children: [app.translator.trans('core.forum.user.posts_link'), <span className="Button-badge">{user.commentsCount()}</span>],
-        icon: 'comment',
-        iconPrefix: 'far'
+        icon: 'far fa-comment'
       }),
       100
     );
@@ -140,7 +139,7 @@ export default class UserPage extends Page {
       LinkButton.component({
         href: app.route('user.discussions', {username: user.username()}),
         children: [app.translator.trans('core.forum.user.discussions_link'), <span className="Button-badge">{user.discussionsCount()}</span>],
-        icon: 'bars'
+        icon: 'fa fa-bars'
       }),
       90
     );
@@ -151,7 +150,7 @@ export default class UserPage extends Page {
         LinkButton.component({
           href: app.route('settings'),
           children: app.translator.trans('core.forum.user.settings_link'),
-          icon: 'cog'
+          icon: 'fa fa-cog'
         }),
         -100
       );

--- a/js/forum/src/components/UserPage.js
+++ b/js/forum/src/components/UserPage.js
@@ -139,7 +139,7 @@ export default class UserPage extends Page {
       LinkButton.component({
         href: app.route('user.discussions', {username: user.username()}),
         children: [app.translator.trans('core.forum.user.discussions_link'), <span className="Button-badge">{user.discussionsCount()}</span>],
-        icon: 'reorder'
+        icon: 'bars'
       }),
       90
     );

--- a/js/forum/src/components/UserPage.js
+++ b/js/forum/src/components/UserPage.js
@@ -130,7 +130,8 @@ export default class UserPage extends Page {
       LinkButton.component({
         href: app.route('user.posts', {username: user.username()}),
         children: [app.translator.trans('core.forum.user.posts_link'), <span className="Button-badge">{user.commentsCount()}</span>],
-        icon: 'comment-o'
+        icon: 'comment',
+        iconPrefix: 'far'
       }),
       100
     );

--- a/js/forum/src/components/WelcomeHero.js
+++ b/js/forum/src/components/WelcomeHero.js
@@ -21,7 +21,7 @@ export default class WelcomeHero extends Component {
       <header className="Hero WelcomeHero">
         <div class="container">
           {Button.component({
-            icon: 'times',
+            icon: 'fa fa-times',
             onclick: slideUp,
             className: 'Hero-close Button Button--icon Button--link'
           })}

--- a/js/forum/src/initializers/alertEmailConfirmation.js
+++ b/js/forum/src/initializers/alertEmailConfirmation.js
@@ -24,7 +24,7 @@ export default function alertEmailConfirmation(app) {
         url: app.forum.attribute('apiUrl') + '/users/' + user.id() + '/send-confirmation',
       }).then(() => {
         resendButton.props.loading = false;
-        resendButton.props.children = [icon('check'), ' ', app.translator.trans('core.forum.user_email_confirmation.sent_message')];
+        resendButton.props.children = [icon('fa fa-check'), ' ', app.translator.trans('core.forum.user_email_confirmation.sent_message')];
         resendButton.props.disabled = true;
         m.redraw();
       }).catch(() => {

--- a/js/forum/src/utils/DiscussionControls.js
+++ b/js/forum/src/utils/DiscussionControls.js
@@ -109,7 +109,8 @@ export default {
     if (!discussion.isHidden()) {
       if (discussion.canHide()) {
         items.add('hide', Button.component({
-          icon: 'trash-o',
+          icon: 'trash-alt',
+          iconPrefix: 'far',
           children: app.translator.trans('core.forum.discussion_controls.delete_button'),
           onclick: this.hideAction.bind(discussion)
         }));

--- a/js/forum/src/utils/DiscussionControls.js
+++ b/js/forum/src/utils/DiscussionControls.js
@@ -55,12 +55,12 @@ export default {
       items.add('reply',
         !app.session.user || discussion.canReply()
           ? Button.component({
-            icon: 'reply',
+            icon: 'fa fa-reply',
             children: app.translator.trans(app.session.user ? 'core.forum.discussion_controls.reply_button' : 'core.forum.discussion_controls.log_in_to_reply_button'),
             onclick: this.replyAction.bind(discussion, true, false)
           })
           : Button.component({
-            icon: 'reply',
+            icon: 'fa fa-reply',
             children: app.translator.trans('core.forum.discussion_controls.cannot_reply_button'),
             className: 'disabled',
             title: app.translator.trans('core.forum.discussion_controls.cannot_reply_text')
@@ -85,7 +85,7 @@ export default {
 
     if (discussion.canRename()) {
       items.add('rename', Button.component({
-        icon: 'pencil-alt',
+        icon: 'fa fa-pencil-alt',
         children: app.translator.trans('core.forum.discussion_controls.rename_button'),
         onclick: this.renameAction.bind(discussion)
       }));
@@ -109,8 +109,7 @@ export default {
     if (!discussion.isHidden()) {
       if (discussion.canHide()) {
         items.add('hide', Button.component({
-          icon: 'trash-alt',
-          iconPrefix: 'far',
+          icon: 'far fa-trash-alt',
           children: app.translator.trans('core.forum.discussion_controls.delete_button'),
           onclick: this.hideAction.bind(discussion)
         }));
@@ -118,7 +117,7 @@ export default {
     } else {
       if (discussion.canHide()) {
         items.add('restore', Button.component({
-          icon: 'reply',
+          icon: 'fa fa-reply',
           children: app.translator.trans('core.forum.discussion_controls.restore_button'),
           onclick: this.restoreAction.bind(discussion)
         }));
@@ -126,7 +125,7 @@ export default {
 
       if (discussion.canDelete()) {
         items.add('delete', Button.component({
-          icon: 'times',
+          icon: 'fa fa-times',
           children: app.translator.trans('core.forum.discussion_controls.delete_forever_button'),
           onclick: this.deleteAction.bind(discussion)
         }));

--- a/js/forum/src/utils/DiscussionControls.js
+++ b/js/forum/src/utils/DiscussionControls.js
@@ -85,7 +85,7 @@ export default {
 
     if (discussion.canRename()) {
       items.add('rename', Button.component({
-        icon: 'pencil',
+        icon: 'pencil-alt',
         children: app.translator.trans('core.forum.discussion_controls.rename_button'),
         onclick: this.renameAction.bind(discussion)
       }));

--- a/js/forum/src/utils/PostControls.js
+++ b/js/forum/src/utils/PostControls.js
@@ -84,7 +84,8 @@ export default {
     if (post.contentType() === 'comment' && !post.isHidden()) {
       if (post.canEdit()) {
         items.add('hide', Button.component({
-          icon: 'trash-o',
+          icon: 'trash-alt',
+          iconPrefix: 'far',
           children: app.translator.trans('core.forum.post_controls.delete_button'),
           onclick: this.hideAction.bind(post)
         }));

--- a/js/forum/src/utils/PostControls.js
+++ b/js/forum/src/utils/PostControls.js
@@ -59,7 +59,7 @@ export default {
     if (post.contentType() === 'comment' && post.canEdit()) {
       if (!post.isHidden()) {
         items.add('edit', Button.component({
-          icon: 'pencil-alt',
+          icon: 'fa fa-pencil-alt',
           children: app.translator.trans('core.forum.post_controls.edit_button'),
           onclick: this.editAction.bind(post)
         }));
@@ -84,8 +84,7 @@ export default {
     if (post.contentType() === 'comment' && !post.isHidden()) {
       if (post.canEdit()) {
         items.add('hide', Button.component({
-          icon: 'trash-alt',
-          iconPrefix: 'far',
+          icon: 'far fa-trash-alt',
           children: app.translator.trans('core.forum.post_controls.delete_button'),
           onclick: this.hideAction.bind(post)
         }));
@@ -93,14 +92,14 @@ export default {
     } else {
       if (post.contentType() === 'comment' && post.canEdit()) {
         items.add('restore', Button.component({
-          icon: 'reply',
+          icon: 'fa fa-reply',
           children: app.translator.trans('core.forum.post_controls.restore_button'),
           onclick: this.restoreAction.bind(post)
         }));
       }
       if (post.canDelete()) {
         items.add('delete', Button.component({
-          icon: 'times',
+          icon: 'fa fa-times',
           children: app.translator.trans('core.forum.post_controls.delete_forever_button'),
           onclick: this.deleteAction.bind(post, context)
         }));

--- a/js/forum/src/utils/PostControls.js
+++ b/js/forum/src/utils/PostControls.js
@@ -59,7 +59,7 @@ export default {
     if (post.contentType() === 'comment' && post.canEdit()) {
       if (!post.isHidden()) {
         items.add('edit', Button.component({
-          icon: 'pencil',
+          icon: 'pencil-alt',
           children: app.translator.trans('core.forum.post_controls.edit_button'),
           onclick: this.editAction.bind(post)
         }));

--- a/js/forum/src/utils/UserControls.js
+++ b/js/forum/src/utils/UserControls.js
@@ -59,7 +59,7 @@ export default {
 
     if (user.canEdit()) {
       items.add('edit', Button.component({
-        icon: 'pencil',
+        icon: 'pencil-alt',
         children: app.translator.trans('core.forum.user_controls.edit_button'),
         onclick: this.editAction.bind(user)
       }));

--- a/js/forum/src/utils/UserControls.js
+++ b/js/forum/src/utils/UserControls.js
@@ -59,7 +59,7 @@ export default {
 
     if (user.canEdit()) {
       items.add('edit', Button.component({
-        icon: 'pencil-alt',
+        icon: 'fa fa-pencil-alt',
         children: app.translator.trans('core.forum.user_controls.edit_button'),
         onclick: this.editAction.bind(user)
       }));
@@ -82,7 +82,7 @@ export default {
 
     if (user.id() !== '1' && user.canDelete()) {
       items.add('delete', Button.component({
-        icon: 'times',
+        icon: 'fa fa-times',
         children: app.translator.trans('core.forum.user_controls.delete_button'),
         onclick: this.deleteAction.bind(user)
       }));

--- a/js/lib/components/Alert.js
+++ b/js/lib/components/Alert.js
@@ -37,7 +37,7 @@ export default class Alert extends Component {
     if (dismissible || dismissible === undefined) {
       dismissControl.push(
         <Button
-          icon="times"
+          icon="fa fa-times"
           className="Button Button--link Button--icon Alert-dismiss"
           onclick={ondismiss}/>
       );

--- a/js/lib/components/Badge.js
+++ b/js/lib/components/Badge.js
@@ -20,14 +20,13 @@ export default class Badge extends Component {
     const attrs = Object.assign({}, this.props);
     const type = extract(attrs, 'type');
     const iconName = extract(attrs, 'icon');
-    const iconPrefix = extract(attrs, 'iconPrefix');
 
     attrs.className = 'Badge ' + (type ? 'Badge--' + type : '') + ' ' + (attrs.className || '');
     attrs.title = extract(attrs, 'label') || '';
 
     return (
       <span {...attrs}>
-        {iconName ? icon(iconName, {className: 'Badge-icon'}, iconPrefix) : m.trust('&nbsp;')}
+        {iconName ? icon(iconName, {className: 'Badge-icon'}) : m.trust('&nbsp;')}
       </span>
     );
   }

--- a/js/lib/components/Badge.js
+++ b/js/lib/components/Badge.js
@@ -20,13 +20,14 @@ export default class Badge extends Component {
     const attrs = Object.assign({}, this.props);
     const type = extract(attrs, 'type');
     const iconName = extract(attrs, 'icon');
+    const iconPrefix = extract(attrs, 'iconPrefix');
 
     attrs.className = 'Badge ' + (type ? 'Badge--' + type : '') + ' ' + (attrs.className || '');
     attrs.title = extract(attrs, 'label') || '';
 
     return (
       <span {...attrs}>
-        {iconName ? icon(iconName, {className: 'Badge-icon'}) : m.trust('&nbsp;')}
+        {iconName ? icon(iconName, {className: 'Badge-icon'}, iconPrefix) : m.trust('&nbsp;')}
       </span>
     );
   }

--- a/js/lib/components/Button.js
+++ b/js/lib/components/Button.js
@@ -54,10 +54,9 @@ export default class Button extends Component {
    */
   getButtonContent() {
     const iconName = this.props.icon;
-    const iconPrefix = this.props.iconPrefix;
 
     return [
-      iconName && iconName !== true ? icon(iconName, {className: 'Button-icon'}, iconPrefix) : '',
+      iconName && iconName !== true ? icon(iconName, {className: 'Button-icon'}) : '',
       this.props.children ? <span className="Button-label">{this.props.children}</span> : '',
       this.props.loading ? LoadingIndicator.component({size: 'tiny', className: 'LoadingIndicator--inline'}) : ''
     ];

--- a/js/lib/components/Button.js
+++ b/js/lib/components/Button.js
@@ -54,9 +54,10 @@ export default class Button extends Component {
    */
   getButtonContent() {
     const iconName = this.props.icon;
+    const iconPrefix = this.props.iconPrefix;
 
     return [
-      iconName && iconName !== true ? icon(iconName, {className: 'Button-icon'}) : '',
+      iconName && iconName !== true ? icon(iconName, {className: 'Button-icon'}, iconPrefix) : '',
       this.props.children ? <span className="Button-label">{this.props.children}</span> : '',
       this.props.loading ? LoadingIndicator.component({size: 'tiny', className: 'LoadingIndicator--inline'}) : ''
     ];

--- a/js/lib/components/Checkbox.js
+++ b/js/lib/components/Checkbox.js
@@ -52,7 +52,7 @@ export default class Checkbox extends Component {
   getDisplay() {
     return this.loading
       ? LoadingIndicator.component({size: 'tiny'})
-      : icon(this.props.state ? 'check' : 'times');
+      : icon(this.props.state ? 'fa fa-check' : 'fa fa-times');
   }
 
   /**

--- a/js/lib/components/Dropdown.js
+++ b/js/lib/components/Dropdown.js
@@ -26,7 +26,7 @@ export default class Dropdown extends Component {
     props.buttonClassName = props.buttonClassName || '';
     props.menuClassName = props.menuClassName || '';
     props.label = props.label || '';
-    props.caretIcon = typeof props.caretIcon !== 'undefined' ? props.caretIcon : 'caret-down';
+    props.caretIcon = typeof props.caretIcon !== 'undefined' ? props.caretIcon : 'fa fa-caret-down';
   }
 
   init() {
@@ -115,7 +115,7 @@ export default class Dropdown extends Component {
    */
   getButtonContent() {
     return [
-      this.props.icon ? icon(this.props.icon, {className: 'Button-icon'}, this.props.iconPrefix) : '',
+      this.props.icon ? icon(this.props.icon, {className: 'Button-icon'}) : '',
       <span className="Button-label">{this.props.label}</span>,
       this.props.caretIcon ? icon(this.props.caretIcon, {className: 'Button-caret'}) : ''
     ];

--- a/js/lib/components/Dropdown.js
+++ b/js/lib/components/Dropdown.js
@@ -115,7 +115,7 @@ export default class Dropdown extends Component {
    */
   getButtonContent() {
     return [
-      this.props.icon ? icon(this.props.icon, {className: 'Button-icon'}) : '',
+      this.props.icon ? icon(this.props.icon, {className: 'Button-icon'}, this.props.iconPrefix) : '',
       <span className="Button-label">{this.props.label}</span>,
       this.props.caretIcon ? icon(this.props.caretIcon, {className: 'Button-caret'}) : ''
     ];

--- a/js/lib/components/Modal.js
+++ b/js/lib/components/Modal.js
@@ -29,7 +29,7 @@ export default class Modal extends Component {
           {this.isDismissible() ? (
             <div className="Modal-close App-backControl">
               {Button.component({
-                icon: 'times',
+                icon: 'fa fa-times',
                 onclick: this.hide.bind(this),
                 className: 'Button Button--icon Button--link'
               })}

--- a/js/lib/components/Navigation.js
+++ b/js/lib/components/Navigation.js
@@ -52,7 +52,7 @@ export default class Navigation extends Component {
     return LinkButton.component({
       className: 'Button Navigation-back Button--icon',
       href: history.backUrl(),
-      icon: 'chevron-left',
+      icon: 'fa fa-chevron-left',
       title: previous.title,
       config: () => {},
       onclick: e => {
@@ -77,7 +77,7 @@ export default class Navigation extends Component {
     return Button.component({
       className: 'Button Button--icon Navigation-pin' + (pane.pinned ? ' active' : ''),
       onclick: pane.togglePinned.bind(pane),
-      icon: 'thumbtack'
+      icon: 'fa fa-thumbtack'
     });
   }
 
@@ -100,7 +100,7 @@ export default class Navigation extends Component {
         e.stopPropagation();
         drawer.show();
       },
-      icon: 'bars'
+      icon: 'fa fa-bars'
     });
   }
 }

--- a/js/lib/components/Navigation.js
+++ b/js/lib/components/Navigation.js
@@ -77,7 +77,7 @@ export default class Navigation extends Component {
     return Button.component({
       className: 'Button Button--icon Navigation-pin' + (pane.pinned ? ' active' : ''),
       onclick: pane.togglePinned.bind(pane),
-      icon: 'thumb-tack'
+      icon: 'thumbtack'
     });
   }
 
@@ -100,7 +100,7 @@ export default class Navigation extends Component {
         e.stopPropagation();
         drawer.show();
       },
-      icon: 'reorder'
+      icon: 'bars'
     });
   }
 }

--- a/js/lib/components/Select.js
+++ b/js/lib/components/Select.js
@@ -18,7 +18,7 @@ export default class Select extends Component {
         <select className="Select-input FormControl" onchange={onchange ? m.withAttr('value', onchange.bind(this)) : undefined} value={value}>
           {Object.keys(options).map(key => <option value={key}>{options[key]}</option>)}
         </select>
-        {icon('sort', {className: 'Select-caret'})}
+        {icon('fa fa-sort', {className: 'Select-caret'})}
       </span>
     );
   }

--- a/js/lib/components/SelectDropdown.js
+++ b/js/lib/components/SelectDropdown.js
@@ -13,7 +13,7 @@ import icon from 'flarum/helpers/icon';
  */
 export default class SelectDropdown extends Dropdown {
   static initProps(props) {
-    props.caretIcon = typeof props.caretIcon !== 'undefined' ? props.caretIcon : 'sort';
+    props.caretIcon = typeof props.caretIcon !== 'undefined' ? props.caretIcon : 'fa fa-sort';
 
     super.initProps(props);
 

--- a/js/lib/components/SplitDropdown.js
+++ b/js/lib/components/SplitDropdown.js
@@ -28,7 +28,7 @@ export default class SplitDropdown extends Dropdown {
         className={'Dropdown-toggle Button Button--icon ' + this.props.buttonClassName}
         data-toggle="dropdown">
         {icon(this.props.icon, {className: 'Button-icon'})}
-        {icon('caret-down', {className: 'Button-caret'})}
+        {icon('fa fa-caret-down', {className: 'Button-caret'})}
       </button>
     ];
   }

--- a/js/lib/helpers/icon.js
+++ b/js/lib/helpers/icon.js
@@ -1,13 +1,12 @@
 /**
- * The `icon` helper displays a FontAwesome icon. The fa-fw class is applied.
+ * The `icon` helper displays an icon.
  *
- * @param {String} name The name of the icon class, without the `fa-` prefix.
+ * @param {String} fontClass The full icon class, prefix and the icon’s name.
  * @param {Object} attrs Any other attributes to apply.
- * @param {String} prefix The icon class prefix.
  * @return {Object}
  */
-export default function icon(name, attrs = {}) {
-  attrs.className = 'icon ' + name + ' ' + (attrs.className || '');
+export default function icon(fontClass, attrs = {}) {
+  attrs.className = 'icon ' + fontClass + ' ' + (attrs.className || '');
 
   return <i {...attrs}/>;
 }

--- a/js/lib/helpers/icon.js
+++ b/js/lib/helpers/icon.js
@@ -3,10 +3,11 @@
  *
  * @param {String} name The name of the icon class, without the `fa-` prefix.
  * @param {Object} attrs Any other attributes to apply.
+ * @param {String} prefix The icon class prefix.
  * @return {Object}
  */
-export default function icon(name, attrs = {}) {
-  attrs.className = 'icon fa fa-' + name + ' ' + (attrs.className || '');
+export default function icon(name, attrs = {}, prefix = 'fa') {
+  attrs.className = 'icon ' + prefix + ' fa-' + name + ' ' + (attrs.className || '');
 
   return <i {...attrs}/>;
 }

--- a/js/lib/helpers/icon.js
+++ b/js/lib/helpers/icon.js
@@ -6,8 +6,8 @@
  * @param {String} prefix The icon class prefix.
  * @return {Object}
  */
-export default function icon(name, attrs = {}, prefix = 'fa') {
-  attrs.className = 'icon ' + prefix + ' fa-' + name + ' ' + (attrs.className || '');
+export default function icon(name, attrs = {}) {
+  attrs.className = 'icon ' + name + ' ' + (attrs.className || '');
 
   return <i {...attrs}/>;
 }

--- a/js/lib/helpers/userOnline.js
+++ b/js/lib/helpers/userOnline.js
@@ -8,6 +8,6 @@ import icon from 'flarum/helpers/icon';
  */
 export default function userOnline(user) {
     if (user.lastSeenTime() && user.isOnline()) {
-        return <span className="UserOnline">{icon('circle')}</span>;
+        return <span className="UserOnline">{icon('fa fa-circle')}</span>;
     }
 }

--- a/js/lib/models/Discussion.js
+++ b/js/lib/models/Discussion.js
@@ -84,7 +84,7 @@ Object.assign(Discussion.prototype, {
     const items = new ItemList();
 
     if (this.isHidden()) {
-      items.add('hidden', <Badge type="hidden" icon="trash" label={app.translator.trans('core.lib.badge.hidden_tooltip')}/>);
+      items.add('hidden', <Badge type="hidden" icon="fa fa-trash" label={app.translator.trans('core.lib.badge.hidden_tooltip')}/>);
     }
 
     return items;

--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -255,9 +255,11 @@
       font-weight: bold;
 
       &:before {
+        .fa();
         content: @fa-var-comment;
       }
       &:hover:before {
+        .fa();
         content: @fa-var-check;
       }
     }

--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -244,8 +244,8 @@
     padding-left: 21px;
 
     &:before {
-      .fa();
-      content: @fa-var-comment-o;
+      .far();
+      content: @fa-var-comment;
       float: left;
       margin-left: -21px;
       margin-top: 3px;

--- a/less/lib/lib.less
+++ b/less/lib/lib.less
@@ -1,4 +1,7 @@
-@import "font-awesome.less";
+@import "fontawesome.less";
+@import "fa-brands.less";
+@import "fa-regular.less";
+@import "fa-solid.less";
 @fa-font-path: "./fonts";
 
 @import "normalize.less";

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -386,7 +386,7 @@ class InstallCommand extends AbstractCommand
     protected function publishAssets()
     {
         $this->filesystem->copyDirectory(
-            $this->application->basePath().'/vendor/components/font-awesome/fonts',
+            $this->application->basePath().'/vendor/components/font-awesome/webfonts',
             $this->application->publicPath().'/assets/fonts'
         );
     }

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -287,10 +287,10 @@ class InstallCommand extends AbstractCommand
         Group::unguard();
 
         $groups = [
-            [Group::ADMINISTRATOR_ID, 'Admin', 'Admins', '#B72A2A', 'wrench'],
+            [Group::ADMINISTRATOR_ID, 'Admin', 'Admins', '#B72A2A', 'fa fa-wrench'],
             [Group::GUEST_ID, 'Guest', 'Guests', null, null],
             [Group::MEMBER_ID, 'Member', 'Members', null, null],
-            [Group::MODERATOR_ID, 'Mod', 'Mods', '#80349E', 'bolt']
+            [Group::MODERATOR_ID, 'Mod', 'Mods', '#80349E', 'fa fa-bolt']
         ];
 
         foreach ($groups as $group) {


### PR DESCRIPTION
In this PR, I'm updating flarum to use the latest FontAwesome icon font (v5.0.6).

**After this PR, there's probably a need to update icon name in flarum's extension.**

## Issues that will be fixed by this PR:
- #1326 (Update to Font Awesome v5)

## Changes

> Version 5 has been re-written and re-designed completely from scratch.

Most notable change from version 4, in brief :
- New Prefixes (5 instead of 1)
- Icon Name Changes

Please see: [FontAwesome 5 Upgrade Guide](https://fontawesome.com/how-to-use/upgrading-from-4) for more detailed information

### Icon replacement
In FontAwesome 5, icon replacement also occured.
Some of the old icon now got appended `-alt` in it's icon name, and the old-name got a new icon.
(e.g.: the old `expand` become `expand-alt`)

## BC Breaks

- Icon name must be specified in it's long form class syntax.
  Previously, icon can be used just by specifying it's name.
  E.g: `wrench` now became `fa fa-wrench`.

- Groups Icon
  After updating flarum to a version containing this PR, you must manually update icon name in `groups` database table.

## To-Do

Below is list of task I used for this implementation.

- [x] Use latest font-awesome shim package (12e8a2f)
- [x] Adapt file names and directory structure changes (12e8a2f)
- [x] Adapt icon name changes in less (bd61a62, d13bae3)
- JS Changes:
  - [x] ~~Add new parameter for `iconPrefix` (e.g.: `fa`, `far`, `fab`) to the `icon` helper (0121c1e)~~
  - [x] ~~Update js component to use `iconPrefix` parameter (**Partially implemented** on c8fa44a)~~
  - [x] ~~Adapt icon name changes in js (8f96908, 6af9019)~~
- [x] ~~Display non-default (`far`, `fab`) extension icon in Extension Administration Page. (1b348d2)~~
- [x] Refactor Icon Helper API, see https://github.com/flarum/core/pull/1372#issuecomment-366470195 (75ad8ca)
- [x] Re-checking leftover icon classes (1fa8d6c)

## Size Comparison

In #1326 ,  @tobscure requested for a file-size comparisons.

Here's a table comparing compiled assets files size (in bytes), before and after.
Using `ls -l` and `du -b`.

| Type | File Name | Size Before | Size After | Size After Refactor |
| ------------- | ------------- | -------------:| -------------:| -------------:|
| file      | public/assets/admin-*.css |    74 382 |    78 143 |    78 143 |
| file      | public/assets/admin-*.js  |   507 943 |   507 957 |   505 334 |
| directory | public/assets/fonts/*     | 1 085 661 | 1 688 588 | 1 688 588 |
| file      | public/assets/forum-*.css |   113 425 |   117 661 |   118 082 |
| file      | public/assets/forum-*.js  |   865 708 |   865 906 |   867 466 |
