### PR TITLE
Add permission to bypass throttling

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -210,6 +210,12 @@ export default class PermissionGrid extends Component {
       permission: 'discussion.delete'
     }, 80);
 
+    items.add('postWithoutThrottle', {
+      icon: 'fas fa-swimmer',
+      label: app.translator.trans('core.admin.permissions.post_without_throttle_label'),
+      permission: 'postWithoutThrottle'
+    }, 70);
+
     items.add('editPosts', {
       icon: 'fas fa-pencil-alt',
       label: app.translator.trans('core.admin.permissions.edit_posts_label'),
@@ -233,7 +239,7 @@ export default class PermissionGrid extends Component {
       label: app.translator.trans('core.admin.permissions.edit_users_label'),
       permission: 'user.edit'
     }, 60);
-    
+
     return items;
   }
 

--- a/src/Post/Floodgate.php
+++ b/src/Post/Floodgate.php
@@ -33,6 +33,10 @@ class Floodgate
      */
     public function assertNotFlooding(User $actor)
     {
+        if ($actor->can('postWithoutThrottle')) {
+            return;
+        }
+
         if ($this->isFlooding($actor)) {
             throw new FloodingException;
         }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1255**.
**Continues #1586**.

- Permission is called `floodgate.postWithoutThrottle`
  - Should it go under "moderation" instead? Seems to be more of a utility for those with power than normal members... 
  - Should there be a different permission for starting discussions?  

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).

**Required changes:**

- [ ] Related core extension PRs: flarum/english (not done yet, waiting for confirmation)
