### PR TITLE
fixes log in without remember on master

### DIFF
--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -53,7 +53,7 @@ class CookieFactory
         $url = parse_url(rtrim($app->url(), '/'));
 
         // Get the cookie settings from the config or use the default values
-        $this->prefix = $app->config('cookie.name', 'flarum');
+        $this->prefix = $app->config('cookie.prefix', 'flarum');
         $this->path = $app->config('cookie.path', array_get($url, 'path') ?: '/');
         $this->domain = $app->config('cookie.domain');
         $this->secure = $app->config('cookie.secure', array_get($url, 'scheme') === 'https');
@@ -72,7 +72,7 @@ class CookieFactory
      */
     public function make($name, $value = null, $maxAge = null)
     {
-        $cookie = SetCookie::create($this->getName($name), $value);
+        $cookie = SetCookie::create($name, $value);
 
         // Make sure we send both the MaxAge and Expires parameters (the former
         // is not supported by all browser versions)

--- a/src/Http/Middleware/StartSession.php
+++ b/src/Http/Middleware/StartSession.php
@@ -40,7 +40,9 @@ class StartSession implements MiddlewareInterface
     protected $config;
 
     /**
-     * @param CookieFactory $cookie
+     * @param SessionHandlerInterface $handler
+     * @param CookieFactory           $cookie
+     * @param ConfigRepository        $config
      */
     public function __construct(SessionHandlerInterface $handler, CookieFactory $cookie, ConfigRepository $config)
     {


### PR DESCRIPTION
Currently dev-master has an issue with log in. This PR fixes that. The cause is a cookie generated `flarum_flarum_session` the double prefixing is generated inside the CookieFactory.