### PR TITLE
Open up Site for local implementation

### DIFF
--- a/src/Foundation/Site.php
+++ b/src/Foundation/Site.php
@@ -39,12 +39,12 @@ class Site
         }
     }
 
-    private static function hasConfigFile($basePath)
+    protected static function hasConfigFile($basePath)
     {
         return file_exists("$basePath/config.php");
     }
 
-    private static function loadConfig($basePath): array
+    protected static function loadConfig($basePath): array
     {
         $config = include "$basePath/config.php";
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

The visibility of the config file related methods of Site are private. This disallows implementing a different way of using one. Eg virtualised or in the cloud values are set in the environment, which allows for more flexibility. 

I'm proposing opening up the methods to protected, so that a local implementation can take a different course in getting the config file.

**Reviewers should focus on:**

Do we want this?

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
