### PR TITLE
Remove Zend compatability bridge (Beta 13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "laminas/laminas-diactoros": "^1.8.4",
         "laminas/laminas-httphandlerrunner": "^1.0",
         "laminas/laminas-stratigility": "^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "league/flysystem": "^1.0.11",
         "matthiasmullie/minify": "^1.3",
         "middlewares/base-path": "^1.1",


### PR DESCRIPTION
**Fixes #1964**

**Changes proposed in this pull request:**
Trivial commit to remove zend-laminas compatability bridge for beta 13

**Reviewers should focus on:**
I don't think this has any unintended consequences?

**Confirmed**
- [x] Backend changes: tests are green (run `composer test`).
