### PR TITLE
ModalManager: Fix issue when app.current is not defined

### DIFF
--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -49,7 +49,7 @@ export default class ModalManager extends Component {
     this.showing = true;
     this.component = component;
 
-    app.current.retain = true;
+    if (app.current) app.current.retain = true;
 
     m.redraw(true);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Changes proposed in this pull request:**
- Prevent TypeError when `app.current` is not defined when setting `app.current.retain` to `true`

**Reviewers should focus on:**
- If `app.current` should *ever* be undefined

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/43930087-a19cbee0-9c05-11e8-8a74-0599dc3f1e31.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).