### PR TITLE
Fix JS errors that only require a check for truthy value

### DIFF
--- a/js/src/common/components/Dropdown.js
+++ b/js/src/common/components/Dropdown.js
@@ -60,6 +60,10 @@ export default class Dropdown extends Component {
       m.redraw();
 
       const $menu = this.$('.Dropdown-menu');
+
+      // return if menu is not found
+      if (!$menu.length) return;
+
       const isRight = $menu.hasClass('Dropdown-menu--right');
 
       $menu.removeClass('Dropdown-menu--top Dropdown-menu--right');

--- a/js/src/common/components/Dropdown.js
+++ b/js/src/common/components/Dropdown.js
@@ -61,7 +61,8 @@ export default class Dropdown extends Component {
 
       const $menu = this.$('.Dropdown-menu');
 
-      // return if menu is not found
+      // Return early to avoid errors if the menu element doesn't exist.
+      // $.fn.offset() returns null if the element doesn't exist.
       if (!$menu.length) return;
 
       const isRight = $menu.hasClass('Dropdown-menu--right');

--- a/js/src/common/utils/anchorScroll.js
+++ b/js/src/common/utils/anchorScroll.js
@@ -12,10 +12,18 @@
  * @param {Function} callback The callback to run that will change page content.
  */
 export default function anchorScroll(element, callback) {
+  const $element = $(element);
+
+  // return if element doesn't exist
+  if (!$element.length) {
+    callback();
+    return;
+  }
+
   const $window = $(window);
-  const relativeScroll = $(element).offset().top - $window.scrollTop();
+  const relativeScroll = $element.offset().top - $window.scrollTop();
 
   callback();
 
-  $window.scrollTop($(element).offset().top - relativeScroll);
+  $window.scrollTop($element.offset().top - relativeScroll);
 }

--- a/js/src/common/utils/anchorScroll.js
+++ b/js/src/common/utils/anchorScroll.js
@@ -14,7 +14,8 @@
 export default function anchorScroll(element, callback) {
   const $element = $(element);
 
-  // return if element doesn't exist
+  // $element.offset() is null if element doesn't exist,
+  // so we call the callback now and return instead of scrolling.
   if (!$element.length) {
     callback();
     return;

--- a/js/src/forum/components/DiscussionComposer.js
+++ b/js/src/forum/components/DiscussionComposer.js
@@ -98,7 +98,9 @@ export default class DiscussionComposer extends ComposerBody {
       .save(data)
       .then((discussion) => {
         app.composer.hide();
-        app.cache.discussionList.refresh();
+
+        if (app.cache.discussionList) app.cache.discussionList.refresh(discussion);
+
         m.route(app.route.discussion(discussion));
       }, this.loaded.bind(this));
   }


### PR DESCRIPTION
This should fix a bunch of errors that have been thrown recently on our beta demo.

Fixes:
```js
TypeError: Cannot read property 'top' of undefined
  at apply(webpack://@flarum/core/./src/common/components/Dropdown.js:69:15)
```
```js
TypeError: Cannot read property 'content' of null
  at apply(webpack://@flarum/core/./src/forum/components/ReplyPlaceholder.js:55:46)

TypeError: null is not an object (evaluating 'app.composer.component.content')
  at apply(webpack://@flarum/core/./src/forum/components/ReplyPlaceholder.js:70:30)
```
```js
TypeError: undefined is not an object (evaluating '.offset().top')
  at anchorScroll(webpack://@flarum/core/./src/common/utils/anchorScroll.js:16:37)
  at onSuccess(webpack://@flarum/core/./src/forum/components/PostStream.js:115:17)
  ...
  at document(webpack://@flarum/core/./src/forum/components/PostStream.js:66:26)
```
```js
TypeError: Cannot read property 'addDiscussion' of undefined
  at onSuccess(webpack://@flarum/core/./src/forum/components/DiscussionComposer.js:95:34)
```