### PR TITLE
Add DB prefix to PHP tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,6 @@ jobs:
           - php: 7.2
             service: mariadb
             prefix: flarum_
-          - php: 7.3
-            service: mariadb
-            prefix: flarum_
 
     services:
       mysql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3]
+        php: [7.1, 7.2, 7.3, 7.4]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -33,6 +33,12 @@ jobs:
           - php: 7.2
             service: mariadb
             prefix: flarum_
+          - php: 7.4
+            service: 'mysql:5.7'
+            prefix: flarum_
+          - php: 7.4
+            service: mariadb
+            prefix: flarum_
 
     services:
       mysql:
@@ -46,7 +52,14 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Select PHP version
-        run: sudo update-alternatives --set php $(which php${{ matrix.php }})
+        run: |
+          if [ "${{ matrix.php }}" = "7.4" ]; then \
+            packages=$(apt-cache search php7.4- | grep ^php | grep -v ^php7.4-fpm | awk '{print $1}' | awk '{print $1}' | tr '\n' ' ');
+            sudo apt-get install -y php7.4 $packages; \
+          fi
+          sudo update-alternatives --set php $(which php${{ matrix.php }}) && php -v
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       - name: Create MySQL Database
         run: mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 13306
@@ -63,3 +76,4 @@ jobs:
 
       - name: Run Composer tests
         run: composer test
+        continue-on-error: ${{ matrix.php == 7.4 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -33,12 +33,6 @@ jobs:
           - php: 7.2
             service: mariadb
             prefix: flarum_
-          - php: 7.4
-            service: 'mysql:5.7'
-            prefix: flarum_
-          - php: 7.4
-            service: mariadb
-            prefix: flarum_
 
     services:
       mysql:
@@ -52,14 +46,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Select PHP version
-        run: |
-          if [ "${{ matrix.php }}" = "7.4" ]; then \
-            packages=$(apt-cache search php7.4- | grep ^php | grep -v ^php7.4-fpm | awk '{print $1}' | awk '{print $1}' | tr '\n' ' ');
-            sudo apt-get install -y php7.4 $packages; \
-          fi
-          sudo update-alternatives --set php $(which php${{ matrix.php }}) && php -v
-        env:
-          DEBIAN_FRONTEND: noninteractive
+        run: sudo update-alternatives --set php $(which php${{ matrix.php }})
 
       - name: Create MySQL Database
         run: mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 13306
@@ -76,4 +63,3 @@ jobs:
 
       - name: Run Composer tests
         run: composer test
-        continue-on-error: ${{ matrix.php == 7.4 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,41 @@ jobs:
     strategy:
       matrix:
         php: [7.1, 7.2, 7.3]
-        db: ['mysql:5.7', mariadb]
+        service: ['mysql:5.7', mariadb]
+        prefix: ['', flarum_]
+
+        include:
+          - service: 'mysql:5.7'
+            db: MySQL
+          - service: mariadb
+            db: MariaDB
+          - prefix: flarum_
+            prefixStr: (prefix)
+
+        exclude:
+          - php: 7.1
+            service: 'mysql:5.7'
+            prefix: flarum_
+          - php: 7.1
+            service: mariadb
+            prefix: flarum_
+          - php: 7.2
+            service: 'mysql:5.7'
+            prefix: flarum_
+          - php: 7.2
+            service: mariadb
+            prefix: flarum_
+          - php: 7.3
+            service: mariadb
+            prefix: flarum_
 
     services:
       mysql:
-        image: ${{ matrix.db }}
+        image: ${{ matrix.service }}
         ports:
           - 13306:3306
 
-    name: PHP ${{ matrix.php }} with ${{ matrix.db }}
+    name: 'PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}'
 
     steps:
       - uses: actions/checkout@master
@@ -36,6 +62,7 @@ jobs:
         env:
           DB_PORT: 13306
           DB_PASSWORD: root
+          DB_PREFIX: ${{ matrix.prefix }}
 
       - name: Run Composer tests
         run: composer test


### PR DESCRIPTION
Only for PHP 7.3 & MySQL 5.7.

Also simplified job names to show it has a custom prefix.

Only way this worked was by excluding every other job :/