### PR TITLE
Make "own" permissions depend on the user's ability to reply

### DIFF
--- a/src/Discussion/DiscussionPolicy.php
+++ b/src/Discussion/DiscussionPolicy.php
@@ -123,7 +123,7 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function rename(User $actor, Discussion $discussion)
     {
-        if ($discussion->user_id == $actor->id) {
+        if ($discussion->user_id == $actor->id && $actor->can('reply', $discussion)) {
             $allowRenaming = $this->settings->get('allow_renaming');
 
             if ($allowRenaming === '-1'
@@ -141,7 +141,7 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function hide(User $actor, Discussion $discussion)
     {
-        if ($discussion->user_id == $actor->id && $discussion->participant_count <= 1) {
+        if ($discussion->user_id == $actor->id && $discussion->participant_count <= 1 && $actor->can('reply', $discussion)) {
             return true;
         }
     }

--- a/src/Post/PostPolicy.php
+++ b/src/Post/PostPolicy.php
@@ -107,7 +107,7 @@ class PostPolicy extends AbstractPolicy
         // A post is allowed to be edited if the user has permission to moderate
         // the discussion which it's in, or if they are the author and the post
         // hasn't been deleted by someone else.
-        if ($post->user_id == $actor->id && (! $post->hidden_at || $post->hidden_user_id == $actor->id)) {
+        if ($post->user_id == $actor->id && (! $post->hidden_at || $post->hidden_user_id == $actor->id) && $actor->can('reply', $post->discussion)) {
             $allowEditing = $this->settings->get('allow_post_editing');
 
             if ($allowEditing === '-1'


### PR DESCRIPTION
Permission to rename/hide/edit one's own discussion/post is only granted
if the user has permission to reply to the discussion. This makes sense
if you think of these actions as forms of "replying" to a discussion.

**Fixes #1419** because suspended users do not have permission to reply to
discussions, therefore they will not be granted these "own" permissions.

**Related PRs**
https://github.com/flarum/flarum-ext-tags/pull/57
https://github.com/flarum/flarum-ext-lock/pull/15