### PR TITLE
Make AbstractPolicy compatible with both object and class as $model

### DIFF
--- a/src/User/AbstractPolicy.php
+++ b/src/User/AbstractPolicy.php
@@ -35,7 +35,7 @@ abstract class AbstractPolicy
      */
     public function getPermission(GetPermission $event)
     {
-        if (! $event->model instanceof $this->model) {
+        if (! $event->model instanceof $this->model && $event->model !== $this->model) {
             return;
         }
 

--- a/tests/unit/User/AbstractPolicyTest.php
+++ b/tests/unit/User/AbstractPolicyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\User;
+
+use Flarum\Event\GetPermission;
+use Flarum\Tests\unit\TestCase;
+use Flarum\User\User;
+use Illuminate\Events\Dispatcher;
+use Mockery as m;
+
+class AbstractPolicyTest extends TestCase
+{
+    private $policy;
+    private $dispatcher;
+
+    public function setUp()
+    {
+        $this->policy = m::mock(UserPolicy::class)->makePartial();
+        $this->dispatcher = new Dispatcher();
+        $this->dispatcher->subscribe($this->policy);
+        User::setEventDispatcher($this->dispatcher);
+    }
+
+    public function test_policy_can_be_called_with_object()
+    {
+        $this->policy->shouldReceive('edit')->andReturn(true);
+
+        $allowed = $this->dispatcher->until(new GetPermission(new User(), 'edit', new User()));
+
+        $this->assertTrue($allowed);
+    }
+
+    public function test_policy_can_be_called_with_class()
+    {
+        $this->policy->shouldReceive('create')->andReturn(true);
+
+        $allowed = $this->dispatcher->until(new GetPermission(new User(), 'create', User::class));
+
+        $this->assertTrue($allowed);
+    }
+}

--- a/tests/unit/User/UserPolicy.php
+++ b/tests/unit/User/UserPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\User;
+
+use Flarum\User\AbstractPolicy;
+use Flarum\User\User;
+
+class UserPolicy extends AbstractPolicy
+{
+    protected $model = User::class;
+
+    public function create(User $actor)
+    {
+        return true;
+    }
+
+    public function edit(User $actor, User $user)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Extensions were previously unable to use class name -based gate calls on policies that extend `AbstractPolicy`. For example calling `$user->can('create', YourOwnModel::class)` was never calling the `create` method defined in the policy. This PR adds the missing check to support that syntax.

I have also added unit tests. I'm not sure where we want to put the test Policy that's required for the test. I'm using the `User` model as the policy target, but we could use any model, including one created only for the tests.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).

