### PR TITLE
Added console command to reset password for a user

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -12,7 +12,6 @@ namespace Flarum\Console;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
 use Flarum\Database\Console\ResetCommand;
-use Flarum\User\Console\ResetPasswordCommand;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\User\Console\SetPasswordCommand;

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -12,8 +12,10 @@ namespace Flarum\Console;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
 use Flarum\Database\Console\ResetCommand;
+use Flarum\User\Console\ResetPasswordCommand;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Console\CacheClearCommand;
+use Flarum\User\Console\SetPasswordCommand;
 
 class ConsoleServiceProvider extends AbstractServiceProvider
 {
@@ -28,6 +30,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
                 GenerateMigrationCommand::class,
                 MigrateCommand::class,
                 ResetCommand::class,
+                SetPasswordCommand::class,
             ];
         });
     }

--- a/src/User/Console/ResetPasswordCommand.php
+++ b/src/User/Console/ResetPasswordCommand.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Question\Question;
 
 class ResetPasswordCommand extends AbstractCommand
 {
-    protected $questionHelper;
 
     protected $userRepository;
 
@@ -27,9 +26,8 @@ class ResetPasswordCommand extends AbstractCommand
     /**
      * @param UserRepository $userRepository
      */
-    public function __construct(QuestionHelper $questionHelper, UserRepository $userRepository, UserValidator $userValidator)
+    public function __construct(UserRepository $userRepository, UserValidator $userValidator)
     {
-        $this->questionHelper = $questionHelper;
         $this->userRepository = $userRepository;
         $this->userValidator = $userValidator;
 

--- a/src/User/Console/ResetPasswordCommand.php
+++ b/src/User/Console/ResetPasswordCommand.php
@@ -65,7 +65,7 @@ class ResetPasswordCommand extends AbstractCommand
             if ($user) {
                 return $user;
             } else {
-                $this->validationError('User with this username or email does not exist.');
+                $this->error('User with this username or email does not exist.');
                 continue;
             }
         }
@@ -80,7 +80,7 @@ class ResetPasswordCommand extends AbstractCommand
                 $this->userValidator->assertValid(compact('password'));
             } catch (ValidationException $e) {
                 foreach ($e->errors()['password'] as $error) {
-                    $this->validationError($error);
+                    $this->error($error);
                 }
                 continue;
             }
@@ -88,33 +88,11 @@ class ResetPasswordCommand extends AbstractCommand
             $confirmation = $this->secret('New password (confirmation):');
 
             if ($password !== $confirmation) {
-                $this->validationError('The password did not match its confirmation.');
+                $this->error('The password did not match its confirmation.');
                 continue;
             }
 
             return $password;
         }
-    }
-
-    private function ask($question, $default = null)
-    {
-        $question = new Question("<question>$question</question> ", $default);
-
-        return $this->questionHelper->ask($this->input, $this->output, $question);
-    }
-
-    private function secret($question)
-    {
-        $question = new Question("<question>$question</question> ");
-
-        $question->setHidden(true)->setHiddenFallback(true);
-
-        return $this->questionHelper->ask($this->input, $this->output, $question);
-    }
-
-    private function validationError($message)
-    {
-        $this->output->writeln("<error>$message</error>");
-        $this->output->writeln('Please try again.');
     }
 }

--- a/src/User/Console/ResetPasswordCommand.php
+++ b/src/User/Console/ResetPasswordCommand.php
@@ -10,12 +10,14 @@
 namespace Flarum\User\Console;
 
 use Flarum\Console\AbstractCommand;
+use Flarum\Console\AskQuestionTrait;
 use Flarum\User\UserRepository;
 use Flarum\User\UserValidator;
 use Illuminate\Validation\ValidationException;
 
 class ResetPasswordCommand extends AbstractCommand
 {
+    use AskQuestionTrait;
 
     protected $userRepository;
 

--- a/src/User/Console/ResetPasswordCommand.php
+++ b/src/User/Console/ResetPasswordCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\User\UserRepository;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
+
+class ResetPasswordCommand extends AbstractCommand
+{
+    protected $questionHelper;
+
+    protected $userRepository;
+
+    /**
+     * @param UserRepository $userRepository
+     */
+    public function __construct(QuestionHelper $questionHelper, UserRepository $userRepository)
+    {
+        $this->questionHelper = $questionHelper;
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('password:reset')
+            ->setDescription('Reset a user\'s password');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $user = $this->getUser();
+        $user->changePassword($this->askForPassword());
+        $user->save();
+    }
+
+    private function getUser()
+    {
+        while (true) {
+            $identification = $this->ask('Enter username or email:');
+            $user = $this->userRepository->findByIdentification($identification);
+
+            if ($user) {
+                return $user;
+            } else {
+                $this->validationError('User with this username or email does not exist.');
+                continue;
+            }
+        }
+    }
+
+    private function askForPassword()
+    {
+        while (true) {
+            $password = $this->secret('New password (required >= 8 characters):');
+
+            if (strlen($password) < 8) {
+                $this->validationError('Password must be at least 8 characters.');
+                continue;
+            }
+
+            $confirmation = $this->secret('New password (confirmation):');
+
+            if ($password !== $confirmation) {
+                $this->validationError('The password did not match its confirmation.');
+                continue;
+            }
+
+            return $password;
+        }
+    }
+
+    private function ask($question, $default = null)
+    {
+        $question = new Question("<question>$question</question> ", $default);
+
+        return $this->questionHelper->ask($this->input, $this->output, $question);
+    }
+
+    private function secret($question)
+    {
+        $question = new Question("<question>$question</question> ");
+
+        $question->setHidden(true)->setHiddenFallback(true);
+
+        return $this->questionHelper->ask($this->input, $this->output, $question);
+    }
+
+    private function validationError($message)
+    {
+        $this->output->writeln("<error>$message</error>");
+        $this->output->writeln('Please try again.');
+    }
+}

--- a/src/User/Console/ResetPasswordCommand.php
+++ b/src/User/Console/ResetPasswordCommand.php
@@ -13,8 +13,6 @@ use Flarum\Console\AbstractCommand;
 use Flarum\User\UserRepository;
 use Flarum\User\UserValidator;
 use Illuminate\Validation\ValidationException;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Question\Question;
 
 class ResetPasswordCommand extends AbstractCommand
 {

--- a/src/User/Console/SetPasswordCommand.php
+++ b/src/User/Console/SetPasswordCommand.php
@@ -15,7 +15,7 @@ use Flarum\User\UserRepository;
 use Flarum\User\UserValidator;
 use Illuminate\Validation\ValidationException;
 
-class ResetPasswordCommand extends AbstractCommand
+class SetPasswordCommand extends AbstractCommand
 {
     use AskQuestionTrait;
 
@@ -40,8 +40,8 @@ class ResetPasswordCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setName('password:reset')
-            ->setDescription('Reset a user\'s password');
+            ->setName('user:set_password')
+            ->setDescription('Set a user\'s password');
     }
 
     /**

--- a/src/User/Console/SetPasswordCommand.php
+++ b/src/User/Console/SetPasswordCommand.php
@@ -23,9 +23,6 @@ class SetPasswordCommand extends AbstractCommand
 
     protected $userValidator;
 
-    /**
-     * @param UserRepository $userRepository
-     */
     public function __construct(UserRepository $userRepository, UserValidator $userValidator)
     {
         $this->userRepository = $userRepository;


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/1655#issuecomment-394183409**

**Changes proposed in this pull request:**
Added a console command to reset anyone's password. If a forum admin finds themselves logged out with a forgotten password and a broken email configuration, they shouldn't need to reinstall Flarum. Yes, it's also important to work on preventing broken email configuration, but there should be a failsafe.

**Reviewers should focus on:**
- Do we want to add commands for creating an admin user and creating a user?

**Confirmed**

- [x] Backend changes: manually tested.
- [x] Backend changes: tests are green (run `composer test`).

