### PR TITLE
Fix showLanguageSelector reverting to ON whenever BasicsPage is visited

### DIFF
--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -33,7 +33,7 @@ export default class BasicsPage extends Page {
       this.localeOptions[i] = `${locales[i]} (${i})`;
     }
 
-    if (typeof this.values.show_language_selector() !== "number") this.values.show_language_selector(1);
+    if (typeof settings['show_language_selector'] !== "number") this.values.show_language_selector(1);
   }
 
   view() {


### PR DESCRIPTION
The showLanguageSelector reverts to ON state everytime the BasicsPage is visited and saved.

It seems to be a line in BasicsPage which check whether the show_language_selector value is a number, but since it is assigned as m.prop(settings['show_language_selector']) it will always be a function type.

This PR fixes the check to be directly on the settings object where the number is stored.