### PR TITLE
Fixed discussion list pane only showing up after internal clicks

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -1,6 +1,7 @@
 import Page from './Page';
 import ItemList from '../../common/utils/ItemList';
 import DiscussionHero from './DiscussionHero';
+import DiscussionList from './DiscussionList';
 import PostStream from './PostStream';
 import PostStreamScrubber from './PostStreamScrubber';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -32,18 +33,20 @@ export default class DiscussionPage extends Page {
 
     this.refresh();
 
-    // If the discussion list has been loaded, then we'll enable the pane (and
-    // hide it by default). Also, if we've just come from another discussion
-    // page, then we don't want Mithril to redraw the whole page – if it did,
+    // If the discussion list hasn't been loaded, load it in with default values.
+    // Also, if we've just come from another discussion page
+    // then we don't want Mithril to redraw the whole page – if it did,
     // then the pane would which would be slow and would cause problems with
     // event handlers.
-    if (app.cache.discussionList) {
-      app.pane.enable();
-      app.pane.hide();
+    if (!app.cache.discussionList) {
+      app.cache.discussionList = new DiscussionList({params: {}});
+    }
 
-      if (app.previous instanceof DiscussionPage) {
+    app.pane.enable();
+    app.pane.hide();
+
+    if (app.previous instanceof DiscussionPage) {
         m.redraw.strategy('diff');
-      }
     }
 
     app.history.push('discussion');

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -53,6 +53,7 @@ export default class IndexPage extends Page {
 
     if (!app.cache.discussionList) {
       app.cache.discussionList = new DiscussionList({params});
+      app.cache.discussionList.retain = true;
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));


### PR DESCRIPTION
**Fixes #1993**

Right now, the discussion list pane only shows up on discussion pages if the page is accessed in a tab that has previously visited pages. This is mitigated by 2 fixes.

**Changes proposed in this pull request:**
1. If the there is no cached discussion list when accessing a discussion page, one is created. (in DiscussionPage)
2. The cached discussion list is set to be retained by the browser, so as to not be lost if the page refreshes (in IndexPage).

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: Backend Not Affected.