### PR TITLE
Getting user permissions shouldn't stop on the first non-null value

### DIFF
--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -64,12 +64,17 @@ class UserServiceProvider extends AbstractServiceProvider
             // Fire an event so that core and extension policies can hook into
             // this permission query and explicitly grant or deny the
             // permission.
-            $allowed = $this->app->make('events')->until(
+            $allowed = $this->app->make('events')->fire(
                 new GetPermission($actor, $ability, $model)
             );
 
-            if (! is_null($allowed)) {
-                return $allowed;
+            foreach ($allowed as $key => $value) {
+                if (is_null($value)) {
+                    unset($allowed[$key]);
+                }
+            }
+            if (! empty($allowed)) {
+                return ! in_array(false, $allowed, true);
             }
 
             // If no policy covered this permission query, we will only grant


### PR DESCRIPTION
**Fixes #1832**

**Changes proposed in this pull request:**
Permissions shouldn't depend on extension boot order. Right now, they are determined by getting the first non-null Policy response. I propose evaluating all policy responses, discounting any nulls, and returning "false" if ANY policies return false. If all that return non-null return true, the permission would be granted, otherwise, the procedure to handle null permission responses is unchanged.

**Reviewers should focus on:**
- Are there better ways to handle this?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
