### PR TITLE
[b8] master token fix

### DIFF
--- a/src/Api/ApiKey.php
+++ b/src/Api/ApiKey.php
@@ -12,6 +12,7 @@
 namespace Flarum\Api;
 
 use Flarum\Database\AbstractModel;
+use Flarum\User\User;
 
 /**
  * @property int $id
@@ -19,11 +20,14 @@ use Flarum\Database\AbstractModel;
  * @property string|null $allowed_ips
  * @property string|null $scopes
  * @property int|null $user_id
+ * @property \Flarum\User\User|null $user
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon|null $last_activity_at
  */
 class ApiKey extends AbstractModel
 {
+    protected $dates = ['last_activity_at'];
+
     /**
      * Generate an API key.
      *
@@ -36,5 +40,17 @@ class ApiKey extends AbstractModel
         $key->key = str_random(40);
 
         return $key;
+    }
+
+    public function touch()
+    {
+        $this->last_activity_at = Carbon::now();
+
+        return $this->save();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/src/Api/ApiKey.php
+++ b/src/Api/ApiKey.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Api;
 
+use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
 use Flarum\User\User;
 

--- a/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/src/Http/Middleware/AuthenticateWithHeader.php
@@ -34,8 +34,9 @@ class AuthenticateWithHeader implements Middleware
 
             if ($key = ApiKey::where('key', $id)->first()) {
                 $key->touch();
-                
-                $actor = $key->user ?? $this->getUser($parts[1]);
+
+                $userId = $parts[1] ?? '';
+                $actor = $key->user ?? $this->getUser($userId);
 
                 $request = $request->withAttribute('apiKey', $key);
                 $request = $request->withAttribute('bypassFloodgate', true);

--- a/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/src/Http/Middleware/AuthenticateWithHeader.php
@@ -32,13 +32,13 @@ class AuthenticateWithHeader implements Middleware
         if (isset($parts[0]) && starts_with($parts[0], self::TOKEN_PREFIX)) {
             $id = substr($parts[0], strlen(self::TOKEN_PREFIX));
 
-            if (isset($parts[1])) {
-                if ($key = ApiKey::find($id)) {
-                    $actor = $this->getUser($parts[1]);
+            if ($key = ApiKey::where('key', $id)->first()) {
+                $key->touch();
+                
+                $actor = $key->user ?? $this->getUser($parts[1]);
 
-                    $request = $request->withAttribute('apiKey', $key);
-                    $request = $request->withAttribute('bypassFloodgate', true);
-                }
+                $request = $request->withAttribute('apiKey', $key);
+                $request = $request->withAttribute('bypassFloodgate', true);
             } elseif ($token = AccessToken::find($id)) {
                 $token->touch();
 

--- a/tests/Api/Auth/AuthenticateWithApiKeyTest.php
+++ b/tests/Api/Auth/AuthenticateWithApiKeyTest.php
@@ -5,10 +5,8 @@ namespace Flarum\Tests\Api\Auth;
 use Carbon\Carbon;
 use Flarum\Api\ApiKey;
 use Flarum\Api\Controller\CreateGroupController;
-use Flarum\Event\ConfigureMiddleware;
 use Flarum\Tests\Test\Concerns\RetrievesAuthorizedUsers;
 use Flarum\Tests\Test\TestCase;
-use Illuminate\Contracts\Events\Dispatcher;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -119,16 +117,10 @@ class AuthenticateWithApiKeyTest extends TestCase
         $key->delete();
     }
 
-    /**
-     * @return \Illuminate\Foundation\Application|mixed
-     */
     protected function injectAuthorizationPipeline(): MiddlewarePipe
     {
-        /** @var Dispatcher $events */
-        $events = app(Dispatcher::class);
-
-        $events->listen(ConfigureMiddleware::class, function (ConfigureMiddleware $e) {
-            $e->pipe(new class implements MiddlewareInterface
+        app()->resolving('flarum.api.middleware', function ($pipeline) {
+            $pipeline->pipe(new class implements MiddlewareInterface
             {
                 /**
                  * Process an incoming server request and return a response, optionally delegating

--- a/tests/Api/Auth/AuthenticateWithApiKeyTest.php
+++ b/tests/Api/Auth/AuthenticateWithApiKeyTest.php
@@ -129,8 +129,7 @@ class AuthenticateWithApiKeyTest extends TestCase
     protected function injectAuthorizationPipeline(): MiddlewarePipe
     {
         app()->resolving('flarum.api.middleware', function ($pipeline) {
-            $pipeline->pipe(new class implements MiddlewareInterface
-            {
+            $pipeline->pipe(new class implements MiddlewareInterface {
                 public function process(
                     ServerRequestInterface $request,
                     RequestHandlerInterface $handler


### PR DESCRIPTION
**Changes proposed in this pull request:**

Two issues covered in this PR:

- Fixes the master token not working. The `id` column on the `api_keys` table is no longer used for the token strings. We introduced the `key` column for that. The `AuthenticateWithHeader` middleware now uses that.
- The `api_keys` column now has an user_id column, this allows generating a token forced for a specific user. In order to adhere to that while still allowing full admin use, the middleware no longer requires a `; userId=` part to see whether an ApiKey is available. In addition it now applies a touched at date in the `last_activity_at` column the same way the AccessToken works.

**Reviewers should focus on:**

Is this okay? Any security complications we can see in the PR?
Do we need a follow up issue to clean up the code duplication with ApiKey and AccessToken?

I think this needs a test too.. At least confirming the bare functionality of master tokens work because I believe it's a very strong feature used by integrations..

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
