### PR TITLE
Less broad system font stack

### DIFF
--- a/less/common/scaffolding.less
+++ b/less/common/scaffolding.less
@@ -9,7 +9,7 @@
 body {
   background: @body-bg;
   color: @text-color;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Ubuntu, Cantarell, Oxygen, Roboto, Helvetica, Arial, sans-serif;
   font-size: 13px;
   line-height: 1.5;
   overflow-y: scroll;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Change the `font-family` in `less/common/scaffolding.less` (add `system-ui` to the front and `Ubuntu, Cantarell, Oxygen` to the middle)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
