### PR TITLE
[WIP] dismiss translation files of extensions not installed

### DIFF
--- a/src/Extend/LanguagePack.php
+++ b/src/Extend/LanguagePack.php
@@ -11,6 +11,7 @@ namespace Flarum\Extend;
 
 use DirectoryIterator;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 use Flarum\Locale\LocaleManager;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
@@ -49,13 +50,13 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
 
         $container->resolving(
             LocaleManager::class,
-            function (LocaleManager $locales) use ($extension, $locale, $title) {
-                $this->registerLocale($locales, $extension, $locale, $title);
+            function (LocaleManager $locales) use ($extension, $locale, $title, $container) {
+                $this->registerLocale($container, $locales, $extension, $locale, $title);
             }
         );
     }
 
-    private function registerLocale(LocaleManager $locales, Extension $extension, $locale, $title)
+    private function registerLocale(Container $container, LocaleManager $locales, Extension $extension, $locale, $title)
     {
         $locales->addLocale($locale, $title);
 
@@ -75,8 +76,15 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
             $locales->addCssFile($locale, $file);
         }
 
+        /** @var ExtensionManager $extensions */
+        $extensions = $container->make(ExtensionManager::class);
+
         foreach (new DirectoryIterator($directory) as $file) {
-            if ($file->isFile() && in_array($file->getExtension(), ['yml', 'yaml'])) {
+            $slug = $file->getBasename(".{$file->getExtension()}");
+
+            if ($file->isFile()
+                && in_array($file->getExtension(), ['yml', 'yaml'])
+                && (strstr($slug, '-') || $extensions->isEnabled($slug))) {
                 $locales->addTranslations($locale, $file->getPathname());
             }
         }


### PR DESCRIPTION

**Fixes #1837**

**Changes proposed in this pull request:**

If I'm not mistaken, this PR is an easy implementation to ignore translation files for extensions not installed. It will however re-read them every time the translation cache files are updated. In addition one can still force files into the translator if one has to.

**Reviewers should focus on:**

Is this okay?

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [ ] Backend changes: tests are green (run `composer test`).
