### PR TITLE
Fix for SourceMaps not adding extension source maps

### DIFF
--- a/src/Frontend/Asset/ExtensionAssets.php
+++ b/src/Frontend/Asset/ExtensionAssets.php
@@ -46,6 +46,9 @@ class ExtensionAssets implements AssetInterface
     public function js(SourceCollector $sources)
     {
         if ($this->js) {
+			$sources->addString(function() {
+				return $this->js.'.map';
+			});
             $sources->addString(function () {
                 $name = $this->extension->getId();
 

--- a/src/Frontend/Asset/ExtensionAssets.php
+++ b/src/Frontend/Asset/ExtensionAssets.php
@@ -46,9 +46,9 @@ class ExtensionAssets implements AssetInterface
     public function js(SourceCollector $sources)
     {
         if ($this->js) {
-			$sources->addString(function() {
-				return $this->js.'.map';
-			});
+            $sources->addString(function () {
+                return $this->js.'.map';
+            });
             $sources->addString(function () {
                 $name = $this->extension->getId();
 

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -26,7 +26,6 @@ class JsCompiler extends RevisionCompiler
         $map = new SourceMap();
         $map->file = $mapFile;
         $output = [];
-        $line = 0;
 
         // For each of the sources, get their content and add it to the
         // output. For file sources, if a sourcemap is present, add it to
@@ -38,13 +37,12 @@ class JsCompiler extends RevisionCompiler
                 $sourceMap = $source->getPath().'.map';
 
                 if (file_exists($sourceMap)) {
-                    $map->concat($sourceMap, $line);
+                    $map->merge($sourceMap);
                 }
             }
 
             $content = $this->format($content);
             $output[] = $content;
-            $line += substr_count($content, "\n") + 1;
         }
 
         // Add a comment to the end of our file to point to the sourcemap

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -60,7 +60,7 @@ class JsCompiler extends RevisionCompiler
 
         $mapTemp = tempnam(sys_get_temp_dir(), $mapFile);
         $map->save($mapTemp);
-        $this->assetsDir->put($mapFile, preg_replace('/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\)\/\/[^"\'].*))/', '', file_get_contents($mapTemp)));
+        $this->assetsDir->put($mapFile, file_get_contents($mapTemp));
         @unlink($mapTemp);
 
         return true;

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -26,35 +26,41 @@ class JsCompiler extends RevisionCompiler
         $map = new SourceMap();
         $map->file = $mapFile;
         $output = [];
+        $line = 0;
 
         // For each of the sources, get their content and add it to the
         // output. For file sources, if a sourcemap is present, add it to
         // the output sourcemap.
         foreach ($sources as $source) {
-            $content = preg_replace('~//# sourceMappingURL.*$~s', '', $source->getContent());
+            $content = $source->getContent();
+			
+			if (strpos($this->format($content), '.js.map')) {
+				$map->concat($content, ($line));
+			} else {
+				if ($source instanceof FileSource) {
+					$sourceMap = $source->getPath().'.map';
 
-            if ($source instanceof FileSource) {
-                $sourceMap = $source->getPath().'.map';
-
-                if (file_exists($sourceMap)) {
-                    $map->merge($sourceMap);
-                }
-            }
-
-            $content = $this->format($content);
-            $output[] = $content;
-        }
+					if (file_exists($sourceMap)) {
+						$map->concat($sourceMap, $line);
+					}
+				}
+			
+				$content = $this->format($content);
+				$output[] = $content;
+				$line += substr_count($content, "\n") + 1;
+			}
+		}
 
         // Add a comment to the end of our file to point to the sourcemap
         // we just constructed. We will then write the JS file, save the
         // map to a temporary location, and then move it to the asset dir.
         $output[] = '//# sourceMappingURL='.$this->assetsDir->url($mapFile);
 
-        $this->assetsDir->put($file, $output);
+        $this->assetsDir->put($file, implode("\n", $output));
 
         $mapTemp = tempnam(sys_get_temp_dir(), $mapFile);
         $map->save($mapTemp);
-        $this->assetsDir->put($mapFile, file_get_contents($mapTemp));
+        $this->assetsDir->put($mapFile, preg_replace('/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\)\/\/[^"\'].*))/', '', file_get_contents($mapTemp)));
         @unlink($mapTemp);
 
         return true;

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -31,7 +31,7 @@ class JsCompiler extends RevisionCompiler
         // output. For file sources, if a sourcemap is present, add it to
         // the output sourcemap.
         foreach ($sources as $source) {
-            $content = $source->getContent();
+            $content = preg_replace('~//# sourceMappingURL.*$~s', '', $source->getContent());
 
             if ($source instanceof FileSource) {
                 $sourceMap = $source->getPath().'.map';
@@ -50,7 +50,7 @@ class JsCompiler extends RevisionCompiler
         // map to a temporary location, and then move it to the asset dir.
         $output[] = '//# sourceMappingURL='.$this->assetsDir->url($mapFile);
 
-        $this->assetsDir->put($file, implode("\n", $output));
+        $this->assetsDir->put($file, $output);
 
         $mapTemp = tempnam(sys_get_temp_dir(), $mapFile);
         $map->save($mapTemp);

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -33,23 +33,23 @@ class JsCompiler extends RevisionCompiler
         // the output sourcemap.
         foreach ($sources as $source) {
             $content = $source->getContent();
-			
-			if (strpos($this->format($content), '.js.map')) {
-				$map->concat($content, ($line));
-			} else {
-				if ($source instanceof FileSource) {
-					$sourceMap = $source->getPath().'.map';
 
-					if (file_exists($sourceMap)) {
-						$map->concat($sourceMap, $line);
-					}
-				}
-			
-				$content = $this->format($content);
-				$output[] = $content;
-				$line += substr_count($content, "\n") + 1;
-			}
-		}
+            if (strpos($this->format($content), '.js.map')) {
+                $map->concat($content, ($line));
+            } else {
+                if ($source instanceof FileSource) {
+                    $sourceMap = $source->getPath().'.map';
+
+                    if (file_exists($sourceMap)) {
+                        $map->concat($sourceMap, $line);
+                    }
+                }
+
+                $content = $this->format($content);
+                $output[] = $content;
+                $line += substr_count($content, "\n") + 1;
+            }
+        }
 
         // Add a comment to the end of our file to point to the sourcemap
         // we just constructed. We will then write the JS file, save the


### PR DESCRIPTION
Extension's sourcemaps weren't being added to the main assets map file causing wrong line numbers to be shown on a break point. 

* **Fixes** #1538


**Screenshots**

Before: 
![image](https://user-images.githubusercontent.com/13856015/44129127-b7f7b83a-9ffb-11e8-9f05-6e8dac147aef.png)

After: 
![image](https://user-images.githubusercontent.com/13856015/44132615-a726fdae-a00f-11e8-8a3e-5847abe6fe4a.png)



Before: 
![image](https://user-images.githubusercontent.com/13856015/44129188-fbe4fb98-9ffb-11e8-8036-5caa8430cb75.png)

After: 
![image](https://user-images.githubusercontent.com/13856015/44132621-b291764c-a00f-11e8-9200-2506f1e5d9cc.png)



