### PR TITLE
Throw FileNotFoundException when FileSource path does not exist

### DIFF
--- a/src/Frontend/Compiler/Source/FileSource.php
+++ b/src/Frontend/Compiler/Source/FileSource.php
@@ -11,6 +11,8 @@
 
 namespace Flarum\Frontend\Compiler\Source;
 
+use League\Flysystem\FileNotFoundException;
+
 class FileSource implements SourceInterface
 {
     /**
@@ -23,6 +25,8 @@ class FileSource implements SourceInterface
      */
     public function __construct(string $path)
     {
+        if (!file_exists($path)) throw new FileNotFoundException($path);
+
         $this->path = $path;
     }
 

--- a/src/Frontend/Compiler/Source/FileSource.php
+++ b/src/Frontend/Compiler/Source/FileSource.php
@@ -11,8 +11,6 @@
 
 namespace Flarum\Frontend\Compiler\Source;
 
-use League\Flysystem\FileNotFoundException;
-
 class FileSource implements SourceInterface
 {
     /**
@@ -26,8 +24,9 @@ class FileSource implements SourceInterface
     public function __construct(string $path)
     {
         if (! file_exists($path)) {
-            throw new FileNotFoundException($path);
+            throw new \InvalidArgumentException("File not found at path: $path");
         }
+
         $this->path = $path;
     }
 

--- a/src/Frontend/Compiler/Source/FileSource.php
+++ b/src/Frontend/Compiler/Source/FileSource.php
@@ -25,8 +25,9 @@ class FileSource implements SourceInterface
      */
     public function __construct(string $path)
     {
-        if (!file_exists($path)) throw new FileNotFoundException($path);
-
+        if (! file_exists($path)) {
+            throw new FileNotFoundException($path);
+        }
         $this->path = $path;
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Throw `League\Flysystem\FileNotFoundException` when asset file is not found

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/48811146-6b3dee00-ecfa-11e8-9c62-ce440948022c.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
