### PR TITLE
Fix new post injected above unread sticky

### DIFF
--- a/js/src/forum/components/DiscussionComposer.js
+++ b/js/src/forum/components/DiscussionComposer.js
@@ -92,7 +92,7 @@ export default class DiscussionComposer extends ComposerBody {
     app.store.createRecord('discussions').save(data).then(
       discussion => {
         app.composer.hide();
-        app.cache.discussionList.addDiscussion(discussion);
+        app.cache.discussionList.refresh();
         m.route(app.route.discussion(discussion));
       },
       this.loaded.bind(this)

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -205,14 +205,4 @@ export default class DiscussionList extends Component {
       this.discussions.splice(index, 1);
     }
   }
-
-  /**
-   * Add a discussion to the top of the list.
-   *
-   * @param {Discussion} discussion
-   * @public
-   */
-  addDiscussion(discussion) {
-    this.discussions.unshift(discussion);
-  }
 }


### PR DESCRIPTION
**Fixes #1751**

**Changes proposed in this pull request:**
instead of prepending the new discussion to the list, this refreshes the list

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~Backend changes: tests are green (run `php vendor/bin/phpunit`).~
