### PR TITLE
allowing configurable flood gate

### DIFF
--- a/src/Post/Event/CheckingForFlooding.php
+++ b/src/Post/Event/CheckingForFlooding.php
@@ -13,24 +13,18 @@ namespace Flarum\Post\Event;
 
 use Flarum\User\User;
 
-class ChecksForFlooding
+class CheckingForFlooding
 {
     /**
      * @var User
      */
     public $actor;
-    /**
-     * @var bool|null
-     */
-    public $isFlooding;
 
     /**
      * @param User|null $actor
-     * @param bool|null $isFlooding
      */
-    public function __construct(User $actor = null, bool &$isFlooding = null)
+    public function __construct(User $actor = null)
     {
         $this->actor = $actor;
-        $this->isFlooding = &$isFlooding;
     }
 }

--- a/src/Post/Event/ChecksForFlooding.php
+++ b/src/Post/Event/ChecksForFlooding.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Post\Event;
+
+use Flarum\User\User;
+
+class ChecksForFlooding
+{
+    /**
+     * @var User
+     */
+    public $actor;
+    /**
+     * @var bool|null
+     */
+    public $isFlooding;
+
+    /**
+     * @param User|null $actor
+     * @param bool|null $isFlooding
+     */
+    public function __construct(User $actor = null, bool &$isFlooding = null)
+    {
+        $this->actor = $actor;
+        $this->isFlooding = &$isFlooding;
+    }
+}

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -12,7 +12,7 @@
 namespace Flarum\Post;
 
 use DateTime;
-use Flarum\Post\Event\ChecksForFlooding;
+use Flarum\Post\Event\CheckingForFlooding;
 use Flarum\Post\Exception\FloodingException;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -46,10 +46,8 @@ class Floodgate
      */
     public function isFlooding(User $actor): bool
     {
-        $isFlooding = null;
-
-        $this->events->dispatch(
-            new ChecksForFlooding($actor, $isFlooding)
+        $isFlooding = $this->events->until(
+            new CheckingForFlooding($actor)
         );
 
         return $isFlooding ?? Post::where('user_id', $actor->id)->where('time', '>=', new DateTime('-10 seconds'))->exists();

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -12,14 +12,26 @@
 namespace Flarum\Post;
 
 use DateTime;
+use Flarum\Post\Event\ChecksForFlooding;
 use Flarum\Post\Exception\FloodingException;
 use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class Floodgate
 {
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    public function __construct(Dispatcher $events)
+    {
+        $this->events = $events;
+    }
+
+    /**
      * @param User $actor
-     * @throws \Flarum\Post\Exception\FloodingException
+     * @throws FloodingException
      */
     public function assertNotFlooding(User $actor)
     {
@@ -32,8 +44,14 @@ class Floodgate
      * @param User $actor
      * @return bool
      */
-    public function isFlooding(User $actor)
+    public function isFlooding(User $actor): bool
     {
-        return Post::where('user_id', $actor->id)->where('time', '>=', new DateTime('-10 seconds'))->exists();
+        $isFlooding = null;
+
+        $this->events->dispatch(
+            new ChecksForFlooding($actor, $isFlooding)
+        );
+
+        return $isFlooding ?? Post::where('user_id', $actor->id)->where('time', '>=', new DateTime('-10 seconds'))->exists();
     }
 }


### PR DESCRIPTION
This will allow any extension to return a boolean to prevent or enforce opening or closing the gate. Stacked listeners might be .. problematic but let's get one solution in for now.