### PR TITLE
Travis: Add table prefix to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
     - php: 7.2
       env: DB=mysql
 
+    - php: 7.2
+      env: DB=mysql PREFIX=forum_
+
     - php: 7.1
       addons:
         mariadb: '10.2'

--- a/tests/Test/Concerns/CreatesForum.php
+++ b/tests/Test/Concerns/CreatesForum.php
@@ -89,6 +89,7 @@ trait CreatesForum
         $database['database'] = env('DB_DATABASE', $database['database']);
         $database['username'] = env('DB_USERNAME', $database['username']);
         $database['password'] = env('DB_PASSWORD', $database['password']);
+        $database['prefix'] = env('DB_PREFIX', $database['prefix']);
         $this->configuration->setDatabaseConfiguration($database);
     }
 


### PR DESCRIPTION
**Fixes #1564**
Suggested in #1344.

**Changes proposed in this pull request:**
Run all tests with a database table prefix at least once.

**Reviewers should focus on:**
Correct combination of environment variables?

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
