### PR TITLE
Some improvements to request error handling and modal error formatting

### DIFF
--- a/js/src/common/components/RequestErrorModal.js
+++ b/js/src/common/components/RequestErrorModal.js
@@ -6,16 +6,26 @@ export default class RequestErrorModal extends Modal {
   }
 
   title() {
-    return this.props.error.xhr ? this.props.error.xhr.status + ' ' + this.props.error.xhr.statusText : '';
+    return this.props.error.xhr ? `${this.props.error.xhr.status} ${this.props.error.xhr.statusText}` : '';
   }
 
   content() {
+    const { error, formattedError } = this.props;
+
     let responseText;
 
-    try {
-      responseText = JSON.stringify(JSON.parse(this.props.error.responseText), null, 2);
-    } catch (e) {
-      responseText = this.props.error.responseText;
+    // If the error is already formatted, just add line endings;
+    // else try to parse it as JSON and stringify it with indentation
+    if (formattedError) {
+      responseText = formattedError.join('\n\n');
+    } else {
+      try {
+        const json = error.response || JSON.parse(error.responseText);
+
+        responseText = JSON.stringify(json, null, 2);
+      } catch (e) {
+        responseText = error.responseText;
+      }
     }
 
     return (


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Only show error(s) detail in debug modal, if found
- Log the request URL, method, status, and response
  - Only logs error(s) detail if found, else it logs the whole error object
  - Logs with a group so the error data can be hidden

**Reviewers should focus on:**
The alert appearing was causing the modal to "close" but the background overlay remained... not sure if that's a bug or intended (?) so I closed the currently opened modal - though I don't think want to do that.

**Screenshot**
<details>
<summary>POST /api/flags 404</summary>

![image](https://user-images.githubusercontent.com/6401250/68529931-abaec700-02d1-11ea-87aa-eff10831a5ac.png)
![image](https://user-images.githubusercontent.com/6401250/68529942-c84aff00-02d1-11ea-9d34-2ec850406788.png)
![image](https://user-images.githubusercontent.com/6401250/68529946-d26cfd80-02d1-11ea-9493-4d7ff69ddc47.png)
</details>
<details>
<summary>POST /flags 404</summary>

![image](https://user-images.githubusercontent.com/6401250/68529962-faf4f780-02d1-11ea-8adc-3f9dd92d7661.png)
![image](https://user-images.githubusercontent.com/6401250/68529960-f4668000-02d1-11ea-8f82-c49e1ea5becd.png)
</details>

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~

