### PR TITLE
Add canonical URL to discussion list

### DIFF
--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -58,9 +58,11 @@ class Index
         ];
 
         $apiDocument = $this->getApiDocument($request->getAttribute('actor'), $params);
+        $defaultRoute = app()->make('flarum.settings')->get('default_route');
 
         $document->content = $this->view->make('flarum.forum::frontend.content.index', compact('apiDocument', 'page'));
         $document->payload['apiDocument'] = $apiDocument;
+        $document->canonicalUrl = $defaultRoute === '/all' ? app()->url() : $request->getUri()->withQuery('');
 
         return $document;
     }

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -14,6 +14,7 @@ namespace Flarum\Forum\Content;
 use Flarum\Api\Client;
 use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Frontend\Document;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
@@ -32,13 +33,20 @@ class Index
     protected $view;
 
     /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
      * @param Client $api
      * @param Factory $view
+     * @param SettingsRepositoryInterface $settings
      */
-    public function __construct(Client $api, Factory $view)
+    public function __construct(Client $api, Factory $view, SettingsRepositoryInterface $settings)
     {
         $this->api = $api;
         $this->view = $view;
+        $this->settings = $settings;
     }
 
     public function __invoke(Document $document, Request $request)
@@ -58,7 +66,7 @@ class Index
         ];
 
         $apiDocument = $this->getApiDocument($request->getAttribute('actor'), $params);
-        $defaultRoute = app()->make('flarum.settings')->get('default_route');
+        $defaultRoute = $this->settings->get('default_route');
 
         $document->content = $this->view->make('flarum.forum::frontend.content.index', compact('apiDocument', 'page'));
         $document->payload['apiDocument'] = $apiDocument;

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -14,6 +14,7 @@ namespace Flarum\Forum\Content;
 use Flarum\Api\Client;
 use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Frontend\Document;
+use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\View\Factory;
@@ -38,15 +39,22 @@ class Index
     protected $settings;
 
     /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    /**
      * @param Client $api
      * @param Factory $view
      * @param SettingsRepositoryInterface $settings
+     * @param UrlGenerator $url
      */
-    public function __construct(Client $api, Factory $view, SettingsRepositoryInterface $settings)
+    public function __construct(Client $api, Factory $view, SettingsRepositoryInterface $settings, UrlGenerator $url)
     {
         $this->api = $api;
         $this->view = $view;
         $this->settings = $settings;
+        $this->url = $url;
     }
 
     public function __invoke(Document $document, Request $request)
@@ -70,7 +78,7 @@ class Index
 
         $document->content = $this->view->make('flarum.forum::frontend.content.index', compact('apiDocument', 'page'));
         $document->payload['apiDocument'] = $apiDocument;
-        $document->canonicalUrl = $defaultRoute === '/all' ? app()->url() : $request->getUri()->withQuery('');
+        $document->canonicalUrl = $defaultRoute === '/all' ? $this->url->to('forum')->base() : $request->getUri()->withQuery('');
 
         return $document;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Refs #1134**

**Changes proposed in this pull request:**
Add a canonical URL that defaults to the base URL if the default route is set to the All Discussions route.

**Reviewers should focus on:**
Not sure if this is how we want to check the default route or use the logic for `/all` without query.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [ ] Related core extension PRs:
    - flarum/tags will need a PR too to complete requirements of #1134.
