### PR TITLE
Fix scrubber index exceeding post count

### DIFF
--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -315,7 +315,7 @@ export default class PostStreamScrubber extends Component {
     const visible = this.visible || 1;
 
     const $scrubber = this.$();
-    $scrubber.find('.Scrubber-index').text(formatNumber(Math.ceil(index + visible)));
+    $scrubber.find('.Scrubber-index').text(formatNumber(Math.min(Math.ceil(index + visible), count)));
     $scrubber.find('.Scrubber-description').text(this.description);
     $scrubber.toggleClass('disabled', this.disabled());
 

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -99,7 +99,7 @@ export default class PostStreamScrubber extends Component {
                 <div className="Scrubber-bar"/>
                 <div className="Scrubber-info">
                   <strong>{viewing}</strong>
-                  <span class="Scrubber-description">{retain || this.description}</span>
+                  <span className="Scrubber-description">{retain || this.description}</span>
                 </div>
               </div>
               <div className="Scrubber-after"/>
@@ -132,7 +132,7 @@ export default class PostStreamScrubber extends Component {
    */
   goToLast() {
     this.props.stream.goToLast();
-    this.index = this.props.stream.count();
+    this.index = this.count();
     this.renderScrollbar(true);
   }
 
@@ -190,7 +190,6 @@ export default class PostStreamScrubber extends Component {
     const marginTop = stream.getMarginTop();
     const viewportTop = scrollTop + marginTop;
     const viewportHeight = $(window).height() - marginTop;
-    const viewportBottom = viewportTop + viewportHeight;
 
     // Before looping through all of the posts, we reset the scrollbar
     // properties to a 'default' state. These values reflect what would be


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1221 and #1279** (which both ended up closed without being actually fixed)

Also mentionned in #1279 

**Changes proposed in this pull request:**
Add a missing `Math.min()` check for the post scrubber. That code is actually duplicated in the `view()` method and the manual jQuery update. `Math.min()` was missing from the jQuery update while present in the `view()`.

**Screenshot**
Fixes this kind of nonsense when clicking now or dragging the scrubber to the bottom:
![image](https://user-images.githubusercontent.com/5264300/48316528-3092d200-e5e5-11e8-9172-dd5d47431d48.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
