### PR TITLE
Add 'oldUsername' to User\Event\Renamed

### DIFF
--- a/src/User/Event/Renamed.php
+++ b/src/User/Event/Renamed.php
@@ -21,17 +21,24 @@ class Renamed
     public $user;
 
     /**
+     * @var string
+     */
+    public $oldUsername;
+
+    /**
      * @var User
      */
     public $actor;
 
     /**
      * @param User $user
+     * @param string $oldUsername
      * @param User $actor
      */
-    public function __construct(User $user, User $actor = null)
+    public function __construct(User $user, string $oldUsername, User $actor = null)
     {
         $this->user = $user;
+        $this->oldUsername = $oldUsername;
         $this->actor = $actor;
     }
 }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -198,9 +198,10 @@ class User extends AbstractModel
     public function rename($username)
     {
         if ($username !== $this->username) {
+            $oldUsername = $this->username;
             $this->username = $username;
 
-            $this->raise(new Renamed($this));
+            $this->raise(new Renamed($this, $oldUsername));
         }
 
         return $this;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Add `$oldUsername` to `User\Event\Renamed`
    - Allows to act on old & new after renaming
    - Maintains consistency with `Discussion\Event\Renamed`

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
