### PR TITLE
add message to Dispatch exceptions

### DIFF
--- a/src/Http/Middleware/DispatchRoute.php
+++ b/src/Http/Middleware/DispatchRoute.php
@@ -59,9 +59,9 @@ class DispatchRoute
 
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:
-                throw new RouteNotFoundException;
+                throw new RouteNotFoundException($uri);
             case Dispatcher::METHOD_NOT_ALLOWED:
-                throw new MethodNotAllowedException;
+                throw new MethodNotAllowedException($method);
             case Dispatcher::FOUND:
                 $handler = $routeInfo[1];
                 $parameters = $routeInfo[2];


### PR DESCRIPTION
I´m developing my first extensions ... and for creating custom routes it would be better, if the thrown exception would contain the not found URI - so the flarum.log also gets more informative

log was

```
[2018-02-21 07:44:20] production.DEBUG: Flarum\Http\Exception\RouteNotFoundException in C:\Users\pokrandtm\workspaceDiscuss\discussVgbOrg\vendor\flarum\core\src\Http\Middleware\DispatchRoute.php:62
Stack trace:

```
is now

```
[2018-02-21 07:44:44] production.DEBUG: Flarum\Http\Exception\RouteNotFoundException: /rrr in C:\Users\pokrandtm\workspaceDiscuss\discussVgbOrg\vendor\flarum\core\src\Http\Middleware\DispatchRoute.php:62
Stack trace:
#0 C:\Users\pokrandtm\workspaceDiscuss\discussVgbOrg\vendor\zendframework\zend-stratigility\src\Dispatch.php(212): Flarum\Http\Middleware\DispatchRoute->__invoke(Object(Zend\Stratigility\Http\Request), Object(Zend\Stratigility\Http\Response), Object(Zend\Stratigility\Next))

```