### PR TITLE
Fix UpdateHandler BasePath

### DIFF
--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -92,6 +92,7 @@ class InstalledApp implements AppInterface
     private function getUpdaterHandler()
     {
         $pipe = new MiddlewarePipe;
+        $pipe->pipe(new BasePath($this->basePath()));
         $pipe->pipe(
             new DispatchRoute($this->container->make('flarum.update.routes'))
         );


### PR DESCRIPTION
**Fixes #0000**
Fixes Error:
Calling UpdateHandler causes RouteNotFoundException when basepath is not /. 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).

