### PR TITLE
Always return a promise in PostStream#update

### DIFF
--- a/js/forum/src/components/PostStream.js
+++ b/js/forum/src/components/PostStream.js
@@ -122,7 +122,7 @@ class PostStream extends Component {
    * @public
    */
   update() {
-    if (!this.viewingEnd) return;
+    if (!this.viewingEnd) return Promise.resolve();
 
     this.visibleEnd = this.count();
 

--- a/js/forum/src/components/PostStream.js
+++ b/js/forum/src/components/PostStream.js
@@ -124,7 +124,6 @@ class PostStream extends Component {
   update() {
     if (!this.viewingEnd) return m.deferred().resolve().promise;
 
-
     this.visibleEnd = this.count();
 
     return this.loadRange(this.visibleStart, this.visibleEnd).then(() => m.redraw());

--- a/js/forum/src/components/PostStream.js
+++ b/js/forum/src/components/PostStream.js
@@ -122,7 +122,8 @@ class PostStream extends Component {
    * @public
    */
   update() {
-    if (!this.viewingEnd) return Promise.resolve();
+    if (!this.viewingEnd) return m.deferred().resolve().promise;
+
 
     this.visibleEnd = this.count();
 


### PR DESCRIPTION
_Most likely_ fixes #1390

Replaces `return` with `return Promise.resolve()` so a Promise is returned, but not an error (Promise.reject)