### PR TITLE
Add disabled prop to the Select component

### DIFF
--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -8,14 +8,15 @@ import icon from '../helpers/icon';
  * - `options` A map of option values to labels.
  * - `onchange` A callback to run when the selected value is changed.
  * - `value` The value of the selected option.
+ * - `disabled` Disabled state for the input.
  */
 export default class Select extends Component {
   view() {
-    const {options, onchange, value} = this.props;
+    const {options, onchange, value, disabled} = this.props;
 
     return (
       <span className="Select">
-        <select className="Select-input FormControl" onchange={onchange ? m.withAttr('value', onchange.bind(this)) : undefined} value={value}>
+        <select className="Select-input FormControl" onchange={onchange ? m.withAttr('value', onchange.bind(this)) : undefined} value={value} disabled={disabled}>
           {Object.keys(options).map(key => <option value={key}>{options[key]}</option>)}
         </select>
         {icon('fas fa-sort', {className: 'Select-caret'})}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add ability to mark a `Select` component disabled. There's no special style, it just marks the underlying `<select>` disabled, which was previously not possible.

**Screenshot**

![image](https://user-images.githubusercontent.com/5264300/73127342-01386d00-3fbf-11ea-94d1-e7faa85130f3.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
