### PR TITLE
Queue command fixes

### DIFF
--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -33,7 +33,7 @@ class QueueServiceProvider extends AbstractServiceProvider
         Commands\ForgetFailedCommand::class,
         Console\ListenCommand::class,
         Commands\ListFailedCommand::class,
-//        Commands\RestartCommand::class,
+        Commands\RestartCommand::class,
         Commands\RetryCommand::class,
         Commands\WorkCommand::class,
     ];
@@ -86,6 +86,11 @@ class QueueServiceProvider extends AbstractServiceProvider
                 public function driver()
                 {
                     return $this->app['cache.store'];
+                }
+
+                public function __call($name, $arguments)
+                {
+                    return call_user_func_array([$this->driver(), $name], $arguments);
                 }
             };
         });


### PR DESCRIPTION
**Fixes #1879 **

**Changes proposed in this pull request:**

Allowed pass through of forever (and any other method) to the cache driver to fix the queue:restart command.

The queue:listen command already works.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
