### PR TITLE
Make user posts page similar to discussion page, add empty text

### DIFF
--- a/js/src/forum/components/PostsUserPage.js
+++ b/js/src/forum/components/PostsUserPage.js
@@ -1,6 +1,7 @@
 import UserPage from './UserPage';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Button from '../../common/components/Button';
+import Placeholder from '../../common/components/Placeholder';
 import CommentPost from './CommentPost';
 
 /**
@@ -59,6 +60,15 @@ export default class PostsUserPage extends UserPage {
       );
     }
 
+    if (this.posts.length === 0 && !this.loading) {
+      const text = app.translator.trans('core.forum.user.posts_empty_text');
+      return (
+        <div className="PostsUserPage">
+          {Placeholder.component({text})}
+        </div>
+      );
+    }
+
     return (
       <div className="PostsUserPage">
         <ul className="PostsUserPage-list">
@@ -71,7 +81,9 @@ export default class PostsUserPage extends UserPage {
             </li>
           ))}
         </ul>
-        {footer}
+        <div className="PostsUserPage-loadMore">
+          {footer}
+        </div>
       </div>
     );
   }

--- a/less/forum/ActivityPage.less
+++ b/less/forum/ActivityPage.less
@@ -1,5 +1,6 @@
 .PostsUserPage-loadMore {
   text-align: center;
+  margin-top: 10px;
 
   .LoadingIndicator {
     height: 46px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Make `PostsUserPage` look more like `DiscussionsUserPage` (which uses `DiscussionList`)

**Reviewers should focus on:**
- Locale text

**Screenshot**
![2018-09-22 17-10-32](https://user-images.githubusercontent.com/6401250/45921793-92a74480-be8a-11e8-8872-862ffeed3a95.gif)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [x] Related core extension PRs: https://github.com/flarum/flarum-ext-english/pull/133
