### PR TITLE
Fix wrong permission in UserPolicy#find

### DIFF
--- a/src/User/UserPolicy.php
+++ b/src/User/UserPolicy.php
@@ -38,7 +38,7 @@ class UserPolicy extends AbstractPolicy
      */
     public function find(User $actor, Builder $query)
     {
-        if ($actor->cannot('viewDiscussions')) {
+        if ($actor->cannot('viewUserList')) {
             $query->whereRaw('FALSE');
         }
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Fixes #1245**

**Changes proposed in this pull request:**
- Changes `UserPolicy#find` permission check from `viewDiscussions` to `viewUserList`.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).