### PR TITLE
check class string before concat

### DIFF
--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -80,7 +80,7 @@ export default class CommentPost extends Post {
     const post = this.props.post;
     const attrs = super.attrs();
 
-    attrs.className += ' '+classList({
+    attrs.className = (attrs.className || '') + ' ' + classList({
       'CommentPost': true,
       'Post--hidden': post.isHidden(),
       'Post--edited': post.isEdited(),

--- a/js/src/forum/components/EventPost.js
+++ b/js/src/forum/components/EventPost.js
@@ -18,7 +18,7 @@ export default class EventPost extends Post {
   attrs() {
     const attrs = super.attrs();
 
-    attrs.className += ' EventPost ' + ucfirst(this.props.post.contentType()) + 'Post';
+    attrs.className = (attrs.className || '') + ' EventPost ' + ucfirst(this.props.post.contentType()) + 'Post';
 
     return attrs;
   }


### PR DESCRIPTION
fixes #1454

I couldn't find anything else. there might be more of this.
there is few `+=` in `Dropdown` components, but they seem alright.