### PR TITLE
Set Whoops middleware HTTP status to error code

### DIFF
--- a/src/Http/Middleware/HandleErrorsWithWhoops.php
+++ b/src/Http/Middleware/HandleErrorsWithWhoops.php
@@ -46,7 +46,8 @@ class HandleErrorsWithWhoops implements Middleware
                 $this->logger->error($e);
             }
 
-            return WhoopsRunner::handle($e, $request);
+            return WhoopsRunner::handle($e, $request)
+                ->withStatus($e->getCode() ?? 500);
         }
     }
 }

--- a/src/Http/Middleware/HandleErrorsWithWhoops.php
+++ b/src/Http/Middleware/HandleErrorsWithWhoops.php
@@ -42,12 +42,19 @@ class HandleErrorsWithWhoops implements Middleware
         try {
             return $handler->handle($request);
         } catch (Throwable $e) {
-            if ($e->getCode() !== 404) {
+            $status = 500;
+            $errorCode = $e->getCode();
+
+            if ($errorCode !== 404) {
                 $this->logger->error($e);
             }
 
+            if (is_int($errorCode) && $errorCode >= 400 && $errorCode < 600) {
+                $status = $errorCode;
+            }
+
             return WhoopsRunner::handle($e, $request)
-                ->withStatus($e->getCode() ?? 500);
+                ->withStatus($status);
         }
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Refs #1641 ([comment](https://github.com/flarum/core/issues/1641#issuecomment-439217306))**

**Changes proposed in this pull request:**
- When in debug mode, sets the HTTP status code to the error code
  - [WhoopsRunner sets the status code to 500](https://github.com/franzliedke/whoops-middleware/blob/master/src/WhoopsRunner.php#L28)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->


**Screenshot**

Before:
![image](https://user-images.githubusercontent.com/6401250/48810010-07fd8d00-ecf5-11e8-888a-06ec3465975e.png)

After:
![image](https://user-images.githubusercontent.com/6401250/48809992-f320f980-ecf4-11e8-972a-c303fc6f92dd.png)

Both:
![image](https://user-images.githubusercontent.com/6401250/48810067-4004d000-ecf5-11e8-98bf-11f67c3bc0f2.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).