### PR TITLE
removed form title from email subject

### DIFF
--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -89,7 +89,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
 
         $this->mailer->raw($body, function (Message $message) use ($actor, $data) {
             $message->to($actor->email);
-            $message->subject('['.$data['{forum}'].'] '.$this->translator->trans('core.email.activate_account.subject'));
+            $message->subject($this->translator->trans('core.email.activate_account.subject'));
         });
 
         return new EmptyResponse;


### PR DESCRIPTION
From this update, users will have full freedom to customize the email subject as they want.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
