### PR TITLE
Stop '@' and '*' from crashing the forum

### DIFF
--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -72,7 +72,7 @@ export default class DiscussionListItem extends Component {
         jumpTo = post.number();
       }
 
-      const phrase = this.props.params.q;
+      const phrase = app.current.searching();
       this.highlightRegExp = new RegExp(phrase+'|'+phrase.trim().replace(/\s+/g, '|'), 'gi');
     } else {
       jumpTo = Math.min(discussion.lastPostNumber(), (discussion.readNumber() || 0) + 1);

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -280,7 +280,7 @@ export default class IndexPage extends Page {
    * @return {String}
    */
   searching() {
-    return this.params().q;
+    return this.params().q && this.params().q.replace(/([@*])/g, '');
   }
 
   /**

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -24,7 +24,7 @@ export default class Search extends Component {
      *
      * @type {Function}
      */
-    this.value = m.prop('');
+    this.value = m.prop();
 
     /**
      * Whether or not the search input has focus.

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -74,6 +74,8 @@ export default class Search extends Component {
       this.value(currentSearch || '');
     }
 
+    const value = this.value();
+
     return (
       <div className={'Search ' + classList({
         open: this.value() && this.hasFocus,
@@ -85,8 +87,8 @@ export default class Search extends Component {
           <input className="FormControl"
             type="search"
             placeholder={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
-            value={this.value()}
-            oninput={m.withAttr('value', this.value)}
+            value={value}
+            oninput={m.withAttr('value', (query) => this.value(this.formatQuery(query)))}
             onfocus={() => this.hasFocus = true}
             onblur={() => this.hasFocus = false}/>
           {this.loadingSources
@@ -96,8 +98,8 @@ export default class Search extends Component {
               : ''}
         </div>
         <ul className="Dropdown-menu Search-results">
-          {this.value() && this.hasFocus
-            ? this.sources.map(source => source.view(this.value()))
+          {value && this.hasFocus
+            ? this.sources.map(source => source.view(value))
             : ''}
         </ul>
       </div>
@@ -136,9 +138,8 @@ export default class Search extends Component {
     // Handle input key events on the search input, triggering results to load.
     $input
       .on('input focus', function() {
-        const query = this.value.toLowerCase();
-
-        if (!query) return;
+        if (!this.value) return;
+        const query = this.value;
 
         clearTimeout(search.searchTimeout);
         search.searchTimeout = setTimeout(() => {
@@ -294,5 +295,9 @@ export default class Search extends Component {
         $dropdown.stop(true).animate({scrollTop}, 100);
       }
     }
+  }
+
+  formatQuery(query) {
+    return query && query.toLowerCase().replace(/([@*])/g, '');
   }
 }

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -31,7 +31,7 @@ class FulltextGambit implements GambitInterface
 
         // The @ character crashes fulltext searches on InnoDB tables.
         // See https://bugs.mysql.com/bug.php?id=74042
-        $bit = str_replace('@', '*', $bit);
+        $bit = str_replace(['@', '*'], '', $bit); // ALSO NEEDS TO BE REPLACED IN JS FOR RESULT MATCHING
 
         $search->getQuery()
             ->selectRaw('SUBSTRING_INDEX(GROUP_CONCAT(posts.id ORDER BY MATCH(posts.content) AGAINST (?) DESC), \',\', 1) as most_relevant_post_id', [$bit])


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Fixes #1498**

**Changes proposed in this pull request:**
- FulltextGambit replaces `@` and `*` with nothing
- DiscussionListItem now retrieves the current search from `app.current.searching` (same as `Search`) instead from the unformatted query
- `IndexPage#searching` removes `@` and `*`
- `Search#view` formats the input on change before setting to `this.value`, therefore making uses unable of typing `@` or `*` (nothing happens)

**Reviewers should focus on:**
- __Same issue__ occurs with characters such as `?`. We may want to restrict search to alphanumeric characters
![image](https://user-images.githubusercontent.com/6401250/44006330-eb0b709c-9e50-11e8-8c95-7d9a5dc9d4d5.png)


**Screenshot**

Before:
![image](https://user-images.githubusercontent.com/6401250/44006324-d3ab17ae-9e50-11e8-8efd-01cbc910388b.png)

After:
![image](https://user-images.githubusercontent.com/6401250/44006320-bd2133ce-9e50-11e8-9db2-52ef5aa737a6.png)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `php vendor/bin/phpunit`).