### PR TITLE
[wip] 1211 mariadb compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,12 @@ addons:
   mariadb: '10.2'
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      addons: # to prevent mariadb
-      services: mysql
-      env:
-        - DB=mysql
     - php: 7.1
       addons: # to prevent mariadb
       services: mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: php
 sudo: false
 
 env:
-  - DB_USERNAME=travis
-  - DB=mysql
-  - DB=mariadb
+  - DB_USERNAME=travis DB=mysql
+  - DB_USERNAME=travis DB=mariadb
+services:
+  - mysql
 addons:
   mariadb: '10.2'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   global:
-    - DB_DATABASE=mariadb
+    - DB=mariadb
 
 addons:
   mariadb: '10.2'
@@ -20,17 +20,17 @@ matrix:
       addons: # to prevent mariadb
       services: mysql
       env:
-        - DB_DATABASE=mysql
+        - DB=mysql
     - php: 7.1
       addons: # to prevent mariadb
       services: mysql
       env:
-        - DB_DATABASE=mysql
+        - DB=mysql
     - php: 7.2
       addons: # to prevent mariadb
       services: mysql
       env:
-        - DB_DATABASE=mysql
+        - DB=mysql
 
 before_install:
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e 'CREATE DATABASE flarum;'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
+sudo: false
 
 env:
   - DB_USERNAME=travis
-services:
-  - mysql
+  - DB=mysql
+  - DB=mariadb
+addons:
+  mariadb: '10.2'
 
 php:
   - 7.0
@@ -13,7 +16,7 @@ php:
 matrix:
   fast_finish: true
 before_install:
-  - mysql -e 'CREATE DATABASE flarum;'
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e 'CREATE DATABASE flarum;'; fi
 before_script:
   - composer self-update
   - composer install
@@ -27,5 +30,3 @@ notifications:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: php
 sudo: false
 
 env:
-  - DB_USERNAME=travis DB=mysql
-  - DB_USERNAME=travis DB=mariadb
-services:
-  - mysql
+  global:
+    - DB_DATABASE=mariadb
+
 addons:
   mariadb: '10.2'
 
@@ -16,6 +15,23 @@ php:
 
 matrix:
   fast_finish: true
+  include:
+    - php: 7.0
+      addons: # to prevent mariadb
+      services: mysql
+      env:
+        - DB_DATABASE=mysql
+    - php: 7.1
+      addons: # to prevent mariadb
+      services: mysql
+      env:
+        - DB_DATABASE=mysql
+    - php: 7.2
+      addons: # to prevent mariadb
+      services: mysql
+      env:
+        - DB_DATABASE=mysql
+
 before_install:
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e 'CREATE DATABASE flarum;'; fi
 before_script:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,9 @@
             <exclude>./tests/Install</exclude>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Test/Concerns/CreatesForum.php
+++ b/tests/Test/Concerns/CreatesForum.php
@@ -75,9 +75,10 @@ trait CreatesForum
         $data->setSetting('mail_driver', 'log');
 
         $database = $data->getDatabaseConfiguration();
-        $database['database'] = env('DB_DATABASE', 'flarum');
-        $database['username'] = env('DB_USERNAME', 'root');
-        $database['password'] = env('DB_PASSWORD', '');
+        $database['host'] = env('DB_HOST', $database['host']);
+        $database['database'] = env('DB_DATABASE', $database['database']);
+        $database['username'] = env('DB_USERNAME', $database['username']);
+        $database['password'] = env('DB_PASSWORD', $database['password']);
         $data->setDatabaseConfiguration($database);
 
         $this->configuration = $data;


### PR DESCRIPTION
fixes #1211 

This PR keeps track of our compatibility with MariaDB.

- [ ] doctrine/dbal 2.7.0+ is compatible but requires php 7.1