### PR TITLE
adds log rotation, reducing file size per log file and easier to delete

### DIFF
--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -43,7 +43,7 @@ use Illuminate\Mail\MailServiceProvider;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\View\ViewServiceProvider;
 use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
+use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 
@@ -219,7 +219,7 @@ class InstalledSite implements SiteInterface
     private function registerLogger(Application $app)
     {
         $logPath = $app->storagePath().'/logs/flarum.log';
-        $handler = new StreamHandler($logPath, Logger::INFO);
+        $handler = new RotatingFileHandler($logPath, Logger::INFO);
         $handler->setFormatter(new LineFormatter(null, null, true, true));
 
         $app->instance('log', new Logger($app->environment(), [$handler]));


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
This changes the log writing behavior (only for InstalledSite) to rotate per default. What I noticed on an older (unused even) Flarum installation is that the one log file increased to 100MB+, which is still okay. Forums with high traffic might see these explode in no time. This PR adds log rotation per day. Allowing for easier managing in the long run.

**Reviewers should focus on:**
Do we want this?

**Screenshot**

![image](https://user-images.githubusercontent.com/504687/46688523-dfff1200-cbfd-11e8-8cbc-80f930509159.png)

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

