### PR TITLE
Error handling: Fix status codes

### DIFF
--- a/src/Api/Controller/ListNotificationsController.php
+++ b/src/Api/Controller/ListNotificationsController.php
@@ -15,12 +15,14 @@ use Flarum\Api\Serializer\NotificationSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\UrlGenerator;
 use Flarum\Notification\NotificationRepository;
-use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\AssertPermissionTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
 class ListNotificationsController extends AbstractListController
 {
+    use AssertPermissionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -67,9 +69,7 @@ class ListNotificationsController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        if ($actor->isGuest()) {
-            throw new PermissionDeniedException;
-        }
+        $this->assertRegistered($actor);
 
         $actor->markNotificationsAsRead()->save();
 

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -14,7 +14,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\Http\UrlGenerator;
 use Flarum\Search\SearchCriteria;
-use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -22,6 +22,8 @@ use Tobscure\JsonApi\Document;
 
 class ListUsersController extends AbstractListController
 {
+    use AssertPermissionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -70,9 +72,8 @@ class ListUsersController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        if ($actor->cannot('viewUserList')) {
-            throw new PermissionDeniedException;
-        }
+        $this->assertRegistered($actor);
+        $this->assertCan($actor, 'viewUserList');
 
         $query = Arr::get($this->extractFilter($request), 'q');
         $sort = $this->extractSort($request);

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -72,7 +72,6 @@ class ListUsersController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        $this->assertRegistered($actor);
         $this->assertCan($actor, 'viewUserList');
 
         $query = Arr::get($this->extractFilter($request), 'q');

--- a/src/Foundation/ErrorServiceProvider.php
+++ b/src/Foundation/ErrorServiceProvider.php
@@ -31,6 +31,7 @@ class ErrorServiceProvider extends AbstractServiceProvider
 
                 // 401 Unauthorized
                 'invalid_access_token' => 401,
+                'not_authenticated' => 401,
 
                 // 403 Forbidden
                 'forbidden' => 403,

--- a/src/Group/Command/CreateGroupHandler.php
+++ b/src/Group/Command/CreateGroupHandler.php
@@ -49,6 +49,7 @@ class CreateGroupHandler
         $actor = $command->actor;
         $data = $command->data;
 
+        $this->assertRegistered($actor);
         $this->assertCan($actor, 'createGroup');
 
         $group = Group::build(

--- a/src/Group/Command/CreateGroupHandler.php
+++ b/src/Group/Command/CreateGroupHandler.php
@@ -49,7 +49,6 @@ class CreateGroupHandler
         $actor = $command->actor;
         $data = $command->data;
 
-        $this->assertRegistered($actor);
         $this->assertCan($actor, 'createGroup');
 
         $group = Group::build(

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -17,6 +17,13 @@ use Flarum\User\Exception\PermissionDeniedException;
 trait AssertPermissionTrait
 {
     /**
+     * Ensure the current user is allowed to do something.
+     *
+     * If the condition is not met, an exception will be thrown that signals the
+     * lack of permissions. This is about *authorization*, i.e. retrying such a
+     * request / operation without a change in permissions (or using another
+     * user account) is pointless.
+     *
      * @param bool $condition
      * @throws PermissionDeniedException
      */
@@ -28,6 +35,12 @@ trait AssertPermissionTrait
     }
 
     /**
+     * Ensure the current user is authenticated.
+     *
+     * This will throw an exception for guest users, signaling that
+     * *authorization* failed. Thus, they could retry the operation after
+     * logging in (or using other means of authentication).
+     *
      * @param bool $condition
      * @throws NotAuthenticatedException
      */

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -11,18 +11,30 @@
 
 namespace Flarum\User;
 
+use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\Exception\PermissionDeniedException;
 
 trait AssertPermissionTrait
 {
     /**
-     * @param $condition
+     * @param bool $condition
      * @throws PermissionDeniedException
      */
     protected function assertPermission($condition)
     {
         if (! $condition) {
             throw new PermissionDeniedException;
+        }
+    }
+
+    /**
+     * @param bool $condition
+     * @throws NotAuthenticatedException
+     */
+    protected function assertAuthentication($condition)
+    {
+        if (! $condition) {
+            throw new NotAuthenticatedException;
         }
     }
 
@@ -39,20 +51,11 @@ trait AssertPermissionTrait
 
     /**
      * @param User $actor
-     * @throws \Flarum\User\Exception\PermissionDeniedException
-     */
-    protected function assertGuest(User $actor)
-    {
-        $this->assertPermission($actor->isGuest());
-    }
-
-    /**
-     * @param User $actor
-     * @throws PermissionDeniedException
+     * @throws NotAuthenticatedException
      */
     protected function assertRegistered(User $actor)
     {
-        $this->assertPermission(! $actor->isGuest());
+        $this->assertAuthentication(! $actor->isGuest());
     }
 
     /**

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -55,15 +55,23 @@ trait AssertPermissionTrait
      * @param User $actor
      * @param string $ability
      * @param mixed $arguments
+     * @throws NotAuthenticatedException
      * @throws PermissionDeniedException
      */
     protected function assertCan(User $actor, $ability, $arguments = [])
     {
+        // For non-authenticated users, we throw a different exception to signal
+        // that logging in may help.
+        $this->assertRegistered($actor);
+
+        // If we're logged in, then we need to communicate that the current
+        // account simply does not have enough permissions.
         $this->assertPermission($actor->can($ability, $arguments));
     }
 
     /**
      * @param User $actor
+     * @throws NotAuthenticatedException
      * @throws PermissionDeniedException
      */
     protected function assertAdmin(User $actor)

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -35,18 +35,18 @@ trait AssertPermissionTrait
     }
 
     /**
-     * Ensure the current user is authenticated.
+     * Ensure the given actor is authenticated.
      *
      * This will throw an exception for guest users, signaling that
      * *authorization* failed. Thus, they could retry the operation after
      * logging in (or using other means of authentication).
      *
-     * @param bool $condition
+     * @param User $actor
      * @throws NotAuthenticatedException
      */
-    protected function assertAuthentication($condition)
+    protected function assertRegistered(User $actor)
     {
-        if (! $condition) {
+        if ($actor->isGuest()) {
             throw new NotAuthenticatedException;
         }
     }
@@ -60,15 +60,6 @@ trait AssertPermissionTrait
     protected function assertCan(User $actor, $ability, $arguments = [])
     {
         $this->assertPermission($actor->can($ability, $arguments));
-    }
-
-    /**
-     * @param User $actor
-     * @throws NotAuthenticatedException
-     */
-    protected function assertRegistered(User $actor)
-    {
-        $this->assertAuthentication(! $actor->isGuest());
     }
 
     /**

--- a/src/User/Command/RegisterUserHandler.php
+++ b/src/User/Command/RegisterUserHandler.php
@@ -74,7 +74,7 @@ class RegisterUserHandler
         $data = $command->data;
 
         if (! $this->settings->get('allow_sign_up')) {
-            $this->assertAdmin($actor);
+            $this->assertPermission($actor->can('administrate'));
         }
 
         $password = Arr::get($data, 'attributes.password');

--- a/src/User/Exception/NotAuthenticatedException.php
+++ b/src/User/Exception/NotAuthenticatedException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Exception;
+
+use Exception;
+use Flarum\Foundation\KnownError;
+
+class NotAuthenticatedException extends Exception implements KnownError
+{
+    public function getType(): string
+    {
+        return 'not_authenticated';
+    }
+}

--- a/tests/integration/api/Auth/AuthenticateWithApiKeyTest.php
+++ b/tests/integration/api/Auth/AuthenticateWithApiKeyTest.php
@@ -65,7 +65,7 @@ class AuthenticateWithApiKeyTest extends TestCase
 
         $response = $api->send(CreateGroupController::class, new Guest);
 
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     /**

--- a/tests/integration/api/Controller/CreateGroupControllerTest.php
+++ b/tests/integration/api/Controller/CreateGroupControllerTest.php
@@ -80,7 +80,7 @@ class CreateGroupControllerTest extends ApiControllerTestCase
     /**
      * @test
      */
-    public function unauthorized_user_cannot_create_group()
+    public function normal_user_cannot_create_group()
     {
         $this->actor = User::find(2);
 

--- a/tests/integration/api/Controller/ListNotificationsControllerTest.php
+++ b/tests/integration/api/Controller/ListNotificationsControllerTest.php
@@ -36,7 +36,7 @@ class ListNotificationsControllerTest extends ApiControllerTestCase
     {
         $response = $this->callWith();
 
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     /**

--- a/tests/integration/api/Controller/ListUsersControllerTest.php
+++ b/tests/integration/api/Controller/ListUsersControllerTest.php
@@ -42,7 +42,7 @@ class ListUsersControllerTest extends ApiControllerTestCase
     {
         $response = $this->callWith();
 
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
**Refs #1641**

**Changes proposed in this pull request:**

This builds on top of #1843 to make error status codes consistent.

Before my refactoring, two exceptions were handled differently by the API
layer (which let the exception handlers determine the status code) vs. the
middleware used by the frontends (which used the "code" that was set
when throwing the exceptions).

When extracting the logic, I mostly used the exception codes, which
now changed the behavior of the API, e.g. when raising a "permission
denied" error when incorrect login credentials were entered.

For the case of login, this actually meant that you would now get a rather
confusing generic error message when trying to login with an incorrect
password. This is now fixed.

**Reviewers should focus on:**

- Does this make sense?
- Logic correct?
- Any cases I missed?

**Confirmed**

- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).
