### PR TITLE
Add migration to add 'fa fa-' to group icons

### DIFF
--- a/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
+++ b/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Illuminate\Database\Schema\Builder;
 
 return [
@@ -14,7 +23,7 @@ return [
             $schema->getConnection()->table('groups')
                 ->where('id', $group->id)
                 ->update([
-                    'icon' => 'fa fa-' . $group->icon
+                    'icon' => 'fa fa-'.$group->icon
                 ]);
         }
     },

--- a/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
+++ b/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
@@ -23,7 +23,7 @@ return [
             $schema->getConnection()->table('groups')
                 ->where('id', $group->id)
                 ->update([
-                    'icon' => 'fa fa-'.$group->icon
+                    'icon' => 'fas fa-'.$group->icon
                 ]);
         }
     },

--- a/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
+++ b/migrations/2018_10_08_144700_add_shim_prefix_to_group_icons.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $groups = $schema->getConnection()->table('groups')
+            ->where('icon', '<>', '')
+            ->where('icon', 'NOT LIKE', '%fa-%')
+            ->select('id', 'icon')
+            ->cursor();
+
+        foreach ($groups as $group) {
+            $schema->getConnection()->table('groups')
+                ->where('id', $group->id)
+                ->update([
+                    'icon' => 'fa fa-' . $group->icon
+                ]);
+        }
+    },
+
+    'down' => function (Builder $schema) {
+        //
+    }
+];


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Add migration that adds `fa fa-` to group icons that aren't empty and don't contain `fa-`

**Reviewers should focus on:**
- Do we want to update each one individually, or use the following raw SQL query?
  ```php
  $connection = $schema->getConnection();
  $prefix = $connection->getTablePrefix();
  $connection->statement("UPDATE ${prefix}groups SET icon = CONCAT('fa fa-', icon) WHERE 
  (`icon` <> '') AND (`icon` NOT LIKE '%fa-%')");
  ```
  Both work exactly the same, I just feel like the above would be a tad faster as it doesn't perform a 
query per group, only one to update them all (don't quote me on that, I have no idea on SQL 
benchmarks).
  However, it would most likely not impact anybody as I doubt most Flarum instances have over 10 groups anyway.
- Do we want a down migration to remove the `fa fa-` prefix?

**Screenshot**

After migration ran, only group ID 4 (Mod) was modified, adding the `fa fa-` to the beginning.

![image](https://user-images.githubusercontent.com/6401250/46617996-54e22700-caec-11e8-81f3-2f14e234281a.png)

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
