### PR TITLE
Fix post composer width bug on profile

### DIFF
--- a/less/forum/Composer.less
+++ b/less/forum/Composer.less
@@ -304,10 +304,9 @@
 
 @media @desktop-up {
   .Composer:not(.fullScreen) {
-    .App--index & {
-      margin-left: 220px;
-      margin-right: -20px;
-    }
+    margin-left: 220px;
+    margin-right: -20px;
+
     .App--discussion & {
       margin-left: -20px;
       margin-right: 205px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Fixes #1509**

**Changes proposed in this pull request:**
- Set the normal margin left & right on all pages by default, not only `IndexPage`

**Screenshot**
![44006140-2b79b016-9e4d-11e8-9628-90518b803185](https://user-images.githubusercontent.com/6401250/44006478-2f82c674-9e53-11e8-90df-f1eb34438900.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.