### PR TITLE
Enable scrollbars in login button popups

### DIFF
--- a/js/src/forum/components/LogInButton.js
+++ b/js/src/forum/components/LogInButton.js
@@ -22,7 +22,7 @@ export default class LogInButton extends Button {
         `height=${height},` +
         `top=${$window.height() / 2 - height / 2},` +
         `left=${$window.width() / 2 - width / 2},` +
-        'status=no,scrollbars=no,resizable=no');
+        'status=no,scrollbars=yes,resizable=no');
     };
 
     super.initProps(props);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1716**

**Changes proposed in this pull request:**
Allow scrollbars in OAuth login popups

**Reviewers should focus on:**
Not sure why they were disabled in the first place.

**Screenshot**
Works on Firefox 69, didn't before.

![image](https://user-images.githubusercontent.com/6401250/65924311-1eb34c80-e3ba-11e9-9f77-53f39bcaee73.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
