### PR TITLE
add security email address in flarum/core readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository contains Flarum's core code. If you want to set up a forum, visi
 ## Contributing
 
 Flarum is open-source and we would love your help building it! Please read the [Contributing Guide](https://github.com/flarum/flarum/blob/master/CONTRIBUTING.md) to learn how you can help.
+
+### Security Vulnerabilities
+
+If you discover a security vulnerability within Flarum, please send an email to [security@flarum.org](mailto:security@flarum.org).


### PR DESCRIPTION
Let's make the security email address even more visible.