### PR TITLE
Pass event to KeyboardNavigatable whenCallback

### DIFF
--- a/js/src/forum/utils/KeyboardNavigatable.js
+++ b/js/src/forum/utils/KeyboardNavigatable.js
@@ -7,10 +7,24 @@
  */
 export default class KeyboardNavigatable {
   constructor() {
+    /**
+     * Callback to be executed for a specified input.
+     *
+     * @callback KeyboardNavigatable~keyCallback
+     * @param {KeyboardEvent} event
+     * @returns {boolean}
+     */
     this.callbacks = {};
 
-    // By default, always handle keyboard navigation.
-    this.whenCallback = () => true;
+    /**
+     * Callback that determines whether keyboard input should be handled.
+     * By default, always handle keyboard navigation.
+     *
+     * @callback whenCallback
+     * @param {KeyboardEvent} event
+     * @returns {boolean}
+     */
+    this.whenCallback = event => true;
   }
 
   /**
@@ -19,7 +33,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Up key.
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~keyCallback} callback
    * @return {KeyboardNavigatable}
    */
   onUp(callback) {
@@ -37,7 +51,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Down key.
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~keyCallback} callback
    * @return {KeyboardNavigatable}
    */
   onDown(callback) {
@@ -55,7 +69,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Return and Tab keys..
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~keyCallback} callback
    * @return {KeyboardNavigatable}
    */
   onSelect(callback) {
@@ -73,7 +87,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Escape key.
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~keyCallback} callback
    * @return {KeyboardNavigatable}
    */
   onCancel(callback) {
@@ -92,7 +106,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Backspace key.
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~keyCallback} callback
    * @return {KeyboardNavigatable}
    */
   onRemove(callback) {
@@ -110,7 +124,7 @@ export default class KeyboardNavigatable {
    * Provide a callback that determines whether keyboard input should be handled.
    *
    * @public
-   * @param {Function} callback
+   * @param {KeyboardNavigatable~whenCallback} callback
    * @return {KeyboardNavigatable}
    */
   when(callback) {

--- a/js/src/forum/utils/KeyboardNavigatable.js
+++ b/js/src/forum/utils/KeyboardNavigatable.js
@@ -138,7 +138,7 @@ export default class KeyboardNavigatable {
    */
   navigate(event) {
     // This callback determines whether keyboard should be handled or ignored.
-    if (!this.whenCallback()) return;
+    if (!this.whenCallback(event)) return;
 
     const keyCallback = this.callbacks[event.which];
     if (keyCallback) {

--- a/js/src/forum/utils/KeyboardNavigatable.js
+++ b/js/src/forum/utils/KeyboardNavigatable.js
@@ -81,7 +81,7 @@ export default class KeyboardNavigatable {
       e.stopPropagation();
       e.preventDefault();
       callback(e);
-    }
+    };
 
     return this;
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
This is something I noticed while working on Kilowhat Mailing. I wanted to set an `onSelect` callback, but still allow TABing out of the field when nothing was typed. Because `preventDefault()` is already called before the `onSelect` callback when we set it, the only place I could prevent the event from being prevented (you follow?) was inside the `whenCallback`. But in the `whenCallback` it wasn't possible to know the key that's been pressed.

So I just added a new parameter to the whenCallback. Existing implementations didn't read any parameter so it won't break anything, and new implementations will have the benefit of being able to access the event.

An example implementation can be seen here: https://github.com/kilowhat/flarum-ext-mailing/blob/69fffe46b2b0ea2b07b89acd43d4687e780e6bb4/js/src/forum/components/EmailUserModal.js#L39 Mailing is using its own "FixedKeyboardNavigatable" that just extends the original, changing the same method as I do in this PR.

**Reviewers should focus on:**
I don't see how this could break any existing stuff. I don't even know if any extension (other than Mailing) is using the `KeyboardNavigatable` utility.

**Screenshot**
No visible changes.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
