### PR TITLE
Add year, localization support for displaying things older than 1 year

### DIFF
--- a/js/src/common/utils/humanTime.js
+++ b/js/src/common/utils/humanTime.js
@@ -26,7 +26,7 @@ export default function humanTime(time) {
     if (m.year() === moment().year()) {
       ago = m.format('D MMM');
     } else {
-      ago = m.format('MMM \'YY');
+      ago = m.format('ll');
     }
   } else {
     ago = m.fromNow();


### PR DESCRIPTION
**Fixes #815 **

**Changes proposed in this pull request:**
Improved dates:
< 30 days ago: Relative
30 days ago < DATE < 1 year: D MMM
GTE 1 year: full day, month, and year, with format localized

Cleanup of #2026 