### PR TITLE
Fix User@getLocaleFunction using non-existent config method

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -18,7 +18,6 @@ use Flarum\Database\ScopeVisibilityTrait;
 use Flarum\Event\ConfigureUserPreferences;
 use Flarum\Event\GetDisplayName;
 use Flarum\Event\PrepareUserGroups;
-use Flarum\Foundation\Application;
 use Flarum\Foundation\EventGeneratorTrait;
 use Flarum\Group\Group;
 use Flarum\Group\Permission;
@@ -321,7 +320,7 @@ class User extends AbstractModel
      */
     public function getLocaleAttribute($value)
     {
-        return $value ?: Application::config('locale', 'en');
+        return $value ?: app('app')->config('locale', 'en');
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Replace `Application::config` call with `app('app')->config`

**Reviewers should focus on:**
- `app('app')`, `app(Application::class)`, or something else?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
