### PR TITLE
Fix profile page layout jumping when scrolling

### DIFF
--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -98,6 +98,7 @@
 @media @desktop-up {
   .sideNav {
     float: left;
+    height: 0;
 
     &, > ul {
       width: 190px;

--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -98,6 +98,9 @@
 @media @desktop-up {
   .sideNav {
     float: left;
+
+    // Prevents the sidenav from changing the height of the content beside it because of floating wizardry
+    // Without this, the content on the right (like a post) would have a height of at least the height of the sidenav
     height: 0;
 
     &, > ul {


### PR DESCRIPTION
The first post height was affected by the floating block when affix wasn't active.

This issue is best observed when there are many menu items on the left (link to settings, link to Masquerade, ...) and the first post listed for the user is very short.

For some reason the floating property of the .sideNav caused the first post to always be as tall as the menu. But then when you scroll and the affix effect is applied to the nav, this side effect cease and this cause a jump in the list of posts when the first post gets back to intended height.

Here's how the bug looked like:

without scrolling past the affix trigger point:
![image](https://user-images.githubusercontent.com/5264300/38772953-b0c49628-4042-11e8-9afd-bbbfa9a9c4d1.png)
after scrolling a little and triggering the affix on the nav:
![image](https://user-images.githubusercontent.com/5264300/38772955-bb68976e-4042-11e8-9525-0db6677d7e16.png)


I tried a few things to fix it and I don't think my solution is very pretty. But setting the height of the container to 0 fixes the issue. Tested in Firefox and Chrome.