### PR TITLE
Use PSR-15 middleware standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,8 @@
         "nikic/fast-route": "^0.6",
         "oyejorge/less.php": "~1.5",
         "psr/http-message": "^1.0",
+        "psr/http-server-handler": "^1.0",
+        "psr/http-server-middleware": "^1.0",
         "symfony/config": "^3.3",
         "symfony/console": "^3.3",
         "symfony/http-foundation": "^3.3",
@@ -54,9 +56,8 @@
         "symfony/yaml": "^3.3",
         "s9e/text-formatter": "^0.8.1",
         "tobscure/json-api": "^0.3.0",
-        "zendframework/zend-diactoros": "^1.6",
-        "zendframework/zend-stratigility": "^2.2",
-        "http-interop/http-middleware": "^0.4.0"
+        "zendframework/zend-diactoros": "^1.7",
+        "zendframework/zend-stratigility": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",

--- a/src/Admin/Middleware/RequireAdministrateAbility.php
+++ b/src/Admin/Middleware/RequireAdministrateAbility.php
@@ -12,18 +12,19 @@
 namespace Flarum\Admin\Middleware;
 
 use Flarum\User\AssertPermissionTrait;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class RequireAdministrateAbility implements MiddlewareInterface
+class RequireAdministrateAbility implements Middleware
 {
     use AssertPermissionTrait;
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $this->assertAdmin($request->getAttribute('actor'));
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Api/Middleware/FakeHttpMethods.php
+++ b/src/Api/Middleware/FakeHttpMethods.php
@@ -11,15 +11,16 @@
 
 namespace Flarum\Api\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class FakeHttpMethods implements MiddlewareInterface
+class FakeHttpMethods implements Middleware
 {
     const HEADER_NAME = 'x-http-method-override';
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         if ($request->getMethod() === 'POST' && $request->hasHeader(self::HEADER_NAME)) {
             $fakeMethod = $request->getHeaderLine(self::HEADER_NAME);
@@ -27,6 +28,6 @@ class FakeHttpMethods implements MiddlewareInterface
             $request = $request->withMethod(strtoupper($fakeMethod));
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Api/Middleware/HandleErrors.php
+++ b/src/Api/Middleware/HandleErrors.php
@@ -13,12 +13,12 @@ namespace Flarum\Api\Middleware;
 
 use Exception;
 use Flarum\Api\ErrorHandler;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class HandleErrors implements MiddlewareInterface
+class HandleErrors implements Middleware
 {
     /**
      * @var ErrorHandler
@@ -35,15 +35,11 @@ class HandleErrors implements MiddlewareInterface
 
     /**
      * Catch all errors that happen during further middleware execution.
-     *
-     * @param Request $request
-     * @param DelegateInterface $delegate
-     * @return Response
      */
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         try {
-            return $delegate->process($request);
+            return $handler->handle($request);
         } catch (Exception $e) {
             return $this->errorHandler->handle($e);
         }

--- a/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/src/Http/Middleware/AuthenticateWithHeader.php
@@ -14,15 +14,16 @@ namespace Flarum\Http\Middleware;
 use Flarum\Api\ApiKey;
 use Flarum\Http\AccessToken;
 use Flarum\User\User;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class AuthenticateWithHeader implements MiddlewareInterface
+class AuthenticateWithHeader implements Middleware
 {
     const TOKEN_PREFIX = 'Token ';
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $headerLine = $request->getHeaderLine('authorization');
 
@@ -50,7 +51,7 @@ class AuthenticateWithHeader implements MiddlewareInterface
             }
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 
     private function getUser($string)

--- a/src/Http/Middleware/AuthenticateWithSession.php
+++ b/src/Http/Middleware/AuthenticateWithSession.php
@@ -14,13 +14,14 @@ namespace Flarum\Http\Middleware;
 use Flarum\User\Guest;
 use Flarum\User\User;
 use Illuminate\Contracts\Session\Session;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class AuthenticateWithSession implements MiddlewareInterface
+class AuthenticateWithSession implements Middleware
 {
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $session = $request->getAttribute('session');
 
@@ -30,7 +31,7 @@ class AuthenticateWithSession implements MiddlewareInterface
 
         $request = $request->withAttribute('actor', $actor);
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 
     private function getActor(Session $session)

--- a/src/Http/Middleware/CollectGarbage.php
+++ b/src/Http/Middleware/CollectGarbage.php
@@ -16,12 +16,13 @@ use Flarum\User\AuthToken;
 use Flarum\User\EmailToken;
 use Flarum\User\PasswordToken;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 use SessionHandlerInterface;
 
-class CollectGarbage implements MiddlewareInterface
+class CollectGarbage implements Middleware
 {
     /**
      * @var SessionHandlerInterface
@@ -39,11 +40,11 @@ class CollectGarbage implements MiddlewareInterface
         $this->sessionConfig = $config->get('session');
     }
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $this->collectGarbageSometimes();
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 
     private function collectGarbageSometimes()

--- a/src/Http/Middleware/DispatchRoute.php
+++ b/src/Http/Middleware/DispatchRoute.php
@@ -15,12 +15,12 @@ use FastRoute\Dispatcher;
 use Flarum\Http\Exception\MethodNotAllowedException;
 use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Http\RouteCollection;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class DispatchRoute implements MiddlewareInterface
+class DispatchRoute implements Middleware
 {
     /**
      * @var RouteCollection
@@ -45,13 +45,10 @@ class DispatchRoute implements MiddlewareInterface
     /**
      * Dispatch the given request to our route collection.
      *
-     * @param Request $request
-     * @param DelegateInterface $delegate
-     * @return Response
      * @throws MethodNotAllowedException
      * @throws RouteNotFoundException
      */
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $method = $request->getMethod();
         $uri = $request->getUri()->getPath() ?: '/';

--- a/src/Http/Middleware/HandleErrors.php
+++ b/src/Http/Middleware/HandleErrors.php
@@ -15,15 +15,15 @@ use Exception;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Franzl\Middleware\Whoops\WhoopsRunner;
 use Illuminate\Contracts\View\Factory as ViewFactory;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 
-class HandleErrors implements MiddlewareInterface
+class HandleErrors implements Middleware
 {
     /**
      * @var ViewFactory
@@ -68,15 +68,11 @@ class HandleErrors implements MiddlewareInterface
 
     /**
      * Catch all errors that happen during further middleware execution.
-     *
-     * @param Request $request
-     * @param DelegateInterface $delegate
-     * @return Response
      */
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         try {
-            return $delegate->process($request);
+            return $handler->handle($request);
         } catch (Exception $e) {
             if ($this->debug) {
                 return WhoopsRunner::handle($e, $request);

--- a/src/Http/Middleware/ParseJsonBody.php
+++ b/src/Http/Middleware/ParseJsonBody.php
@@ -11,13 +11,14 @@
 
 namespace Flarum\Http\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class ParseJsonBody implements MiddlewareInterface
+class ParseJsonBody implements Middleware
 {
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         if (str_contains($request->getHeaderLine('content-type'), 'json')) {
             $input = json_decode($request->getBody(), true);
@@ -25,6 +26,6 @@ class ParseJsonBody implements MiddlewareInterface
             $request = $request->withParsedBody($input ?: []);
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Http/Middleware/RememberFromCookie.php
+++ b/src/Http/Middleware/RememberFromCookie.php
@@ -13,11 +13,12 @@ namespace Flarum\Http\Middleware;
 
 use Flarum\Http\AccessToken;
 use Flarum\Http\CookieFactory;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class RememberFromCookie implements MiddlewareInterface
+class RememberFromCookie implements Middleware
 {
     /**
      * @var CookieFactory
@@ -32,7 +33,7 @@ class RememberFromCookie implements MiddlewareInterface
         $this->cookie = $cookie;
     }
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $id = array_get($request->getCookieParams(), $this->cookie->getName('remember'));
 
@@ -48,6 +49,6 @@ class RememberFromCookie implements MiddlewareInterface
             }
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Http/Middleware/SetLocale.php
+++ b/src/Http/Middleware/SetLocale.php
@@ -12,11 +12,12 @@
 namespace Flarum\Http\Middleware;
 
 use Flarum\Locale\LocaleManager;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class SetLocale implements MiddlewareInterface
+class SetLocale implements Middleware
 {
     /**
      * @var LocaleManager
@@ -31,7 +32,7 @@ class SetLocale implements MiddlewareInterface
         $this->locales = $locales;
     }
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $actor = $request->getAttribute('actor');
 
@@ -45,6 +46,6 @@ class SetLocale implements MiddlewareInterface
             $this->locales->setLocale($locale);
         }
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Http/Middleware/ShareErrorsFromSession.php
+++ b/src/Http/Middleware/ShareErrorsFromSession.php
@@ -13,16 +13,17 @@ namespace Flarum\Http\Middleware;
 
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\ViewErrorBag;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 
 /**
  * Inspired by Illuminate\View\Middleware\ShareErrorsFromSession.
  *
  * @author Taylor Otwell
  */
-class ShareErrorsFromSession implements MiddlewareInterface
+class ShareErrorsFromSession implements Middleware
 {
     /**
      * @var ViewFactory
@@ -37,7 +38,7 @@ class ShareErrorsFromSession implements MiddlewareInterface
         $this->view = $view;
     }
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $session = $request->getAttribute('session');
 
@@ -54,6 +55,6 @@ class ShareErrorsFromSession implements MiddlewareInterface
 
         $session->remove('errors');
 
-        return $delegate->process($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Http/Middleware/StartSession.php
+++ b/src/Http/Middleware/StartSession.php
@@ -16,13 +16,13 @@ use Flarum\Http\CookieFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Session\Store;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
 use SessionHandlerInterface;
 
-class StartSession implements MiddlewareInterface
+class StartSession implements Middleware
 {
     /**
      * @var SessionHandlerInterface
@@ -51,7 +51,7 @@ class StartSession implements MiddlewareInterface
         $this->config = $config->get('session');
     }
 
-    public function process(Request $request, DelegateInterface $delegate)
+    public function process(Request $request, Handler $handler): Response
     {
         $request = $request->withAttribute(
             'session',
@@ -59,7 +59,7 @@ class StartSession implements MiddlewareInterface
         );
 
         $session->start();
-        $response = $delegate->process($request);
+        $response = $handler->handle($request);
         $session->save();
 
         $response = $this->withCsrfTokenHeader($response, $session);


### PR DESCRIPTION
This finally adopts the new standardized interfaces instead of the
work-in-progress ones with the `Interop\` prefix.

Since we have now updated to PHP 7.1, we can also use Stratigility
3.0 as the middleware dispatcher.

Supersedes #1404.