### PR TITLE
Allow extensions to specify a load priority

### DIFF
--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -276,7 +276,7 @@ class ExtensionManager
 
         return $enabled->sortByDesc(function ($extension, $name) {
             return $extension->composerJsonAttribute('extra.flarum-extension.priority');
-        });;
+        });
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -21,6 +21,8 @@ use Flarum\Foundation\Application;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -86,10 +88,9 @@ class ExtensionManager
 
                 $extensions->put($extension->getId(), $extension);
             }
-            $this->extensions = $extensions->sortByDesc(function ($extension, $name) {
-                return $extension->composerJsonAttribute('extra.flarum-extension.priority');
+            $this->extensions = $extensions->sortBy(function ($extension, $name) {
+                return $extension->composerJsonAttribute('extra.flarum-extension.title');
             });
-
         }
 
         return $this->extensions;
@@ -228,8 +229,8 @@ class ExtensionManager
      */
     public function migrate(Extension $extension, $direction = 'up')
     {
-        $this->app->bind('Illuminate\Database\Schema\Builder', function ($container) {
-            return $container->make('Illuminate\Database\ConnectionInterface')->getSchemaBuilder();
+        $this->app->bind(Builder::class, function ($container) {
+            return $container->make(ConnectionInterface::class)->getSchemaBuilder();
         });
 
         $extension->migrate($this->migrator, $direction);
@@ -259,7 +260,7 @@ class ExtensionManager
     /**
      * Get only enabled extensions.
      *
-     * @return array
+     * @return Collection
      */
     public function getEnabledExtensions()
     {

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -283,7 +283,13 @@ class ExtensionManager
      */
     public function extend(Container $app)
     {
-        foreach ($this->getEnabledExtensions() as $extension) {
+        $extensions = new Collection($this->getEnabledExtensions());
+
+        $extensions = $extensions->sortByDesc(function ($extension, $name) {
+            return $extension->composerJsonAttribute('extra.flarum-extension.priority');
+        });
+
+        foreach ($extensions as $extension) {
             $extension->extend($app);
         }
     }


### PR DESCRIPTION
This would allow a simple fix to #1832 as well as other load priority problems. I have confirmed that after using these proposed changes + adding a priority to the lock extension the issue went away.

**Changes proposed in this pull request:**
Allow extensions to specify an **optional** load "priority" in their `composer.json` under Flarum extension that dictates the order they are loaded in (higher means first)

**Reviewers should focus on:**
Is this the best way to do this?

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- Extensions such as lock need a priority set