### PR TITLE
Aligns icons and text on dropdowns

### DIFF
--- a/less/common/Dropdown.less
+++ b/less/common/Dropdown.less
@@ -51,6 +51,7 @@
         margin-top: 2px;
         width: 16px;
         text-align: center;
+        line-height: initial;
       }
 
       &.disabled {


### PR DESCRIPTION
**Fixes #1484**

**Changes proposed in this pull request:**
This PR fixes the alignment issue where icons and text on dropdowns are not aligned well reported previously by me.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).