### PR TITLE
Add CSRF exempt route support to middleware extender

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -53,7 +53,7 @@ class AdminServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $this->$app->singleton('flarum.admin.middleware.csrf', function () {
+        $this->app->singleton('flarum.admin.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.admin.csrfExemptRoutes'));
         });
 

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -53,7 +53,7 @@ class AdminServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $app->bind('flarum.admin.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.admin.middleware.csrf', function ($app) {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.admin.csrfExemptRoutes'));
         });
 

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -53,7 +53,7 @@ class AdminServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $this->$app->singleton('flarum.admin.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.admin.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.admin.csrfExemptRoutes'));
         });
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -45,8 +45,8 @@ class ApiServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->singleton('flarum.api.csrfExemptRoutes', function () {
-            // No exempt routes by default
-            return [];
+            // Exempt API token view by default
+            return ['/api/token'];
         });
 
         $app->bind('flarum.api.middleware.csrf', function ($app) {

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -49,7 +49,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             return ['/api/token'];
         });
 
-        $app->bind('flarum.api.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.api.middleware.csrf', function ($app) {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.api.csrfExemptRoutes'));
         });
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -49,7 +49,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             return ['/api/token'];
         });
 
-        $this->$app->singleton('flarum.api.middleware.csrf', function () {
+        $this->app->singleton('flarum.api.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.api.csrfExemptRoutes'));
         });
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -49,7 +49,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             return ['/api/token'];
         });
 
-        $this->$app->singleton('flarum.api.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.api.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.api.csrfExemptRoutes'));
         });
 

--- a/src/Extend/Middleware.php
+++ b/src/Extend/Middleware.php
@@ -110,7 +110,7 @@ class Middleware implements ExtenderInterface
         });
 
         $container->extend("flarum.{$this->frontend}.csrfExemptRoutes", function ($existingExemptRoutes) {
-            return $existingExemptRoutes + $this->csrfExemptRoutes;
+            return array_merge($existingExemptRoutes + $this->csrfExemptRoutes);
         });
     }
 }

--- a/src/Extend/Middleware.php
+++ b/src/Extend/Middleware.php
@@ -14,12 +14,13 @@ use Illuminate\Contracts\Container\Container;
 
 class Middleware implements ExtenderInterface
 {
-    private $addMiddlewares = [];
-    private $removeMiddlewares = [];
-    private $replaceMiddlewares = [];
-    private $insertBeforeMiddlewares = [];
-    private $insertAfterMiddlewares = [];
-    private $frontend;
+    protected $addMiddlewares = [];
+    protected $removeMiddlewares = [];
+    protected $replaceMiddlewares = [];
+    protected $insertBeforeMiddlewares = [];
+    protected $insertAfterMiddlewares = [];
+    protected $csrfExemptRoutes = [];
+    protected $frontend;
 
     public function __construct(string $frontend)
     {
@@ -57,6 +58,13 @@ class Middleware implements ExtenderInterface
     public function insertAfter($originalMiddleware, $newMiddleware)
     {
         $this->replaceMiddlewares[$originalMiddleware] = $newMiddleware;
+
+        return $this;
+    }
+
+    public function addCsrfExemptRoute($route)
+    {
+        $this->csrfExemptRoutes[] = $route;
 
         return $this;
     }
@@ -99,6 +107,10 @@ class Middleware implements ExtenderInterface
             $existingMiddleware = array_diff($existingMiddleware, $this->removeMiddlewares);
 
             return $existingMiddleware;
+        });
+
+        $container->extend("flarum.{$this->frontend}.csrfExemptRoutes", function ($existingExemptRoutes) {
+            return $existingExemptRoutes + $this->csrfExemptRoutes;
         });
     }
 }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -63,7 +63,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $this->$app->singleton('flarum.forum.middleware.csrf', function () {
+        $this->app->singleton('flarum.forum.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.forum.csrfExemptRoutes'));
         });
 

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -63,7 +63,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $this->$app->singleton('flarum.forum.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.forum.middleware.csrf', function () {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.forum.csrfExemptRoutes'));
         });
 

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -63,6 +63,10 @@ class ForumServiceProvider extends AbstractServiceProvider
             return [];
         });
 
+        $app->bind('flarum.forum.middleware.csrf', function ($app) {
+            return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.forum.csrfExemptRoutes'));
+        });
+
         $this->app->singleton('flarum.forum.middleware', function () {
             return [
                 HttpMiddleware\ParseJsonBody::class,
@@ -70,7 +74,7 @@ class ForumServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\StartSession::class,
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
-                HttpMiddleware\CheckCsrfToken::class,
+                'flarum.forum.middleware.csrf',
                 HttpMiddleware\SetLocale::class,
                 HttpMiddleware\ShareErrorsFromSession::class
             ];
@@ -87,11 +91,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             ));
 
             foreach ($this->app->make('flarum.forum.middleware') as $middleware) {
-                if ($middleware == HttpMiddleware\CheckCsrfToken::class) {
-                    $pipe->pipe(new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.forum.csrfExemptRoutes')));
-                } else {
-                    $pipe->pipe($this->app->make($middleware));
-                }
+                $pipe->pipe($this->app->make($middleware));
             }
 
             $pipe->pipe(new HttpMiddleware\DispatchRoute($this->app->make('flarum.forum.routes')));

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -63,7 +63,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             return [];
         });
 
-        $app->bind('flarum.forum.middleware.csrf', function ($app) {
+        $this->$app->singleton('flarum.forum.middleware.csrf', function ($app) {
             return new HttpMiddleware\CheckCsrfToken($this->app->make('flarum.forum.csrfExemptRoutes'));
         });
 

--- a/src/Http/Middleware/CheckCsrfToken.php
+++ b/src/Http/Middleware/CheckCsrfToken.php
@@ -29,7 +29,7 @@ class CheckCsrfToken implements Middleware
     {
         foreach ($this->exemptRoutes as $exemptRoute) {
             $path = $request->getUri()->getPath() ?: '/';
-            if (fnmatch($exemptRoute, $path) or fnmatch($exemptRoute, (string)$request->getUri())) {
+            if (fnmatch($exemptRoute, $path) or fnmatch($exemptRoute, (string) $request->getUri())) {
                 return $handler->handle($request);
             }
         }

--- a/src/Http/Middleware/CheckCsrfToken.php
+++ b/src/Http/Middleware/CheckCsrfToken.php
@@ -17,8 +17,23 @@ use Psr\Http\Server\RequestHandlerInterface as Handler;
 
 class CheckCsrfToken implements Middleware
 {
+
+    protected $exemptRoutes;
+
+    public function __construct(array $exemptRoutes)
+    {
+        $this->exemptRoutes = $exemptRoutes;
+    }
+
     public function process(Request $request, Handler $handler): Response
     {
+        foreach ($this->exemptRoutes as $exemptRoute) {
+            $path = $request->getUri()->getPath() ?: '/';
+            if (fnmatch($exemptRoute, $path) or fnmatch($exemptRoute, (string)$request->getUri())) {
+                return $handler->handle($request);
+            }
+        }
+
         if (in_array($request->getMethod(), ['GET', 'HEAD', 'OPTIONS'])) {
             return $handler->handle($request);
         }

--- a/src/Http/Middleware/CheckCsrfToken.php
+++ b/src/Http/Middleware/CheckCsrfToken.php
@@ -17,7 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface as Handler;
 
 class CheckCsrfToken implements Middleware
 {
-
     protected $exemptRoutes;
 
     public function __construct(array $exemptRoutes)


### PR DESCRIPTION
**Fixes #1941, #1905 **

Part of #1891 

**Changes proposed in this pull request:**
- Add an addCsrfExemptRoute method to the Middleware extender
- Improve Middleware processing system to support this

As per https://github.com/flarum/core/issues/1941#issuecomment-586217862, CSRF exemption is likely to be one of the most common use cases of the middleware extender. As such, considering that there isn't a lot of complexity, it might be easier to implement on our end instead of forcing everyone to override the CheckCsrfToken middleware.

TODO:
- Add integration tests for this (will be done after @flarum/core decides which extender this should be a part of).

**Reviewers should focus on:**
1. Should this be a separate extender? I thought that since it affects middleware, and we already have lots of extenders planned, it would be best to have it as a part of the middleware extender
2. Is the mechanism for providing the exempt paths to the CheckCsrfToken middleware the best approach possible? I modeled this largely off of the Routes extender
3. Code style?
4. Is the mechanism for matching paths to exempt routes what we want? (currently done via wildcards).

**Confirmed**
- [x] Backend changes: tests are green (run `composer test`).
- [x] Backend manual testing