### PR TITLE
Configure external links before dispatching textformatter configuring event

### DIFF
--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -117,9 +117,9 @@ class Formatter
         $configurator->Autolink;
         $configurator->tags->onDuplicate('replace');
 
-        $this->events->dispatch(new Configuring($configurator));
-
         $this->configureExternalLinks($configurator);
+
+        $this->events->dispatch(new Configuring($configurator));
 
         return $configurator;
     }


### PR DESCRIPTION
This way extensions can override the link attributes.

I'm not sure why this was done in the opposite order until now. That part of the code seems to be 3 years old. It seems a lot more logical for me to configure the links before dispatching the event, so that extension have an opportunity to override it.

Use case include extensions that might want to remove set `target` or `rel` to another value. It's impossible right now as the template is always overridden after the event.