### PR TITLE
Fixes #1877 Replace getIdsForUsername() with subquery instead.

### DIFF
--- a/src/User/Search/Gambit/FulltextGambit.php
+++ b/src/User/Search/Gambit/FulltextGambit.php
@@ -31,14 +31,24 @@ class FulltextGambit implements GambitInterface
     }
 
     /**
+     * @param $searchValue
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    private function getUserSearchSubQuery($searchValue)
+    {
+        return $this->users
+            ->query()
+            ->select('id')
+            ->where('username', 'like', "{$searchValue}%");
+    }
+
+    /**
      * {@inheritdoc}
      */
-    public function apply(AbstractSearch $search, $bit)
+    public function apply(AbstractSearch $search, $searchValue)
     {
-        $users = $this->users->getIdsForUsername($bit, $search->getActor());
-
-        $search->getQuery()->whereIn('id', $users);
-
-        $search->setDefaultSort(['id' => $users]);
+        $search->getQuery()
+            ->whereIn('id',
+                $this->getUserSearchSubQuery($searchValue));
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1877 **

**Changes proposed in this pull request:**
Replaces the use of getIdsForUsername() with a sub-query, offloading the processing to the database. 

Currently if the array returned from getIdsForUsername() is too big, it can fill up the placeholder values for the user fulltext search gambit, throwing an exception.

**Reviewers should focus on:**
Query looks fine, I decided to put the subquery into a separate private method to keep the code clean.

