### PR TITLE
fix empty base url

### DIFF
--- a/src/Install/Controller/InstallController.php
+++ b/src/Install/Controller/InstallController.php
@@ -77,7 +77,7 @@ class InstallController implements RequestHandlerInterface
             'email'                 => array_get($input, 'adminEmail'),
         ]);
 
-        $baseUrl = rtrim((string) $request->getAttribute('originalUri'), '/');
+        $baseUrl = rtrim((string) $request->getUri(), '/');
         $data->setBaseUrl($baseUrl);
 
         $data->setSetting('forum_title', array_get($input, 'forumTitle'));


### PR DESCRIPTION
not sure why but in my local install `originalUri` attribute is empty, therefore `baseUrl` is empty, `url` attribute in `config.php` was empty and `mail_from` has been set `noreply@` in `settings` table.

not sure why this happening, maybe it's because of my nginx config?