### PR TITLE
Fixes #1738 : Search Title within discussions

### DIFF
--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -52,7 +52,7 @@ class FulltextGambit implements GambitInterface
         // discussions that have a relevant title or that contain relevant posts.
         $query
             ->addSelect('posts_ft.most_relevant_post_id')
-            ->join(
+            ->leftJoin(
                 new Expression('('.$subquery->toSql().') '.$grammar->wrapTable('posts_ft')),
                 'posts_ft.discussion_id', '=', 'discussions.id'
             )


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1738 **

**Changes proposed in this pull request:**
You can search in title discussion even if word does not appear in a post of this discussion

**Reviewers should focus on:**
Test searching toolbar with a word in discussion title
