### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 
@@ -21,12 +21,6 @@ jobs:
             prefixStr: (prefix)
 
         exclude:
-          - php: 7.1
-            service: 'mysql:5.7'
-            prefix: flarum_
-          - php: 7.1
-            service: mariadb
-            prefix: flarum_
           - php: 7.2
             service: 'mysql:5.7'
             prefix: flarum_

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
             "email": "franz@develophp.org"
         },
         {
-          "name": "Daniel Klabbers",
-          "email": "daniel@klabbers.email"
+            "name": "Daniel Klabbers",
+            "email": "daniel@klabbers.email"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "symfony/translation": "^3.3",
         "symfony/yaml": "^3.3",
         "tobscure/json-api": "^0.3.0",
-        "wikimedia/less.php": "^2.0"
+        "wikimedia/less.php": "^1.8"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "symfony/translation": "^3.3",
         "symfony/yaml": "^3.3",
         "tobscure/json-api": "^0.3.0",
-        "wikimedia/less.php": "^1.8"
+        "wikimedia/less.php": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "docs": "https://flarum.org/docs/"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "axy/sourcemap": "^0.1.4",
         "components/font-awesome": "5.9.*",
         "dflydev/fig-cookies": "^1.0.2",

--- a/src/Install/Installation.php
+++ b/src/Install/Installation.php
@@ -87,7 +87,7 @@ class Installation
     public function prerequisites(): Prerequisite\PrerequisiteInterface
     {
         return new Prerequisite\Composite(
-            new Prerequisite\PhpVersion('7.1.0'),
+            new Prerequisite\PhpVersion('7.2.0'),
             new Prerequisite\PhpExtensions([
                 'dom',
                 'gd',


### PR DESCRIPTION
**Fixes #1988 **

**Changes proposed in this pull request:**
- Drop support for PHP 7.1
- Use v1 of wikimedia/less (more up to date)

**Reviewers should focus on:**
- Wikimedia less is planning to release v3.0.0 shortly (https://github.com/wikimedia/less.php/pull/26) to clear up their versioning. I think we shouldn't merge till then, and update our composer.json when they do.
- ~~In https://github.com/flarum/core/issues/1988#issuecomment-583945173, Matt suggested upgrading Laravel to 6.x. When I tried doing this, our automated tests would fail when ran in github actions (although not on my local machine). Do we want to look into this update and compatibility with our setup? If so, here, or in a second PR?~~
