### PR TITLE
Fix dropdown icon not showing in UserCard when on UserPage

### DIFF
--- a/less/forum/UserPage.less
+++ b/less/forum/UserPage.less
@@ -1,10 +1,5 @@
 .UserPage {
-  .UserCard-controls {
-    float: right;
-
-    .Dropdown-toggle .Button-icon {
-      display: none;
-    }
+  .UserHero .Dropdown-toggle .Button-icon {
+    display: none;
   }
 }
-


### PR DESCRIPTION
The rule hiding the icon in the UserHero was too broad and applied to UserCard in the list of posts as well
The float rule was redundant

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Previous (when seen on user profile page):

![image](https://user-images.githubusercontent.com/5264300/57042328-a149ab80-6c64-11e9-85ce-ffb80d6ab705.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
