### PR TITLE
(#845) Hide permission groups

### DIFF
--- a/js/src/admin/components/EditGroupModal.js
+++ b/js/src/admin/components/EditGroupModal.js
@@ -3,7 +3,7 @@ import Button from '../../common/components/Button';
 import Badge from '../../common/components/Badge';
 import Group from '../../common/models/Group';
 import ItemList from '../../common/utils/ItemList';
-import Checkbox from '../../common/components/Checkbox';
+import Switch from '../../common/components/Switch';
 
 /**
  * The `EditGroupModal` component shows a modal dialog which allows the user
@@ -69,15 +69,22 @@ export default class EditGroupModal extends Modal {
       <input className="FormControl" placeholder="fas fa-bolt" value={this.icon()} oninput={m.withAttr('value', this.icon)}/>
     </div>, 10);
 
-
     items.add('hidden', <div className="Form-group">
-      <div>
-        <label className="checkbox">
-          <input type="checkbox" value="1" checked={this.isHidden()} onChange={m.withAttr('checked', this.isHidden)}/>
-          {app.translator.trans('core.admin.edit_group.hide_label')}
-        </label>
-      </div>
+      {Switch.component({
+        state: !!Number(this.isHidden()),
+        children: app.translator.trans('core.admin.edit_group.hide_label'),
+        onchange: this.isHidden
+      })}
     </div>, 10);
+
+    // items.add('hidden', <div className="Form-group">
+    //   <div>
+    //     <label className="checkbox">
+    //       <input type="checkbox" value="1" checked={this.isHidden()} onChange={m.withAttr('checked', this.isHidden)}/>
+    //       {app.translator.trans('core.admin.edit_group.hide_label')}
+    //     </label>
+    //   </div>
+    // </div>, 10);
 
     items.add('submit', <div className="Form-group">
       {Button.component({

--- a/js/src/admin/components/EditGroupModal.js
+++ b/js/src/admin/components/EditGroupModal.js
@@ -77,15 +77,6 @@ export default class EditGroupModal extends Modal {
       })}
     </div>, 10);
 
-    // items.add('hidden', <div className="Form-group">
-    //   <div>
-    //     <label className="checkbox">
-    //       <input type="checkbox" value="1" checked={this.isHidden()} onChange={m.withAttr('checked', this.isHidden)}/>
-    //       {app.translator.trans('core.admin.edit_group.hide_label')}
-    //     </label>
-    //   </div>
-    // </div>, 10);
-
     items.add('submit', <div className="Form-group">
       {Button.component({
         type: 'submit',

--- a/js/src/admin/components/EditGroupModal.js
+++ b/js/src/admin/components/EditGroupModal.js
@@ -3,6 +3,7 @@ import Button from '../../common/components/Button';
 import Badge from '../../common/components/Badge';
 import Group from '../../common/models/Group';
 import ItemList from '../../common/utils/ItemList';
+import Checkbox from '../../common/components/Checkbox';
 
 /**
  * The `EditGroupModal` component shows a modal dialog which allows the user
@@ -16,6 +17,7 @@ export default class EditGroupModal extends Modal {
     this.namePlural = m.prop(this.group.namePlural() || '');
     this.icon = m.prop(this.group.icon() || '');
     this.color = m.prop(this.group.color() || '');
+    this.isHidden = m.prop(this.group.isHidden() || false);
   }
 
   className() {
@@ -67,6 +69,16 @@ export default class EditGroupModal extends Modal {
       <input className="FormControl" placeholder="fas fa-bolt" value={this.icon()} oninput={m.withAttr('value', this.icon)}/>
     </div>, 10);
 
+
+    items.add('hidden', <div className="Form-group">
+      <div>
+        <label className="checkbox">
+          <input type="checkbox" value="1" checked={this.isHidden()} onChange={m.withAttr('checked', this.isHidden)}/>
+          {app.translator.trans('core.admin.edit_group.hide_label')}
+        </label>
+      </div>
+    </div>, 10);
+
     items.add('submit', <div className="Form-group">
       {Button.component({
         type: 'submit',
@@ -89,7 +101,8 @@ export default class EditGroupModal extends Modal {
       nameSingular: this.nameSingular(),
       namePlural: this.namePlural(),
       color: this.color(),
-      icon: this.icon()
+      icon: this.icon(),
+      isHidden: this.isHidden()
     };
   }
 

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -91,6 +91,12 @@ export default class PermissionGrid extends Component {
       allowGuest: true
     }, 100);
 
+    items.add('viewHiddenGroups', {
+      icon: 'fas fa-users',
+      label: app.translator.trans('core.admin.permissions.view_hidden_groups_list_label'),
+      permission: 'viewHiddenGroups',
+    }, 100);
+
     items.add('viewUserList', {
       icon: 'fas fa-users',
       label: app.translator.trans('core.admin.permissions.view_user_list_label'),

--- a/js/src/common/models/Group.js
+++ b/js/src/common/models/Group.js
@@ -6,7 +6,8 @@ Object.assign(Group.prototype, {
   nameSingular: Model.attribute('nameSingular'),
   namePlural: Model.attribute('namePlural'),
   color: Model.attribute('color'),
-  icon: Model.attribute('icon')
+  icon: Model.attribute('icon'),
+  isHidden: Model.attribute('isHidden')
 });
 
 Group.ADMINISTRATOR_ID = '1';

--- a/migrations/2020_01_14_130500_change_permission_groups_add_is_hidden.php
+++ b/migrations/2020_01_14_130500_change_permission_groups_add_is_hidden.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('groups', [
+    'is_hidden' => ['boolean', 'default' => 0]
+]);

--- a/migrations/2020_01_14_130500_change_permission_groups_add_is_hidden.php
+++ b/migrations/2020_01_14_130500_change_permission_groups_add_is_hidden.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-
 use Flarum\Database\Migration;
 
 return Migration::addColumns('groups', [

--- a/src/Api/Controller/ListGroupsController.php
+++ b/src/Api/Controller/ListGroupsController.php
@@ -26,6 +26,8 @@ class ListGroupsController extends AbstractListController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        return Group::all();
+        $actor = $request->getAttribute('actor');
+
+        return Group::whereVisibleTo($actor)->get();
     }
 }

--- a/src/Api/Serializer/BasicUserSerializer.php
+++ b/src/Api/Serializer/BasicUserSerializer.php
@@ -45,6 +45,10 @@ class BasicUserSerializer extends AbstractSerializer
      */
     protected function groups($user)
     {
-        return $this->hasMany($user, GroupSerializer::class);
+        if ($this->getActor()->can('viewHiddenGroups')) {
+            return $this->hasMany($user, GroupSerializer::class);
+        }
+
+        return $this->hasMany($user, GroupSerializer::class, 'visibleGroups');
     }
 }

--- a/src/Api/Serializer/GroupSerializer.php
+++ b/src/Api/Serializer/GroupSerializer.php
@@ -52,6 +52,7 @@ class GroupSerializer extends AbstractSerializer
             'namePlural'   => $this->translateGroupName($group->name_plural),
             'color'        => $group->color,
             'icon'         => $group->icon,
+            'isHidden'     => $group->is_hidden
         ];
     }
 

--- a/src/Group/Command/CreateGroupHandler.php
+++ b/src/Group/Command/CreateGroupHandler.php
@@ -55,7 +55,7 @@ class CreateGroupHandler
             Arr::get($data, 'attributes.namePlural'),
             Arr::get($data, 'attributes.color'),
             Arr::get($data, 'attributes.icon'),
-            Arr::get($data, 'attributes.isHidden')
+            Arr::get($data, 'attributes.isHidden', false)
         );
 
         $this->events->dispatch(

--- a/src/Group/Command/CreateGroupHandler.php
+++ b/src/Group/Command/CreateGroupHandler.php
@@ -54,7 +54,8 @@ class CreateGroupHandler
             Arr::get($data, 'attributes.nameSingular'),
             Arr::get($data, 'attributes.namePlural'),
             Arr::get($data, 'attributes.color'),
-            Arr::get($data, 'attributes.icon')
+            Arr::get($data, 'attributes.icon'),
+            Arr::get($data, 'attributes.isHidden')
         );
 
         $this->events->dispatch(

--- a/src/Group/Command/EditGroupHandler.php
+++ b/src/Group/Command/EditGroupHandler.php
@@ -74,6 +74,10 @@ class EditGroupHandler
             $group->icon = $attributes['icon'];
         }
 
+        if (isset($attributes['isHidden'])) {
+            $group->is_hidden = $attributes['isHidden'];
+        }
+
         $this->events->dispatch(
             new Saving($group, $actor, $data)
         );

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -73,9 +73,10 @@ class Group extends AbstractModel
      * @param string $namePlural
      * @param string $color
      * @param string $icon
+     * @param bool   $isHidden
      * @return static
      */
-    public static function build(string $nameSingular, string $namePlural, string $color, string $icon, bool $isHidden = false): self
+    public static function build($nameSingular, $namePlural, $color = null, $icon = null, bool $isHidden = false): self
     {
         $group = new static;
 

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -23,6 +23,7 @@ use Flarum\User\User;
  * @property string $name_plural
  * @property string|null $color
  * @property string|null $icon
+ * @property bool $is_hidden
  * @property \Illuminate\Database\Eloquent\Collection $users
  * @property \Illuminate\Database\Eloquent\Collection $permissions
  */
@@ -74,7 +75,7 @@ class Group extends AbstractModel
      * @param string $icon
      * @return static
      */
-    public static function build($nameSingular, $namePlural, $color, $icon)
+    public static function build(string $nameSingular, string $namePlural, string $color, string $icon, bool $isHidden = false): Group
     {
         $group = new static;
 
@@ -82,6 +83,7 @@ class Group extends AbstractModel
         $group->name_plural = $namePlural;
         $group->color = $color;
         $group->icon = $icon;
+        $group->is_hidden = $isHidden;
 
         $group->raise(new Created($group));
 

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -75,7 +75,7 @@ class Group extends AbstractModel
      * @param string $icon
      * @return static
      */
-    public static function build(string $nameSingular, string $namePlural, string $color, string $icon, bool $isHidden = false): Group
+    public static function build(string $nameSingular, string $namePlural, string $color, string $icon, bool $isHidden = false): self
     {
         $group = new static;
 

--- a/src/Group/GroupPolicy.php
+++ b/src/Group/GroupPolicy.php
@@ -11,6 +11,7 @@ namespace Flarum\Group;
 
 use Flarum\User\AbstractPolicy;
 use Flarum\User\User;
+use Illuminate\Database\Eloquent\Builder;
 
 class GroupPolicy extends AbstractPolicy
 {
@@ -28,6 +29,17 @@ class GroupPolicy extends AbstractPolicy
     {
         if ($actor->hasPermission('group.'.$ability)) {
             return true;
+        }
+    }
+
+    /**
+     * @param User $actor
+     * @param Builder $query
+     */
+    public function find(User $actor, Builder $query)
+    {
+        if ($actor->cannot('viewHiddenGroups')) {
+            $query->where('is_hidden', false);
         }
     }
 }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -606,6 +606,11 @@ class User extends AbstractModel
         return $this->belongsToMany(Group::class);
     }
 
+    public function visibleGroups()
+    {
+        return $this->belongsToMany(Group::class)->where('is_hidden', false);
+    }
+
     /**
      * Define the relationship with the user's notifications.
      *

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -18,8 +18,6 @@ class ListTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
 
-    protected $controller = ListGroupsController::class;
-
     public function setUp()
     {
         parent::setUp();
@@ -59,8 +57,11 @@ class ListTest extends TestCase
      */
     public function shows_index_for_admin()
     {
-        $this->actor = User::find(1);
-        $response = $this->callWith();
+        $response = $this->send(
+            $this->request('GET', '/api/groups', [
+                'authenticatedAs' => 1,
+            ])
+        );
 
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -14,10 +14,31 @@ use Flarum\Tests\integration\TestCase;
 
 class ListTest extends TestCase
 {
+    protected $controller = ListGroupsController::class;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->adminUser(),
+                $this->normalUser(),
+            ],
+            'groups' => [
+                $this->adminGroup(),
+                $this->hiddenGroup()
+            ],
+            'group_user' => [
+                ['user_id' => 1, 'group_id' => 1],
+            ],
+        ]);
+    }
+
     /**
      * @test
      */
-    public function shows_index_for_guest()
+    public function shows_limited_index_for_guest()
     {
         $response = $this->send(
             $this->request('GET', '/api/groups')
@@ -26,6 +47,33 @@ class ListTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode($response->getBody()->getContents(), true);
 
+        $this->assertEquals(Group::where('is_hidden', 0)->count(), count($data['data']));
+    }
+
+
+    /**
+     * @test
+     */
+    public function shows_index_for_admin()
+    {
+        $this->actor = $this->adminUser();
+        $response = $this->callWith();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody()->getContents(), true);
+
         $this->assertEquals(Group::count(), count($data['data']));
+    }
+
+    protected function hiddenGroup(): array
+    {
+        return [
+            'id' => 10,
+            'name_singular' => 'Hidden',
+            'name_plural' => 'Ninjas',
+            'color' => null,
+            'icon' => 'fas fa-wrench',
+            'is_hidden' => 1
+        ];
     }
 }

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -50,7 +50,6 @@ class ListTest extends TestCase
         $this->assertEquals(Group::where('is_hidden', 0)->count(), count($data['data']));
     }
 
-
     /**
      * @test
      */

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -10,11 +10,14 @@
 namespace Flarum\Tests\integration\api\groups;
 
 use Flarum\Group\Group;
+use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
 use Flarum\User\User;
 
 class ListTest extends TestCase
 {
+    use RetrievesAuthorizedUsers;
+
     protected $controller = ListGroupsController::class;
 
     public function setUp()

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\api\groups;
 
 use Flarum\Group\Group;
 use Flarum\Tests\integration\TestCase;
+use Flarum\User\User;
 
 class ListTest extends TestCase
 {
@@ -55,7 +56,7 @@ class ListTest extends TestCase
      */
     public function shows_index_for_admin()
     {
-        $this->actor = $this->adminUser();
+        $this->actor = User::find(1);
         $response = $this->callWith();
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/integration/api/groups/ListTest.php
+++ b/tests/integration/api/groups/ListTest.php
@@ -12,7 +12,6 @@ namespace Flarum\Tests\integration\api\groups;
 use Flarum\Group\Group;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
-use Flarum\User\User;
 
 class ListTest extends TestCase
 {


### PR DESCRIPTION
~~I have been unable to get the admin checkbox to work, even though it exactly resembles the one from the Tag extension. Help appreciated.~~ Fixed.

For reviewers:

- Is this approach okay? Alternative suggestions?

**Fixes #845**

- added permission
- changed serializer
- created column
- modified policy

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related core extension PRs: https://github.com/flarum/lang-english/pull/153
