### PR TITLE
Loads language packs during the installation

### DIFF
--- a/src/Event/ConfigureLocales.php
+++ b/src/Event/ConfigureLocales.php
@@ -57,7 +57,7 @@ class ConfigureLocales
             throw new RuntimeException("Language pack $name must define \"extra.flarum-locale.code\" in composer.json.");
         }
 
-        $this->locales->addLocale($locale, $title);
+        $this->locales->addLoadedLocale($locale, $title);
 
         if (! is_dir($localeDir = $directory.'/locale')) {
             throw new RuntimeException("Language pack $name must have a \"locale\" subdirectory.");

--- a/src/Extend/LanguagePack.php
+++ b/src/Extend/LanguagePack.php
@@ -37,17 +37,22 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
             );
         }
 
-        $container->resolving(
-            LocaleManager::class,
-            function (LocaleManager $locales) use ($extension, $locale, $title) {
-                $this->registerLocale($locales, $extension, $locale, $title);
-            }
-        );
+        if ($container->resolved(LocaleManager::class)) {
+            $locales = $container->get(LocaleManager::class);
+            $this->registerLocale($locales, $extension, $locale, $title);
+        } else {
+            $container->resolving(
+                LocaleManager::class,
+                function (LocaleManager $locales) use ($extension, $locale, $title) {
+                    $this->registerLocale($locales, $extension, $locale, $title);
+                }
+            );
+        }
     }
 
     private function registerLocale(LocaleManager $locales, Extension $extension, $locale, $title)
     {
-        $locales->addLocale($locale, $title);
+        $locales->addLoadedLocale($locale, $title);
 
         $directory = $extension->getPath().'/locale';
 

--- a/src/Extension/ExtensionFinder.php
+++ b/src/Extension/ExtensionFinder.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension;
+
+use Flarum\Foundation\Application;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class ExtensionFinder
+{
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @var Collection
+     */
+    protected $extensions;
+
+    public function __construct(Application $app, Filesystem $filesystem)
+    {
+        $this->basePath = $app->basePath();
+        $this->filesystem = $filesystem;
+        $this->extensions = new Collection();
+        $this->scanForExtensions();
+    }
+
+    private function scanForExtensions()
+    {
+        $installedPath = $this->basePath.'/vendor/composer/installed.json';
+
+        // Check whether there's a installed.json file.
+        if (! $this->filesystem->exists($installedPath)) {
+            return;
+        }
+
+        // Load all packages installed by composer.
+        $installed = json_decode($this->filesystem->get($installedPath), true);
+
+        foreach ($installed as $package) {
+            // Ignore all non flarum extension packages
+            if (Arr::get($package, 'type') != 'flarum-extension' || empty(Arr::get($package, 'name'))) {
+                continue;
+            }
+
+            $this->extensions->push($package);
+        }
+    }
+
+    /**
+     * Gets a collections of available extensions.
+     *
+     * @return Collection
+     */
+    public function getExtensions()
+    {
+        return $this->extensions;
+    }
+
+    /**
+     * Gets a collections of available language packs.
+     *
+     * @return Collection
+     */
+    public function getLanguagePacks()
+    {
+        return $this->extensions->filter(function ($value) {
+            return Arr::get($value, 'extra.flarum-locale.code') != null;
+        });
+    }
+}

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -44,6 +44,11 @@ class ExtensionManager
     protected $filesystem;
 
     /**
+     * @var ExtensionFinder
+     */
+    protected $finder;
+
+    /**
      * @var Collection|null
      */
     protected $extensions;
@@ -53,13 +58,15 @@ class ExtensionManager
         Application $app,
         Migrator $migrator,
         Dispatcher $dispatcher,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        ExtensionFinder $finder
     ) {
         $this->config = $config;
         $this->app = $app;
         $this->migrator = $migrator;
         $this->dispatcher = $dispatcher;
         $this->filesystem = $filesystem;
+        $this->finder = $finder;
     }
 
     /**
@@ -67,16 +74,10 @@ class ExtensionManager
      */
     public function getExtensions()
     {
-        if (is_null($this->extensions) && $this->filesystem->exists($this->app->basePath().'/vendor/composer/installed.json')) {
+        if (is_null($this->extensions)) {
             $extensions = new Collection();
 
-            // Load all packages installed by composer.
-            $installed = json_decode($this->filesystem->get($this->app->basePath().'/vendor/composer/installed.json'), true);
-
-            foreach ($installed as $package) {
-                if (Arr::get($package, 'type') != 'flarum-extension' || empty(Arr::get($package, 'name'))) {
-                    continue;
-                }
+            foreach ($this->finder->getExtensions() as $package) {
                 // Instantiates an Extension object using the package path and composer.json file.
                 $extension = new Extension($this->getExtensionsDir().'/'.Arr::get($package, 'name'), $package);
 

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -21,6 +21,7 @@ class ExtensionServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
+        $this->app->singleton(ExtensionFinder::class);
         $this->app->singleton(ExtensionManager::class);
         $this->app->alias(ExtensionManager::class, 'flarum.extensions');
 

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Foundation;
 
+use Flarum\Extension\ExtensionFinder;
 use Flarum\Install\Installer;
 use Flarum\Install\InstallServiceProvider;
 use Flarum\Locale\LocaleServiceProvider;
@@ -65,6 +66,7 @@ class UninstalledSite implements SiteInterface
 
         $this->registerLogger($laravel);
 
+        $laravel->singleton(ExtensionFinder::class);
         $laravel->register(LocaleServiceProvider::class);
         $laravel->register(FilesystemServiceProvider::class);
         $laravel->register(SessionServiceProvider::class);

--- a/src/Install/Console/InstallCommand.php
+++ b/src/Install/Console/InstallCommand.php
@@ -16,6 +16,7 @@ use Exception;
 use Flarum\Console\AbstractCommand;
 use Flarum\Database\DatabaseMigrationRepository;
 use Flarum\Database\Migrator;
+use Flarum\Extension\ExtensionFinder;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application as FlarumApplication;
 use Flarum\Foundation\Site;
@@ -314,7 +315,8 @@ class InstallCommand extends AbstractCommand
             $this->application,
             $this->migrator,
             $this->application->make(Dispatcher::class),
-            $this->application->make('files')
+            $this->application->make('files'),
+            $this->application->make(ExtensionFinder::class)
         );
 
         $disabled = [

--- a/src/Install/Controller/IndexController.php
+++ b/src/Install/Controller/IndexController.php
@@ -13,6 +13,7 @@ namespace Flarum\Install\Controller;
 
 use Flarum\Http\Controller\AbstractHtmlController;
 use Flarum\Install\Prerequisite\PrerequisiteInterface;
+use Flarum\Locale\LocaleManager;
 use Illuminate\Contracts\View\Factory;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -29,13 +30,20 @@ class IndexController extends AbstractHtmlController
     protected $prerequisite;
 
     /**
+     * @var LocaleManager
+     */
+    protected $locale;
+
+    /**
      * @param Factory $view
      * @param PrerequisiteInterface $prerequisite
+     * @param LocaleManager $locale
      */
-    public function __construct(Factory $view, PrerequisiteInterface $prerequisite)
+    public function __construct(Factory $view, PrerequisiteInterface $prerequisite, LocaleManager $locale)
     {
         $this->view = $view;
         $this->prerequisite = $prerequisite;
+        $this->locale = $locale;
     }
 
     /**
@@ -48,6 +56,13 @@ class IndexController extends AbstractHtmlController
 
         $this->prerequisite->check();
         $errors = $this->prerequisite->getErrors();
+
+        if ($this->locale->getLoadedLocales() < 1) {
+            array_push($errors, [
+                'message' => 'No language pack installed.',
+                'detail' => 'You have to install a language pack to continue with the installation.'
+            ]);
+        }
 
         if (count($errors)) {
             $view->with('content', $this->view->make('flarum.install::errors')->with('errors', $errors));

--- a/src/Locale/LanguagePackLoader.php
+++ b/src/Locale/LanguagePackLoader.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Locale;
+
+use Flarum\Extend\LanguagePack;
+use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionFinder;
+use Flarum\Foundation\Application;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * This class provides a basic loader for the
+ * language packs. It should only used when
+ * it's not possible to load extensions normally.
+ */
+class LanguagePackLoader
+{
+    /**
+     * @var ExtensionFinder
+     */
+    protected $finder;
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * LanguagePackLoader constructor.
+     * @param ExtensionFinder $finder
+     * @param Filesystem $filesystem
+     * @param Application $app
+     */
+    public function __construct(ExtensionFinder $finder, Filesystem $filesystem, Application $app)
+    {
+        $this->finder = $finder;
+        $this->filesystem = $filesystem;
+        $this->app = $app;
+    }
+
+    /**
+     * Loads all available languages packs.
+     */
+    public function load()
+    {
+        $packs = $this->finder->getLanguagePacks();
+
+        foreach ($packs as $pack) {
+            // We load the language packs like normal extensions
+            $extensionDir = $this->app->basePath().'/vendor/'.array_get($pack, 'name');
+            $requirePath = $extensionDir.'/extend.php';
+            $composerPath = $extensionDir.'/composer.json';
+
+            if (! $this->filesystem->exists($requirePath) || ! $this->filesystem->extension($composerPath)) {
+                continue;
+            }
+
+            $extenders = require $requirePath;
+
+            if (! is_array($extenders)) {
+                $extenders = [$extenders];
+            }
+
+            $foundLanguagePack = false;
+
+            foreach ($extenders as $extender) {
+                if ($extender instanceof LanguagePack) {
+                    $foundLanguagePack = true;
+                }
+            }
+
+            if (! $foundLanguagePack) {
+                continue;
+            }
+
+            $composerJson = $this->filesystem->get($composerPath);
+            $extension = new Extension($extensionDir, json_decode($composerJson, true));
+            $extension->extend($this->app);
+            // $extension->enable($this->app);
+        }
+    }
+}

--- a/src/Locale/LocaleManager.php
+++ b/src/Locale/LocaleManager.php
@@ -20,6 +20,8 @@ class LocaleManager
 
     protected $locales = [];
 
+    protected $loadedLocales = 0;
+
     protected $js = [];
 
     protected $css = [];
@@ -50,9 +52,20 @@ class LocaleManager
         $this->locales[$locale] = $name;
     }
 
+    public function addLoadedLocale($locale, $name)
+    {
+        $this->addLocale($locale, $name);
+        $this->loadedLocales++;
+    }
+
     public function getLocales(): array
     {
         return $this->locales;
+    }
+
+    public function getLoadedLocales()
+    {
+        return $this->loadedLocales;
     }
 
     public function hasLocale(string $locale): bool

--- a/src/Locale/LocaleServiceProvider.php
+++ b/src/Locale/LocaleServiceProvider.php
@@ -32,6 +32,11 @@ class LocaleServiceProvider extends AbstractServiceProvider
 
         $events->dispatch(new ConfigureLocales($locales));
 
+        if ($locales->getLoadedLocales() < 1) {
+            // Maybe we're just installing Flarum, so we're using our LanguagePackLoader
+            $this->app->make(LanguagePackLoader::class)->load();
+        }
+
         $events->listen(ClearingCache::class, function () use ($locales) {
             $locales->clearCache();
         });
@@ -42,6 +47,8 @@ class LocaleServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
+        $this->app->singleton(LanguagePackLoader::class);
+
         $this->app->singleton(LocaleManager::class, function () {
             return new LocaleManager(
                 $this->app->make('translator'),


### PR DESCRIPTION
**Fixes #1212**

**Changes proposed in this pull request:**
A error will be shown if no language pack is available.
The process of detecting extension is moved to a own class.

**Reviewers should focus on:**
If everything is compatible to the new extension system and updates in the last year.

Also there's an error when I'm trying to install it using the Web interface:
`Error booting Flarum: Too few arguments to function Illuminate\Support\Manager::createDriver(), 0 passed in D:\lukas\Coding\PhpstormProjects\flarum\flarum\vendor\illuminate\support\Manager.php on line 88 and exactly 1 expected`
But this error is related to an invalid mail driver name and it also appears without my changes.
The installation works if I'm using the console.

**Screenshot**
![firefox_2018-12-15_13-21-39](https://user-images.githubusercontent.com/8070210/50042973-6b68a980-006c-11e9-8c70-b8132173e0ae.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `php vendor/bin/phpunit`).