### PR TITLE
Add discussion_id foreign key to posts table

### DIFF
--- a/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
+++ b/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        // Delete rows with non-existent entities so that we will be able to create
+        // foreign keys without any issues.
+        $connection = $schema->getConnection();
+        $connection->table('posts')
+            ->orWhereNotExists(function ($query) {
+                $query->selectRaw(1)->from('discussions')->whereColumn('id', 'discussion_id');
+            })
+            ->delete();
+
+
+        $schema->table('posts', function (Blueprint $table) {
+            $table->foreign('discussion_id')->references('id')->on('discussions')->onDelete('cascade');
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('posts', function (Blueprint $table) {
+            $table->dropForeign(['discussion_id']);
+        });
+    }
+];

--- a/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
+++ b/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -13,7 +22,6 @@ return [
                 $query->selectRaw(1)->from('discussions')->whereColumn('id', 'discussion_id');
             })
             ->delete();
-
 
         $schema->table('posts', function (Blueprint $table) {
             $table->foreign('discussion_id')->references('id')->on('discussions')->onDelete('cascade');

--- a/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
+++ b/migrations/2019_10_12_195349_change_posts_add_discussion_foreign_key.php
@@ -9,7 +9,7 @@ return [
         // foreign keys without any issues.
         $connection = $schema->getConnection();
         $connection->table('posts')
-            ->orWhereNotExists(function ($query) {
+            ->whereNotExists(function ($query) {
                 $query->selectRaw(1)->from('discussions')->whereColumn('id', 'discussion_id');
             })
             ->delete();

--- a/tests/integration/api/Controller/DeleteDiscussionControllerTest.php
+++ b/tests/integration/api/Controller/DeleteDiscussionControllerTest.php
@@ -27,7 +27,9 @@ class DeleteDiscussionControllerTest extends ApiControllerTestCase
             'discussions' => [
                 ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2],
             ],
-            'posts' => [],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
+            ],
             'users' => [
                 $this->adminUser(),
                 $this->normalUser(),
@@ -51,5 +53,17 @@ class DeleteDiscussionControllerTest extends ApiControllerTestCase
         $response = $this->callWith([], ['id' => 1]);
 
         $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function deleting_discussions_deletes_their_posts()
+    {
+        $this->actor = User::find(1);
+
+        $this->callWith([], ['id' => 1]);
+
+        $this->assertNull($this->database()->table('posts')->find(1), 'Post exists in the DB');
     }
 }

--- a/tests/integration/api/Controller/ListDiscussionsControllerTest.php
+++ b/tests/integration/api/Controller/ListDiscussionsControllerTest.php
@@ -78,14 +78,14 @@ class ListDiscussionsControllerTest extends ApiControllerTestCase
      */
     public function can_search_for_word_in_title_and_post()
     {
+        $this->database()->table('discussions')->insert([
+            ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
+            ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
+        ]);
+
         $this->database()->table('posts')->insert([
             ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
             ['id' => 3, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
-        ]);
-
-        $this->database()->table('discussions')->insert([
-            ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1],
-            ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 3, 'comment_count' => 1],
         ]);
 
         $response = $this->callWith([], [
@@ -106,14 +106,14 @@ class ListDiscussionsControllerTest extends ApiControllerTestCase
      */
     public function ignores_non_word_characters_when_searching()
     {
+        $this->database()->table('discussions')->insert([
+            ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
+            ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'comment_count' => 1],
+        ]);
+
         $this->database()->table('posts')->insert([
             ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>not in text</p></t>'],
             ['id' => 3, 'discussion_id' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>lightsail in text</p></t>'],
-        ]);
-
-        $this->database()->table('discussions')->insert([
-            ['id' => 2, 'title' => 'lightsail in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 1],
-            ['id' => 3, 'title' => 'not in title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 3, 'comment_count' => 1],
         ]);
 
         $response = $this->callWith([], [


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1909**

**Changes proposed in this pull request:**
Create foreign key for `discussion_id`, cascade on delete.

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
