### PR TITLE
New extender for adding variables to HtmlDocument payload

### DIFF
--- a/src/Admin/Content/AdminPayload.php
+++ b/src/Admin/Content/AdminPayload.php
@@ -52,7 +52,7 @@ class AdminPayload implements ContentInterface
         $this->events = $events;
     }
 
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $settings = $this->settings->all();
 

--- a/src/Forum/Content/AssertRegistered.php
+++ b/src/Forum/Content/AssertRegistered.php
@@ -20,7 +20,7 @@ class AssertRegistered implements ContentInterface
 {
     use AssertPermissionTrait;
 
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $this->assertRegistered($request->getAttribute('actor'));
     }

--- a/src/Forum/Content/Discussion.php
+++ b/src/Forum/Content/Discussion.php
@@ -49,7 +49,7 @@ class Discussion implements ContentInterface
         $this->view = $view;
     }
 
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $queryParams = $request->getQueryParams();
         $page = max(1, array_get($queryParams, 'page'));

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -44,7 +44,7 @@ class Index implements ContentInterface
     /**
      * {@inheritdoc}
      */
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $queryParams = $request->getQueryParams();
 

--- a/src/Frontend/Content/ContentInterface.php
+++ b/src/Frontend/Content/ContentInterface.php
@@ -20,5 +20,5 @@ interface ContentInterface
      * @param HtmlDocument $document
      * @param Request $request
      */
-    public function populate(HtmlDocument $document, Request $request);
+    public function __invoke(HtmlDocument $document, Request $request);
 }

--- a/src/Frontend/Content/CorePayload.php
+++ b/src/Frontend/Content/CorePayload.php
@@ -41,7 +41,7 @@ class CorePayload implements ContentInterface
         $this->api = $api;
     }
 
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $document->payload = array_merge(
             $document->payload,

--- a/src/Frontend/Content/Layout.php
+++ b/src/Frontend/Content/Layout.php
@@ -29,7 +29,7 @@ class Layout implements ContentInterface
         $this->layoutView = $layoutView;
     }
 
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $document->layoutView = $this->layoutView;
     }

--- a/src/Frontend/Content/Meta.php
+++ b/src/Frontend/Content/Meta.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Meta implements ContentInterface
 {
-    public function populate(HtmlDocument $document, Request $request)
+    public function __invoke(HtmlDocument $document, Request $request)
     {
         $document->meta = array_merge($document->meta, $this->buildMeta($document));
         $document->head = array_merge($document->head, $this->buildHead($document));

--- a/src/Frontend/HtmlDocumentFactory.php
+++ b/src/Frontend/HtmlDocumentFactory.php
@@ -61,7 +61,7 @@ class HtmlDocumentFactory
     }
 
     /**
-     * @param ContentInterface $content
+     * @param ContentInterface|callable $content
      */
     public function add($content)
     {
@@ -116,7 +116,7 @@ class HtmlDocumentFactory
     protected function populate(HtmlDocument $view, Request $request)
     {
         foreach ($this->content as $content) {
-            $content->populate($view, $request);
+            $content($view, $request);
         }
     }
 


### PR DESCRIPTION
**Fixes #1602**

**Changes proposed in this pull request:**
Add a `document()` method to the `Frontend` extender as proposed in #1602.

**Reviewers should focus on:**
The method accepts a closure as well as a class name, to allow for more complex logic to be encapsulated in a class.

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [x] Fix database columns in flarum/statistics
- [ ] Adopt extender in flarum/statistics
