### PR TITLE
Fixes the new Edit user permission label

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -230,7 +230,7 @@ export default class PermissionGrid extends Component {
 
     items.add('userEdit', {
       icon: 'fas fa-user-cog',
-      label: app.translator.trans('core.admin.permissions.edit_user_label'),
+      label: app.translator.trans('core.admin.permissions.edit_users_label'),
       permission: 'user.edit'
     }, 60);
     


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This fixes the Edit user label in the admin permissions grid. This change needs to take place because of fixes that took place to https://github.com/flarum/lang-english/pull/145 that changed the translation key. The same change was not made to the JS before the original pull request made it to master.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Current:
![image](https://user-images.githubusercontent.com/3457368/64393281-aeb1e080-d01e-11e9-8db1-b27cbce35191.png)

Fix:
![image](https://user-images.githubusercontent.com/3457368/64393334-e28d0600-d01e-11e9-876a-e829698068d5.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `php vendor/bin/phpunit`).
