### PR TITLE
Added escape for invalid regex in search

### DIFF
--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -74,9 +74,17 @@ export default class DiscussionListItem extends Component {
 
       const phrase = this.props.params.q;
       try {
-        this.highlightRegExp = new RegExp(phrase+'|'+phrase.trim().replace(/\s+/g, '|'), 'gi');
+        this.highlightRegExp = new RegExp(phrase + '|' + phrase.trim().replace(/\s+/g, '|'), 'gi');
       } catch {
-        this.highlightRegExp = new RegExp(phrase + '|' +phrase.trim().replace(/[\/\\^$*+?.()|[\]{}]/g, '').replace(/\s+/g, '|'), 'gi');
+        this.highlightRegExp = new RegExp(
+          phrase +
+            '|' +
+            phrase
+              .trim()
+              .replace(/[\/\\^$*+?.()|[\]{}]/g, '')
+              .replace(/\s+/g, '|'),
+          'gi'
+        );
       }
     } else {
       jumpTo = Math.min(discussion.lastPostNumber(), (discussion.lastReadPostNumber() || 0) + 1);

--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -73,7 +73,11 @@ export default class DiscussionListItem extends Component {
       }
 
       const phrase = this.props.params.q;
-      this.highlightRegExp = new RegExp(phrase + '|' + phrase.trim().replace(/\s+/g, '|'), 'gi');
+      try {
+        this.highlightRegExp = new RegExp(phrase+'|'+phrase.trim().replace(/\s+/g, '|'), 'gi');
+      } catch {
+        this.highlightRegExp = new RegExp(phrase + '|' +phrase.trim().replace(/[\/\\^$*+?.()|[\]{}]/g, '').replace(/\s+/g, '|'), 'gi');
+      }
     } else {
       jumpTo = Math.min(discussion.lastPostNumber(), (discussion.lastReadPostNumber() || 0) + 1);
     }


### PR DESCRIPTION
**Fixes #1458**

**Changes proposed in this pull request:**
Added escape to invalid regular expressions while preserving core of functionality.

**Reviewers should focus on:**
Is there a more elegant way to do this?


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.