### PR TITLE
Allow ItemList method chaining (add, merge, remove, replace)

### DIFF
--- a/js/src/common/utils/ItemList.js
+++ b/js/src/common/utils/ItemList.js
@@ -64,10 +64,13 @@ export default class ItemList {
    * @param {*} content The item's content.
    * @param {Integer} [priority] The priority of the item. Items with a higher
    *     priority will be positioned before items with a lower priority.
+   * @return {ItemList}
    * @public
    */
   add(key, content, priority = 0) {
     this.items[key] = new Item(content, priority);
+
+    return this;
   }
 
   /**
@@ -76,6 +79,7 @@ export default class ItemList {
    * @param {String} key
    * @param {*} [content]
    * @param {Integer} [priority]
+   * @return {ItemList}
    * @public
    */
   replace(key, content = null, priority = null) {
@@ -88,22 +92,28 @@ export default class ItemList {
         this.items[key].priority = priority;
       }
     }
+
+    return this;
   }
 
   /**
    * Remove an item from the list.
    *
    * @param {String} key
+   * @return {ItemList}
    * @public
    */
   remove(key) {
     delete this.items[key];
+
+    return this;
   }
 
   /**
    * Merge another list's items into this one.
    *
    * @param {ItemList} items
+   * @return {ItemList}
    * @public
    */
   merge(items) {
@@ -112,6 +122,8 @@ export default class ItemList {
         this.items[i] = items.items[i];
       }
     }
+
+    return this;
   }
 
   /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Related to #1317**

**Changes proposed in this pull request:**
- Make `ItemList#add`, `ItemList#remove`, `ItemList#merge`, and `ItemList#replace` chainable (return ItemList instance)

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/46564443-4bcb3d00-c8d5-11e8-8cfd-34a4aa813124.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
