### PR TITLE
Add back defaults for language and direction attributes

### DIFF
--- a/src/Frontend/Content/Meta.php
+++ b/src/Frontend/Content/Meta.php
@@ -12,13 +12,30 @@
 namespace Flarum\Frontend\Content;
 
 use Flarum\Frontend\Document;
+use Flarum\Locale\LocaleManager;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Meta
 {
+    /**
+     * @var LocaleManager
+     */
+    private $locales;
+
+    /**
+     * @param LocaleManager $locales
+     */
+    public function __construct(LocaleManager $locales)
+    {
+        $this->locales = $locales;
+    }
+
     public function __invoke(Document $document, Request $request)
     {
+        $document->language = $this->locales->getLocale();
+        $document->direction = 'ltr';
+
         $document->meta = array_merge($document->meta, $this->buildMeta($document));
         $document->head = array_merge($document->head, $this->buildHead($document));
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1772**

**Changes proposed in this pull request:**
- Adds back `language` and `direction` attribute defaults

**Reviewers should focus on:**
- Do we want a method in the `LanguagePack` extender to set the direction ? It would simplify having to use the Frontend extender and checking for the current locale

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).