### PR TITLE
Improve logging

### DIFF
--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -25,7 +25,6 @@ use Flarum\Http\RouteCollection;
 use Flarum\Http\RouteHandlerFactory;
 use Flarum\Http\UrlGenerator;
 use Tobscure\JsonApi\ErrorHandler;
-use Tobscure\JsonApi\Exception\Handler\FallbackExceptionHandler;
 use Tobscure\JsonApi\Exception\Handler\InvalidParameterExceptionHandler;
 use Zend\Stratigility\MiddlewarePipe;
 
@@ -80,7 +79,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             $handler->registerHandler(new ExceptionHandler\TokenMismatchExceptionHandler);
             $handler->registerHandler(new ExceptionHandler\ValidationExceptionHandler);
             $handler->registerHandler(new InvalidParameterExceptionHandler);
-            $handler->registerHandler(new FallbackExceptionHandler($this->app->inDebugMode()));
+            $handler->registerHandler(new ExceptionHandler\FallbackExceptionHandler($this->app->inDebugMode(), $this->app->make('log')));
 
             return $handler;
         });

--- a/src/Api/ErrorHandler.php
+++ b/src/Api/ErrorHandler.php
@@ -12,6 +12,7 @@
 namespace Flarum\Api;
 
 use Exception;
+use Throwable;
 use Tobscure\JsonApi\Document;
 use Tobscure\JsonApi\ErrorHandler as JsonApiErrorHandler;
 
@@ -34,8 +35,12 @@ class ErrorHandler
      * @param Exception $e
      * @return JsonApiResponse
      */
-    public function handle(Exception $e)
+    public function handle(Throwable $e)
     {
+        if (! $e instanceof Exception) {
+            $e = new Exception($e->getMessage(), $e->getCode(), $e);
+        }
+
         $response = $this->errorHandler->handle($e);
 
         $document = new Document;

--- a/src/Api/ExceptionHandler/FallbackExceptionHandler.php
+++ b/src/Api/ExceptionHandler/FallbackExceptionHandler.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\ExceptionHandler;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+use Tobscure\JsonApi\Exception\Handler\ExceptionHandlerInterface;
+use Tobscure\JsonApi\Exception\Handler\ResponseBag;
+
+class FallbackExceptionHandler implements ExceptionHandlerInterface
+{
+    /**
+     * @var bool
+     */
+    protected $debug;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param bool $debug
+     * @param LoggerInterface $logger
+     */
+    public function __construct($debug, LoggerInterface $logger)
+    {
+        $this->debug = $debug;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function manages(Exception $e)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Exception $e)
+    {
+        $status = 500;
+        $error = $this->constructError($e, $status);
+
+        if (! $this->debug) {
+            $this->logger->error($e);
+        }
+
+        return new ResponseBag($status, [$error]);
+    }
+
+    /**
+     * @param Exception $e
+     * @param $status
+     * @return array
+     */
+    private function constructError(Exception $e, $status)
+    {
+        $error = ['code' => $status, 'title' => 'Internal server error'];
+
+        if ($this->debug) {
+            $error['detail'] = (string) $e;
+        }
+
+        return $error;
+    }
+}

--- a/src/Api/ExceptionHandler/FallbackExceptionHandler.php
+++ b/src/Api/ExceptionHandler/FallbackExceptionHandler.php
@@ -54,9 +54,7 @@ class FallbackExceptionHandler implements ExceptionHandlerInterface
         $status = 500;
         $error = $this->constructError($e, $status);
 
-        if (! $this->debug) {
-            $this->logger->error($e);
-        }
+        $this->logger->error($e);
 
         return new ResponseBag($status, [$error]);
     }

--- a/src/Api/Middleware/HandleErrors.php
+++ b/src/Api/Middleware/HandleErrors.php
@@ -11,12 +11,12 @@
 
 namespace Flarum\Api\Middleware;
 
-use Exception;
 use Flarum\Api\ErrorHandler;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
+use Throwable;
 
 class HandleErrors implements Middleware
 {
@@ -40,7 +40,7 @@ class HandleErrors implements Middleware
     {
         try {
             return $handler->handle($request);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return $this->errorHandler->handle($e);
         }
     }

--- a/src/Http/Middleware/HandleErrorsWithView.php
+++ b/src/Http/Middleware/HandleErrorsWithView.php
@@ -11,7 +11,6 @@
 
 namespace Flarum\Http\Middleware;
 
-use Exception;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -20,6 +19,7 @@ use Psr\Http\Server\MiddlewareInterface as Middleware;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Throwable;
 use Zend\Diactoros\Response\HtmlResponse;
 
 class HandleErrorsWithView implements Middleware
@@ -65,12 +65,12 @@ class HandleErrorsWithView implements Middleware
     {
         try {
             return $handler->handle($request);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return $this->formatException($e);
         }
     }
 
-    protected function formatException(Exception $error)
+    protected function formatException(Throwable $error)
     {
         $status = 500;
         $errorCode = $error->getCode();

--- a/src/Http/Middleware/HandleErrorsWithView.php
+++ b/src/Http/Middleware/HandleErrorsWithView.php
@@ -81,11 +81,10 @@ class HandleErrorsWithView implements Middleware
             $status = $errorCode;
         }
 
-        // Log the exception (with trace)
-        $this->logger->debug($error);
-
         if (! $this->view->exists($name = "flarum.forum::error.$status")) {
             $name = 'flarum.forum::error.default';
+
+            $this->logger->error($error);
         }
 
         $view = $this->view->make($name)

--- a/src/Http/Middleware/HandleErrorsWithWhoops.php
+++ b/src/Http/Middleware/HandleErrorsWithWhoops.php
@@ -16,10 +16,24 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class HandleErrorsWithWhoops implements Middleware
 {
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
     /**
      * Catch all errors that happen during further middleware execution.
      */
@@ -28,6 +42,10 @@ class HandleErrorsWithWhoops implements Middleware
         try {
             return $handler->handle($request);
         } catch (Throwable $e) {
+            if ($e->getCode() !== 404) {
+                $this->logger->error($e);
+            }
+
             return WhoopsRunner::handle($e, $request);
         }
     }

--- a/src/Http/Middleware/HandleErrorsWithWhoops.php
+++ b/src/Http/Middleware/HandleErrorsWithWhoops.php
@@ -11,12 +11,12 @@
 
 namespace Flarum\Http\Middleware;
 
-use Exception;
 use Franzl\Middleware\Whoops\WhoopsRunner;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
+use Throwable;
 
 class HandleErrorsWithWhoops implements Middleware
 {
@@ -27,7 +27,7 @@ class HandleErrorsWithWhoops implements Middleware
     {
         try {
             return $handler->handle($request);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return WhoopsRunner::handle($e, $request);
         }
     }


### PR DESCRIPTION
**Fixes #1619**
**Fixes #991**

**Changes proposed in this pull request:**

* Catch Throwables so that we handle and log internal PHP errors too
* Stop logging errors that use a custom view (eg. 404 - RouteNotFound)
* Log errors that occur in the API stack

See commit messages for more details.

This is not a definitive implementation for optimal error handling and logging. Ideally we should have a more advanced error handling solution like the [one referenced](https://github.com/laravel/framework/blob/c30a784f56e5f0c4c54ffbb601280bc278227a9b/src/Illuminate/Foundation/Exceptions/Handler.php#L60) in #1619. But I thought it would be good to implement a least-resistance stopgap in the meantime.

**Reviewers should focus on:**
Is this acceptable for the purposes of beta 8. 

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).