### PR TITLE
Fixed extenders added after app initialized not working

### DIFF
--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -57,7 +57,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function extend(ExtenderInterface $extender)
     {
-        $this->extenders[] = $extender;
+        if (is_null($this->app)) {
+            $this->extenders[] = $extender;
+        } else {
+            $extender->extend($this->app->getContainer());
+        }
     }
 
     /**


### PR DESCRIPTION
**Fixes #2035 **

**Changes proposed in this pull request:**
If extenders are added in a test case after the app has been initalized, extend the app with them. Right now, they do nothing, which makes it impossible to do anything in the database prior to initializing the app.