### PR TITLE
Add Edit User permission to permissions grid

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -228,6 +228,11 @@ export default class PermissionGrid extends Component {
       permission: 'discussion.deletePosts'
     }, 60);
 
+    items.add('userEdit', {
+      icon: 'fas fa-user-cog',
+      label: app.translator.trans('core.admin.permissions.edit_user_label'),
+      permission: 'user.edit'
+    }, 60);
     return items;
   }
 

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -233,6 +233,7 @@ export default class PermissionGrid extends Component {
       label: app.translator.trans('core.admin.permissions.edit_user_label'),
       permission: 'user.edit'
     }, 60);
+    
     return items;
   }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1845**

**Changes proposed in this pull request:**
This change adds the User Edit permission to the permissions panel in the administration view

**Reviewers should focus on:**
General code, this is my first pull request for Flarum, the lang-eng repo will also have a pull request that adds the translation for the label

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![Annotation 2019-08-24 210709](https://user-images.githubusercontent.com/3457368/63644272-3c9eda80-c6b3-11e9-85d0-fcc9619afe0c.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**
- [x] Related core extension PRs: https://github.com/flarum/lang-english/pull/145
