### PR TITLE
InfoCommand improvements

### DIFF
--- a/src/Foundation/Console/InfoCommand.php
+++ b/src/Foundation/Console/InfoCommand.php
@@ -64,8 +64,9 @@ class InfoCommand extends AbstractCommand
 
         foreach ($this->extensions->getEnabledExtensions() as $extension) {
             /* @var \Flarum\Extension\Extension $extension */
-            $name = $extension->getId();
-            $version = $this->findPackageVersion($extension->getPath(), $extension->getVersion());
+            $name = str_pad($extension->getId(), 25);
+            $fallback = str_pad($extension->getVersion(), 15);
+            $version = $this->findPackageVersion($extension->getPath(), $fallback);
 
             $this->info("EXT $name $version");
         }

--- a/src/Foundation/Console/InfoCommand.php
+++ b/src/Foundation/Console/InfoCommand.php
@@ -99,7 +99,7 @@ class InfoCommand extends AbstractCommand
 
             $output = [];
             $status = null;
-            exec('git rev-parse HEAD', $output, $status);
+            exec('git rev-parse HEAD 2> /dev/null', $output, $status);
 
             chdir($cwd);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Ignore error output of `git rev-parse-head`
  - Would output the following if a git repository existed but had no commits:
    ```bash
    fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
    ```
- Pad extension id & version to make look cleaner

**Screenshot**

Before:
![image](https://user-images.githubusercontent.com/6401250/44988080-7719df80-af57-11e8-848b-97d6e90d5917.png)

After:
![image](https://user-images.githubusercontent.com/6401250/44988169-c102c580-af57-11e8-871d-e58917397bba.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `php vendor/bin/phpunit`).