### PR TITLE
fix: icon alignment for tag modal

### DIFF
--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -111,6 +111,13 @@
   padding: 20px;
   text-align: center;
   color: @muted-color;
+
+  .icon {
+    position: relative;
+    top: 2px;
+    width: 16px;
+    text-align: center;
+  }
 }
 .Modal-loading {
   position: absolute;
@@ -128,13 +135,6 @@
     opacity: 1;
     pointer-events: auto;
   }
-}
-
-.icon {
-  position: relative;
-  top: 2px;
-  width: 16px;
-  text-align: center;
 }
 
 @media @phone {

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -130,6 +130,12 @@
   }
 }
 
+.icon {
+  position: relative;
+  top: 2px;
+  width: 16px;
+  text-align: center;
+}
 
 @media @phone {
   .ModalManager.fade {


### PR DESCRIPTION
**Changes proposed in this pull request:**
The alignment of the Font Awesome icons in the tag selection modal is all over the place (and it also affects the alignment of the "Tag name" and "Tag description" rows in the same modal. Both, horizontal and vertical alignment is chaotic. This PR fixes the horizontal alignment by giving icons a specific width. It also visually improves the vertical alignment by giving the icons a little top-offset (however this is very much dependent on the specific icon, and impossible to get right for all icons).

**Screenshot**
Before:
<img width="699" alt="Screenshot 2020-02-13 12 19 42" src="https://user-images.githubusercontent.com/4677417/74429663-ab3b4480-4e5b-11ea-9ca4-403eb99e187e.png">

After:
<img width="699" alt="Screenshot 2020-02-13 12 20 35" src="https://user-images.githubusercontent.com/4677417/74429672-b0988f00-4e5b-11ea-8896-37c6363bfb73.png">
