### PR TITLE
Get translations from fallback catalogues

### DIFF
--- a/src/Frontend/AddTranslations.php
+++ b/src/Frontend/AddTranslations.php
@@ -55,6 +55,7 @@ class AddTranslations
     {
         $catalogue = $this->locales->getTranslator()->getCatalogue($locale);
         $translations = $catalogue->all('messages');
+
         while ($catalogue = $catalogue->getFallbackCatalogue()) {
             $translations = array_replace($catalogue->all('messages'), $translations);
         }

--- a/src/Frontend/AddTranslations.php
+++ b/src/Frontend/AddTranslations.php
@@ -53,7 +53,11 @@ class AddTranslations
 
     private function getTranslations(string $locale)
     {
-        $translations = $this->locales->getTranslator()->getCatalogue($locale)->all('messages');
+        $catalogue = $this->locales->getTranslator()->getCatalogue($locale);
+        $translations = $catalogue->all('messages');
+        while ($catalogue = $catalogue->getFallbackCatalogue()) {
+            $translations = array_replace($catalogue->all('messages'), $translations);
+        }        
 
         return Arr::only(
             $translations,

--- a/src/Frontend/AddTranslations.php
+++ b/src/Frontend/AddTranslations.php
@@ -57,7 +57,7 @@ class AddTranslations
         $translations = $catalogue->all('messages');
         while ($catalogue = $catalogue->getFallbackCatalogue()) {
             $translations = array_replace($catalogue->all('messages'), $translations);
-        }        
+        }
 
         return Arr::only(
             $translations,


### PR DESCRIPTION
**Fixes #1774**

**Changes proposed in this pull request:**
Compute the front-end translations by combining the messages with the entries of the fallback catalogue(s), see [Symfony documentation](https://symfony.com/doc/current/components/translation/usage.html#retrieving-the-message-catalog).

**Reviewers should focus on:**
The initialization of the fallback catalogue(s) has not been verified since it apparently works as expected (at least in my environment). Maybe this needs to be double-checked.

**Screenshot**
_(A language other than English needs to be selected to let the fallback catalogue take effect.)_
Current:
![image](https://user-images.githubusercontent.com/2153728/71732149-d25b2b00-2e46-11ea-83dc-bd4cb12172aa.png)
Fixed:
![image](https://user-images.githubusercontent.com/2153728/71732355-544b5400-2e47-11ea-86be-034fe770f3be.png)


**Confirmed**

- [ ] ~Frontend changes: tested on a local Flarum installation.~
- [x] Backend changes: tests are green (run `composer test`).
