### PR TITLE
Fix PostStreamScrubber click

### DIFF
--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -424,7 +424,7 @@ export default class PostStreamScrubber extends Component {
     // 1. Get the offset of the click from the top of the scrollbar, as a
     //    percentage of the scrollbar's height.
     const $scrollbar = this.$('.Scrubber-scrollbar');
-    const offsetPixels = (e.clientY || e.originalEvent.touches[0].clientY) - $scrollbar.offset().top + $('body').scrollTop();
+    const offsetPixels = (e.pageY || e.originalEvent.touches[0].pageY) - $scrollbar.offset().top + $('body').scrollTop();
     let offsetPercent = offsetPixels / $scrollbar.outerHeight() * 100;
 
     // 2. We want the handle of the scrollbar to end up centered on the click


### PR DESCRIPTION
### Fixes a bug. To replicate:
Go to any discussion on the desktop version, f.e. https://discuss.flarum.org/d/187-word-association-game
Click on the scrubber scrollbar, when it is not on the first position. Instead of the clicked position it will jump back to the first position. 

**Changes proposed in this pull request:**

This is because $scrollbar.offset().top adjusts based on the scrolled position, while clientY of the mouseevent is independent of the scrolled position. Use pageY instead.

Shouldn't affect mobile, since there's no click functionality there.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

