### PR TITLE
Fix DELETE /api/extensions/* returning 500

### DIFF
--- a/src/Api/Controller/UninstallExtensionController.php
+++ b/src/Api/Controller/UninstallExtensionController.php
@@ -38,7 +38,9 @@ class UninstallExtensionController extends AbstractDeleteController
 
         $name = array_get($request->getQueryParams(), 'name');
 
-        if ($this->extensions->getExtension($name) == null) return;
+        if ($this->extensions->getExtension($name) == null) {
+            return;
+        }
 
         $this->extensions->uninstall($name);
     }

--- a/src/Api/Controller/UninstallExtensionController.php
+++ b/src/Api/Controller/UninstallExtensionController.php
@@ -38,9 +38,9 @@ class UninstallExtensionController extends AbstractDeleteController
 
         $name = array_get($request->getQueryParams(), 'name');
 
-        $extension = $this->extensions->getExtension($name);
+        if ($this->extensions->getExtension($name) == null) return;
 
-        $this->extensions->disable($extension);
-        $this->extensions->uninstall($extension);
+        $this->extensions->disable($name);
+        $this->extensions->uninstall($name);
     }
 }

--- a/src/Api/Controller/UninstallExtensionController.php
+++ b/src/Api/Controller/UninstallExtensionController.php
@@ -40,7 +40,6 @@ class UninstallExtensionController extends AbstractDeleteController
 
         if ($this->extensions->getExtension($name) == null) return;
 
-        $this->extensions->disable($name);
         $this->extensions->uninstall($name);
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Uses extension name instead of extension object for `ExtensionManager@uninstall` method call
- Removed `ExtensionManager@disable` as `ExtensionManager@uninstall` calls it as well

**Reviewers should focus on:**
- Should those methods accept strings or an extension object, as most in the method do?
- Is the check for the extension existing needed?
- Is "uninstall" the right name for this method? 

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
