### PR TITLE
history back function fix

### DIFF
--- a/js/src/forum/utils/History.js
+++ b/js/src/forum/utils/History.js
@@ -92,7 +92,7 @@ export default class History {
 
     this.stack.pop();
 
-    this.canGoBack() ? m.route(this.getCurrent().url) : this.home();
+    m.route(this.getCurrent().url);
   }
 
   /**


### PR DESCRIPTION
it shouldn't check for canGoBack again after the array pop()

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

posted it yesterday to:
https://discuss.flarum.org/d/22045-bug-back-button-on-mobile-always-returns-to-all-discussions-page

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.

**Required changes:**

