### PR TITLE
update postStreamScrubber

### DIFF
--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -198,6 +198,7 @@ export default class PostStreamScrubber extends Component {
     let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';
+    let indexUpdated = false;
 
     // Now loop through each of the items in the discussion. An 'item' is
     // either a single post or a 'gap' of one or more posts that haven't
@@ -223,8 +224,9 @@ export default class PostStreamScrubber extends Component {
       const visibleBottom = Math.min(height, viewportTop + viewportHeight - top);
       const visiblePost = visibleBottom - visibleTop;
 
-      if (top <= viewportTop) {
+      if (!indexUpdated) {
         index = parseFloat($this.data('index')) + visibleTop / height;
+        indexUpdated = true;
       }
 
       if (visiblePost > 0) {


### PR DESCRIPTION
fixes the scrubber in the case that posts have margins

**Fixes #0000**

Fixes the scrubber in case posts have margins.

**Changes proposed in this pull request:**

The check "top <= viewportTop" is not necessary. it's sufficient to take the index from the first item that passed the previous checks. it's the postStream-item that is first visible in the viewport.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

