### PR TITLE
Replacement of bell with globe (#1490)

### DIFF
--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -177,7 +177,7 @@ export default class NotificationGrid extends Component {
 
     items.add('alert', {
       name: 'alert',
-      icon: 'fas fa-bell',
+      icon: 'fas fa-globe',
       label: app.translator.trans('core.forum.settings.notify_by_web_heading'),
     });
 


### PR DESCRIPTION
**Fixes #1490**

**Changes proposed in this pull request:**
Bell icon replacement with globe at notification settings.

**Reviewers should focus on:**
Line 180

**Screenshot**

![screenshot_2018-07-06 settings - flarum community](https://user-images.githubusercontent.com/17576065/42349353-2d375f08-80b5-11e8-80d7-8124b2fd8b2d.png)