### PR TITLE
Change token error message

### DIFF
--- a/src/Forum/Controller/ConfirmEmailController.php
+++ b/src/Forum/Controller/ConfirmEmailController.php
@@ -20,7 +20,6 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\RedirectResponse;
 
 class ConfirmEmailController implements RequestHandlerInterface

--- a/src/Forum/Controller/ConfirmEmailController.php
+++ b/src/Forum/Controller/ConfirmEmailController.php
@@ -64,7 +64,7 @@ class ConfirmEmailController implements RequestHandlerInterface
                 new ConfirmEmail($token)
             );
         } catch (InvalidConfirmationTokenException $e) {
-            return new HtmlResponse('Invalid confirmation token');
+            return new HtmlResponse('The confirmation token is either invalid or has already been used');
         }
 
         $session = $request->getAttribute('session');

--- a/src/Forum/Controller/ConfirmEmailController.php
+++ b/src/Forum/Controller/ConfirmEmailController.php
@@ -12,6 +12,7 @@
 namespace Flarum\Forum\Controller;
 
 use Flarum\Foundation\Application;
+use Flarum\Http\Exception\CustomException;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\User\Command\ConfirmEmail;
 use Flarum\User\Exception\InvalidConfirmationTokenException;
@@ -54,6 +55,7 @@ class ConfirmEmailController implements RequestHandlerInterface
     /**
      * @param Request $request
      * @return ResponseInterface
+     * @throws CustomException
      */
     public function handle(Request $request): ResponseInterface
     {
@@ -64,7 +66,7 @@ class ConfirmEmailController implements RequestHandlerInterface
                 new ConfirmEmail($token)
             );
         } catch (InvalidConfirmationTokenException $e) {
-            return new HtmlResponse('The confirmation token is either invalid or has already been used');
+            throw new CustomException('core.views.error.400_invalid_confirmation_token', 404, $e);
         }
 
         $session = $request->getAttribute('session');

--- a/src/Forum/Controller/ConfirmEmailController.php
+++ b/src/Forum/Controller/ConfirmEmailController.php
@@ -65,7 +65,7 @@ class ConfirmEmailController implements RequestHandlerInterface
                 new ConfirmEmail($token)
             );
         } catch (InvalidConfirmationTokenException $e) {
-            throw new CustomException('core.views.error.400_invalid_confirmation_token', 404, $e);
+            throw new CustomException('core.views.error.404_invalid_confirmation_token', 404, $e);
         }
 
         $session = $request->getAttribute('session');

--- a/src/Http/Exception/CustomException.php
+++ b/src/Http/Exception/CustomException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Http\Exception;
+
+use Exception;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class CustomException extends Exception
+{
+    public $view;
+
+    public function __construct($message, $code, Exception $previous = null)
+    {
+        $this->view = 'flarum.forum::error.custom';
+
+        parent::__construct(
+            app(TranslatorInterface::class)->trans($message),
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Http/Middleware/HandleErrors.php
+++ b/src/Http/Middleware/HandleErrors.php
@@ -96,7 +96,7 @@ class HandleErrors implements Middleware
         // Log the exception (with trace)
         $this->logger->debug($error);
 
-        if (! $this->view->exists($name = "flarum.forum::error.$status")) {
+        if (! $this->view->exists($name = $error->view ?? "flarum.forum::error.$status")) {
             $name = 'flarum.forum::error.default';
         }
 

--- a/views/error/custom.blade.php
+++ b/views/error/custom.blade.php
@@ -1,0 +1,7 @@
+@extends('flarum.forum::layouts.basic')
+
+@section('content')
+    <p>
+        {{ $error->getMessage() ?? $message }}
+    </p>
+@endsection


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Fixes #1337**

**Changes proposed in this pull request:**
- Error message mentions possibility of the confirmation token having already been used

**Reviewers should focus on:**
- Language
- _Maybe_ creating an exception for custom error messages (similar to 404 but more customizable)

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/43686959-eb3c12c0-989b-11e8-9747-a5d51d784328.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
