### PR TITLE
Updated names to match components in fontawsome

### DIFF
--- a/less/common/common.less
+++ b/less/common/common.less
@@ -1,7 +1,7 @@
 @import "fontawesome";
-@import "fa-brands";
-@import "fa-regular";
-@import "fa-solid";
+@import "brands";
+@import "regular";
+@import "solid";
 @fa-font-path: "./fonts";
 
 @import "normalize";


### PR DESCRIPTION
fa-* named components are not present, hence updated to matching names.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
In file common.less Changes are proposed.
fa-brands to brands as the components in the fontawsome folder are now with name as brands.

**Confirmed**

- [Y ] Frontend changes: tested on a local Flarum installation.
- [Y ] Frontend changes: tested on a vps Server, Ubuntu 16.04 LTS, PHP7.3, Flarum installation.

**Required changes:**
Update the common.less file with correct names to match components in font awesome.