### PR TITLE
Fix index names in migrations

### DIFF
--- a/migrations/2018_01_11_094000_change_access_tokens_add_foreign_keys.php
+++ b/migrations/2018_01_11_094000_change_access_tokens_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -23,14 +24,18 @@ return [
             })
             ->delete();
 
-        $schema->table('access_tokens', function (Blueprint $table) {
+        $schema->table('access_tokens', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('access_tokens', function (Blueprint $table) {
+        $schema->table('access_tokens', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_11_095000_change_api_keys_columns.php
+++ b/migrations/2018_01_11_095000_change_api_keys_columns.php
@@ -9,18 +9,21 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $schema->table('api_keys', function (Blueprint $table) {
+        $schema->table('api_keys', function (Blueprint $table) use ($schema) {
             $table->dropPrimary(['id']);
             $table->renameColumn('id', 'key');
             $table->unique('key');
+
+            Migration::fixIndexNames($schema, $table);
         });
 
-        $schema->table('api_keys', function (Blueprint $table) {
+        $schema->table('api_keys', function (Blueprint $table) use ($schema) {
             $table->increments('id');
             $table->string('allowed_ips')->nullable();
             $table->string('scopes')->nullable();
@@ -29,19 +32,25 @@ return [
             $table->dateTime('last_activity_at')->nullable();
 
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('api_keys', function (Blueprint $table) {
+        $schema->table('api_keys', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id']);
             $table->dropColumn('id', 'allowed_ips', 'user_id', 'scopes', 'created_at');
+
+            Migration::fixIndexNames($schema, $table);
         });
 
-        $schema->table('api_keys', function (Blueprint $table) {
+        $schema->table('api_keys', function (Blueprint $table) use ($schema) {
             $table->dropUnique(['key']);
             $table->renameColumn('key', 'id');
             $table->primary('id');
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_11_155300_change_discussions_add_foreign_keys.php
+++ b/migrations/2018_01_11_155300_change_discussions_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
@@ -33,21 +34,25 @@ return [
             'last_post_id' => $selectId('posts', 'last_post_id'),
         ]);
 
-        $schema->table('discussions', function (Blueprint $table) {
+        $schema->table('discussions', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('last_posted_user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('hidden_user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('first_post_id')->references('id')->on('posts')->onDelete('set null');
             $table->foreign('last_post_id')->references('id')->on('posts')->onDelete('set null');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('discussions', function (Blueprint $table) {
+        $schema->table('discussions', function (Blueprint $table) use ($schema) {
             $table->dropForeign([
                 'user_id', 'last_posted_user_id', 'hidden_user_id',
                 'first_post_id', 'last_post_id'
             ]);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_15_071900_change_discussion_user_add_foreign_keys.php
+++ b/migrations/2018_01_15_071900_change_discussion_user_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -26,15 +27,19 @@ return [
             })
             ->delete();
 
-        $schema->table('discussion_user', function (Blueprint $table) {
+        $schema->table('discussion_user', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('discussion_id')->references('id')->on('discussions')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('discussion_user', function (Blueprint $table) {
+        $schema->table('discussion_user', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id', 'discussion_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_15_072700_change_email_tokens_add_foreign_keys.php
+++ b/migrations/2018_01_15_072700_change_email_tokens_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -23,14 +24,18 @@ return [
             })
             ->delete();
 
-        $schema->table('email_tokens', function (Blueprint $table) {
+        $schema->table('email_tokens', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('email_tokens', function (Blueprint $table) {
+        $schema->table('email_tokens', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_18_130500_change_group_permission_add_foreign_keys.php
+++ b/migrations/2018_01_18_130500_change_group_permission_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -23,14 +24,18 @@ return [
             })
             ->delete();
 
-        $schema->table('group_permission', function (Blueprint $table) {
+        $schema->table('group_permission', function (Blueprint $table) use ($schema) {
             $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('group_permission', function (Blueprint $table) {
+        $schema->table('group_permission', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['group_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_18_130700_change_group_user_add_foreign_keys.php
+++ b/migrations/2018_01_18_130700_change_group_user_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -26,15 +27,19 @@ return [
             })
             ->delete();
 
-        $schema->table('group_user', function (Blueprint $table) {
+        $schema->table('group_user', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('group_user', function (Blueprint $table) {
+        $schema->table('group_user', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id', 'group_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_18_133100_change_notifications_add_foreign_keys.php
+++ b/migrations/2018_01_18_133100_change_notifications_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -30,15 +31,19 @@ return [
             })
             ->update(['from_user_id' => null]);
 
-        $schema->table('notifications', function (Blueprint $table) {
+        $schema->table('notifications', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('from_user_id')->references('id')->on('users')->onDelete('set null');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('notifications', function (Blueprint $table) {
+        $schema->table('notifications', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id', 'from_user_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_18_134500_change_password_tokens_add_foreign_keys.php
+++ b/migrations/2018_01_18_134500_change_password_tokens_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -23,14 +24,18 @@ return [
             })
             ->delete();
 
-        $schema->table('password_tokens', function (Blueprint $table) {
+        $schema->table('password_tokens', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('password_tokens', function (Blueprint $table) {
+        $schema->table('password_tokens', function (Blueprint $table) use ($schema) {
             $table->dropForeign(['user_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_01_18_135100_change_posts_add_foreign_keys.php
+++ b/migrations/2018_01_18_135100_change_posts_add_foreign_keys.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
@@ -31,19 +32,23 @@ return [
             'hidden_user_id' => $selectId('users', 'hidden_user_id'),
         ]);
 
-        $schema->table('posts', function (Blueprint $table) {
+        $schema->table('posts', function (Blueprint $table) use ($schema) {
             $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('edited_user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('hidden_user_id')->references('id')->on('users')->onDelete('set null');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('posts', function (Blueprint $table) {
+        $schema->table('posts', function (Blueprint $table) use ($schema) {
             $table->dropForeign([
                 'user_id', 'discussion_id',
                 'edited_user_id', 'hidden_user_id'
             ]);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_09_15_041340_add_users_indicies.php
+++ b/migrations/2018_09_15_041340_add_users_indicies.php
@@ -9,25 +9,30 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', function (Blueprint $table) use ($schema) {
             $table->index('joined_at');
             $table->index('last_seen_at');
             $table->index('discussion_count');
             $table->index('comment_count');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', function (Blueprint $table) use ($schema) {
             $table->dropIndex(['joined_at']);
             $table->dropIndex(['last_seen_at']);
             $table->dropIndex(['discussion_count']);
             $table->dropIndex(['comment_count']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_09_15_041828_add_discussions_indicies.php
+++ b/migrations/2018_09_15_041828_add_discussions_indicies.php
@@ -9,12 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $schema->table('discussions', function (Blueprint $table) {
+        $schema->table('discussions', function (Blueprint $table) use ($schema) {
             $table->index('last_posted_at');
             $table->index('last_posted_user_id');
             $table->index('created_at');
@@ -22,11 +23,13 @@ return [
             $table->index('comment_count');
             $table->index('participant_count');
             $table->index('hidden_at');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('discussions', function (Blueprint $table) {
+        $schema->table('discussions', function (Blueprint $table) use ($schema) {
             $table->dropIndex(['last_posted_at']);
             $table->dropIndex(['last_posted_user_id']);
             $table->dropIndex(['created_at']);
@@ -34,6 +37,8 @@ return [
             $table->dropIndex(['comment_count']);
             $table->dropIndex(['participant_count']);
             $table->dropIndex(['hidden_at']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_09_15_043337_add_notifications_indices.php
+++ b/migrations/2018_09_15_043337_add_notifications_indices.php
@@ -9,19 +9,24 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $schema->table('notifications', function (Blueprint $table) {
+        $schema->table('notifications', function (Blueprint $table) use ($schema) {
             $table->index('user_id');
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('notifications', function (Blueprint $table) {
+        $schema->table('notifications', function (Blueprint $table) use ($schema) {
             $table->dropIndex(['user_id']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/migrations/2018_09_15_043621_add_posts_indices.php
+++ b/migrations/2018_09_15_043621_add_posts_indices.php
@@ -9,23 +9,28 @@
  * file that was distributed with this source code.
  */
 
+use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $schema->table('posts', function (Blueprint $table) {
+        $schema->table('posts', function (Blueprint $table) use ($schema) {
             $table->index(['discussion_id', 'number']);
             $table->index(['discussion_id', 'created_at']);
             $table->index(['user_id', 'created_at']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     },
 
     'down' => function (Builder $schema) {
-        $schema->table('posts', function (Blueprint $table) {
+        $schema->table('posts', function (Blueprint $table) use ($schema) {
             $table->dropIndex(['discussion_id', 'number']);
             $table->dropIndex(['discussion_id', 'created_at']);
             $table->dropIndex(['user_id', 'created_at']);
+
+            Migration::fixIndexNames($schema, $table);
         });
     }
 ];

--- a/src/Database/Migration.php
+++ b/src/Database/Migration.php
@@ -29,7 +29,11 @@ abstract class Migration
     {
         return [
             'up' => function (Builder $schema) use ($name, $definition) {
-                $schema->create($name, $definition);
+                $schema->create($name, function (Blueprint $table) use ($schema, $definition) {
+                    $definition($table);
+
+                    static::fixIndexNames($schema, $table);
+                });
             },
             'down' => function (Builder $schema) use ($name) {
                 $schema->drop($name);
@@ -59,11 +63,13 @@ abstract class Migration
     {
         return [
             'up' => function (Builder $schema) use ($tableName, $columnDefinitions) {
-                $schema->table($tableName, function (Blueprint $table) use ($columnDefinitions) {
+                $schema->table($tableName, function (Blueprint $table) use ($schema, $columnDefinitions) {
                     foreach ($columnDefinitions as $columnName => $options) {
                         $type = array_shift($options);
                         $table->addColumn($type, $columnName, $options);
                     }
+
+                    Migration::fixIndexNames($schema, $table);
                 });
             },
             'down' => function (Builder $schema) use ($tableName, $columnDefinitions) {
@@ -186,5 +192,28 @@ abstract class Migration
                 }
             }
         ];
+    }
+
+    /**
+     * Add a prefix to index names on the given table blueprint.
+     *
+     * Laravel 5.5 doesn't automatically add the table prefix to index
+     * names, but this has been fixed in 5.7. We will manually fix the
+     * names for now, and we can remove this when we upgrade to 5.7.
+     */
+    public static function fixIndexNames(Builder $schema, Blueprint $table)
+    {
+        $indexCommands = [
+            'unique', 'index', 'spatialIndex', 'foreign',
+            'dropUnique', 'dropIndex', 'dropSpatialIndex', 'dropForeign'
+        ];
+
+        $prefix = $schema->getConnection()->getTablePrefix();
+
+        foreach ($table->getCommands() as $command) {
+            if (in_array($command->name, $indexCommands)) {
+                $command->index = $prefix.$command->index;
+            }
+        }
     }
 }


### PR DESCRIPTION
Background: beta.8 introduces database indices and foreign keys. The names of these must be unique across the whole database. However, a longstanding Laravel bug means that indices are named without the configured table prefix. Thus, if you run two Flarum installations in one database, there would be conflicts.

For beta.8, this is the simplest, least "invasive" fix I can think of. This can be reverted for beta.9 when we upgrade to Laravel 5.7.

I've tested this with a fresh installation in a database that already contains another Flarum installation.

If we're happy with this, I will update all extensions as well.