### PR TITLE
fixes author gambit when used with fulltext search, added test to cover

### DIFF
--- a/src/Discussion/Search/Gambit/AuthorGambit.php
+++ b/src/Discussion/Search/Gambit/AuthorGambit.php
@@ -54,6 +54,6 @@ class AuthorGambit extends AbstractRegexGambit
             $ids[] = $this->users->getIdForUsername($username);
         }
 
-        $search->getQuery()->whereIn('user_id', $ids, 'and', $negate);
+        $search->getQuery()->whereIn('discussions.user_id', $ids, 'and', $negate);
     }
 }

--- a/tests/Api/Controller/ListDiscussionControllerTest.php
+++ b/tests/Api/Controller/ListDiscussionControllerTest.php
@@ -13,9 +13,12 @@ namespace Flarum\Tests\Api\Controller;
 
 use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Discussion\Discussion;
+use Flarum\Tests\Test\Concerns\RetrievesAuthorizedUsers;
 
 class ListDiscussionControllerTest extends ApiControllerTestCase
 {
+    use RetrievesAuthorizedUsers;
+
     protected $controller = ListDiscussionsController::class;
 
     /**
@@ -29,5 +32,22 @@ class ListDiscussionControllerTest extends ApiControllerTestCase
         $data = json_decode($response->getBody()->getContents(), true);
 
         $this->assertEquals(Discussion::count(), count($data['data']));
+    }
+
+    /**
+     * @test
+     */
+    public function can_search_for_author()
+    {
+        $user = $this->getNormalUser();
+
+        $response = $this->callWith([], [
+            'filter' => [
+                'q' => 'author:' . $user->username . ' foo'
+            ],
+            'include' => 'mostRelevantPost'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/tests/Api/Controller/ListDiscussionControllerTest.php
+++ b/tests/Api/Controller/ListDiscussionControllerTest.php
@@ -43,7 +43,7 @@ class ListDiscussionControllerTest extends ApiControllerTestCase
 
         $response = $this->callWith([], [
             'filter' => [
-                'q' => 'author:' . $user->username . ' foo'
+                'q' => 'author:'.$user->username.' foo'
             ],
             'include' => 'mostRelevantPost'
         ]);


### PR DESCRIPTION
**Changes proposed in this pull request:**

Fixes an issue on discuss where using the search `author:luceos $_SERVER` breaks with a 500. The Author gambit has an ambiguous use of `user_id`.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
