### PR TITLE
Create new hidePosts permission

### DIFF
--- a/js/src/admin/AdminApplication.js
+++ b/js/src/admin/AdminApplication.js
@@ -55,7 +55,7 @@ export default class AdminApplication extends Application {
       required.push('discussion.hide');
     }
     if (permission === 'discussion.deletePosts') {
-      required.push('discussion.editPosts');
+      required.push('discussion.hidePosts');
     }
 
     return required;

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -206,9 +206,15 @@ export default class PermissionGrid extends Component {
 
     items.add('editPosts', {
       icon: 'fas fa-pencil-alt',
-      label: app.translator.trans('core.admin.permissions.edit_and_delete_posts_label'),
+      label: app.translator.trans('core.admin.permissions.edit_posts_label'),
       permission: 'discussion.editPosts'
     }, 70);
+
+    items.add('hidePosts', {
+      icon: 'far fa-trash-alt',
+      label: app.translator.trans('core.admin.permissions.delete_posts_label'),
+      permission: 'discussion.hidePosts'
+    }, 60);
 
     items.add('deletePosts', {
       icon: 'fas fa-times',

--- a/js/src/common/models/Post.js
+++ b/js/src/common/models/Post.js
@@ -24,5 +24,6 @@ Object.assign(Post.prototype, {
   isHidden: computed('hideTime', hideTime => !!hideTime),
 
   canEdit: Model.attribute('canEdit'),
+  canHide: Model.attribute('canHide'),
   canDelete: Model.attribute('canDelete')
 });

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -82,7 +82,7 @@ export default {
     const items = new ItemList();
 
     if (post.contentType() === 'comment' && !post.isHidden()) {
-      if (post.canEdit()) {
+      if (post.canHide()) {
         items.add('hide', Button.component({
           icon: 'far fa-trash-alt',
           children: app.translator.trans('core.forum.post_controls.delete_button'),
@@ -90,7 +90,7 @@ export default {
         }));
       }
     } else {
-      if (post.contentType() === 'comment' && post.canEdit()) {
+      if (post.contentType() === 'comment' && post.canHide()) {
         items.add('restore', Button.component({
           icon: 'fas fa-reply',
           children: app.translator.trans('core.forum.post_controls.restore_button'),

--- a/src/Api/Serializer/PostSerializer.php
+++ b/src/Api/Serializer/PostSerializer.php
@@ -66,7 +66,8 @@ class PostSerializer extends BasicPostSerializer
 
         $attributes += [
             'canEdit'   => $canEdit,
-            'canDelete' => $gate->allows('delete', $post)
+            'canDelete' => $gate->allows('delete', $post),
+            'canHide'   => $gate->allows('hide', $post)
         ];
 
         return $attributes;

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -319,6 +319,7 @@ class InstallCommand extends AbstractCommand
             // Moderators can edit + delete stuff
             [Group::MODERATOR_ID, 'discussion.hide'],
             [Group::MODERATOR_ID, 'discussion.editPosts'],
+            [Group::MODERATOR_ID, 'discussion.hidePosts'],
             [Group::MODERATOR_ID, 'discussion.rename'],
             [Group::MODERATOR_ID, 'discussion.viewIpsPosts'],
         ];

--- a/src/Post/Command/EditPostHandler.php
+++ b/src/Post/Command/EditPostHandler.php
@@ -68,7 +68,7 @@ class EditPostHandler
             }
 
             if (isset($attributes['isHidden'])) {
-                $this->assertCan($actor, 'edit', $post);
+                $this->assertCan($actor, 'hide', $post);
 
                 if ($attributes['isHidden']) {
                     $post->hide($actor);

--- a/src/Post/PostPolicy.php
+++ b/src/Post/PostPolicy.php
@@ -79,7 +79,7 @@ class PostPolicy extends AbstractPolicy
         // Hide hidden posts, unless they are authored by the current user, or
         // the current user has permission to view hidden posts in the
         // discussion.
-        if (! $actor->hasPermission('discussion.editPosts')) {
+        if (! $actor->hasPermission('discussion.hidePosts')) {
             $query->where(function ($query) use ($actor) {
                 $query->whereNull('posts.hide_time')
                     ->orWhere('user_id', $actor->id)
@@ -89,7 +89,7 @@ class PostPolicy extends AbstractPolicy
                             ->whereRaw('discussions.id = posts.discussion_id')
                             ->where(function ($query) use ($actor) {
                                 $this->events->dispatch(
-                                    new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'editPosts')
+                                    new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
                                 );
                             });
                     });


### PR DESCRIPTION
In this PR, I'm adding a new `hidePosts` permission.

I thought it's better to make `editPosts` literally a permission to just edit posts. And let the `hidePosts` handle permission to delete posts. (which means: Groups with `editPosts` permission will be unable to delete posts. You must have `hidePosts` permission to do so.)

I also prefer to use `hidePosts` since it's represent soft delete and `deletePosts` may represent hard deletion. Just like permission in discussion.

## Issues that will be fixed by this PR:
- #1387 (Split permission for editing and deleting posts)
