### PR TITLE
Unfuzz Times

### DIFF
--- a/js/src/common/utils/humanTime.js
+++ b/js/src/common/utils/humanTime.js
@@ -18,26 +18,15 @@ export default function humanTime(time) {
 
   const day = 864e5;
   const diff = m.diff(moment());
-  const userLang = (navigator.language || navigator.userLanguage).toLowerCase();
   let ago = null;
 
   // If this date was more than a month ago, we'll show the name of the month
   // in the string. If it wasn't this year, we'll show the year as well.
   if (diff < -30 * day) {
     if (m.year() === moment().year()) {
-      // By default, moment's en locale uses MDY. If language is english and the user's browser is not US or CA, DMY should be used instead.
-      if (moment.locale() == 'en' && (userLang == 'en-us' || userLang == 'en-ca')) {
-        ago = m.format('MMM D');
-      } else {
-        ago = m.format('D MMM');
-      }
+      ago = m.format('D MMM');
     } else {
-      // By default, moment's en locale uses MDY. If the user's browser is not US or CA, DMY should be used instead.
-      if (moment.locale() == 'en' && !(userLang == 'en-us' || userLang == 'en-ca')) {
-        ago = m.format('D MMM YYYY');
-      } else {
-        ago = m.format('ll');
-      }
+      ago = m.format('ll');
     }
   } else {
     ago = m.fromNow();

--- a/js/src/common/utils/humanTime.js
+++ b/js/src/common/utils/humanTime.js
@@ -18,23 +18,25 @@ export default function humanTime(time) {
 
   const day = 864e5;
   const diff = m.diff(moment());
-  var userLang = navigator.language || navigator.userLanguage;
+  const userLang = (navigator.language || navigator.userLanguage).toLowerCase();
   let ago = null;
 
   // If this date was more than a month ago, we'll show the name of the month
   // in the string. If it wasn't this year, we'll show the year as well.
   if (diff < -30 * day) {
     if (m.year() === moment().year()) {
-      if (userLang == 'en-US') {
+      // By default, moment's en locale uses MDY. If language is english and the user's browser is not US or CA, DMY should be used instead.
+      if (moment.locale() == 'en' && (userLang == 'en-us' || userLang == 'en-ca')) {
         ago = m.format('MMM D');
       } else {
         ago = m.format('D MMM');
       }
     } else {
-      if (userLang == 'en-US') {
-        ago = m.format('MMM D, YYYY');
-      } else {
+      // By default, moment's en locale uses MDY. If the user's browser is not US or CA, DMY should be used instead.
+      if (moment.locale() == 'en' && !(userLang == 'en-us' || userLang == 'en-ca')) {
         ago = m.format('D MMM YYYY');
+      } else {
+        ago = m.format('ll');
       }
     }
   } else {

--- a/js/src/common/utils/humanTime.js
+++ b/js/src/common/utils/humanTime.js
@@ -18,19 +18,24 @@ export default function humanTime(time) {
 
   const day = 864e5;
   const diff = m.diff(moment());
+  var userLang = navigator.language || navigator.userLanguage;
   let ago = null;
 
   // If this date was more than a month ago, we'll show the name of the month
   // in the string. If it wasn't this year, we'll show the year as well.
   if (diff < -30 * day) {
     if (m.year() === moment().year()) {
-      if (moment.locale() == 'en') {
+      if (userLang == 'en-US') {
         ago = m.format('MMM D');
       } else {
         ago = m.format('D MMM');
       }
     } else {
-      ago = m.format('ll');
+      if (userLang == 'en-US') {
+        ago = m.format('MMM D, YYYY');
+      } else {
+        ago = m.format('D MMM YYYY');
+      }
     }
   } else {
     ago = m.fromNow();

--- a/js/src/common/utils/humanTime.js
+++ b/js/src/common/utils/humanTime.js
@@ -24,9 +24,13 @@ export default function humanTime(time) {
   // in the string. If it wasn't this year, we'll show the year as well.
   if (diff < -30 * day) {
     if (m.year() === moment().year()) {
-      ago = m.format('D MMM');
+      if (moment.locale() == 'en') {
+        ago = m.format('MMM D');
+      } else {
+        ago = m.format('D MMM');
+      }
     } else {
-      ago = m.format('MMM \'YY');
+      ago = m.format('ll');
     }
   } else {
     ago = m.fromNow();


### PR DESCRIPTION
**Fixes #815**

**Changes proposed in this pull request:**
Improved dates:
< 30 days ago: Relative
30 days ago < DATE < 1 year: MMM D (if US), D MMM (if not US)
> 1 year: MMM D, YYYY (if US), D MMM YYYY (if not US)

**Reviewers should focus on:**
- Should we change months to non-abbreviated?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
