### PR TITLE
Remove post id from serializer attributes

### DIFF
--- a/src/Api/Serializer/BasicPostSerializer.php
+++ b/src/Api/Serializer/BasicPostSerializer.php
@@ -37,7 +37,6 @@ class BasicPostSerializer extends AbstractSerializer
         }
 
         $attributes = [
-            'id'          => (int) $post->id,
             'number'      => (int) $post->number,
             'createdAt'   => $this->formatDate($post->created_at),
             'contentType' => $post->type


### PR DESCRIPTION
**Changes proposed in this pull request:**
Remove the unneeded, duplicate post ID from the post serialized attributes. It's already present as the resource ID and I have not found any use of that duplicate attribute that's been there since 4 years. This attribute is not present in the javascript model for Post so I don't think it's used at all.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

I just noticed this and didn't want to open an issue just for that, but can't test dev-master right now. I can verify this PR on a dev-master stup this weekend if needed.