### PR TITLE
Migrations: Simplify interface

### DIFF
--- a/src/Database/DatabaseMigrationRepository.php
+++ b/src/Database/DatabaseMigrationRepository.php
@@ -11,16 +11,16 @@
 
 namespace Flarum\Database;
 
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\ConnectionInterface;
 
 class DatabaseMigrationRepository implements MigrationRepositoryInterface
 {
     /**
-     * The database connection resolver instance.
+     * The name of the database connection to use.
      *
-     * @var \Illuminate\Database\ConnectionResolverInterface
+     * @var ConnectionInterface
      */
-    protected $resolver;
+    protected $connection;
 
     /**
      * The name of the migration table.
@@ -30,22 +30,15 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     protected $table;
 
     /**
-     * The name of the database connection to use.
-     *
-     * @var string
-     */
-    protected $connection;
-
-    /**
      * Create a new database migration repository instance.
      *
-     * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
-     * @param  string                                           $table
+     * @param  \Illuminate\Database\ConnectionInterface $connection
+     * @param  string                                   $table
      */
-    public function __construct(Resolver $resolver, $table)
+    public function __construct(ConnectionInterface $connection, $table)
     {
+        $this->connection = $connection;
         $this->table = $table;
-        $this->resolver = $resolver;
     }
 
     /**
@@ -104,7 +97,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function createRepository()
     {
-        $schema = $this->getConnection()->getSchemaBuilder();
+        $schema = $this->connection->getSchemaBuilder();
 
         $schema->create($this->table, function ($table) {
             $table->string('migration');
@@ -119,7 +112,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function repositoryExists()
     {
-        $schema = $this->getConnection()->getSchemaBuilder();
+        $schema = $this->connection->getSchemaBuilder();
 
         return $schema->hasTable($this->table);
     }
@@ -131,37 +124,6 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     protected function table()
     {
-        return $this->getConnection()->table($this->table);
-    }
-
-    /**
-     * Get the connection resolver instance.
-     *
-     * @return \Illuminate\Database\ConnectionResolverInterface
-     */
-    public function getConnectionResolver()
-    {
-        return $this->resolver;
-    }
-
-    /**
-     * Resolve the database connection instance.
-     *
-     * @return \Illuminate\Database\Connection
-     */
-    public function getConnection()
-    {
-        return $this->resolver->connection($this->connection);
-    }
-
-    /**
-     * Set the information source to gather data.
-     *
-     * @param  string  $name
-     * @return void
-     */
-    public function setSource($name)
-    {
-        $this->connection = $name;
+        return $this->connection->table($this->table);
     }
 }

--- a/src/Database/Migration.php
+++ b/src/Database/Migration.php
@@ -11,8 +11,7 @@
 
 namespace Flarum\Database;
 
-use Flarum\Settings\SettingsRepositoryInterface;
-use Illuminate\Database\ConnectionInterface;
+use Flarum\Settings\DatabaseSettingsRepository;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -100,12 +99,20 @@ abstract class Migration
     public static function addSettings(array $defaults)
     {
         return [
-            'up' => function (SettingsRepositoryInterface $settings) use ($defaults) {
+            'up' => function (Builder $schema) use ($defaults) {
+                $settings = new DatabaseSettingsRepository(
+                    $schema->getConnection()
+                );
+
                 foreach ($defaults as $key => $value) {
                     $settings->set($key, $value);
                 }
             },
-            'down' => function (SettingsRepositoryInterface $settings) use ($defaults) {
+            'down' => function (Builder $schema) use ($defaults) {
+                $settings = new DatabaseSettingsRepository(
+                    $schema->getConnection()
+                );
+
                 foreach (array_keys($defaults) as $key) {
                     $settings->delete($key);
                 }
@@ -130,7 +137,9 @@ abstract class Migration
         }
 
         return [
-            'up' => function (ConnectionInterface $db) use ($keys) {
+            'up' => function (Builder $schema) use ($keys) {
+                $db = $schema->getConnection();
+
                 foreach ($keys as $key) {
                     $instance = $db->table('permissions')->where($key)->first();
 
@@ -140,7 +149,9 @@ abstract class Migration
                 }
             },
 
-            'down' => function (ConnectionInterface $db) use ($keys) {
+            'down' => function (Builder $schema) use ($keys) {
+                $db = $schema->getConnection();
+
                 foreach ($keys as $key) {
                     $db->table('permissions')->where($key)->delete();
                 }

--- a/src/Database/MigrationRepositoryInterface.php
+++ b/src/Database/MigrationRepositoryInterface.php
@@ -52,12 +52,4 @@ interface MigrationRepositoryInterface
      * @return bool
      */
     public function repositoryExists();
-
-    /**
-     * Set the information source to gather data.
-     *
-     * @param  string  $name
-     * @return void
-     */
-    public function setSource($name);
 }

--- a/src/Database/MigrationServiceProvider.php
+++ b/src/Database/MigrationServiceProvider.php
@@ -22,7 +22,7 @@ class MigrationServiceProvider extends AbstractServiceProvider
     public function register()
     {
         $this->app->singleton('Flarum\Database\MigrationRepositoryInterface', function ($app) {
-            return new DatabaseMigrationRepository($app['db'], 'migrations');
+            return new DatabaseMigrationRepository($app['flarum.db'], 'migrations');
         });
 
         $this->app->bind(MigrationCreator::class, function (Application $app) {


### PR DESCRIPTION
Extracted from #1416. To prevent people from depending on the old behavior (and reduce the amount of changes that need to be reviewed in that PR), let's get this part merged first.

1. This unifies the implementations of all pre-defined migration helpers.
2. This improves their implementation: By not pulling dependencies such as a settings repository from the IoC container (one that is decorated with caching), migrations more clearly and explicitly define their desired implementation: We want to write this setting to the database, period!
3. Most importantly, IoC configuration can be simplified in different contexts, e.g. when installing.
4. I really disliked having that `app()->call()` in the migrator class. It contradicts the point of dependency injection, by hiding what dependencies are required.

(All extensions have previously been converted to only depend on schema builder in closure migrations, see https://github.com/flarum/flarum-ext-tags/commit/1d1b1b5176a17e8a9a455c3a267a699d1bf2df2a for an example.)