### PR TITLE
Fix dropdown menu hidden by PermissionsPage header when going up

### DIFF
--- a/less/admin/PermissionsPage.less
+++ b/less/admin/PermissionsPage.less
@@ -32,7 +32,6 @@
 
 .PermissionsPage-permissions {
   padding: 20px 0 200px;
-  overflow: auto;
 }
 
 .PermissionGrid {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Remove `overflow: auto` from `.PermissionsPage-permissions`
  - Scroll isn't even managed by this container, the whole page content scrolls, so not sure why it was here in the first place

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/6401250/48094020-fe493500-e1de-11e8-85bd-47e54c9f5e6d.png)

After:
![image](https://user-images.githubusercontent.com/6401250/48094013-f8535400-e1de-11e8-984b-8621f491cb6c.png)



**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
