### PR TITLE
Allow creating access tokens without passing a CSRF token

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -51,6 +51,8 @@ class AdminServiceProvider extends AbstractServiceProvider
             return $routes;
         });
 
+        $this->app->singleton('flarum.admin.csrf-middleware', HttpMiddleware\CheckCsrfToken::class);
+
         $this->app->singleton('flarum.admin.middleware', function (Application $app) {
             $pipe = new MiddlewarePipe;
 
@@ -65,7 +67,7 @@ class AdminServiceProvider extends AbstractServiceProvider
             $pipe->pipe($app->make(HttpMiddleware\StartSession::class));
             $pipe->pipe($app->make(HttpMiddleware\RememberFromCookie::class));
             $pipe->pipe($app->make(HttpMiddleware\AuthenticateWithSession::class));
-            $pipe->pipe($app->make(HttpMiddleware\CheckCsrfToken::class));
+            $pipe->pipe($app->make('flarum.admin.csrf-middleware'));
             $pipe->pipe($app->make(HttpMiddleware\SetLocale::class));
             $pipe->pipe($app->make(Middleware\RequireAdministrateAbility::class));
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -47,6 +47,14 @@ class ApiServiceProvider extends AbstractServiceProvider
             return $routes;
         });
 
+        $this->app->singleton('flarum.api.csrf-middleware', function () {
+            $checkCsrf = $this->app->make(HttpMiddleware\CheckCsrfToken::class);
+
+            $checkCsrf->ignorePath('/token');
+
+            return $checkCsrf;
+        });
+
         $this->app->singleton('flarum.api.middleware', function (Application $app) {
             $pipe = new MiddlewarePipe;
 
@@ -62,7 +70,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             $pipe->pipe($app->make(HttpMiddleware\RememberFromCookie::class));
             $pipe->pipe($app->make(HttpMiddleware\AuthenticateWithSession::class));
             $pipe->pipe($app->make(HttpMiddleware\AuthenticateWithHeader::class));
-            $pipe->pipe($app->make(HttpMiddleware\CheckCsrfToken::class));
+            $pipe->pipe($app->make('flarum.api.csrf-middleware'));
             $pipe->pipe($app->make(HttpMiddleware\SetLocale::class));
 
             event(new ConfigureMiddleware($pipe, 'api'));

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -61,6 +61,8 @@ class ForumServiceProvider extends AbstractServiceProvider
             $this->setDefaultRoute($routes);
         });
 
+        $this->app->singleton('flarum.forum.csrf-middleware', HttpMiddleware\CheckCsrfToken::class);
+
         $this->app->singleton('flarum.forum.middleware', function (Application $app) {
             $pipe = new MiddlewarePipe;
 
@@ -76,7 +78,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             $pipe->pipe($app->make(HttpMiddleware\StartSession::class));
             $pipe->pipe($app->make(HttpMiddleware\RememberFromCookie::class));
             $pipe->pipe($app->make(HttpMiddleware\AuthenticateWithSession::class));
-            $pipe->pipe($app->make(HttpMiddleware\CheckCsrfToken::class));
+            $pipe->pipe($app->make('flarum.forum.csrf-middleware'));
             $pipe->pipe($app->make(HttpMiddleware\SetLocale::class));
             $pipe->pipe($app->make(HttpMiddleware\ShareErrorsFromSession::class));
 

--- a/src/Http/Middleware/CheckCsrfToken.php
+++ b/src/Http/Middleware/CheckCsrfToken.php
@@ -19,9 +19,20 @@ use Psr\Http\Server\RequestHandlerInterface as Handler;
 
 class CheckCsrfToken implements Middleware
 {
+    protected $ignorePaths = [];
+
+    public function ignorePath(string $path)
+    {
+        $this->ignorePaths[] = $path;
+    }
+
     public function process(Request $request, Handler $handler): Response
     {
         if (in_array($request->getMethod(), ['GET', 'HEAD', 'OPTIONS'])) {
+            return $handler->handle($request);
+        }
+
+        if (in_array($request->getUri()->getPath(), $this->ignorePaths)) {
             return $handler->handle($request);
         }
 


### PR DESCRIPTION
Also allows extension to register their own CSRF ignored paths

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1905**

**Changes proposed in this pull request:**
Fixes the linked issue and makes it possible for extension to register their own ignored paths.

**Reviewers should focus on:**
Do we want to expose the middleware itself through a singleton or should we create a new separate class to contain the ignored paths ?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
