### PR TITLE
Modal isDismissible() should protect the modal from closing by pressing Esc

### DIFF
--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -53,7 +53,12 @@ export default class ModalManager extends Component {
 
     m.redraw(true);
 
-    this.$().modal({backdrop: this.component.isDismissible() ? true : 'static'}).modal('show');
+    var dismissible = !!this.component.isDismissible();
+    this.$().modal({
+      backdrop: dismissible || 'static',
+      keyboard: dismissible
+    }).modal('show');
+
     this.onready();
   }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
- js/src/common/components/ModalManager.js

**Reviewers should focus on:**
By default Bootstrap Modal does not prevent modal from closing when you press Esc, even if backdrop: 'static' is enabled. keyboard: false required.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
