### PR TITLE
[BUGFIX] The avatar_path should be changed to avatar_url

### DIFF
--- a/src/User/AvatarUploader.php
+++ b/src/User/AvatarUploader.php
@@ -11,6 +11,7 @@
 
 namespace Flarum\User;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\Image;
 use League\Flysystem\FilesystemInterface;
@@ -46,7 +47,7 @@ class AvatarUploader
 
     public function remove(User $user)
     {
-        $avatarPath = array_get($user->getAttributes(), 'avatar_url');
+        $avatarPath = Arr::get($user->getAttributes(), 'avatar_url');
 
         $user->afterSave(function () use ($avatarPath) {
             if ($this->uploadDir->has($avatarPath)) {

--- a/src/User/AvatarUploader.php
+++ b/src/User/AvatarUploader.php
@@ -46,7 +46,7 @@ class AvatarUploader
 
     public function remove(User $user)
     {
-        $avatarPath = $user->avatar_path;
+        $avatarPath = array_get($user->getAttributes(), 'avatar_url',);
 
         $user->afterSave(function () use ($avatarPath) {
             if ($this->uploadDir->has($avatarPath)) {

--- a/src/User/AvatarUploader.php
+++ b/src/User/AvatarUploader.php
@@ -46,7 +46,7 @@ class AvatarUploader
 
     public function remove(User $user)
     {
-        $avatarPath = array_get($user->getAttributes(), 'avatar_url',);
+        $avatarPath = array_get($user->getAttributes(), 'avatar_url');
 
         $user->afterSave(function () use ($avatarPath) {
             if ($this->uploadDir->has($avatarPath)) {


### PR DESCRIPTION
In a previous commit, after avatar_path is renamed, this place is not changed.

The consequence is that, when avatar is uploaded, the previous image file is not deleted.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ x ] Frontend changes: tested on a local Flarum installation.
- [ x ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
