### PR TITLE
Allow fallback to check for bound mail drivers

### DIFF
--- a/src/Foundation/MailServiceProvider.php
+++ b/src/Foundation/MailServiceProvider.php
@@ -63,8 +63,8 @@ class MailServiceProvider extends AbstractServiceProvider
             case 'log':
                 return new LogTransport($this->app->make(LoggerInterface::class));
             default:
-                if ($this->app->bound('mail.driver.' . $driver)) {
-                    return $this->app->make('mail.driver.' . $driver);
+                if ($this->app->bound('mail.driver.'.$driver)) {
+                    return $this->app->make('mail.driver.'.$driver);
                 }
 
                 throw new InvalidArgumentException('Invalid mail driver configuration');

--- a/src/Foundation/MailServiceProvider.php
+++ b/src/Foundation/MailServiceProvider.php
@@ -55,7 +55,7 @@ class MailServiceProvider extends AbstractServiceProvider
 
     private function buildTransport(SettingsRepositoryInterface $settings): Swift_Transport
     {
-        switch ($settings->get('mail_driver')) {
+        switch ($driver = $settings->get('mail_driver')) {
             case 'smtp':
                 return $this->buildSmtpTransport($settings);
             case 'mail':
@@ -63,6 +63,10 @@ class MailServiceProvider extends AbstractServiceProvider
             case 'log':
                 return new LogTransport($this->app->make(LoggerInterface::class));
             default:
+                if ($this->app->bound('mail.driver.' . $driver)) {
+                    return $this->app->make('mail.driver.' . $driver);
+                }
+
                 throw new InvalidArgumentException('Invalid mail driver configuration');
         }
     }


### PR DESCRIPTION
**Relates to #1169**

**Changes proposed in this pull request:**

Adds a fallback to bound mail drivers.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

