### PR TITLE
Fix the "reply posted" alert empty body

### DIFF
--- a/js/src/forum/components/ReplyComposer.js
+++ b/js/src/forum/components/ReplyComposer.js
@@ -102,7 +102,7 @@ export default class ReplyComposer extends ComposerBody {
           app.alerts.show(
             alert = new Alert({
               type: 'success',
-              message: app.translator.trans('core.forum.composer_reply.posted_message'),
+              children: app.translator.trans('core.forum.composer_reply.posted_message'),
               controls: [viewButton]
             })
           );


### PR DESCRIPTION
An issue I noticed today. The text for the "reply posted" alert wasn't visible because an incorrect key was used. This alert is visible when you post a reply but you are lo longer on the discussion page.

**Screenshot**

Before fix:

![Capture d’écran - 2020-01-25 à 21 09 58](https://user-images.githubusercontent.com/5264300/73127144-58890e00-3fbc-11ea-974b-b6bcfa3ca386.png)

After fix:

![Capture d’écran - 2020-01-25 à 21 11 49](https://user-images.githubusercontent.com/5264300/73127145-5a52d180-3fbc-11ea-9e3a-e02f6acb2297.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.