### PR TITLE
Disable PHP default errors display

### DIFF
--- a/src/Foundation/AbstractServer.php
+++ b/src/Foundation/AbstractServer.php
@@ -152,6 +152,7 @@ abstract class AbstractServer
         }
 
         date_default_timezone_set('UTC');
+        ini_set('display_errors', 'off');
 
         $app = new Application($this->basePath, $this->publicPath);
 


### PR DESCRIPTION
**Fixes #1421 **

**Changes proposed in this pull request:**
Temporarily disables php error displaying before figuring out the new provider, interface and handler class for the master branch.
