### PR TITLE
Fix frontend extender using old container & wrong class

### DIFF
--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -14,6 +14,7 @@ namespace Flarum\Extend;
 use Flarum\Extension\Extension;
 use Flarum\Frontend\Assets;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Frontend\Frontend as FlarumFrontend;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Http\RouteHandlerFactory;
 use Illuminate\Contracts\Container\Container;
@@ -139,8 +140,8 @@ class Frontend implements ExtenderInterface
         }
 
         $container->resolving(
-            "flarum.$this->frontend.frontend",
-            function (Frontend $frontend, Container $container) {
+            "flarum.frontend.$this->frontend",
+            function (FlarumFrontend $frontend, Container $container) {
                 foreach ($this->content as $content) {
                     if (is_string($content)) {
                         $content = $container->make($content);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://github.com/flarum/core/issues/1601#issuecomment-441031735**
**Caused by https://github.com/flarum/core/commit/edaca3160ed856ef2b42d043c8276c33dc8ea6cd**

**Changes proposed in this pull request:**
- Fixes `Extend\Frontend@registerContent` using wrong container name when resolving, and wrong `Frontend` class in argument
  - Argument was using `Frontend` extender instead of `Frontend\Frontend`


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).