### PR TITLE
Allow extending UninstalledSite / Installer

### DIFF
--- a/src/Foundation/Concerns/Extending.php
+++ b/src/Foundation/Concerns/Extending.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Flarum\Foundation\Concerns;
 
 use Flarum\Foundation\SiteInterface;

--- a/src/Foundation/Concerns/Extending.php
+++ b/src/Foundation/Concerns/Extending.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Flarum\Foundation\Concerns;
+
+use Flarum\Foundation\SiteInterface;
+
+trait Extending
+{
+    /**
+     * @var \Flarum\Extend\ExtenderInterface[]
+     */
+    protected $extenders = [];
+
+    /**
+     * @param \Flarum\Extend\ExtenderInterface[] $extenders
+     * @return SiteInterface
+     */
+    public function extendWith(array $extenders): SiteInterface
+    {
+        $this->extenders = $extenders;
+
+        return $this;
+    }
+}

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -48,6 +48,7 @@ use Psr\Log\LoggerInterface;
 
 class InstalledSite implements SiteInterface
 {
+    use Concerns\Extending;
     /**
      * @var array
      */
@@ -57,11 +58,6 @@ class InstalledSite implements SiteInterface
      * @var array
      */
     private $config;
-
-    /**
-     * @var \Flarum\Extend\ExtenderInterface[]
-     */
-    private $extenders = [];
 
     public function __construct(array $paths, array $config)
     {
@@ -80,17 +76,6 @@ class InstalledSite implements SiteInterface
             $this->bootLaravel(),
             $this->config
         );
-    }
-
-    /**
-     * @param \Flarum\Extend\ExtenderInterface[] $extenders
-     * @return InstalledSite
-     */
-    public function extendWith(array $extenders): self
-    {
-        $this->extenders = $extenders;
-
-        return $this;
     }
 
     private function bootLaravel(): Application

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -31,6 +31,8 @@ use Psr\Log\LoggerInterface;
 
 class UninstalledSite implements SiteInterface
 {
+    use Concerns\Extending;
+    
     /**
      * @var array
      */
@@ -88,6 +90,12 @@ class UninstalledSite implements SiteInterface
             return new \Illuminate\View\Factory(
                 $engines, $finder, $dispatcher
             );
+        });
+
+        $laravel->booting(function (Container $app) {
+            foreach ($this->extenders as $extension) {
+                $extension->extend($app);
+            }
         });
 
         $laravel->boot();

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
 class UninstalledSite implements SiteInterface
 {
     use Concerns\Extending;
-    
+
     /**
      * @var array
      */


### PR DESCRIPTION
**Changes proposed in this pull request:**

The goal of Flarum is to allow easy extensibility. In certain specific situations you might want to hook into the Installer or UninstalledSite as well. Currently there is absolutely no way of hooking any extender into it, even though the skeleton could be changed to allow that.

This PR adds a trait that moves the `extendWith` call and it's related array of ExtenderInterfaces outside of InstalledSite and adds it to UninstalledSite.

**Reviewers should focus on:**

- [ ] Do we want to allow this?
- [ ] Do we want to use a trait/concern?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
