### PR TITLE
Users should not be able to restore discussions if deleted by admins

### DIFF
--- a/src/Discussion/DiscussionPolicy.php
+++ b/src/Discussion/DiscussionPolicy.php
@@ -141,7 +141,7 @@ class DiscussionPolicy extends AbstractPolicy
     {
         if ($discussion->user_id == $actor->id
             && $discussion->participant_count <= 1
-            && (!$discussion->hidden_at || $discussion->hidden_user_id == $actor->id)
+            && (! $discussion->hidden_at || $discussion->hidden_user_id == $actor->id)
             && $actor->can('reply', $discussion)
         ) {
             return true;

--- a/src/Discussion/DiscussionPolicy.php
+++ b/src/Discussion/DiscussionPolicy.php
@@ -139,7 +139,11 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function hide(User $actor, Discussion $discussion)
     {
-        if ($discussion->user_id == $actor->id && $discussion->participant_count <= 1 && $actor->can('reply', $discussion)) {
+        if ($discussion->user_id == $actor->id
+            && $discussion->participant_count <= 1
+            && (!$discussion->hidden_at || $discussion->hidden_user_id == $actor->id)
+            && $actor->can('reply', $discussion)
+        ) {
             return true;
         }
     }


### PR DESCRIPTION
**Fixes #1230 **

**Changes proposed in this pull request:**
Users should not be able to restore discussions if deleted by admins

**Reviewers should focus on:**
Seems fairly trivial

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
