### PR TITLE
Mark notification as read without visiting discussion

### DIFF
--- a/js/src/forum/components/Notification.js
+++ b/js/src/forum/components/Notification.js
@@ -2,6 +2,7 @@ import Component from '../../common/Component';
 import avatar from '../../common/helpers/avatar';
 import icon from '../../common/helpers/icon';
 import humanTime from '../../common/helpers/humanTime';
+import Button from "../../common/components/Button";
 
 /**
  * The `Notification` component abstract displays a single notification.
@@ -26,6 +27,17 @@ export default class Notification extends Component {
 
           if (!isInitialized) $(element).click(this.markAsRead.bind(this));
         }}>
+        {!notification.isRead() && Button.component({
+          className: 'Notification-action Button Button--icon Button--link',
+          icon: 'fas fa-check',
+          title: app.translator.trans('core.forum.notifications.mark_as_read_tooltip'),
+          onclick: e => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            this.markAsRead();
+          }
+        })}
         {avatar(notification.fromUser())}
         {icon(this.icon(), {className: 'Notification-icon'})}
         <span className="Notification-content">{this.content()}</span>

--- a/js/src/forum/components/Notification.js
+++ b/js/src/forum/components/Notification.js
@@ -2,7 +2,7 @@ import Component from '../../common/Component';
 import avatar from '../../common/helpers/avatar';
 import icon from '../../common/helpers/icon';
 import humanTime from '../../common/helpers/humanTime';
-import Button from "../../common/components/Button";
+import Button from '../../common/components/Button';
 
 /**
  * The `Notification` component abstract displays a single notification.

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -87,6 +87,10 @@
   &:hover {
     text-decoration: none;
     background: @control-bg;
+    
+    .Notification-action {
+      display: block;
+    }
   }
   .Avatar {
     .Avatar--size(24px);
@@ -101,6 +105,7 @@
 
   .Notification-action {
     float: right;
+    display: none;
     margin-top: -11px;
     margin-right: -11px;
 

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -106,8 +106,10 @@
   .Notification-action {
     float: right;
     display: none;
-    margin-top: -11px;
-    margin-right: -11px;
+    margin-top: -7px;
+    margin-right: -10px;
+    line-height: inherit;
+    padding: 5px 0;
 
     & when (@config-colored-header = true) {
       .Button--color(@control-color, @control-bg);

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -98,6 +98,24 @@
     font-weight: bold;
     text-transform: uppercase;
   }
+
+  .Notification-action {
+    float: right;
+    margin-top: -11px;
+    margin-right: -11px;
+
+    & when (@config-colored-header = true) {
+      .Button--color(@control-color, @control-bg);
+
+      &:hover {
+        color: @link-color;
+      }
+    }
+
+    i.icon {
+      font-size: 12px;
+    }
+  }
 }
 .Notification-icon {
   float: left;

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -117,7 +117,7 @@
       }
     }
 
-    i.icon {
+    .icon {
       font-size: 12px;
     }
   }


### PR DESCRIPTION
**Fixes #151**

**Continues #1596** (deleted repository 🙈)

> **Changes proposed in this pull request:**
> - `Notification` component now has a checkbox to mark notification as read
> 
> **Reviewers should focus on:**
> - Do we really need `slidable` with this? The current structure of notifications made it hard, and I was unable to integrate the `slidable` util... though I have never used it before, so that may be why.
> - Is `core.forum.notifications.mark_as_read_tooltip` ok?
> 
> **Screenshot**
> 
> ![screen recording 2018-10-06 at 10 01 40 am](https://user-images.githubusercontent.com/6401250/46572155-12cfae80-c94f-11e8-983f-cb18f20fce02.gif)
> 
> 
> **Confirmed**
> 
> - [x] Frontend changes: tested on a local Flarum installation.
> - ~~Backend changes: tests are green (run `php vendor/bin/phpunit`)~~.
> 
> **Required changes:**
> 
> - [x] Related core extension PRs: https://github.com/flarum/lang-english/pull/146