### PR TITLE
Avatar Canvas CORS problem

### DIFF
--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -91,7 +91,7 @@ Object.assign(User.prototype, {
       user.freshness = new Date();
       m.redraw();
     };
-    image.crossOrigin = 'Anonymous';
+    image.crossOrigin = 'anonymous';
     image.src = this.avatarUrl();
   },
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #445**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
I have SSO implemented in my forum, so all avatar urls are remote (from my Azure storage).

When an user card was shown, there was an error in JS by Color Thief (same as issue #445), the canvas would stuck inside body and the user card would be grey.

Following the instructions on https://lokeshdhakar.com/projects/color-thief/, I added a `image.crossOrigin = 'Anonymous';` that fixes my issue.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
There is just one add to include the crossOrigin attribute.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/379339/65380165-81666300-dcab-11e9-9c9a-7593764604e5.png)

For example, one of those avatars are in https://codeartbr.blob.core.windows.net/user-avatars/d3wNdIniabWR8mLdMQO6yzYriLw2.jpg 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
