### PR TITLE
Initial template for Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+daysUntilStale: 90
+daysUntilClose: 90
+
+exemptLabels:
+- type/bug
+- type/cleanup
+- type/feature
+- type/infrastructure
+- critical
+- security
+exemptMilestones: true
+exemptAssignees: true
+
+staleLabel: wontfix
+
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,9 +3,7 @@ daysUntilClose: 90
 
 exemptLabels:
 - type/bug
-- type/cleanup
-- type/feature
-- type/infrastructure
+- type/regression
 - critical
 - security
 exemptMilestones: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,9 +1,10 @@
 daysUntilStale: 90
-daysUntilClose: 90
+daysUntilClose: 30
 
 staleLabel: stale
 
 exemptLabels:
+- org/keep
 - type/bug
 - type/regression
 - critical

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,25 @@
 daysUntilStale: 90
 daysUntilClose: 90
 
+staleLabel: stale
+
 exemptLabels:
 - type/bug
 - type/regression
 - critical
 - security
-exemptMilestones: true
 exemptAssignees: true
-
-staleLabel: wontfix
+exemptMilestones: true
+exemptProjects: true
 
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. It will be closed if no further activity occurs. We do this
+  to keep the amount of open issues to a manageable minimum.
+
+  In any case, thanks for taking an interest in this software and contributing
+  by opening the issue in the first place!
+
+closeComment: >
+  We are closing this issue as it seems to have grown stale. If you still
+  encounter this problem with the latest version, feel free to re-open it.


### PR DESCRIPTION
Current configuration:

Issues & PR's are marked as stale after 90 days of inactivity. If another 90 days follow that period of inactivity with no activity as well, the issue is closed. Some labels are exempt from having issues marked as stale, as well as issues in a milestone or with assignees. 

---

We need to come up with a better mark comment.

Are the exempt labels ok to avoid those issues being marked ? We might want to limit the bot to "needs-discussion" labeled issues and label a bunch of issues that need discussion but never ### received the label.

Additional features include a comment when closing, comment when unmarking (probably not wanted). Special rules can also be set for issues & PR's separately, or limited to simply issues.