### PR TITLE
Only create migration table if it doesn't exist

### DIFF
--- a/src/Database/DatabaseMigrationRepository.php
+++ b/src/Database/DatabaseMigrationRepository.php
@@ -99,10 +99,12 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->connection->getSchemaBuilder();
 
-        $schema->create($this->table, function ($table) {
-            $table->string('migration');
-            $table->string('extension')->nullable();
-        });
+        if (!$schema->hasTable('migrations')) {
+            $schema->create($this->table, function ($table) {
+                $table->string('migration');
+                $table->string('extension')->nullable();
+            });
+        }
     }
 
     /**

--- a/src/Database/DatabaseMigrationRepository.php
+++ b/src/Database/DatabaseMigrationRepository.php
@@ -99,12 +99,10 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->connection->getSchemaBuilder();
 
-        if (!$schema->hasTable('migrations')) {
-            $schema->create($this->table, function ($table) {
-                $table->string('migration');
-                $table->string('extension')->nullable();
-            });
-        }
+        $schema->create($this->table, function ($table) {
+            $table->string('migration');
+            $table->string('extension')->nullable();
+        });
     }
 
     /**

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -264,7 +264,12 @@ class InstallCommand extends AbstractCommand
     protected function runMigrations()
     {
         $this->migrator->setOutput($this->output);
-        $this->migrator->getRepository()->createRepository();
+        $repository = $this->migrator->getRepository();
+
+        if (! $repository->repositoryExists()) {
+            $repository->createRepository();
+        }
+
         $this->migrator->run(__DIR__.'/../../../migrations');
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently, if you try to install and it fails, you can't recover without dropping the whole install because Flarum will try to create the migration table again. This fix allows you to attempt to install again even after a fail (such as not using Innodb)

**Reviewers should focus on:**
* Can we simplify this logic?


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

