### PR TITLE
Support PHP 7.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3]
+        php: [7.1, 7.2, 7.3, 7.4]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -31,6 +31,12 @@ jobs:
             service: 'mysql:5.7'
             prefix: flarum_
           - php: 7.2
+            service: mariadb
+            prefix: flarum_
+          - php: 7.3
+            service: 'mysql:5.7'
+            prefix: flarum_
+          - php: 7.3
             service: mariadb
             prefix: flarum_
 

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "middlewares/request-handler": "^1.2",
         "monolog/monolog": "^1.16.0",
         "nikic/fast-route": "^0.6",
-        "oyejorge/less.php": "^1.7",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
@@ -67,7 +66,8 @@
         "symfony/event-dispatcher": "^4.3.2",
         "symfony/translation": "^3.3",
         "symfony/yaml": "^3.3",
-        "tobscure/json-api": "^0.3.0"
+        "tobscure/json-api": "^0.3.0",
+        "wikimedia/less.php": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -108,7 +108,10 @@ class UninstalledSite implements SiteInterface
                 'lifetime' => 120,
                 'files' => $this->paths['storage'].'/sessions',
                 'cookie' => 'session'
-            ]
+            ],
+            'view' => [
+                'paths' => [],
+            ],
         ]);
     }
 


### PR DESCRIPTION
**Fixes #1980**

This fixes two issues in some of our dependencies, that caused problems when installing Flarum on a PHP 7.4 system. We only encountered deprecation warnings - which were either shown or not, depending on the system's configured error reporting level.

- Switch to Wikimedia's fork of less.php
- Work around an issue in Laravel (the "old" version we use is no longer supported)