### PR TITLE
fixes session loading when forum not yet installed

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -113,6 +113,7 @@ class Server
     protected function getInstallerMiddleware(MiddlewarePipe $pipe)
     {
         $this->app->register(InstallServiceProvider::class);
+        $this->app->register(SessionServiceProvider::class);
 
         // FIXME: Re-enable HandleErrors middleware, if possible
         // (Right now it tries to resolve a database connection because of the injected settings repo instance)

--- a/src/Http/SessionServiceProvider.php
+++ b/src/Http/SessionServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Http;
+
+use Flarum\Foundation\AbstractServiceProvider;
+use Illuminate\Session\FileSessionHandler;
+use SessionHandlerInterface;
+
+class SessionServiceProvider extends AbstractServiceProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        $this->registerSession();
+    }
+
+    protected function registerSession()
+    {
+        $this->app->singleton('session.handler', function ($app) {
+            return new FileSessionHandler(
+                $app['files'],
+                $app['config']['session.files'],
+                $app['config']['session.lifetime']
+            );
+        });
+
+        $this->app->alias('session.handler', SessionHandlerInterface::class);
+    }
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -14,10 +14,9 @@ namespace Flarum\User;
 use Flarum\Event\ConfigureUserPreferences;
 use Flarum\Event\GetPermission;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Http\SessionServiceProvider;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Session\FileSessionHandler;
 use RuntimeException;
-use SessionHandlerInterface;
 
 class UserServiceProvider extends AbstractServiceProvider
 {
@@ -26,22 +25,10 @@ class UserServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->registerSession();
+        $this->app->register(SessionServiceProvider::class);
+
         $this->registerGate();
         $this->registerAvatarsFilesystem();
-    }
-
-    protected function registerSession()
-    {
-        $this->app->singleton('session.handler', function ($app) {
-            return new FileSessionHandler(
-                $app['files'],
-                $app['config']['session.files'],
-                $app['config']['session.lifetime']
-            );
-        });
-
-        $this->app->alias('session.handler', SessionHandlerInterface::class);
     }
 
     protected function registerGate()


### PR DESCRIPTION
Currently the session isn't configured whenever Flarum is not yet installed. This PR offers an intermediate fix until Franz' full rewrite passes, it might fix it, it might not.

The cause of the SessionHandlerInterface not being bound is because the UserServiceProvider is only registered when the Forum is installed. Simply registering that UserServiceProvider in all situations doesn't work because it subscribes the `EmailConfirmationMailer` which requires the `SettingsRepositoryInterface` and that one requires a database which hasn't been set up yet. One of the drawbacks of resolving from IoC in listener constructs I guess 🤷‍♂️ 

Let me know what you think!