### PR TITLE
Fix notification isRead value not being updated in API update response

### DIFF
--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -39,7 +39,7 @@ class ReadNotificationHandler
         ])
             ->update(['read_at' => Carbon::now()]);
 
-        $notification->is_read = true;
+        $notification->read_at = Carbon::now();
 
         return $notification;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://discuss.flarum.org/d/17518-negative-notifications** (was apparently not reported here)

**Changes proposed in this pull request:**
Fix a likely oversight after the rename of database columns causing the notification tray not updating the isRead status when clicking on a notification. It was only an issue in the returned payload from the API not containing the updated value...

And this fixes the negative notification count caused by this very issue. Maybe it might be interesting to also prevent negative notifications from appearing at all but I suppose that would be another issue.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
