### PR TITLE
Update AvatarEditor.js onchange to oninput

### DIFF
--- a/js/src/forum/components/AvatarEditor.js
+++ b/js/src/forum/components/AvatarEditor.js
@@ -150,7 +150,7 @@ export default class AvatarEditor extends Component {
     const user = this.props.user;
     const $input = $('<input type="file">');
 
-    $input.appendTo('body').hide().click().on('change', e => {
+    $input.appendTo('body').hide().click().on('input', e => {
       this.upload($(e.target)[0].files[0]);
     });
   }


### PR DESCRIPTION
onchange does not work in IE11 and other IE browsers. This change works with all modern browsers as well.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1125**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
