### PR TITLE
Fix 'Debug mode' in InfoCommand not showing

### DIFF
--- a/src/Foundation/Console/InfoCommand.php
+++ b/src/Foundation/Console/InfoCommand.php
@@ -72,7 +72,7 @@ class InfoCommand extends AbstractCommand
 
         $this->info('Base URL: '.$this->config['url']);
         $this->info('Installation path: '.getcwd());
-        $this->info('Debug mode '.$this->config['debug'] ? 'ON' : 'off');
+        $this->info('Debug mode '.($this->config['debug'] ? 'ON' : 'off'));
     }
 
     /**


### PR DESCRIPTION
Fixes `Debug mode` in InfoCommand not showing because of missing parenthesis in conditional


Before:
![image](https://user-images.githubusercontent.com/6401250/37743899-c052b27c-2d42-11e8-8600-1c9fbd839840.png)
After:
![image](https://user-images.githubusercontent.com/6401250/37743903-c4c851fe-2d42-11e8-9ce4-70ffb32af080.png)
