### PR TITLE
Error handling in console

### DIFF
--- a/src/Console/Event/Configuring.php
+++ b/src/Console/Event/Configuring.php
@@ -32,21 +32,15 @@ class Configuring
      * @var ConsoleApplication
      */
     public $console;
-    /**
-     * @var EventDispatcher
-     */
-    public $eventDispatcher;
 
     /**
      * @param Application        $app
      * @param ConsoleApplication $console
-     * @param EventDispatcher    $eventDispatcher
      */
-    public function __construct(Application $app, ConsoleApplication $console, EventDispatcher $eventDispatcher)
+    public function __construct(Application $app, ConsoleApplication $console)
     {
         $this->app = $app;
         $this->console = $console;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**

--- a/src/Console/Event/Configuring.php
+++ b/src/Console/Event/Configuring.php
@@ -14,7 +14,6 @@ namespace Flarum\Console\Event;
 use Flarum\Foundation\Application;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Application as ConsoleApplication;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * Configure the console application.

--- a/src/Console/Server.php
+++ b/src/Console/Server.php
@@ -13,9 +13,13 @@ namespace Flarum\Console;
 
 use Flarum\Console\Event\Configuring;
 use Flarum\Foundation\Application;
+use Flarum\Foundation\ErrorHandling\Registry;
+use Flarum\Foundation\ErrorHandling\Reporter;
 use Flarum\Foundation\SiteInterface;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Server
@@ -46,8 +50,31 @@ class Server
     {
         $app = Application::getInstance();
 
+        $this->handleErrors($app, $console);
+
         $events = $app->make(Dispatcher::class);
-        $events->fire(new Configuring($app, $console, $dispatcher = new EventDispatcher()));
+
+        $events->fire(new Configuring($app, $console));
+    }
+
+    private function handleErrors(Application $app, ConsoleApplication $console)
+    {
+        $dispatcher = new EventDispatcher();
+
+        $dispatcher->addListener(ConsoleEvents::ERROR, function (ConsoleErrorEvent $event) use ($app) {
+            /** @var Registry $registry */
+            $registry = $app->make(Registry::class);
+
+            $error = $registry->handle($event->getError());
+
+            $reporters = $app->tagged(Reporter::class);
+
+            if ($error->shouldBeReported()) {
+                foreach ($reporters as $reporter) {
+                    $reporter->report($error->getException());
+                }
+            }
+        });
 
         $console->setDispatcher($dispatcher);
     }


### PR DESCRIPTION
**Follow up of #1810**

**Changes proposed in this pull request:**

This improves the error handling in the console, a requirement when relying on our queues. As suggested, I've re-used the Registry and Reporters (not the formatters) to report errors.

Companion PR for fof/sentry: https://github.com/FriendsOfFlarum/sentry/tree/dk/revisit-console-listener

**Reviewers should focus on:**

- [ ] Should the error handling logic for the console server be moved outside of this class? I think it's small enough to be encapsulated herein, but opinions might differ. Please advise.

**Confirmed**

- [x] Logging to sentry.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
