### PR TITLE
Rewrite sites / app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "league/flysystem": "^1.0.11",
         "league/oauth2-client": "~1.0",
         "matthiasmullie/minify": "^1.3",
+        "middlewares/base-path": "^1.1",
         "middlewares/base-path-router": "^0.2.1",
         "middlewares/request-handler": "^1.2",
         "monolog/monolog": "^1.16.0",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
         "league/flysystem": "^1.0.11",
         "league/oauth2-client": "~1.0",
         "matthiasmullie/minify": "^1.3",
+        "middlewares/base-path-router": "^0.2.1",
+        "middlewares/request-handler": "^1.2",
         "monolog/monolog": "^1.16.0",
         "nikic/fast-route": "^0.6",
         "oyejorge/less.php": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "symfony/yaml": "^3.3",
         "tobscure/json-api": "^0.3.0",
         "zendframework/zend-diactoros": "^1.8.4",
+        "zendframework/zend-httphandlerrunner": "^1.0",
         "zendframework/zend-stratigility": "^3.0"
     },
     "require-dev": {

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -17,7 +17,8 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Http\Middleware\AuthenticateWithSession;
 use Flarum\Http\Middleware\DispatchRoute;
-use Flarum\Http\Middleware\HandleErrors;
+use Flarum\Http\Middleware\HandleErrorsWithView;
+use Flarum\Http\Middleware\HandleErrorsWithWhoops;
 use Flarum\Http\Middleware\ParseJsonBody;
 use Flarum\Http\Middleware\RememberFromCookie;
 use Flarum\Http\Middleware\SetLocale;
@@ -46,8 +47,11 @@ class AdminServiceProvider extends AbstractServiceProvider
             $pipe = new MiddlewarePipe;
 
             // All requests should first be piped through our global error handler
-            $debugMode = ! $app->isUpToDate() || $app->inDebugMode();
-            $pipe->pipe($app->make(HandleErrors::class, ['debug' => $debugMode]));
+            if ($app->inDebugMode()) {
+                $pipe->pipe($app->make(HandleErrorsWithWhoops::class));
+            } else {
+                $pipe->pipe($app->make(HandleErrorsWithView::class));
+            }
 
             $pipe->pipe($app->make(ParseJsonBody::class));
             $pipe->pipe($app->make(StartSession::class));

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -62,7 +62,7 @@ class AdminServiceProvider extends AbstractServiceProvider
 
             event(new ConfigureMiddleware($pipe, 'admin'));
 
-            $pipe->pipe($app->make(DispatchRoute::class, ['routes' => $app->make('flarum.admin.routes')]));
+            $pipe->pipe(new DispatchRoute($app->make('flarum.admin.routes')));
 
             return $pipe;
         });

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -66,7 +66,7 @@ class ApiServiceProvider extends AbstractServiceProvider
 
             event(new ConfigureMiddleware($pipe, 'api'));
 
-            $pipe->pipe($app->make(DispatchRoute::class, ['routes' => $app->make('flarum.api.routes')]));
+            $pipe->pipe(new DispatchRoute($app->make('flarum.api.routes')));
 
             return $pipe;
         });

--- a/src/Bus/BusServiceProvider.php
+++ b/src/Bus/BusServiceProvider.php
@@ -12,17 +12,27 @@
 namespace Flarum\Bus;
 
 use Flarum\Foundation\AbstractServiceProvider;
-use Illuminate\Contracts\Bus\Dispatcher as BusContract;
+use Illuminate\Bus\Dispatcher as BaseDispatcher;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Bus\QueueingDispatcher as QueueingDispatcherContract;
 use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
 
 class BusServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->bind(BusContract::class, function ($app) {
+        $this->app->bind(BaseDispatcher::class, function ($app) {
             return new Dispatcher($app, function ($connection = null) use ($app) {
                 return $app[QueueFactoryContract::class]->connection($connection);
             });
         });
+
+        $this->app->alias(
+            BaseDispatcher::class, DispatcherContract::class
+        );
+
+        $this->app->alias(
+            BaseDispatcher::class, QueueingDispatcherContract::class
+        );
     }
 }

--- a/src/Console/Server.php
+++ b/src/Console/Server.php
@@ -12,74 +12,37 @@
 namespace Flarum\Console;
 
 use Flarum\Console\Event\Configuring;
-use Flarum\Database\Console\GenerateMigrationCommand;
-use Flarum\Database\Console\MigrateCommand;
-use Flarum\Database\Console\ResetCommand;
 use Flarum\Foundation\Application;
-use Flarum\Foundation\Console\CacheClearCommand;
-use Flarum\Foundation\Console\InfoCommand;
-use Flarum\Foundation\Site;
-use Flarum\Install\Console\InstallCommand;
-use Flarum\Install\InstallServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Application as ConsoleApplication;
 
 class Server
 {
-    /**
-     * @param Site $site
-     * @return Server
-     */
-    public static function fromSite(Site $site)
-    {
-        return new static($site->boot());
-    }
+    protected $commands;
 
-    public function __construct(Application $app)
+    public function __construct(array $commands)
     {
-        $this->app = $app;
+        $this->commands = $commands;
     }
 
     public function listen()
     {
-        $console = $this->getConsoleApplication();
+        $console = new ConsoleApplication('Flarum', Application::VERSION);
+
+        foreach ($this->commands as $command) {
+            $console->add($command);
+        }
+
+        $this->extend($console);
 
         exit($console->run());
     }
 
-    /**
-     * @return ConsoleApplication
-     */
-    protected function getConsoleApplication()
+    private function extend(ConsoleApplication $console)
     {
-        $console = new ConsoleApplication('Flarum', $this->app->version());
+        $app = Application::getInstance();
 
-        $this->app->register(InstallServiceProvider::class);
-
-        $commands = [
-            InstallCommand::class,
-            MigrateCommand::class,
-            ResetCommand::class,
-            GenerateMigrationCommand::class,
-        ];
-
-        if ($this->app->isInstalled()) {
-            $commands = array_merge($commands, [
-                InfoCommand::class,
-                CacheClearCommand::class
-            ]);
-        }
-
-        foreach ($commands as $command) {
-            $console->add($this->app->make(
-                $command,
-                ['config' => $this->app->isInstalled() ? $this->app->make('flarum.config') : []]
-            ));
-        }
-
-        $events = $this->app->make(Dispatcher::class);
-        $events->fire(new Configuring($this->app, $console));
-
-        return $console;
+        $events = $app->make(Dispatcher::class);
+        $events->fire(new Configuring($app, $console));
     }
 }

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -50,9 +50,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        if ($this->app->isInstalled()) {
-            AbstractModel::setConnectionResolver($this->app->make('Illuminate\Database\ConnectionResolverInterface'));
-            AbstractModel::setEventDispatcher($this->app->make('events'));
-        }
+        AbstractModel::setConnectionResolver($this->app->make('Illuminate\Database\ConnectionResolverInterface'));
+        AbstractModel::setEventDispatcher($this->app->make('events'));
     }
 }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -17,7 +17,8 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Http\Middleware\AuthenticateWithSession;
 use Flarum\Http\Middleware\CollectGarbage;
 use Flarum\Http\Middleware\DispatchRoute;
-use Flarum\Http\Middleware\HandleErrors;
+use Flarum\Http\Middleware\HandleErrorsWithView;
+use Flarum\Http\Middleware\HandleErrorsWithWhoops;
 use Flarum\Http\Middleware\ParseJsonBody;
 use Flarum\Http\Middleware\RememberFromCookie;
 use Flarum\Http\Middleware\SetLocale;
@@ -49,8 +50,11 @@ class ForumServiceProvider extends AbstractServiceProvider
             $pipe = new MiddlewarePipe;
 
             // All requests should first be piped through our global error handler
-            $debugMode = ! $app->isUpToDate() || $app->inDebugMode();
-            $pipe->pipe($app->make(HandleErrors::class, ['debug' => $debugMode]));
+            if ($app->inDebugMode()) {
+                $pipe->pipe($app->make(HandleErrorsWithWhoops::class));
+            } else {
+                $pipe->pipe($app->make(HandleErrorsWithView::class));
+            }
 
             $pipe->pipe($app->make(ParseJsonBody::class));
             $pipe->pipe($app->make(CollectGarbage::class));

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -66,7 +66,7 @@ class ForumServiceProvider extends AbstractServiceProvider
 
             event(new ConfigureMiddleware($pipe, 'forum'));
 
-            $pipe->pipe($app->make(DispatchRoute::class, ['routes' => $app->make('flarum.forum.routes')]));
+            $pipe->pipe(new DispatchRoute($app->make('flarum.forum.routes')));
 
             return $pipe;
         });

--- a/src/Foundation/AppInterface.php
+++ b/src/Foundation/AppInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+interface AppInterface
+{
+    /**
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    public function getRequestHandler();
+
+    /**
+     * @return \Symfony\Component\Console\Command\Command[]
+     */
+    public function getConsoleCommands();
+}

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -11,7 +11,6 @@
 
 namespace Flarum\Foundation;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Events\EventServiceProvider;
@@ -115,34 +114,13 @@ class Application extends Container implements ApplicationContract
     }
 
     /**
-     * Determine if Flarum has been installed.
-     *
-     * @return bool
-     */
-    public function isInstalled(): bool
-    {
-        return $this->bound('flarum.config');
-    }
-
-    public function isUpToDate(): bool
-    {
-        $settings = $this->make(SettingsRepositoryInterface::class);
-
-        try {
-            $version = $settings->get('version');
-        } finally {
-            return isset($version) && $version === $this->version();
-        }
-    }
-
-    /**
      * @param string $key
      * @param mixed $default
      * @return mixed
      */
     public function config($key, $default = null)
     {
-        return $this->isInstalled() ? array_get($this->make('flarum.config'), $key, $default) : $default;
+        return array_get($this->make('flarum.config'), $key, $default);
     }
 
     /**
@@ -152,7 +130,7 @@ class Application extends Container implements ApplicationContract
      */
     public function inDebugMode()
     {
-        return ! $this->isInstalled() || $this->config('debug');
+        return $this->config('debug', true);
     }
 
     /**
@@ -163,7 +141,7 @@ class Application extends Container implements ApplicationContract
      */
     public function url($path = null)
     {
-        $config = $this->isInstalled() ? $this->make('flarum.config') : [];
+        $config = $this->make('flarum.config');
         $url = array_get($config, 'url', array_get($_SERVER, 'REQUEST_URI'));
 
         if (is_array($url)) {

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -47,9 +47,9 @@ class InstalledApp implements AppInterface
     public function getRequestHandler()
     {
         if ($this->inMaintenanceMode()) {
-            return $this->getMaintenanceMiddleware();
+            return $this->getMaintenanceHandler();
         } elseif ($this->needsUpdate()) {
-            return $this->getUpdaterMiddleware();
+            return $this->getUpdaterHandler();
         }
 
         $pipe = new MiddlewarePipe;
@@ -69,7 +69,7 @@ class InstalledApp implements AppInterface
     /**
      * @return \Psr\Http\Server\RequestHandlerInterface
      */
-    private function getMaintenanceMiddleware()
+    private function getMaintenanceHandler()
     {
         $pipe = new MiddlewarePipe;
 
@@ -95,7 +95,7 @@ class InstalledApp implements AppInterface
     /**
      * @return \Psr\Http\Server\RequestHandlerInterface
      */
-    public function getUpdaterMiddleware()
+    public function getUpdaterHandler()
     {
         $pipe = new MiddlewarePipe;
         $pipe->pipe(

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+use Flarum\Database\Console\GenerateMigrationCommand;
+use Flarum\Database\Console\MigrateCommand;
+use Flarum\Database\Console\ResetCommand;
+use Flarum\Foundation\Console\CacheClearCommand;
+use Flarum\Foundation\Console\InfoCommand;
+use Flarum\Http\Middleware\DispatchRoute;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Stratigility\MiddlewarePipe;
+use function Zend\Stratigility\middleware;
+use function Zend\Stratigility\path;
+
+class InstalledApp implements AppInterface
+{
+    /**
+     * @var Application
+     */
+    protected $laravel;
+
+    /**
+     * @var array
+     */
+    protected $config;
+
+    public function __construct(Application $laravel, array $config)
+    {
+        $this->laravel = $laravel;
+        $this->config = $config;
+    }
+
+    /**
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    public function getRequestHandler()
+    {
+        if ($this->inMaintenanceMode()) {
+            return $this->getMaintenanceMiddleware();
+        } elseif ($this->needsUpdate()) {
+            return $this->getUpdaterMiddleware();
+        }
+
+        $pipe = new MiddlewarePipe;
+
+        $pipe->pipe($this->subPath('api', 'flarum.api.middleware'));
+        $pipe->pipe($this->subPath('admin', 'flarum.admin.middleware'));
+        $pipe->pipe($this->subPath('', 'flarum.forum.middleware'));
+
+        return $pipe;
+    }
+
+    private function inMaintenanceMode(): bool
+    {
+        return $this->config['offline'] ?? false;
+    }
+
+    /**
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    private function getMaintenanceMiddleware()
+    {
+        $pipe = new MiddlewarePipe;
+
+        $pipe->pipe(middleware(function () {
+            // FIXME: Fix path to 503.html
+            // TODO: FOR API render JSON-API error document for HTTP 503
+            return new HtmlResponse(
+                file_get_contents(__DIR__.'/../../503.html'), 503
+            );
+        }));
+
+        return $pipe;
+    }
+
+    private function needsUpdate(): bool
+    {
+        $settings = $this->laravel->make(SettingsRepositoryInterface::class);
+        $version = $settings->get('version');
+
+        return $version !== Application::VERSION;
+    }
+
+    /**
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    public function getUpdaterMiddleware()
+    {
+        $pipe = new MiddlewarePipe;
+        $pipe->pipe(
+            $this->laravel->make(
+                DispatchRoute::class,
+                ['routes' => $this->laravel->make('flarum.update.routes')]
+            )
+        );
+
+        return $pipe;
+    }
+
+    private function subPath($pathName, $middlewareStack)
+    {
+        return path(
+            parse_url($this->laravel->url($pathName), PHP_URL_PATH) ?: '/',
+            $this->laravel->make($middlewareStack)
+        );
+    }
+
+    /**
+     * @return \Symfony\Component\Console\Command\Command[]
+     */
+    public function getConsoleCommands()
+    {
+        return [
+            $this->laravel->make(GenerateMigrationCommand::class),
+            $this->laravel->make(InfoCommand::class, ['config' => $this->config]),
+            $this->laravel->make(MigrateCommand::class),
+            $this->laravel->make(ResetCommand::class),
+            $this->laravel->make(CacheClearCommand::class),
+        ];
+    }
+}

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -99,10 +99,7 @@ class InstalledApp implements AppInterface
     {
         $pipe = new MiddlewarePipe;
         $pipe->pipe(
-            $this->laravel->make(
-                DispatchRoute::class,
-                ['routes' => $this->laravel->make('flarum.update.routes')]
-            )
+            new DispatchRoute($this->laravel->make('flarum.update.routes'))
         );
 
         return $pipe;

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -18,9 +18,7 @@ use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
 use Flarum\Http\Middleware\DispatchRoute;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Stratigility\MiddlewarePipe;
-use function Zend\Stratigility\middleware;
 use function Zend\Stratigility\path;
 
 class InstalledApp implements AppInterface
@@ -47,7 +45,7 @@ class InstalledApp implements AppInterface
     public function getRequestHandler()
     {
         if ($this->inMaintenanceMode()) {
-            return $this->getMaintenanceHandler();
+            return new MaintenanceModeHandler();
         } elseif ($this->needsUpdate()) {
             return $this->getUpdaterHandler();
         }
@@ -64,24 +62,6 @@ class InstalledApp implements AppInterface
     private function inMaintenanceMode(): bool
     {
         return $this->config['offline'] ?? false;
-    }
-
-    /**
-     * @return \Psr\Http\Server\RequestHandlerInterface
-     */
-    private function getMaintenanceHandler()
-    {
-        $pipe = new MiddlewarePipe;
-
-        $pipe->pipe(middleware(function () {
-            // FIXME: Fix path to 503.html
-            // TODO: FOR API render JSON-API error document for HTTP 503
-            return new HtmlResponse(
-                file_get_contents(__DIR__.'/../../503.html'), 503
-            );
-        }));
-
-        return $pipe;
     }
 
     private function needsUpdate(): bool

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -29,6 +29,7 @@ use Flarum\Search\SearchServiceProvider;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Settings\SettingsServiceProvider;
 use Flarum\Update\UpdateServiceProvider;
+use Flarum\User\SessionServiceProvider;
 use Flarum\User\UserServiceProvider;
 use Illuminate\Cache\FileStore;
 use Illuminate\Cache\Repository as CacheRepository;
@@ -143,6 +144,7 @@ class InstalledSite implements SiteInterface
         $laravel->register(NotificationServiceProvider::class);
         $laravel->register(PostServiceProvider::class);
         $laravel->register(SearchServiceProvider::class);
+        $laravel->register(SessionServiceProvider::class);
         $laravel->register(UserServiceProvider::class);
         $laravel->register(UpdateServiceProvider::class);
 

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -13,7 +13,7 @@ namespace Flarum\Foundation;
 
 use Flarum\Admin\AdminServiceProvider;
 use Flarum\Api\ApiServiceProvider;
-use Flarum\Bus\BusServiceProvider as BusProvider;
+use Flarum\Bus\BusServiceProvider;
 use Flarum\Database\DatabaseServiceProvider;
 use Flarum\Database\MigrationServiceProvider;
 use Flarum\Discussion\DiscussionServiceProvider;
@@ -124,8 +124,6 @@ class InstalledSite implements SiteInterface
         $laravel->register(MailServiceProvider::class);
         $laravel->register(ViewServiceProvider::class);
         $laravel->register(ValidationServiceProvider::class);
-
-        $laravel->register(BusProvider::class);
 
         $settings = $laravel->make(SettingsRepositoryInterface::class);
 

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+use Flarum\Admin\AdminServiceProvider;
+use Flarum\Api\ApiServiceProvider;
+use Flarum\Bus\BusServiceProvider as BusProvider;
+use Flarum\Database\DatabaseServiceProvider;
+use Flarum\Database\MigrationServiceProvider;
+use Flarum\Discussion\DiscussionServiceProvider;
+use Flarum\Extension\ExtensionServiceProvider;
+use Flarum\Formatter\FormatterServiceProvider;
+use Flarum\Forum\ForumServiceProvider;
+use Flarum\Frontend\FrontendServiceProvider;
+use Flarum\Group\GroupServiceProvider;
+use Flarum\Locale\LocaleServiceProvider;
+use Flarum\Notification\NotificationServiceProvider;
+use Flarum\Post\PostServiceProvider;
+use Flarum\Search\SearchServiceProvider;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Settings\SettingsServiceProvider;
+use Flarum\Update\UpdateServiceProvider;
+use Flarum\User\UserServiceProvider;
+use Illuminate\Cache\FileStore;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Hashing\HashServiceProvider;
+use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+class InstalledSite implements SiteInterface
+{
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string
+     */
+    protected $publicPath;
+
+    /**
+     * @var string
+     */
+    protected $storagePath;
+
+    /**
+     * @var array
+     */
+    protected $config;
+
+    public function __construct($basePath, $publicPath, array $config)
+    {
+        $this->basePath = $basePath;
+        $this->publicPath = $publicPath;
+        $this->config = $config;
+    }
+
+    /**
+     * Create and boot a Flarum application instance.
+     *
+     * @return AppInterface
+     */
+    public function bootApp(): AppInterface
+    {
+        return new InstalledApp(
+            $this->bootLaravel(),
+            $this->config
+        );
+    }
+
+    /**
+     * @param $storagePath
+     * @return static
+     */
+    public function setStoragePath($storagePath)
+    {
+        $this->storagePath = $storagePath;
+
+        return $this;
+    }
+
+    protected function bootLaravel(): Application
+    {
+        $laravel = new Application($this->basePath, $this->publicPath);
+
+        if ($this->storagePath) {
+            $laravel->useStoragePath($this->storagePath);
+        }
+
+        $laravel->instance('env', 'production');
+        $laravel->instance('flarum.config', $this->config);
+        $laravel->instance('config', $config = $this->getIlluminateConfig($laravel));
+
+        $this->registerLogger($laravel);
+        $this->registerCache($laravel);
+
+        $laravel->register(DatabaseServiceProvider::class);
+        $laravel->register(MigrationServiceProvider::class);
+        $laravel->register(SettingsServiceProvider::class);
+        $laravel->register(LocaleServiceProvider::class);
+        $laravel->register(BusServiceProvider::class);
+        $laravel->register(FilesystemServiceProvider::class);
+        $laravel->register(HashServiceProvider::class);
+        $laravel->register(MailServiceProvider::class);
+        $laravel->register(ViewServiceProvider::class);
+        $laravel->register(ValidationServiceProvider::class);
+
+        $laravel->register(BusProvider::class);
+
+        $settings = $laravel->make(SettingsRepositoryInterface::class);
+
+        $config->set('mail.driver', $settings->get('mail_driver'));
+        $config->set('mail.host', $settings->get('mail_host'));
+        $config->set('mail.port', $settings->get('mail_port'));
+        $config->set('mail.from.address', $settings->get('mail_from'));
+        $config->set('mail.from.name', $settings->get('forum_title'));
+        $config->set('mail.encryption', $settings->get('mail_encryption'));
+        $config->set('mail.username', $settings->get('mail_username'));
+        $config->set('mail.password', $settings->get('mail_password'));
+
+        $laravel->register(DiscussionServiceProvider::class);
+        $laravel->register(FormatterServiceProvider::class);
+        $laravel->register(FrontendServiceProvider::class);
+        $laravel->register(GroupServiceProvider::class);
+        $laravel->register(NotificationServiceProvider::class);
+        $laravel->register(PostServiceProvider::class);
+        $laravel->register(SearchServiceProvider::class);
+        $laravel->register(UserServiceProvider::class);
+        $laravel->register(UpdateServiceProvider::class);
+
+        $laravel->register(ApiServiceProvider::class);
+        $laravel->register(ForumServiceProvider::class);
+        $laravel->register(AdminServiceProvider::class);
+
+        $laravel->register(ExtensionServiceProvider::class);
+
+        $laravel->boot();
+
+        return $laravel;
+    }
+
+    /**
+     * @param Application $app
+     * @return ConfigRepository
+     */
+    protected function getIlluminateConfig(Application $app)
+    {
+        return new ConfigRepository([
+            'view' => [
+                'paths' => [],
+                'compiled' => $app->storagePath().'/views',
+            ],
+            'mail' => [
+                'driver' => 'mail',
+            ],
+            'filesystems' => [
+                'default' => 'local',
+                'cloud' => 's3',
+                'disks' => [
+                    'flarum-assets' => [
+                        'driver' => 'local',
+                        'root'   => $app->publicPath().'/assets',
+                        'url'    => $app->url('assets')
+                    ],
+                    'flarum-avatars' => [
+                        'driver' => 'local',
+                        'root'   => $app->publicPath().'/assets/avatars'
+                    ]
+                ]
+            ],
+            'session' => [
+                'lifetime' => 120,
+                'files' => $app->storagePath().'/sessions',
+                'cookie' => 'session'
+            ]
+        ]);
+    }
+
+    protected function registerLogger(Application $app)
+    {
+        $logPath = $app->storagePath().'/logs/flarum.log';
+        $handler = new StreamHandler($logPath, Logger::INFO);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+
+        $app->instance('log', new Logger($app->environment(), [$handler]));
+        $app->alias('log', LoggerInterface::class);
+    }
+
+    protected function registerCache(Application $app)
+    {
+        $app->singleton('cache.store', function ($app) {
+            return new CacheRepository($app->make('cache.filestore'));
+        });
+        $app->alias('cache.store', Repository::class);
+
+        $app->singleton('cache.filestore', function ($app) {
+            return new FileStore(new Filesystem, $app->storagePath().'/cache');
+        });
+        $app->alias('cache.filestore', Store::class);
+    }
+}

--- a/src/Foundation/MaintenanceModeHandler.php
+++ b/src/Foundation/MaintenanceModeHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Tobscure\JsonApi\Document;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Diactoros\Response\JsonResponse;
+
+class MaintenanceModeHandler implements RequestHandlerInterface
+{
+    const MESSAGE = 'Currently down for maintenance. Please come back later.';
+
+    /**
+     * Handle the request and return a response.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // Special handling for API requests: they get a proper API response
+        if ($this->isApiRequest($request)) {
+            return $this->apiResponse();
+        }
+
+        // By default, return a simple text message.
+        return new HtmlResponse(self::MESSAGE, 503);
+    }
+
+    private function isApiRequest(ServerRequestInterface $request): bool
+    {
+        return str_contains(
+            $request->getHeaderLine('Accept'),
+            'application/vnd.api+json'
+        );
+    }
+
+    private function apiResponse(): ResponseInterface
+    {
+        return new JsonResponse(
+            (new Document)->setErrors([
+                'status' => '503',
+                'title' => self::MESSAGE
+            ]),
+            503,
+            ['Content-Type' => 'application/vnd.api+json']
+        );
+    }
+}

--- a/src/Foundation/Site.php
+++ b/src/Foundation/Site.php
@@ -11,281 +11,53 @@
 
 namespace Flarum\Foundation;
 
-use Flarum\Admin\AdminServiceProvider;
-use Flarum\Api\ApiServiceProvider;
-use Flarum\Bus\BusServiceProvider as BusProvider;
-use Flarum\Database\DatabaseServiceProvider;
-use Flarum\Database\MigrationServiceProvider;
-use Flarum\Discussion\DiscussionServiceProvider;
-use Flarum\Extension\ExtensionServiceProvider;
-use Flarum\Formatter\FormatterServiceProvider;
-use Flarum\Forum\ForumServiceProvider;
-use Flarum\Frontend\FrontendServiceProvider;
-use Flarum\Group\GroupServiceProvider;
-use Flarum\Locale\LocaleServiceProvider;
-use Flarum\Notification\NotificationServiceProvider;
-use Flarum\Post\PostServiceProvider;
-use Flarum\Search\SearchServiceProvider;
-use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\Settings\SettingsServiceProvider;
-use Flarum\User\UserServiceProvider;
-use Illuminate\Bus\BusServiceProvider;
-use Illuminate\Config\Repository as ConfigRepository;
-use Illuminate\Filesystem\FilesystemServiceProvider;
-use Illuminate\Hashing\HashServiceProvider;
-use Illuminate\Mail\MailServiceProvider;
-use Illuminate\Validation\ValidationServiceProvider;
-use Illuminate\View\ViewServiceProvider;
-use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
+use InvalidArgumentException;
+use RuntimeException;
 
-// TODO: This should be an interface maybe?
 class Site
 {
     /**
-     * @var Application
+     * @param array $paths
+     * @return SiteInterface
      */
-    protected $app;
-
-    /**
-     * @var string
-     */
-    protected $basePath;
-
-    /**
-     * @var string
-     */
-    protected $publicPath;
-
-    /**
-     * @var string
-     */
-    protected $storagePath;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    protected $extenders = [];
-
-    public function __construct()
+    public static function fromPaths(array $paths)
     {
-        $this->basePath = getcwd();
-        $this->publicPath = $this->basePath;
-    }
-
-    /**
-     * @return Application
-     */
-    public function boot()
-    {
-        return $this->getApp();
-    }
-
-    /**
-     * @param $basePath
-     * @return static
-     */
-    public function setBasePath($basePath)
-    {
-        $this->basePath = $basePath;
-
-        return $this;
-    }
-
-    /**
-     * @param $publicPath
-     * @return static
-     */
-    public function setPublicPath($publicPath)
-    {
-        $this->publicPath = $publicPath;
-
-        return $this;
-    }
-
-    /**
-     * @param $storagePath
-     * @return static
-     */
-    public function setStoragePath($storagePath)
-    {
-        $this->storagePath = $storagePath;
-
-        return $this;
-    }
-
-    /**
-     * @param array $config
-     * @return static
-     */
-    public function setConfig(array $config)
-    {
-        $this->config = $config;
-
-        return $this;
-    }
-
-    protected function getConfig()
-    {
-        if (empty($this->config) && file_exists($file = $this->basePath.'/config.php')) {
-            $this->config = include $file;
+        if (! isset($paths['base'])) {
+            throw new InvalidArgumentException(
+                'No base path given'
+            );
         }
 
-        return $this->config;
-    }
-
-    /**
-     * @return Application
-     */
-    protected function getApp()
-    {
-        if ($this->app !== null) {
-            return $this->app;
+        if (! isset($paths['public'])) {
+            $paths['public'] = $paths['base'];
         }
 
         date_default_timezone_set('UTC');
 
-        $app = new Application($this->basePath, $this->publicPath);
-
-        if ($this->storagePath) {
-            $app->useStoragePath($this->storagePath);
-        }
-
-        $app->instance('env', 'production');
-        $app->instance('flarum.config', $this->getConfig());
-        $app->instance('config', $config = $this->getIlluminateConfig($app));
-
-        $this->registerLogger($app);
-
-        $this->registerCache($app);
-
-        $app->register(DatabaseServiceProvider::class);
-        $app->register(MigrationServiceProvider::class);
-        $app->register(SettingsServiceProvider::class);
-        $app->register(LocaleServiceProvider::class);
-        $app->register(BusServiceProvider::class);
-        $app->register(FilesystemServiceProvider::class);
-        $app->register(HashServiceProvider::class);
-        $app->register(MailServiceProvider::class);
-        $app->register(ViewServiceProvider::class);
-        $app->register(ValidationServiceProvider::class);
-
-        $app->register(BusProvider::class);
-
-        if ($app->isInstalled() && $app->isUpToDate()) {
-            $settings = $app->make(SettingsRepositoryInterface::class);
-
-            $config->set('mail.driver', $settings->get('mail_driver'));
-            $config->set('mail.host', $settings->get('mail_host'));
-            $config->set('mail.port', $settings->get('mail_port'));
-            $config->set('mail.from.address', $settings->get('mail_from'));
-            $config->set('mail.from.name', $settings->get('forum_title'));
-            $config->set('mail.encryption', $settings->get('mail_encryption'));
-            $config->set('mail.username', $settings->get('mail_username'));
-            $config->set('mail.password', $settings->get('mail_password'));
-
-            $app->register(DiscussionServiceProvider::class);
-            $app->register(FormatterServiceProvider::class);
-            $app->register(FrontendServiceProvider::class);
-            $app->register(GroupServiceProvider::class);
-            $app->register(NotificationServiceProvider::class);
-            $app->register(PostServiceProvider::class);
-            $app->register(SearchServiceProvider::class);
-            $app->register(UserServiceProvider::class);
-
-            $app->register(ApiServiceProvider::class);
-            $app->register(ForumServiceProvider::class);
-            $app->register(AdminServiceProvider::class);
-
-            foreach ($this->extenders as $extender) {
-                // TODO: Create extenders architecture
-                // $extender->apply($app);
-            }
-
-            $app->register(ExtensionServiceProvider::class);
-        }
-
-        $app->boot();
-
-        $this->app = $app;
-
-        return $app;
-    }
-
-    /**
-     * @param Application $app
-     * @return ConfigRepository
-     */
-    protected function getIlluminateConfig(Application $app)
-    {
-        return new ConfigRepository([
-            'view' => [
-                'paths' => [],
-                'compiled' => $app->storagePath().'/views',
-            ],
-            'mail' => [
-                'driver' => 'mail',
-            ],
-            'filesystems' => [
-                'default' => 'local',
-                'cloud' => 's3',
-                'disks' => [
-                    'flarum-assets' => [
-                        'driver' => 'local',
-                        'root'   => $app->publicPath().'/assets',
-                        'url'    => $app->url('assets')
-                    ],
-                    'flarum-avatars' => [
-                        'driver' => 'local',
-                        'root'   => $app->publicPath().'/assets/avatars'
-                    ]
-                ]
-            ],
-            'session' => [
-                'lifetime' => 120,
-                'files' => $app->storagePath().'/sessions',
-                'cookie' => 'session'
-            ]
-        ]);
-    }
-
-    /**
-     * @param Application $app
-     */
-    protected function registerLogger(Application $app)
-    {
-        $logger = new Logger($app->environment());
-        $logPath = $app->storagePath().'/logs/flarum.log';
-
-        $handler = new StreamHandler($logPath, Logger::DEBUG);
-        $handler->setFormatter(new LineFormatter(null, null, true, true));
-
-        $logger->pushHandler($handler);
-
-        $app->instance('log', $logger);
-        $app->alias('log', 'Psr\Log\LoggerInterface');
-    }
-
-    /**
-     * @param Application $app
-     */
-    protected function registerCache(Application $app)
-    {
-        $app->singleton('cache.store', function ($app) {
-            return new \Illuminate\Cache\Repository($app->make('cache.filestore'));
-        });
-
-        $app->singleton('cache.filestore', function ($app) {
-            return new \Illuminate\Cache\FileStore(
-                new \Illuminate\Filesystem\Filesystem(),
-                $app->storagePath().'/cache'
+        if (static::hasConfigFile($paths['base'])) {
+            return new InstalledSite(
+                $paths['base'],
+                $paths['public'],
+                static::loadConfig($paths['base'])
             );
-        });
+        } else {
+            return new UninstalledSite($paths['base'], $paths['public']);
+        }
+    }
 
-        $app->alias('cache.filestore', 'Illuminate\Contracts\Cache\Store');
-        $app->alias('cache.store', 'Illuminate\Contracts\Cache\Repository');
+    private static function hasConfigFile($basePath)
+    {
+        return file_exists("$basePath/config.php");
+    }
+
+    private static function loadConfig($basePath): array
+    {
+        $config = include "$basePath/config.php";
+
+        if (! is_array($config)) {
+            throw new RuntimeException('config.php should return an array');
+        }
+
+        return $config;
     }
 }

--- a/src/Foundation/SiteInterface.php
+++ b/src/Foundation/SiteInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+interface SiteInterface
+{
+    /**
+     * Create and boot a Flarum application instance.
+     *
+     * @return AppInterface
+     */
+    public function bootApp(): AppInterface;
+}

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -16,6 +16,7 @@ use Flarum\Install\InstallServiceProvider;
 use Flarum\Locale\LocaleServiceProvider;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Settings\UninstalledSettingsRepository;
+use Flarum\User\SessionServiceProvider;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Filesystem\FilesystemServiceProvider;
@@ -79,6 +80,7 @@ class UninstalledSite implements SiteInterface
 
         $laravel->register(LocaleServiceProvider::class);
         $laravel->register(FilesystemServiceProvider::class);
+        $laravel->register(SessionServiceProvider::class);
         $laravel->register(ValidationServiceProvider::class);
 
         $laravel->register(InstallServiceProvider::class);

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation;
+
+use Flarum\Install\Installer;
+use Flarum\Install\InstallServiceProvider;
+use Flarum\Locale\LocaleServiceProvider;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Settings\UninstalledSettingsRepository;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\FileViewFinder;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+class UninstalledSite implements SiteInterface
+{
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string
+     */
+    protected $publicPath;
+
+    /**
+     * @var string
+     */
+    protected $storagePath;
+
+    public function __construct($basePath, $publicPath)
+    {
+        $this->basePath = $basePath;
+        $this->publicPath = $publicPath;
+    }
+
+    /**
+     * Create and boot a Flarum application instance.
+     *
+     * @return AppInterface
+     */
+    public function bootApp(): AppInterface
+    {
+        return new Installer(
+            $this->bootLaravel()
+        );
+    }
+
+    private function bootLaravel(): Application
+    {
+        $laravel = new Application($this->basePath, $this->publicPath);
+
+        if ($this->storagePath) {
+            $laravel->useStoragePath($this->storagePath);
+        }
+
+        $laravel->instance('env', 'production');
+        $laravel->instance('flarum.config', []);
+        $laravel->instance('config', $config = $this->getIlluminateConfig($laravel));
+
+        $this->registerLogger($laravel);
+
+        $laravel->register(LocaleServiceProvider::class);
+        $laravel->register(FilesystemServiceProvider::class);
+        $laravel->register(ValidationServiceProvider::class);
+
+        $laravel->register(InstallServiceProvider::class);
+
+        $laravel->singleton(
+            SettingsRepositoryInterface::class,
+            UninstalledSettingsRepository::class
+        );
+
+        $laravel->singleton('view', function ($app) {
+            $engines = new EngineResolver();
+            $engines->register('php', function () {
+                return new PhpEngine();
+            });
+            $finder = new FileViewFinder($app->make('files'), []);
+            $dispatcher = $app->make(Dispatcher::class);
+
+            return new \Illuminate\View\Factory(
+                $engines, $finder, $dispatcher
+            );
+        });
+
+        $laravel->boot();
+
+        return $laravel;
+    }
+
+    /**
+     * @param Application $app
+     * @return ConfigRepository
+     */
+    protected function getIlluminateConfig(Application $app)
+    {
+        return new ConfigRepository([
+            'session' => [
+                'lifetime' => 120,
+                'files' => $app->storagePath().'/sessions',
+                'cookie' => 'session'
+            ]
+        ]);
+    }
+
+    protected function registerLogger(Application $app)
+    {
+        $logPath = $app->storagePath().'/logs/flarum-installer.log';
+        $handler = new StreamHandler($logPath, Logger::DEBUG);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+
+        $app->instance('log', new Logger('Flarum Installer', [$handler]));
+        $app->alias('log', LoggerInterface::class);
+    }
+}

--- a/src/Http/Middleware/HandleErrorsWithView.php
+++ b/src/Http/Middleware/HandleErrorsWithView.php
@@ -13,7 +13,6 @@ namespace Flarum\Http\Middleware;
 
 use Exception;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Franzl\Middleware\Whoops\WhoopsRunner;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -23,7 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 
-class HandleErrors implements Middleware
+class HandleErrorsWithView implements Middleware
 {
     /**
      * @var ViewFactory
@@ -46,24 +45,17 @@ class HandleErrors implements Middleware
     protected $settings;
 
     /**
-     * @var bool
-     */
-    protected $debug;
-
-    /**
      * @param ViewFactory $view
      * @param LoggerInterface $logger
      * @param TranslatorInterface $translator
      * @param SettingsRepositoryInterface $settings
-     * @param bool $debug
      */
-    public function __construct(ViewFactory $view, LoggerInterface $logger, TranslatorInterface $translator, SettingsRepositoryInterface $settings, $debug = false)
+    public function __construct(ViewFactory $view, LoggerInterface $logger, TranslatorInterface $translator, SettingsRepositoryInterface $settings)
     {
         $this->view = $view;
         $this->logger = $logger;
         $this->translator = $translator;
         $this->settings = $settings;
-        $this->debug = $debug;
     }
 
     /**
@@ -74,11 +66,7 @@ class HandleErrors implements Middleware
         try {
             return $handler->handle($request);
         } catch (Exception $e) {
-            if ($this->debug) {
-                return WhoopsRunner::handle($e, $request);
-            } else {
-                return $this->formatException($e);
-            }
+            return $this->formatException($e);
         }
     }
 

--- a/src/Http/Middleware/HandleErrorsWithWhoops.php
+++ b/src/Http/Middleware/HandleErrorsWithWhoops.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Http\Middleware;
+
+use Exception;
+use Franzl\Middleware\Whoops\WhoopsRunner;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
+
+class HandleErrorsWithWhoops implements Middleware
+{
+    /**
+     * Catch all errors that happen during further middleware execution.
+     */
+    public function process(Request $request, Handler $handler): Response
+    {
+        try {
+            return $handler->handle($request);
+        } catch (Exception $e) {
+            return WhoopsRunner::handle($e, $request);
+        }
+    }
+}

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -11,149 +11,27 @@
 
 namespace Flarum\Http;
 
-use Flarum\Foundation\Application;
-use Flarum\Foundation\Site;
-use Flarum\Http\Middleware\DispatchRoute;
-use Flarum\Http\Middleware\HandleErrors;
-use Flarum\Http\Middleware\StartSession;
-use Flarum\Install\InstallServiceProvider;
-use Flarum\Update\UpdateServiceProvider;
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Server\MiddlewareInterface as Middleware;
-use Psr\Http\Server\RequestHandlerInterface as Handler;
-use Zend\Diactoros\Response\HtmlResponse;
+use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Server as DiactorosServer;
-use Zend\Stratigility\MiddlewarePipe;
-use function Zend\Stratigility\middleware;
-use function Zend\Stratigility\path;
 
-class Server implements Middleware, Handler
+class Server
 {
-    /**
-     * @param Site $site
-     * @return Server
-     */
-    public static function fromSite(Site $site)
-    {
-        return new static($site->boot());
-    }
+    protected $requestHandler;
 
-    public function __construct(Application $app)
+    public function __construct(RequestHandlerInterface $requestHandler)
     {
-        $this->app = $app;
+        $this->requestHandler = $requestHandler;
     }
 
     public function listen()
     {
         DiactorosServer::createServer(
-            [$this, 'handle'],
+            [$this->requestHandler, 'handle'],
             $_SERVER,
             $_GET,
             $_POST,
             $_COOKIE,
             $_FILES
         )->listen();
-    }
-
-    /**
-     * Use as PSR-15 middleware.
-     */
-    public function process(Request $request, Handler $handler): Response
-    {
-        $middleware = $this->getMiddleware($request->getUri()->getPath());
-
-        return $middleware->process($request, $handler);
-    }
-
-    /**
-     * Use as PSR-15 request handler.
-     */
-    public function handle(Request $request): Response
-    {
-        $middleware = $this->getMiddleware($request->getUri()->getPath());
-
-        return $middleware->handle($request);
-    }
-
-    /**
-     * @param string $requestPath
-     * @return MiddlewarePipe
-     */
-    protected function getMiddleware($requestPath)
-    {
-        $pipe = new MiddlewarePipe;
-
-        if (! $this->app->isInstalled()) {
-            return $this->getInstallerMiddleware($pipe);
-        }
-
-        if ($this->app->isDownForMaintenance()) {
-            return $this->getMaintenanceMiddleware($pipe);
-        }
-
-        if (! $this->app->isUpToDate()) {
-            return $this->getUpdaterMiddleware($pipe);
-        }
-
-        $api = parse_url($this->app->url('api'), PHP_URL_PATH);
-        $admin = parse_url($this->app->url('admin'), PHP_URL_PATH);
-        $forum = parse_url($this->app->url(''), PHP_URL_PATH) ?: '/';
-
-        if ($this->pathStartsWith($requestPath, $api)) {
-            $pipe->pipe(path($api, $this->app->make('flarum.api.middleware')));
-        } elseif ($this->pathStartsWith($requestPath, $admin)) {
-            $pipe->pipe(path($admin, $this->app->make('flarum.admin.middleware')));
-        } else {
-            $pipe->pipe(path($forum, $this->app->make('flarum.forum.middleware')));
-        }
-
-        return $pipe;
-    }
-
-    private function pathStartsWith($path, $prefix)
-    {
-        return $path === $prefix || starts_with($path, "$prefix/");
-    }
-
-    protected function getInstallerMiddleware(MiddlewarePipe $pipe)
-    {
-        $this->app->register(InstallServiceProvider::class);
-
-        // FIXME: Re-enable HandleErrors middleware, if possible
-        // (Right now it tries to resolve a database connection because of the injected settings repo instance)
-        // We could register a different settings repo when Flarum is not installed
-        //$pipe->pipe($this->app->make(HandleErrors::class, ['debug' => true]));
-        //$pipe->pipe($this->app->make(StartSession::class));
-        $pipe->pipe($this->app->make(DispatchRoute::class, ['routes' => $this->app->make('flarum.install.routes')]));
-
-        return $pipe;
-    }
-
-    protected function getMaintenanceMiddleware(MiddlewarePipe $pipe)
-    {
-        $pipe->pipe(middleware(function () {
-            return new HtmlResponse(file_get_contents($this->getErrorDir().'/503.html', 503));
-        }));
-
-        // TODO: FOR API render JSON-API error document for HTTP 503
-
-        return $pipe;
-    }
-
-    protected function getUpdaterMiddleware(MiddlewarePipe $pipe)
-    {
-        $this->app->register(UpdateServiceProvider::class);
-
-        $pipe->pipe($this->app->make(DispatchRoute::class, ['routes' => $this->app->make('flarum.update.routes')]));
-
-        // TODO: FOR API render JSON-API error document for HTTP 503
-
-        return $pipe;
-    }
-
-    private function getErrorDir()
-    {
-        return __DIR__.'/../../error';
     }
 }

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -12,23 +12,23 @@
 namespace Flarum\Install;
 
 use Flarum\Foundation\AppInterface;
-use Flarum\Foundation\Application;
 use Flarum\Http\Middleware\DispatchRoute;
 use Flarum\Http\Middleware\HandleErrorsWithWhoops;
 use Flarum\Http\Middleware\StartSession;
 use Flarum\Install\Console\InstallCommand;
+use Illuminate\Contracts\Container\Container;
 use Zend\Stratigility\MiddlewarePipe;
 
 class Installer implements AppInterface
 {
     /**
-     * @var Application
+     * @var Container
      */
-    protected $laravel;
+    protected $container;
 
-    public function __construct(Application $laravel)
+    public function __construct(Container $container)
     {
-        $this->laravel = $laravel;
+        $this->container = $container;
     }
 
     /**
@@ -37,10 +37,10 @@ class Installer implements AppInterface
     public function getRequestHandler()
     {
         $pipe = new MiddlewarePipe;
-        $pipe->pipe($this->laravel->make(HandleErrorsWithWhoops::class));
-        $pipe->pipe($this->laravel->make(StartSession::class));
+        $pipe->pipe($this->container->make(HandleErrorsWithWhoops::class));
+        $pipe->pipe($this->container->make(StartSession::class));
         $pipe->pipe(
-            new DispatchRoute($this->laravel->make('flarum.install.routes'))
+            new DispatchRoute($this->container->make('flarum.install.routes'))
         );
 
         return $pipe;
@@ -52,7 +52,7 @@ class Installer implements AppInterface
     public function getConsoleCommands()
     {
         return [
-            $this->laravel->make(InstallCommand::class),
+            $this->container->make(InstallCommand::class),
         ];
     }
 }

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -38,7 +38,7 @@ class Installer implements AppInterface
     {
         $pipe = new MiddlewarePipe;
         $pipe->pipe($this->laravel->make(HandleErrorsWithWhoops::class));
-        #$pipe->pipe($this->laravel->make(StartSession::class));
+        $pipe->pipe($this->laravel->make(StartSession::class));
         $pipe->pipe(
             $this->laravel->make(
                 DispatchRoute::class,

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -40,10 +40,7 @@ class Installer implements AppInterface
         $pipe->pipe($this->laravel->make(HandleErrorsWithWhoops::class));
         $pipe->pipe($this->laravel->make(StartSession::class));
         $pipe->pipe(
-            $this->laravel->make(
-                DispatchRoute::class,
-                ['routes' => $this->laravel->make('flarum.install.routes')]
-            )
+            new DispatchRoute($this->laravel->make('flarum.install.routes'))
         );
 
         return $pipe;

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Install;
+
+use Flarum\Foundation\AppInterface;
+use Flarum\Foundation\Application;
+use Flarum\Http\Middleware\DispatchRoute;
+use Flarum\Http\Middleware\HandleErrorsWithWhoops;
+use Flarum\Http\Middleware\StartSession;
+use Flarum\Install\Console\InstallCommand;
+use Zend\Stratigility\MiddlewarePipe;
+
+class Installer implements AppInterface
+{
+    /**
+     * @var Application
+     */
+    protected $laravel;
+
+    public function __construct(Application $laravel)
+    {
+        $this->laravel = $laravel;
+    }
+
+    /**
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    public function getRequestHandler()
+    {
+        $pipe = new MiddlewarePipe;
+        $pipe->pipe($this->laravel->make(HandleErrorsWithWhoops::class));
+        #$pipe->pipe($this->laravel->make(StartSession::class));
+        $pipe->pipe(
+            $this->laravel->make(
+                DispatchRoute::class,
+                ['routes' => $this->laravel->make('flarum.install.routes')]
+            )
+        );
+
+        return $pipe;
+    }
+
+    /**
+     * @return \Symfony\Component\Console\Command\Command[]
+     */
+    public function getConsoleCommands()
+    {
+        return [
+            $this->laravel->make(InstallCommand::class),
+        ];
+    }
+}

--- a/src/Locale/LocaleServiceProvider.php
+++ b/src/Locale/LocaleServiceProvider.php
@@ -13,6 +13,7 @@ namespace Flarum\Locale;
 
 use Flarum\Event\ConfigureLocales;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Symfony\Component\Translation\MessageSelector;
@@ -54,8 +55,8 @@ class LocaleServiceProvider extends AbstractServiceProvider
 
     private function getDefaultLocale(): string
     {
-        return $this->app->isInstalled() && $this->app->isUpToDate()
-            ? $this->app->make('flarum.settings')->get('default_locale', 'en')
-            : 'en';
+        $repo = $this->app->make(SettingsRepositoryInterface::class);
+
+        return $repo->get('default_locale', 'en');
     }
 }

--- a/src/Settings/UninstalledSettingsRepository.php
+++ b/src/Settings/UninstalledSettingsRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Settings;
+
+class UninstalledSettingsRepository implements SettingsRepositoryInterface
+{
+    public function all()
+    {
+        return [];
+    }
+
+    public function get($key, $default = null)
+    {
+        return $default;
+    }
+
+    public function set($key, $value)
+    {
+        // Do nothing
+    }
+
+    public function delete($keyLike)
+    {
+        // Do nothing
+    }
+}

--- a/src/User/SessionServiceProvider.php
+++ b/src/User/SessionServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\User;
+
+use Flarum\Foundation\AbstractServiceProvider;
+use Illuminate\Session\FileSessionHandler;
+use SessionHandlerInterface;
+
+class SessionServiceProvider extends AbstractServiceProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        $this->app->singleton('session.handler', function ($app) {
+            return new FileSessionHandler(
+                $app['files'],
+                $app['config']['session.files'],
+                $app['config']['session.lifetime']
+            );
+        });
+
+        $this->app->alias('session.handler', SessionHandlerInterface::class);
+    }
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -15,9 +15,7 @@ use Flarum\Event\ConfigureUserPreferences;
 use Flarum\Event\GetPermission;
 use Flarum\Foundation\AbstractServiceProvider;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Session\FileSessionHandler;
 use RuntimeException;
-use SessionHandlerInterface;
 
 class UserServiceProvider extends AbstractServiceProvider
 {
@@ -26,22 +24,8 @@ class UserServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->registerSession();
         $this->registerGate();
         $this->registerAvatarsFilesystem();
-    }
-
-    protected function registerSession()
-    {
-        $this->app->singleton('session.handler', function ($app) {
-            return new FileSessionHandler(
-                $app['files'],
-                $app['config']['session.files'],
-                $app['config']['session.lifetime']
-            );
-        });
-
-        $this->app->alias('session.handler', SessionHandlerInterface::class);
     }
 
     protected function registerGate()

--- a/tests/Api/Controller/CreateUserControllerTest.php
+++ b/tests/Api/Controller/CreateUserControllerTest.php
@@ -84,7 +84,7 @@ class CreateUserControllerTest extends ApiControllerTestCase
     public function disabling_sign_up_prevents_user_creation()
     {
         /** @var SettingsRepositoryInterface $settings */
-        $settings = $this->app->make(SettingsRepositoryInterface::class);
+        $settings = app(SettingsRepositoryInterface::class);
         $settings->set('allow_sign_up', false);
 
         try {

--- a/tests/Test/Concerns/MakesApiRequests.php
+++ b/tests/Test/Concerns/MakesApiRequests.php
@@ -11,24 +11,17 @@
 
 namespace Flarum\Tests\Test\Concerns;
 
-use Flarum\Api\ApiServiceProvider;
 use Flarum\Api\Client;
 use Flarum\User\Guest;
-use Flarum\User\SessionServiceProvider;
 use Flarum\User\User;
-use Flarum\User\UserServiceProvider;
 use Psr\Http\Message\ResponseInterface;
 
 trait MakesApiRequests
 {
     public function call(string $controller, User $actor = null, array $queryParams = [], array $body = []): ResponseInterface
     {
-        $this->app->register(SessionServiceProvider::class);
-        $this->app->register(UserServiceProvider::class);
-        $this->app->register(ApiServiceProvider::class);
-        $this->app->make('flarum.api.middleware');
         /** @var Client $api */
-        $api = $this->app->make(Client::class);
+        $api = app(Client::class);
 
         return $api->send($controller, $actor ?? new Guest, $queryParams, $body);
     }

--- a/tests/Test/Concerns/MakesApiRequests.php
+++ b/tests/Test/Concerns/MakesApiRequests.php
@@ -14,6 +14,7 @@ namespace Flarum\Tests\Test\Concerns;
 use Flarum\Api\ApiServiceProvider;
 use Flarum\Api\Client;
 use Flarum\User\Guest;
+use Flarum\User\SessionServiceProvider;
 use Flarum\User\User;
 use Flarum\User\UserServiceProvider;
 use Psr\Http\Message\ResponseInterface;
@@ -22,6 +23,7 @@ trait MakesApiRequests
 {
     public function call(string $controller, User $actor = null, array $queryParams = [], array $body = []): ResponseInterface
     {
+        $this->app->register(SessionServiceProvider::class);
         $this->app->register(UserServiceProvider::class);
         $this->app->register(ApiServiceProvider::class);
         $this->app->make('flarum.api.middleware');


### PR DESCRIPTION
**Fixes #1370**
**Supersedes #1416**

**Changes proposed in this pull request:**
For a while now, we have had some parts of the codebase that needed to check what state the software is in: Is Flarum installed? Is it up-to-date? Is it in maintenance mode? (*Did you know we have that, by the way?*) This always irked me, because it felt very cluttered, and it always led to weird scenarios where we essentially resorted to whack-a-mole bugfixing.

At some point, it occurred to me, that Flarum when installed and when not installed are essentially completely different apps: they have different sets of console commands that are relevant, they have different sets of service providers that are relevant to them, and so on. Some (rather small) parts may be re-used in both apps, but those parts should not care about where they are being used.

In fact, we now have **sites** and **apps** (this terminology might change). A Flarum site (I am hoping this interface might be useful for people hosting multiple instances of Flarum with the same codebase, or pulling their config from somewhere else than the `config.php` file we generate) can either be installed or uninstalled, it can configure its paths (base, public, storage..) in its preferred location. A site is capable of booting an "app" (either an `InstalledApp` or a `Installer`) - it does so by registering a bunch of service providers with Laravel and booting Laravel's, uh, app. The Flarum app can then be asked to provide a) a request handler, usually a middleware stack, for responding to web request (used in `public/index.php`) or a list of console commands (used by `php flarum`). This is all that's needed to model the difference in behavior that we see between installed and not-installed Flarum, all constrained to these four site and app classes.

Side note: The `InstalledApp` generates different request handlers if an already-installed Flarum instance happens to need a database update, or is put into maintenance mode. It will then serve a completely different frontend.

In line with dependency injection, we can have different implementations of interfaces for different apps. For example, the `SettingsRepositoryInterface`. Instead of making the standard database-based implementation work in the installer context, we can have a fake implementation that simply returns default values and ignores writes. For writing (during installation), I can just instantiate the database repository and use that.

Similarly, I started instantiating other objects directly instead of going through the IoC container, *where this makes sense*: mostly when very concrete classes are desired. Example: the `InstallCommand`, where we need a one-off database connection for setting up tables etc. This way, we don't need to worry about how to overwrite a binding in the IoC container that is meant to be configured with values that are meant to be collected inside `InstallCommand`. And the timing of registering and resolving these bindings had to be just right, to avoid problems with auto-injected dependencies whose dependencies already depended on a pre-configured database connection. Yikes.

Now, I have a very simple `Installer` app that has few dependencies from Flarum's core domain, and does not try to inject unnecessary things. In the future, I might even decouple it further from Laravel, so that only the "installed" version of Flarum builds on the framework.

The decision of what site and app we need is now moved to the outer parts, to the earliest part of the request lifecycle. You can easily walk through it starting at [our application skeleton](https://github.com/flarum/flarum/pull/55).

**Additional small changes:**
- I was able to remove some methods like `isUpToDate` or `isInstalled` from the `Application` class (which, uh, still exists in addition to apps), and with them, the temptation to use them all throughout the codebase. It should not be necessary with the new architecture.
- We had a `HandleErrors` middleware that had a lot of dependencies injected because it could handle both the debug mode error handling and our pretty error pages. Split these into two implementations, outsource the decision logic to a service provider, and voila.
- Libraries: Parts of zend-diactoros have been extracted into the beautifully named zend-httphandlerrunner package, so we're using that, too. Also, use libraries from the fantastic ["middlewares" organization](https://github.com/middlewares), which does fantastic work around PSR-7 and has accepted a contribution from me: the base-path-router essentially lazy-loads stacks of middleware depending on a path prefix. Which is just what we need our API, forum and admin layers: no need to instantiate forum middleware when serving API requests, and vice-versa.
- Service Providers: Split / combine some service providers, depending on which apps use them.

**Bugs fixed:**
- Console installation works again (see #1370), and is less likely to break as easily in the future.
- Login after web installation works again

**Reviewers should focus on:**
Wording: Are "sites" and "app" really the best terminology here? I doubt it. :wink: 
Please suggest better ones!

Current class names:
- `SiteInterface` - a thing that can boot an app, depending on the Flarum site's (basically a tenant) state and location.
- `InstalledSite` - the class that knows how to register and connect the dependencies of a fully installed Flarum (database, cache, event listeners, extensions etc.).
- `UninstalledSite` - when no config.php is found, this class uses a limited set of service providers to boot the components that are needed by the installer.
- `AppInterface` - a thing that knows how to create a middleware stack ("request handler") to serve web requests, and a set of console commands for the `php flarum` CLI
- `InstalledApp` - an app serving middleware (and console commands) for forum, admin and API, except when Flarum needs an update or is in maintenance mode
- `Installer` - an implementation of `AppInterface` that serves the web installer and `php flarum install`

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [ ] Related flarum/flarum PR: flarum/flarum#55
