### PR TITLE
Deprecate AssertPermissionTrait

### DIFF
--- a/src/Admin/Middleware/RequireAdministrateAbility.php
+++ b/src/Admin/Middleware/RequireAdministrateAbility.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Admin\Middleware;
 
-use Flarum\User\AssertPermissionTrait;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
@@ -17,11 +16,9 @@ use Psr\Http\Server\RequestHandlerInterface as Handler;
 
 class RequireAdministrateAbility implements Middleware
 {
-    use AssertPermissionTrait;
-
     public function process(Request $request, Handler $handler): Response
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         return $handler->handle($request);
     }

--- a/src/Api/Controller/ClearCacheController.php
+++ b/src/Api/Controller/ClearCacheController.php
@@ -10,7 +10,6 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Foundation\Console\CacheClearCommand;
-use Flarum\User\AssertPermissionTrait;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -18,8 +17,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class ClearCacheController extends AbstractDeleteController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var CacheClearCommand
      */
@@ -38,7 +35,7 @@ class ClearCacheController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $this->command->run(
             new ArrayInput([]),

--- a/src/Api/Controller/DeleteFaviconController.php
+++ b/src/Api/Controller/DeleteFaviconController.php
@@ -10,15 +10,12 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Laminas\Diactoros\Response\EmptyResponse;
 use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DeleteFaviconController extends AbstractDeleteController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -44,7 +41,7 @@ class DeleteFaviconController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $path = $this->settings->get('favicon_path');
 

--- a/src/Api/Controller/DeleteLogoController.php
+++ b/src/Api/Controller/DeleteLogoController.php
@@ -10,15 +10,12 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Laminas\Diactoros\Response\EmptyResponse;
 use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DeleteLogoController extends AbstractDeleteController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -44,7 +41,7 @@ class DeleteLogoController extends AbstractDeleteController
      */
     protected function delete(ServerRequestInterface $request)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $path = $this->settings->get('logo_path');
 

--- a/src/Api/Controller/ListNotificationsController.php
+++ b/src/Api/Controller/ListNotificationsController.php
@@ -13,14 +13,11 @@ use Flarum\Api\Serializer\NotificationSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\UrlGenerator;
 use Flarum\Notification\NotificationRepository;
-use Flarum\User\AssertPermissionTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
 class ListNotificationsController extends AbstractListController
 {
-    use AssertPermissionTrait;
-
     /**
      * {@inheritdoc}
      */
@@ -67,7 +64,7 @@ class ListNotificationsController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        $this->assertRegistered($actor);
+        $actor->assertRegistered();
 
         $actor->markNotificationsAsRead()->save();
 

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -12,7 +12,6 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\Http\UrlGenerator;
 use Flarum\Search\SearchCriteria;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Search\UserSearcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,8 +19,6 @@ use Tobscure\JsonApi\Document;
 
 class ListUsersController extends AbstractListController
 {
-    use AssertPermissionTrait;
-
     /**
      * {@inheritdoc}
      */
@@ -70,7 +67,7 @@ class ListUsersController extends AbstractListController
     {
         $actor = $request->getAttribute('actor');
 
-        $this->assertCan($actor, 'viewUserList');
+        $actor->assertCan('viewUserList');
 
         $query = Arr::get($this->extractFilter($request), 'q');
         $sort = $this->extractSort($request);

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -12,7 +12,6 @@ namespace Flarum\Api\Controller;
 use Flarum\Http\UrlGenerator;
 use Flarum\Mail\Job\SendRawEmailJob;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\EmailToken;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Queue\Queue;
@@ -25,8 +24,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class SendConfirmationEmailController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -69,7 +66,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
         $id = Arr::get($request->getQueryParams(), 'id');
         $actor = $request->getAttribute('actor');
 
-        $this->assertRegistered($actor);
+        $actor->assertRegistered();
 
         if ($actor->id != $id || $actor->is_email_confirmed) {
             throw new PermissionDeniedException;

--- a/src/Api/Controller/SendTestMailController.php
+++ b/src/Api/Controller/SendTestMailController.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Mail\Message;
@@ -21,8 +20,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class SendTestMailController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     protected $container;
 
     protected $mailer;
@@ -39,7 +36,7 @@ class SendTestMailController implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $actor = $request->getAttribute('actor');
-        $this->assertAdmin($actor);
+        $actor->assertAdmin($actor);
 
         $body = $this->translator->trans('core.email.send_test.body', ['{username}' => $actor->username]);
 

--- a/src/Api/Controller/SendTestMailController.php
+++ b/src/Api/Controller/SendTestMailController.php
@@ -36,7 +36,7 @@ class SendTestMailController implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $actor = $request->getAttribute('actor');
-        $actor->assertAdmin($actor);
+        $actor->assertAdmin();
 
         $body = $this->translator->trans('core.email.send_test.body', ['{username}' => $actor->username]);
 

--- a/src/Api/Controller/SetPermissionController.php
+++ b/src/Api/Controller/SetPermissionController.php
@@ -10,7 +10,6 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Group\Permission;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -19,14 +18,12 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SetPermissionController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     /**
      * {@inheritdoc}
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $body = $request->getParsedBody();
         $permission = Arr::get($body, 'permission');

--- a/src/Api/Controller/SetSettingsController.php
+++ b/src/Api/Controller/SetSettingsController.php
@@ -11,7 +11,6 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Settings\Event;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -20,8 +19,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SetSettingsController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     /**
      * @var \Flarum\Settings\SettingsRepositoryInterface
      */
@@ -46,7 +43,7 @@ class SetSettingsController implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $settings = $request->getParsedBody();
 

--- a/src/Api/Controller/ShowMailSettingsController.php
+++ b/src/Api/Controller/ShowMailSettingsController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\MailSettingsSerializer;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;

--- a/src/Api/Controller/ShowMailSettingsController.php
+++ b/src/Api/Controller/ShowMailSettingsController.php
@@ -10,16 +10,12 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Api\Serializer\MailSettingsSerializer;
-use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Validation\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
 class ShowMailSettingsController extends AbstractShowController
 {
-    use AssertPermissionTrait;
-
     /**
      * {@inheritdoc}
      */
@@ -30,7 +26,7 @@ class ShowMailSettingsController extends AbstractShowController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $drivers = array_map(function ($driver) {
             return self::$container->make($driver);

--- a/src/Api/Controller/UninstallExtensionController.php
+++ b/src/Api/Controller/UninstallExtensionController.php
@@ -10,14 +10,11 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Extension\ExtensionManager;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 
 class UninstallExtensionController extends AbstractDeleteController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var ExtensionManager
      */
@@ -33,7 +30,7 @@ class UninstallExtensionController extends AbstractDeleteController
 
     protected function delete(ServerRequestInterface $request)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $name = Arr::get($request->getQueryParams(), 'name');
 

--- a/src/Api/Controller/UpdateExtensionController.php
+++ b/src/Api/Controller/UpdateExtensionController.php
@@ -10,7 +10,6 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Extension\ExtensionManager;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -19,8 +18,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class UpdateExtensionController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     /**
      * @var ExtensionManager
      */
@@ -39,7 +36,7 @@ class UpdateExtensionController implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $enabled = Arr::get($request->getParsedBody(), 'enabled');
         $name = Arr::get($request->getQueryParams(), 'name');

--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -10,7 +10,6 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
@@ -20,8 +19,6 @@ use Tobscure\JsonApi\Document;
 
 class UploadFaviconController extends ShowForumController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -47,7 +44,7 @@ class UploadFaviconController extends ShowForumController
      */
     public function data(ServerRequestInterface $request, Document $document)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $file = Arr::get($request->getUploadedFiles(), 'favicon');
         $extension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -10,7 +10,6 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
@@ -20,8 +19,6 @@ use Tobscure\JsonApi\Document;
 
 class UploadLogoController extends ShowForumController
 {
-    use AssertPermissionTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -47,7 +44,7 @@ class UploadLogoController extends ShowForumController
      */
     public function data(ServerRequestInterface $request, Document $document)
     {
-        $this->assertAdmin($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertAdmin();
 
         $file = Arr::get($request->getUploadedFiles(), 'logo');
 

--- a/src/Discussion/Command/DeleteDiscussionHandler.php
+++ b/src/Discussion/Command/DeleteDiscussionHandler.php
@@ -12,14 +12,12 @@ namespace Flarum\Discussion\Command;
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Discussion\Event\Deleting;
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class DeleteDiscussionHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\Discussion\DiscussionRepository
@@ -47,7 +45,7 @@ class DeleteDiscussionHandler
 
         $discussion = $this->discussions->findOrFail($command->discussionId, $actor);
 
-        $this->assertCan($actor, 'delete', $discussion);
+        $actor->assertCan('delete', $discussion);
 
         $this->events->dispatch(
             new Deleting($discussion, $actor, $command->data)

--- a/src/Discussion/Command/EditDiscussionHandler.php
+++ b/src/Discussion/Command/EditDiscussionHandler.php
@@ -13,14 +13,12 @@ use Flarum\Discussion\DiscussionRepository;
 use Flarum\Discussion\DiscussionValidator;
 use Flarum\Discussion\Event\Saving;
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class EditDiscussionHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var DiscussionRepository
@@ -58,13 +56,13 @@ class EditDiscussionHandler
         $discussion = $this->discussions->findOrFail($command->discussionId, $actor);
 
         if (isset($attributes['title'])) {
-            $this->assertCan($actor, 'rename', $discussion);
+            $actor->assertCan('rename', $discussion);
 
             $discussion->rename($attributes['title']);
         }
 
         if (isset($attributes['isHidden'])) {
-            $this->assertCan($actor, 'hide', $discussion);
+            $actor->assertCan('hide', $discussion);
 
             if ($attributes['isHidden']) {
                 $discussion->hide($actor);

--- a/src/Discussion/Command/ReadDiscussionHandler.php
+++ b/src/Discussion/Command/ReadDiscussionHandler.php
@@ -12,13 +12,11 @@ namespace Flarum\Discussion\Command;
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Discussion\Event\UserDataSaving;
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class ReadDiscussionHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var DiscussionRepository
@@ -44,7 +42,7 @@ class ReadDiscussionHandler
     {
         $actor = $command->actor;
 
-        $this->assertRegistered($actor);
+        $actor->assertRegistered();
 
         $discussion = $this->discussions->findOrFail($command->discussionId, $actor);
 

--- a/src/Discussion/Command/StartDiscussionHandler.php
+++ b/src/Discussion/Command/StartDiscussionHandler.php
@@ -15,7 +15,6 @@ use Flarum\Discussion\DiscussionValidator;
 use Flarum\Discussion\Event\Saving;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Post\Command\PostReply;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Arr;
@@ -23,7 +22,6 @@ use Illuminate\Support\Arr;
 class StartDiscussionHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var BusDispatcher
@@ -58,7 +56,7 @@ class StartDiscussionHandler
         $data = $command->data;
         $ipAddress = $command->ipAddress;
 
-        $this->assertCan($actor, 'startDiscussion');
+        $actor->assertCan('startDiscussion');
 
         // Create a new Discussion entity, persist it, and dispatch domain
         // events. Before persistence, though, fire an event to give plugins

--- a/src/Forum/Content/AssertRegistered.php
+++ b/src/Forum/Content/AssertRegistered.php
@@ -10,15 +10,12 @@
 namespace Flarum\Forum\Content;
 
 use Flarum\Frontend\Document;
-use Flarum\User\AssertPermissionTrait;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class AssertRegistered
 {
-    use AssertPermissionTrait;
-
     public function __invoke(Document $document, Request $request)
     {
-        $this->assertRegistered($request->getAttribute('actor'));
+        $request->getAttribute('actor')->assertRegistered();
     }
 }

--- a/src/Forum/Controller/LogOutController.php
+++ b/src/Forum/Controller/LogOutController.php
@@ -13,7 +13,6 @@ use Flarum\Http\Exception\TokenMismatchException;
 use Flarum\Http\Rememberer;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\Http\UrlGenerator;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Event\LoggedOut;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
@@ -26,8 +25,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class LogOutController implements RequestHandlerInterface
 {
-    use AssertPermissionTrait;
-
     /**
      * @var Dispatcher
      */

--- a/src/Group/Command/CreateGroupHandler.php
+++ b/src/Group/Command/CreateGroupHandler.php
@@ -13,14 +13,12 @@ use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Group\Event\Saving;
 use Flarum\Group\Group;
 use Flarum\Group\GroupValidator;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class CreateGroupHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\Group\GroupValidator
@@ -47,8 +45,8 @@ class CreateGroupHandler
         $actor = $command->actor;
         $data = $command->data;
 
-        $this->assertRegistered($actor);
-        $this->assertCan($actor, 'createGroup');
+        $actor->assertRegistered();
+        $actor->assertCan('createGroup');
 
         $group = Group::build(
             Arr::get($data, 'attributes.nameSingular'),

--- a/src/Group/Command/DeleteGroupHandler.php
+++ b/src/Group/Command/DeleteGroupHandler.php
@@ -12,14 +12,12 @@ namespace Flarum\Group\Command;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Group\Event\Deleting;
 use Flarum\Group\GroupRepository;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class DeleteGroupHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var GroupRepository
@@ -46,7 +44,7 @@ class DeleteGroupHandler
 
         $group = $this->groups->findOrFail($command->groupId, $actor);
 
-        $this->assertCan($actor, 'delete', $group);
+        $actor->assertCan('delete', $group);
 
         $this->events->dispatch(
             new Deleting($group, $actor, $command->data)

--- a/src/Group/Command/EditGroupHandler.php
+++ b/src/Group/Command/EditGroupHandler.php
@@ -14,7 +14,6 @@ use Flarum\Group\Event\Saving;
 use Flarum\Group\Group;
 use Flarum\Group\GroupRepository;
 use Flarum\Group\GroupValidator;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -22,7 +21,6 @@ use Illuminate\Support\Arr;
 class EditGroupHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\Group\GroupRepository
@@ -58,7 +56,7 @@ class EditGroupHandler
 
         $group = $this->groups->findOrFail($command->groupId, $actor);
 
-        $this->assertCan($actor, 'edit', $group);
+        $actor->assertCan('edit', $group);
 
         $attributes = Arr::get($data, 'attributes', []);
 

--- a/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -10,12 +10,9 @@
 namespace Flarum\Notification\Command;
 
 use Flarum\Notification\NotificationRepository;
-use Flarum\User\AssertPermissionTrait;
 
 class ReadAllNotificationsHandler
 {
-    use AssertPermissionTrait;
-
     /**
      * @var NotificationRepository
      */
@@ -37,7 +34,7 @@ class ReadAllNotificationsHandler
     {
         $actor = $command->actor;
 
-        $this->assertRegistered($actor);
+        $actor->assertRegistered();
 
         $this->notifications->markAllAsRead($actor);
     }

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -11,12 +11,9 @@ namespace Flarum\Notification\Command;
 
 use Carbon\Carbon;
 use Flarum\Notification\Notification;
-use Flarum\User\AssertPermissionTrait;
 
 class ReadNotificationHandler
 {
-    use AssertPermissionTrait;
-
     /**
      * @param ReadNotification $command
      * @return \Flarum\Notification\Notification
@@ -26,7 +23,7 @@ class ReadNotificationHandler
     {
         $actor = $command->actor;
 
-        $this->assertRegistered($actor);
+        $actor->assertRegistered();
 
         $notification = Notification::where('user_id', $actor->id)->findOrFail($command->notificationId);
 

--- a/src/Post/Command/DeletePostHandler.php
+++ b/src/Post/Command/DeletePostHandler.php
@@ -12,13 +12,11 @@ namespace Flarum\Post\Command;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Post\Event\Deleting;
 use Flarum\Post\PostRepository;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class DeletePostHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\Post\PostRepository
@@ -46,7 +44,7 @@ class DeletePostHandler
 
         $post = $this->posts->findOrFail($command->postId, $actor);
 
-        $this->assertCan($actor, 'delete', $post);
+        $actor->assertCan('delete', $post);
 
         $this->events->dispatch(
             new Deleting($post, $actor, $command->data)

--- a/src/Post/Command/EditPostHandler.php
+++ b/src/Post/Command/EditPostHandler.php
@@ -14,14 +14,12 @@ use Flarum\Post\CommentPost;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\PostRepository;
 use Flarum\Post\PostValidator;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class EditPostHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\Post\PostRepository
@@ -61,13 +59,13 @@ class EditPostHandler
             $attributes = Arr::get($data, 'attributes', []);
 
             if (isset($attributes['content'])) {
-                $this->assertCan($actor, 'edit', $post);
+                $actor->assertCan('edit', $post);
 
                 $post->revise($attributes['content'], $actor);
             }
 
             if (isset($attributes['isHidden'])) {
-                $this->assertCan($actor, 'hide', $post);
+                $actor->assertCan('hide', $post);
 
                 if ($attributes['isHidden']) {
                     $post->hide($actor);

--- a/src/Post/Command/PostReplyHandler.php
+++ b/src/Post/Command/PostReplyHandler.php
@@ -16,14 +16,12 @@ use Flarum\Notification\NotificationSyncer;
 use Flarum\Post\CommentPost;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\PostValidator;
-use Flarum\User\AssertPermissionTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class PostReplyHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var DiscussionRepository
@@ -77,7 +75,7 @@ class PostReplyHandler
         // If this is the first post in the discussion, it's technically not a
         // "reply", so we won't check for that permission.
         if ($discussion->post_number_index > 0) {
-            $this->assertCan($actor, 'reply', $discussion);
+            $actor->assertCan('reply', $discussion);
         }
 
         // Create a new Post entity, persist it, and dispatch domain events.

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -12,6 +12,9 @@ namespace Flarum\User;
 use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\Exception\PermissionDeniedException;
 
+/**
+ * @deprecated Please use direct methods of the User class instead. E.g. $actor->assertCan($ability);
+ */
 trait AssertPermissionTrait
 {
     /**
@@ -44,9 +47,7 @@ trait AssertPermissionTrait
      */
     protected function assertRegistered(User $actor)
     {
-        if ($actor->isGuest()) {
-            throw new NotAuthenticatedException;
-        }
+        $actor->assertRegistered();
     }
 
     /**
@@ -57,9 +58,7 @@ trait AssertPermissionTrait
      */
     protected function assertCan(User $actor, $ability, $arguments = [])
     {
-        $this->assertPermission(
-            $actor->can($ability, $arguments)
-        );
+        $actor->assertCan($ability, $arguments);
     }
 
     /**
@@ -68,6 +67,6 @@ trait AssertPermissionTrait
      */
     protected function assertAdmin(User $actor)
     {
-        $this->assertCan($actor, 'administrate');
+        $actor->assertCan('administrate');
     }
 }

--- a/src/User/AssertPermissionTrait.php
+++ b/src/User/AssertPermissionTrait.php
@@ -13,7 +13,7 @@ use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\Exception\PermissionDeniedException;
 
 /**
- * @deprecated Please use direct methods of the User class instead. E.g. $actor->assertCan($ability);
+ * @deprecated beta 14, remove beta 15. Please use direct methods of the User class instead. E.g. $actor->assertCan($ability);
  */
 trait AssertPermissionTrait
 {

--- a/src/User/Command/DeleteAvatarHandler.php
+++ b/src/User/Command/DeleteAvatarHandler.php
@@ -10,7 +10,6 @@
 namespace Flarum\User\Command;
 
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\AvatarUploader;
 use Flarum\User\Event\AvatarDeleting;
 use Flarum\User\UserRepository;
@@ -19,7 +18,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 class DeleteAvatarHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var UserRepository
@@ -55,7 +53,7 @@ class DeleteAvatarHandler
         $user = $this->users->findOrFail($command->userId);
 
         if ($actor->id !== $user->id) {
-            $this->assertCan($actor, 'edit', $user);
+            $actor->assertCan('edit', $user);
         }
 
         $this->uploader->remove($user);

--- a/src/User/Command/DeleteUserHandler.php
+++ b/src/User/Command/DeleteUserHandler.php
@@ -10,7 +10,6 @@
 namespace Flarum\User\Command;
 
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Event\Deleting;
 use Flarum\User\Exception\PermissionDeniedException;
 use Flarum\User\UserRepository;
@@ -19,7 +18,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 class DeleteUserHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var UserRepository
@@ -46,7 +44,7 @@ class DeleteUserHandler
         $actor = $command->actor;
         $user = $this->users->findOrFail($command->userId, $actor);
 
-        $this->assertCan($actor, 'delete', $user);
+        $actor->assertCan('delete', $user);
 
         $this->events->dispatch(
             new Deleting($user, $actor, $command->data)

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -10,7 +10,6 @@
 namespace Flarum\User\Command;
 
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\Event\GroupsChanged;
 use Flarum\User\Event\Saving;
 use Flarum\User\User;
@@ -23,7 +22,6 @@ use Illuminate\Validation\ValidationException;
 class EditUserHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\User\UserRepository
@@ -68,7 +66,7 @@ class EditUserHandler
         $validate = [];
 
         if (isset($attributes['username'])) {
-            $this->assertPermission($canEdit);
+            $actor->assertPermission($canEdit);
             $user->rename($attributes['username']);
         }
 
@@ -80,7 +78,7 @@ class EditUserHandler
                     $validate['email'] = $attributes['email'];
                 }
             } else {
-                $this->assertPermission($canEdit);
+                $actor->assertPermission($canEdit);
                 $user->changeEmail($attributes['email']);
             }
         }
@@ -90,19 +88,19 @@ class EditUserHandler
         }
 
         if (isset($attributes['password'])) {
-            $this->assertPermission($canEdit);
+            $actor->assertPermission($canEdit);
             $user->changePassword($attributes['password']);
 
             $validate['password'] = $attributes['password'];
         }
 
         if (! empty($attributes['markedAllAsReadAt'])) {
-            $this->assertPermission($isSelf);
+            $actor->assertPermission($isSelf);
             $user->markAllAsRead();
         }
 
         if (! empty($attributes['preferences'])) {
-            $this->assertPermission($isSelf);
+            $actor->assertPermission($isSelf);
 
             foreach ($attributes['preferences'] as $k => $v) {
                 $user->setPreference($k, $v);
@@ -110,7 +108,7 @@ class EditUserHandler
         }
 
         if (isset($relationships['groups']['data']) && is_array($relationships['groups']['data'])) {
-            $this->assertPermission($canEdit);
+            $actor->assertPermission($canEdit);
 
             $newGroupIds = [];
             foreach ($relationships['groups']['data'] as $group) {

--- a/src/User/Command/RegisterUserHandler.php
+++ b/src/User/Command/RegisterUserHandler.php
@@ -11,7 +11,6 @@ namespace Flarum\User\Command;
 
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\AvatarUploader;
 use Flarum\User\Event\RegisteringFromProvider;
 use Flarum\User\Event\Saving;
@@ -28,7 +27,6 @@ use Intervention\Image\ImageManager;
 class RegisterUserHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var SettingsRepositoryInterface
@@ -72,7 +70,7 @@ class RegisterUserHandler
         $data = $command->data;
 
         if (! $this->settings->get('allow_sign_up')) {
-            $this->assertAdmin($actor);
+            $actor->assertAdmin();
         }
 
         $password = Arr::get($data, 'attributes.password');

--- a/src/User/Command/UploadAvatarHandler.php
+++ b/src/User/Command/UploadAvatarHandler.php
@@ -10,7 +10,6 @@
 namespace Flarum\User\Command;
 
 use Flarum\Foundation\DispatchEventsTrait;
-use Flarum\User\AssertPermissionTrait;
 use Flarum\User\AvatarUploader;
 use Flarum\User\AvatarValidator;
 use Flarum\User\Event\AvatarSaving;
@@ -21,7 +20,6 @@ use Intervention\Image\ImageManager;
 class UploadAvatarHandler
 {
     use DispatchEventsTrait;
-    use AssertPermissionTrait;
 
     /**
      * @var \Flarum\User\UserRepository
@@ -65,7 +63,7 @@ class UploadAvatarHandler
         $user = $this->users->findOrFail($command->userId);
 
         if ($actor->id !== $user->id) {
-            $this->assertCan($actor, 'edit', $user);
+            $actor->assertCan('edit', $user);
         }
 
         $this->validator->assertValid(['avatar' => $command->file]);

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -34,6 +34,8 @@ use Flarum\User\Event\GetDisplayName;
 use Flarum\User\Event\PasswordChanged;
 use Flarum\User\Event\Registered;
 use Flarum\User\Event\Renamed;
+use Flarum\User\Exception\NotAuthenticatedException;
+use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
@@ -575,6 +577,60 @@ class User extends AbstractModel
     public function isGuest()
     {
         return false;
+    }
+
+    /**
+     * Ensure the current user is allowed to do something.
+     *
+     * If the condition is not met, an exception will be thrown that signals the
+     * lack of permissions. This is about *authorization*, i.e. retrying such a
+     * request / operation without a change in permissions (or using another
+     * user account) is pointless.
+     *
+     * @param bool $condition
+     * @throws PermissionDeniedException
+     */
+    public function assertPermission($condition)
+    {
+        if (! $condition) {
+            throw new PermissionDeniedException;
+        }
+    }
+
+    /**
+     * Ensure the given actor is authenticated.
+     *
+     * This will throw an exception for guest users, signaling that
+     * *authorization* failed. Thus, they could retry the operation after
+     * logging in (or using other means of authentication).
+     *
+     * @throws NotAuthenticatedException
+     */
+    public function assertRegistered()
+    {
+        if ($this->isGuest()) {
+            throw new NotAuthenticatedException;
+        }
+    }
+
+    /**
+     * @param string $ability
+     * @param mixed $arguments
+     * @throws PermissionDeniedException
+     */
+    public function assertCan($ability, $arguments = [])
+    {
+        $this->assertPermission(
+            $this->can($ability, $arguments)
+        );
+    }
+
+    /**
+     * @throws PermissionDeniedException
+     */
+    public function assertAdmin()
+    {
+        $this->assertCan($this, 'administrate');
     }
 
     /**


### PR DESCRIPTION
**Fixes #1320 **

**Changes proposed in this pull request:**
Deprecate the AssertPermissionTrait. We should merge this in the next release to give extension authors time to adjust prior to stable.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).