### PR TITLE
Visually distinguish post from self and others

### DIFF
--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -39,7 +39,7 @@ export default class Post extends Component {
   view() {
     const attrs = this.attrs();
 
-    attrs.className = 'Post ' + (this.loading ? 'Post--loading ' : '') + (attrs.className || '');
+    attrs.className = 'Post ' + (this.loading ? 'Post--loading ' : '') + (this.props.post.user() === app.session.user ? 'Post--self' : '') + (attrs.className || '');
 
     return (
       <article {...attrs}>

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -202,9 +202,6 @@
 .Post--loading {
   opacity: 0.5;
 }
-.Post--self {
-  border-left: solid @config-primary-color;
-}
 .PostMeta {
   display: inline;
 }

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -202,6 +202,9 @@
 .Post--loading {
   opacity: 0.5;
 }
+.Post--self {
+  border: solid @config-primary-color;
+}
 .PostMeta {
   display: inline;
 }

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -203,7 +203,7 @@
   opacity: 0.5;
 }
 .Post--self {
-  border: solid @config-primary-color;
+  border-left: solid @config-primary-color;
 }
 .PostMeta {
   display: inline;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Relates to #169**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This pull request adds an indication as to whether a post is by the user currently browsing the discussion, creating a visual difference between other users posts.

**Reviewers should focus on:**
- Code Quality
- Not sure if the LESS changes are in correct location in file
- Not sure if theirs a better way in JS to detect current user vs the post user

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/3457368/68065243-da8ad300-fcfc-11e9-8809-3fb07ffd41cc.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.

