### PR TITLE
Update Font Awesome icons page link

### DIFF
--- a/js/src/admin/components/EditGroupModal.js
+++ b/js/src/admin/components/EditGroupModal.js
@@ -52,7 +52,7 @@ export default class EditGroupModal extends Modal {
           <div className="Form-group">
             <label>{app.translator.trans('core.admin.edit_group.icon_label')}</label>
             <div className="helpText">
-              {app.translator.trans('core.admin.edit_group.icon_text', {a: <a href="http://fortawesome.github.io/Font-Awesome/icons/" tabindex="-1"/>})}
+              {app.translator.trans('core.admin.edit_group.icon_text', {a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1"/>})}
             </div>
             <input className="FormControl" placeholder="bolt" value={this.icon()} oninput={m.withAttr('value', this.icon)}/>
           </div>


### PR DESCRIPTION
**Changes proposed in this pull request:**

I think it is time to use the link to the latest Font Awesome icons page.

Also I used the `?m=free` parameter so it only shows free icons by default, which I believe is what Flarum is using.

**Confirmed**

I just noticed this and created the PR from the web, I don't have a working core setup with me at the moment. I can test this weekend if needed :)

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
