### PR TITLE
Fix permission icon width in admin area

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -44,7 +44,7 @@ export default class PermissionGrid extends Component {
             </tr>
             {section.children.map(child => (
               <tr className="PermissionGrid-child">
-                <th>{icon(child.icon)}{child.label}</th>
+                <th>{icon(child.icon, {className: 'fa-fw'})}{child.label}</th>
                 {permissionCells(child)}
                 <td/>
               </tr>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2016**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Uses the Font Awesome fixed width helper to make all icons the same width so that text aligns

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
* Is this the best way of doing this? Or is there some other way that I missed?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
The screenshots in #2016 clearly show the diffrence

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.

