### PR TITLE
Hidden posts visibility

### DIFF
--- a/src/Post/PostPolicy.php
+++ b/src/Post/PostPolicy.php
@@ -99,6 +99,7 @@ class PostPolicy extends AbstractPolicy
                             ->from('discussions')
                             ->whereColumn('discussions.id', 'posts.discussion_id')
                             ->where(function ($query) use ($actor) {
+                                $query->whereRaw('1=0');
                                 $this->events->dispatch(
                                     new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
                                 );

--- a/src/Post/PostPolicy.php
+++ b/src/Post/PostPolicy.php
@@ -99,12 +99,13 @@ class PostPolicy extends AbstractPolicy
                             ->from('discussions')
                             ->whereColumn('discussions.id', 'posts.discussion_id')
                             ->where(function ($query) use ($actor) {
-                                $query->whereRaw('1=0');
-                                $query->orWhere(function ($query) use ($actor) {
-                                    $this->events->dispatch(
-                                        new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
-                                    );
-                                });
+                                $query
+                                    ->whereRaw('1=0')
+                                    ->orWhere(function ($query) use ($actor) {
+                                        $this->events->dispatch(
+                                            new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
+                                        );
+                                    });
                             });
                     });
             });

--- a/src/Post/PostPolicy.php
+++ b/src/Post/PostPolicy.php
@@ -100,9 +100,11 @@ class PostPolicy extends AbstractPolicy
                             ->whereColumn('discussions.id', 'posts.discussion_id')
                             ->where(function ($query) use ($actor) {
                                 $query->whereRaw('1=0');
-                                $this->events->dispatch(
-                                    new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
-                                );
+                                $query->orWhere(function ($query) use ($actor) {
+                                    $this->events->dispatch(
+                                        new ScopeModelVisibility(Discussion::query()->setQuery($query), $actor, 'hidePosts')
+                                    );
+                                });
                             });
                     });
             });

--- a/tests/integration/api/Controller/ShowDiscussionControllerTest.php
+++ b/tests/integration/api/Controller/ShowDiscussionControllerTest.php
@@ -118,7 +118,7 @@ class ShowDiscussionControllerTest extends ApiControllerTestCase
         $events = app(Dispatcher::class);
 
         $events->listen(ScopeModelVisibility::class, function (ScopeModelVisibility $event) {
-            $event->query->orWhereRaw('1=1');
+            $event->query->whereRaw('1=1');
         });
 
         $response = $this->callWith([], ['id' => 4]);

--- a/tests/integration/api/Controller/ShowDiscussionControllerTest.php
+++ b/tests/integration/api/Controller/ShowDiscussionControllerTest.php
@@ -118,7 +118,9 @@ class ShowDiscussionControllerTest extends ApiControllerTestCase
         $events = app(Dispatcher::class);
 
         $events->listen(ScopeModelVisibility::class, function (ScopeModelVisibility $event) {
-            $event->query->whereRaw('1=1');
+            if ($event->ability === 'discussion.hidePosts') {
+                $event->query->whereRaw('1=1');
+            }
         });
 
         $response = $this->callWith([], ['id' => 4]);

--- a/tests/integration/api/Controller/ShowDiscussionControllerTest.php
+++ b/tests/integration/api/Controller/ShowDiscussionControllerTest.php
@@ -118,7 +118,7 @@ class ShowDiscussionControllerTest extends ApiControllerTestCase
         $events = app(Dispatcher::class);
 
         $events->listen(ScopeModelVisibility::class, function (ScopeModelVisibility $event) {
-            if ($event->ability === 'discussion.hidePosts') {
+            if ($event->ability === 'hidePosts') {
                 $event->query->whereRaw('1=1');
             }
         });

--- a/tests/integration/api/Controller/ShowDiscussionControllerTest.php
+++ b/tests/integration/api/Controller/ShowDiscussionControllerTest.php
@@ -14,7 +14,10 @@ namespace Flarum\Tests\integration\api\Controller;
 use Carbon\Carbon;
 use Flarum\Api\Controller\ShowDiscussionController;
 use Flarum\Discussion\Discussion;
+use Flarum\Event\ScopeModelVisibility;
 use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 
 class ShowDiscussionControllerTest extends ApiControllerTestCase
 {
@@ -34,9 +37,11 @@ class ShowDiscussionControllerTest extends ApiControllerTestCase
                 ['id' => 1, 'title' => 'Empty discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 0],
                 ['id' => 2, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
                 ['id' => 3, 'title' => 'Private discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => null, 'comment_count' => 0, 'is_private' => 1],
+                ['id' => 4, 'title' => 'Discussion with hidden post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1, 'is_private' => 0],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a normal reply - too-obscure</p></t>'],
+                ['id' => 2, 'discussion_id' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>a hidden reply - too-obscure</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
             ],
             'users' => [
                 $this->normalUser(),
@@ -76,6 +81,51 @@ class ShowDiscussionControllerTest extends ApiControllerTestCase
         $response = $this->callWith([], ['id' => 1]);
 
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function guest_cannot_see_hidden_posts()
+    {
+        $response = $this->callWith([], ['id' => 4]);
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertNull(Arr::get($json, 'data.relationships.posts'));
+    }
+
+    /**
+     * @test
+     */
+    public function author_can_see_hidden_posts()
+    {
+        $this->actor = User::find(2);
+
+        $response = $this->callWith([], ['id' => 4]);
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals(2, Arr::get($json, 'data.relationships.posts.data.0.id'));
+    }
+
+    /**
+     * @test
+     */
+    public function when_allowed_guests_can_see_hidden_posts()
+    {
+        /** @var Dispatcher $events */
+        $events = app(Dispatcher::class);
+
+        $events->listen(ScopeModelVisibility::class, function (ScopeModelVisibility $event) {
+            $event->query->orWhereRaw('1=1');
+        });
+
+        $response = $this->callWith([], ['id' => 4]);
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals(2, Arr::get($json, 'data.relationships.posts.data.0.id'));
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1827**

**Changes proposed in this pull request:**

Added a default `1=0` statement that can be bypassed with a `orWhere` from the dispatched event.

**Reviewers should focus on:**

- [ ] Are tests okay.
- [ ] Is the implementation using whereRaw the right one.

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

-  Related core extension PRs: (Remove if irrelevant)
    - [ ] flarum/tags might need a pr