### PR TITLE
Make the Request available to the Formatter\Rendering event

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -102,7 +102,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
         );
 
         $serializer = static::$container->make($this->serializer);
-        $serializer->setActor($request->getAttribute('actor'));
+        $serializer->setRequest($request);
 
         $element = $this->createElement($data, $serializer)
             ->with($this->extractInclude($request))

--- a/src/Api/Serializer/AbstractSerializer.php
+++ b/src/Api/Serializer/AbstractSerializer.php
@@ -20,6 +20,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use LogicException;
+use Psr\Http\Message\ServerRequestInterface as Request;
 use Tobscure\JsonApi\AbstractSerializer as BaseAbstractSerializer;
 use Tobscure\JsonApi\Collection;
 use Tobscure\JsonApi\Relationship;
@@ -28,6 +29,11 @@ use Tobscure\JsonApi\SerializerInterface;
 
 abstract class AbstractSerializer extends BaseAbstractSerializer
 {
+    /**
+     * @var Request
+     */
+    protected $request;
+
     /**
      * @var User
      */
@@ -44,19 +50,28 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     protected static $container;
 
     /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+        $this->actor = $request->getAttribute('actor');
+    }
+
+    /**
      * @return User
      */
     public function getActor()
     {
         return $this->actor;
-    }
-
-    /**
-     * @param User $actor
-     */
-    public function setActor(User $actor)
-    {
-        $this->actor = $actor;
     }
 
     /**
@@ -231,7 +246,7 @@ abstract class AbstractSerializer extends BaseAbstractSerializer
     {
         $serializer = static::$container->make($class);
 
-        $serializer->setActor($this->actor);
+        $serializer->setRequest($this->request);
 
         return $serializer;
     }

--- a/src/Api/Serializer/BasicPostSerializer.php
+++ b/src/Api/Serializer/BasicPostSerializer.php
@@ -44,7 +44,7 @@ class BasicPostSerializer extends AbstractSerializer
         ];
 
         if ($post instanceof CommentPost) {
-            $attributes['contentHtml'] = $post->content_html;
+            $attributes['contentHtml'] = $post->formatContent($this->request);
         } else {
             $attributes['content'] = $post->content;
         }

--- a/src/Api/Serializer/PostSerializer.php
+++ b/src/Api/Serializer/PostSerializer.php
@@ -43,8 +43,6 @@ class PostSerializer extends BasicPostSerializer
         $canEdit = $gate->allows('edit', $post);
 
         if ($post instanceof CommentPost) {
-            $attributes['contentHtml'] = $post->content_html;
-
             if ($canEdit) {
                 $attributes['content'] = $post->content;
             }

--- a/src/Formatter/Event/Rendering.php
+++ b/src/Formatter/Event/Rendering.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\Formatter\Event;
 
+use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Renderer;
 
 class Rendering
@@ -31,14 +32,21 @@ class Rendering
     public $xml;
 
     /**
+     * @var ServerRequestInterface
+     */
+    public $request;
+
+    /**
      * @param Renderer $renderer
      * @param mixed $context
      * @param string $xml
+     * @param ServerRequestInterface|null $request
      */
-    public function __construct(Renderer $renderer, $context, &$xml)
+    public function __construct(Renderer $renderer, $context, &$xml, ServerRequestInterface $request = null)
     {
         $this->renderer = $renderer;
         $this->context = $context;
         $this->xml = &$xml;
+        $this->request = $request;
     }
 }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -16,6 +16,7 @@ use Flarum\Formatter\Event\Parsing;
 use Flarum\Formatter\Event\Rendering;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Configurator;
 use s9e\TextFormatter\Unparser;
 
@@ -69,13 +70,14 @@ class Formatter
      *
      * @param string $xml
      * @param mixed $context
+     * @param ServerRequestInterface|null $request
      * @return string
      */
-    public function render($xml, $context = null)
+    public function render($xml, $context = null, ServerRequestInterface $request = null)
     {
         $renderer = $this->getRenderer();
 
-        $this->events->dispatch(new Rendering($renderer, $context, $xml));
+        $this->events->dispatch(new Rendering($renderer, $context, $xml, $request));
 
         return $renderer->render($xml);
     }

--- a/src/Post/CommentPost.php
+++ b/src/Post/CommentPost.php
@@ -18,12 +18,12 @@ use Flarum\Post\Event\Posted;
 use Flarum\Post\Event\Restored;
 use Flarum\Post\Event\Revised;
 use Flarum\User\User;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * A standard comment in a discussion.
  *
  * @property string $parsed_content
- * @property string $content_html
  */
 class CommentPost extends Post
 {
@@ -166,11 +166,12 @@ class CommentPost extends Post
     /**
      * Get the content rendered as HTML.
      *
+     * @param ServerRequestInterface $request
      * @return string
      */
-    public function getContentHtmlAttribute()
+    public function formatContent(ServerRequestInterface $request)
     {
-        return static::$formatter->render($this->attributes['content'], $this);
+        return static::$formatter->render($this->attributes['content'], $this, $request);
     }
 
     /**


### PR DESCRIPTION
Make the Request available to the Formatter\Rendering event.

This is important because extensions may wish to render post content
differently depending on Request factors such as the actor. For example,
an attachments extension might wish to hide attachments from guests.

This solution is a bit of a hack-job for now, but soon when we refactor
the API layer to use tobscure/json-api-server, and also refactor the
Formatter layer, it can be revised.

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).