### PR TITLE
Extension enable/disable hooks

### DIFF
--- a/src/Database/Console/MigrateCommand.php
+++ b/src/Database/Console/MigrateCommand.php
@@ -67,11 +67,7 @@ class MigrateCommand extends AbstractCommand
         $extensions = $this->container->make('Flarum\Extension\ExtensionManager');
         $extensions->getMigrator()->setOutput($this->output);
 
-        foreach ($extensions->getExtensions() as $name => $extension) {
-            if (! $extension->isEnabled()) {
-                continue;
-            }
-
+        foreach ($extensions->getEnabledExtensions() as $name => $extension) {
             $this->info('Migrating extension: '.$name);
 
             $extensions->migrate($extension);

--- a/src/Extend/Compat.php
+++ b/src/Extend/Compat.php
@@ -32,7 +32,7 @@ class Compat implements ExtenderInterface
         $this->callback = $callback;
     }
 
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         $container->call($this->callback);
     }

--- a/src/Extend/ExtenderInterface.php
+++ b/src/Extend/ExtenderInterface.php
@@ -16,5 +16,5 @@ use Illuminate\Contracts\Container\Container;
 
 interface ExtenderInterface
 {
-    public function __invoke(Container $container, Extension $extension = null);
+    public function extend(Container $container, Extension $extension = null);
 }

--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -30,7 +30,7 @@ class Formatter implements ExtenderInterface
         return $this;
     }
 
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         $events = $container->make(Dispatcher::class);
 

--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -11,15 +11,13 @@
 
 namespace Flarum\Extend;
 
-use Flarum\Extension\Event\Disabled;
-use Flarum\Extension\Event\Enabled;
 use Flarum\Extension\Extension;
 use Flarum\Formatter\Event\Configuring;
 use Flarum\Formatter\Formatter as ActualFormatter;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Events\Dispatcher;
 
-class Formatter implements ExtenderInterface
+class Formatter implements ExtenderInterface, LifecycleInterface
 {
     protected $callback;
 
@@ -40,16 +38,17 @@ class Formatter implements ExtenderInterface
                 call_user_func($this->callback, $event->configurator);
             }
         );
+    }
 
-        // Also set up an event listener to flush the formatter cache whenever
-        // this extension is enabled or disabled.
-        $events->listen(
-            [Enabled::class, Disabled::class],
-            function ($event) use ($container, $extension) {
-                if ($event->extension === $extension) {
-                    $container->make(ActualFormatter::class)->flush();
-                }
-            }
-        );
+    public function onEnable(Container $container, Extension $extension)
+    {
+        // FLush the formatter cache when this extension is enabled
+        $container->make(ActualFormatter::class)->flush();
+    }
+
+    public function onDisable(Container $container, Extension $extension)
+    {
+        // FLush the formatter cache when this extension is disabled
+        $container->make(ActualFormatter::class)->flush();
     }
 }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -51,7 +51,7 @@ class Frontend implements ExtenderInterface
         return $this;
     }
 
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         $this->registerAssets($container, $this->getModuleName($extension));
         $this->registerRoutes($container);

--- a/src/Extend/LanguagePack.php
+++ b/src/Extend/LanguagePack.php
@@ -20,7 +20,7 @@ use RuntimeException;
 
 class LanguagePack implements ExtenderInterface
 {
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         if (is_null($extension)) {
             throw new InvalidArgumentException(

--- a/src/Extend/LifecycleInterface.php
+++ b/src/Extend/LifecycleInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+
+interface LifecycleInterface
+{
+    public function onEnable(Container $container, Extension $extension);
+
+    public function onDisable(Container $container, Extension $extension);
+}

--- a/src/Extend/Locales.php
+++ b/src/Extend/Locales.php
@@ -25,7 +25,7 @@ class Locales implements ExtenderInterface
         $this->directory = $directory;
     }
 
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         /** @var LocaleManager $locales */
         $locales = $container->make(LocaleManager::class);

--- a/src/Extend/Routes.php
+++ b/src/Extend/Routes.php
@@ -63,7 +63,7 @@ class Routes implements ExtenderInterface
         return $this;
     }
 
-    public function __invoke(Container $container, Extension $extension = null)
+    public function extend(Container $container, Extension $extension = null)
     {
         if (empty($this->routes)) {
             return;

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -121,7 +121,7 @@ class Extension implements Arrayable
                 $extender = new Compat($extender);
             }
 
-            $extender($app, $this);
+            $extender->extend($app, $this);
         }
     }
 

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -85,13 +85,6 @@ class Extension implements Arrayable
     protected $version;
 
     /**
-     * Whether the extension is enabled.
-     *
-     * @var bool
-     */
-    protected $enabled = false;
-
-    /**
      * @param       $path
      * @param array $composerJson
      */
@@ -226,8 +219,6 @@ class Extension implements Arrayable
 
     public function enable(Container $container)
     {
-        $this->setEnabled(true);
-
         foreach ($this->getLifecycleExtenders() as $extender) {
             $extender->onEnable($container, $this);
         }
@@ -235,30 +226,9 @@ class Extension implements Arrayable
 
     public function disable(Container $container)
     {
-        $this->setEnabled(false);
-
         foreach ($this->getLifecycleExtenders() as $extender) {
             $extender->onDisable($container, $this);
         }
-    }
-
-    /**
-     * @param bool $enabled
-     * @return Extension
-     */
-    public function setEnabled($enabled)
-    {
-        $this->enabled = $enabled;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEnabled()
-    {
-        return $this->enabled;
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -83,7 +83,6 @@ class ExtensionManager
                 // Per default all extensions are installed if they are registered in composer.
                 $extension->setInstalled(true);
                 $extension->setVersion(Arr::get($package, 'version'));
-                $extension->setEnabled($this->isEnabled($extension->getId()));
 
                 $extensions->put($extension->getId(), $extension);
             }

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -128,7 +128,7 @@ class ExtensionManager
 
             $this->setEnabled($enabled);
 
-            $extension->setEnabled(true);
+            $extension->enable($this->app);
 
             $this->dispatcher->dispatch(new Enabled($extension));
         }
@@ -152,7 +152,7 @@ class ExtensionManager
 
             $this->setEnabled($enabled);
 
-            $extension->setEnabled(false);
+            $extension->disable($this->app);
 
             $this->dispatcher->dispatch(new Disabled($extension));
         }

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -113,25 +113,27 @@ class ExtensionManager
      */
     public function enable($name)
     {
-        if (! $this->isEnabled($name)) {
-            $extension = $this->getExtension($name);
-
-            $this->dispatcher->dispatch(new Enabling($extension));
-
-            $enabled = $this->getEnabled();
-
-            $enabled[] = $name;
-
-            $this->migrate($extension);
-
-            $this->publishAssets($extension);
-
-            $this->setEnabled($enabled);
-
-            $extension->enable($this->app);
-
-            $this->dispatcher->dispatch(new Enabled($extension));
+        if ($this->isEnabled($name)) {
+            return;
         }
+
+        $extension = $this->getExtension($name);
+
+        $this->dispatcher->dispatch(new Enabling($extension));
+
+        $enabled = $this->getEnabled();
+
+        $enabled[] = $name;
+
+        $this->migrate($extension);
+
+        $this->publishAssets($extension);
+
+        $this->setEnabled($enabled);
+
+        $extension->enable($this->app);
+
+        $this->dispatcher->dispatch(new Enabled($extension));
     }
 
     /**
@@ -143,19 +145,21 @@ class ExtensionManager
     {
         $enabled = $this->getEnabled();
 
-        if (($k = array_search($name, $enabled)) !== false) {
-            $extension = $this->getExtension($name);
-
-            $this->dispatcher->dispatch(new Disabling($extension));
-
-            unset($enabled[$k]);
-
-            $this->setEnabled($enabled);
-
-            $extension->disable($this->app);
-
-            $this->dispatcher->dispatch(new Disabled($extension));
+        if (($k = array_search($name, $enabled)) === false) {
+            return;
         }
+
+        $extension = $this->getExtension($name);
+
+        $this->dispatcher->dispatch(new Disabling($extension));
+
+        unset($enabled[$k]);
+
+        $this->setEnabled($enabled);
+
+        $extension->disable($this->app);
+
+        $this->dispatcher->dispatch(new Disabled($extension));
     }
 
     /**

--- a/src/Formatter/FormatterServiceProvider.php
+++ b/src/Formatter/FormatterServiceProvider.php
@@ -11,23 +11,11 @@
 
 namespace Flarum\Formatter;
 
-use Flarum\Extension\Event\Disabled;
-use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\AbstractServiceProvider;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class FormatterServiceProvider extends AbstractServiceProvider
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function boot(Dispatcher $events)
-    {
-        $events->listen(Enabled::class, [$this, 'flushFormatter']);
-        $events->listen(Disabled::class, [$this, 'flushFormatter']);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -42,10 +30,5 @@ class FormatterServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->alias('flarum.formatter', Formatter::class);
-    }
-
-    public function flushFormatter()
-    {
-        $this->app->make('flarum.formatter')->flush();
     }
 }

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -173,7 +173,7 @@ class InstalledSite implements SiteInterface
         $laravel->boot();
 
         foreach ($this->extenders as $extension) {
-            $extension($laravel);
+            $extension->extend($laravel);
         }
 
         return $laravel;


### PR DESCRIPTION
**My shot at #1463**

**Changes proposed in this pull request:**
- Introduce a new `LifecycleInterface` that extenders *can* implement. If they do, the interface's methods (`onEnable()`, `onDisable()`) will be called when the extension is enabled or disabled. They make it easy for extenders to bring along custom logic for these lifecycle events, instead of having to write messy event listeners.
- Change the `Formatter` extender accordingly. Nice demonstration of how much cleaner this becomes. We seem to be discovering a nice abstraction. :wink: 
- Remove the additional flushing of the formatter cache being done in the `FormatterServiceProvider`. Extensions using the `Formatter` hook were already setting up these listeners (and now they're doing it via the lifecycle hooks). In fact, this means the cache will only be flushed when actually necessary, because only extensions with a `Formatter` extender will actually cause a flush.

Additional, smaller changes:
- Small refactorings I came across while working in and around the `ExtensionManager`

**Reviewers should focus on:**
- Should these lifecycle callbacks be in an additional "marker interface" or part of the existing `ExtenderInterface`? The current solution means less code for extenders that don't need them, at the price of an `instanceof`.
- Do we need other callbacks at this point? [The ticket](https://github.com/flarum/core/issues/1463) referenced other types ("before uninstall", "updating"), but so far the extenders don't seem to have a use-case for them...

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
