### PR TITLE
Allow extensions to add routes with custom controller before resolving default route

### DIFF
--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -47,7 +47,10 @@ class ForumServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->singleton('flarum.forum.routes', function () {
-            $routes = new RouteCollection;
+            return new RouteCollection;
+        });
+
+        $this->app->afterResolving('flarum.forum.routes', function (RouteCollection $routes) {
             $this->populateRoutes($routes);
 
             return $routes;


### PR DESCRIPTION
Fixes #1819.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
