### PR TITLE
configure spinner only once

### DIFF
--- a/js/src/common/components/LoadingIndicator.js
+++ b/js/src/common/components/LoadingIndicator.js
@@ -19,7 +19,9 @@ export default class LoadingIndicator extends Component {
     return <div {...attrs}>{m.trust('&nbsp;')}</div>;
   }
 
-  config() {
+  config(isInitialized) {
+    if (isInitialized) return;
+
     const options = { zIndex: 'auto', color: this.$().css('color') };
 
     switch (this.props.size) {


### PR DESCRIPTION
**Changes proposed in this pull request:**
only `LoadingIndicator.js` has been changed, due `spinner.js` is affecting DOM element directly, it should only created once.

**Screenshot**

before:
![before](https://user-images.githubusercontent.com/7693001/43147270-e501a85c-8f77-11e8-908d-b2ee1460ea58.gif)

after:
![after](https://user-images.githubusercontent.com/7693001/43147269-e4a52938-8f77-11e8-8ce5-ebd577191507.gif)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
