### PR TITLE
Align icons & text in SideNav and Dropdown

### DIFF
--- a/less/common/Dropdown.less
+++ b/less/common/Dropdown.less
@@ -51,6 +51,7 @@
         margin-top: 2px;
         width: 16px;
         text-align: center;
+        line-height: initial;
       }
 
       &.disabled {

--- a/less/common/Dropdown.less
+++ b/less/common/Dropdown.less
@@ -51,7 +51,6 @@
         margin-top: 2px;
         width: 16px;
         text-align: center;
-        line-height: initial;
       }
 
       &.disabled {

--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -30,8 +30,8 @@
           & .Button-icon {
             float: left;
             margin-left: -30px;
-            margin-top: 1px;
             font-size: 15px;
+            line-height: initial;
           }
         }
         & > li.active > a {

--- a/less/common/sideNav.less
+++ b/less/common/sideNav.less
@@ -31,7 +31,6 @@
             float: left;
             margin-left: -30px;
             font-size: 15px;
-            line-height: initial;
           }
         }
         & > li.active > a {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews.
-->

**Fixes #1484**

**Changes proposed in this pull request:**
- Removes margin top & makes line height 1 in sideNav icon & Dropdown icon

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
