### PR TITLE
Start testing extenders

### DIFF
--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -16,6 +16,7 @@ use Laminas\Diactoros\CallbackStream;
 use Laminas\Diactoros\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -23,11 +24,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @var \Flarum\Foundation\InstalledApp
      */
     protected $app;
-
-    /**
-     * @var \Psr\Http\Server\RequestHandlerInterface
-     */
-    protected $server;
 
     /**
      * @return \Flarum\Foundation\InstalledApp
@@ -50,6 +46,20 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         }
 
         return $this->app;
+    }
+
+    /**
+     * @var RequestHandlerInterface
+     */
+    protected $server;
+
+    protected function server(): RequestHandlerInterface
+    {
+        if (is_null($this->server)) {
+            $this->server = $this->app()->getRequestHandler();
+        }
+
+        return $this->server;
     }
 
     protected $database;
@@ -103,7 +113,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function send(ServerRequestInterface $request): ResponseInterface
     {
-        return $this->server->handle($request);
+        return $this->server()->handle($request);
     }
 
     /**

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -19,14 +19,6 @@ use Psr\Http\Message\ServerRequestInterface;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        // Boot the Flarum app
-        $this->app();
-    }
-
     /**
      * @var \Flarum\Foundation\InstalledApp
      */

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration;
 
 use Dflydev\FigCookies\SetCookie;
+use Flarum\Extend\ExtenderInterface;
 use Flarum\Foundation\InstalledSite;
 use Illuminate\Database\ConnectionInterface;
 use Laminas\Diactoros\CallbackStream;
@@ -41,11 +42,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 include __DIR__.'/tmp/config.php'
             );
 
+            $site->extendWith($this->extenders);
+
             $this->app = $site->bootApp();
-            $this->server = $this->app->getRequestHandler();
         }
 
         return $this->app;
+    }
+
+    /**
+     * @var ExtenderInterface[]
+     */
+    protected $extenders = [];
+
+    protected function extend(ExtenderInterface $extender)
+    {
+        $this->extenders[] = $extender;
     }
 
     /**

--- a/tests/integration/extenders/RoutesTest.php
+++ b/tests/integration/extenders/RoutesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\Tests\integration\TestCase;
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RoutesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function custom_route_does_not_exist_by_default()
+    {
+        $response = $this->send(
+            $this->request('GET', '/custom')
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_route_can_be_added_by_extender()
+    {
+        $this->extend(
+            (new Extend\Routes('forum'))
+                ->get('/custom', 'custom', CustomRoute::class)
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/custom')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello Flarumites!', $response->getBody());
+    }
+}
+
+class CustomRoute implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new TextResponse('Hello Flarumites!');
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
This adds the basic infrastructure and a first test for our `Route` extender. Using this as a template, we should be able to create more tests for all PHP extenders we currently have - which will greatly help us in defining what they're supposed to do, and guaranteeing we keep backwards compatibility throughout the first release.

The general idea is:
- have one test class per extender
- in each test class, have one test case that tests a behavior with no extender applied (in this case, a custom route does not exist if we haven't registered it with an extender)
- and then, as many test cases as necessary to test the different variants of using the extender, and their effects

**Reviewers should focus on:**
I had to tweak the base class for integration tests, in order to be able to register extenders during a test case. Previously, the app was already booted completely in the `setUp()` method - now, we do this lazily.

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

*None*
