### PR TITLE
Fixes logging in

### DIFF
--- a/src/Http/AccessToken.php
+++ b/src/Http/AccessToken.php
@@ -48,6 +48,7 @@ class AccessToken extends AbstractModel
 
         $token->token = str_random(40);
         $token->user_id = $userId;
+        $token->created_at = Carbon::now();
         $token->last_activity_at = Carbon::now();
         $token->lifetime_seconds = $lifetime;
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

Seems the created_at column has no default value. This was always the case, at least that's what I can tell from a clean install and no migrations changing that default value.

```
$table->timestamp('created_at');
```

**Reviewers should focus on:**

This or create a new migration?

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

