### PR TITLE
Allow a single extender to be returned

### DIFF
--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -119,7 +119,13 @@ class Extension implements Arrayable
             return;
         }
 
-        $extenders = array_flatten((array) require $bootstrapper);
+        $extenders = require $bootstrapper;
+
+        if (! is_array($extenders)) {
+            $extenders = [$extenders];
+        }
+        
+        $extenders = array_flatten($extenders);
 
         foreach ($extenders as $extender) {
             // If an extension has not yet switched to the new bootstrap.php

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -124,7 +124,7 @@ class Extension implements Arrayable
         if (! is_array($extenders)) {
             $extenders = [$extenders];
         }
-        
+
         $extenders = array_flatten($extenders);
 
         foreach ($extenders as $extender) {


### PR DESCRIPTION
Casting an object to an array does not have the intended effect of
wrapping the object in an array. Instead we need to explicitly check
if the returned value is an array or not.

Required to merge flarum/flarum-ext-english#128