### PR TITLE
Recursive Extenders: Allow Extenders to return more Extenders

### DIFF
--- a/src/Extend/ExtenderInterface.php
+++ b/src/Extend/ExtenderInterface.php
@@ -16,5 +16,10 @@ use Illuminate\Contracts\Container\Container;
 
 interface ExtenderInterface
 {
+    /**
+     * @param Container $container
+     * @param Extension|null $extension
+     * @return void|ExtenderInterface|ExtenderInterface[]
+     */
     public function __invoke(Container $container, Extension $extension = null);
 }


### PR DESCRIPTION
This will allow us to make composite Extenders without duplicating logic.

Also allows a single extender to be returned from bootstrap.php rather than an array (see flarum/flarum-ext-english#128)