### PR TITLE
Rename dead is_activated references with the new is_email_confirmed

### DIFF
--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -71,7 +71,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
 
         $this->assertRegistered($actor);
 
-        if ($actor->id != $id || $actor->is_activated) {
+        if ($actor->id != $id || $actor->is_email_confirmed) {
             throw new PermissionDeniedException;
         }
 

--- a/src/User/Command/ConfirmEmailHandler.php
+++ b/src/User/Command/ConfirmEmailHandler.php
@@ -44,9 +44,7 @@ class ConfirmEmailHandler
         $user = $token->user;
         $user->changeEmail($token->email);
 
-        if (! $user->is_activated) {
-            $user->activate();
-        }
+        $user->activate();
 
         $user->save();
         $this->dispatchEventsFor($user);

--- a/tests/integration/api/users/CreationTest.php
+++ b/tests/integration/api/users/CreationTest.php
@@ -111,7 +111,7 @@ class CreationTest extends TestCase
         /** @var User $user */
         $user = User::where('username', 'test')->firstOrFail();
 
-        $this->assertEquals(0, $user->is_activated);
+        $this->assertEquals(0, $user->is_email_confirmed);
         $this->assertEquals('test', $user->username);
         $this->assertEquals('test@machine.local', $user->email);
     }


### PR DESCRIPTION
I noticed this today while browsing the source code. Something that wasn't renamed correctly.

A user was able to continue sending email confirmation emails to themselves via the API even after they had confirmed their account.

The incorrect test in ConfirmEmailHandler was redundant and the correct test is already made inside the activate() method. I removed that condition. Because of that redundancy I believe it was continuing to work as intended.

It was also wrong in one of the tests, but whether the correct or incorrect column is used the tests pass.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
