### PR TITLE
remove use of like

### DIFF
--- a/src/Settings/DatabaseSettingsRepository.php
+++ b/src/Settings/DatabaseSettingsRepository.php
@@ -45,8 +45,8 @@ class DatabaseSettingsRepository implements SettingsRepositoryInterface
         $query->$method(compact('key', 'value'));
     }
 
-    public function delete($keyLike)
+    public function delete($key)
     {
-        $this->database->table('settings')->where('key', 'like', $keyLike)->delete();
+        $this->database->table('settings')->where('key', $key)->delete();
     }
 }

--- a/src/User/UserRepository.php
+++ b/src/User/UserRepository.php
@@ -75,7 +75,7 @@ class UserRepository
      */
     public function getIdForUsername($username, User $actor = null)
     {
-        $query = User::where('username', 'like', $username);
+        $query = User::where('username', $username);
 
         return $this->scopeVisibleTo($query, $actor)->value('id');
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

This relates to https://github.com/flarum/tags/pull/61#discussion_r288466243

The point is that by using `like` in situation where an `_` is used, it allows a one character replacement in MySQL. As such when you have a key named `tes_` and `tes1` by using `$key = 'tes_'` it might return `tes1` instead, which is unwanted.

There are two places this happens. The first one is in the UserRepository, which is being used by the xhr to retrieve a user profile. @meezaan reported he already experienced this issue on his installation where usernames had spaces replaced with underscores. The second one is for the settings repository, this delete method is only used inside the Setting Migration, so it can use an exact match too.