### PR TITLE
Cleaned up discussion idWithSlug handling

### DIFF
--- a/js/src/common/models/Discussion.js
+++ b/js/src/common/models/Discussion.js
@@ -7,6 +7,7 @@ export default class Discussion extends Model {}
 
 Object.assign(Discussion.prototype, {
   title: Model.attribute('title'),
+  slug: Model.attribute('slug'),
   idWithSlug: Model.attribute('idWithSlug'),
 
   createdAt: Model.attribute('createdAt', Model.transformDate),

--- a/js/src/common/models/Discussion.js
+++ b/js/src/common/models/Discussion.js
@@ -7,7 +7,7 @@ export default class Discussion extends Model {}
 
 Object.assign(Discussion.prototype, {
   title: Model.attribute('title'),
-  slug: Model.attribute('slug'),
+  idWithSlug: Model.attribute('idWithSlug'),
 
   createdAt: Model.attribute('createdAt', Model.transformDate),
   user: Model.hasOne('user'),

--- a/js/src/forum/routes.js
+++ b/js/src/forum/routes.js
@@ -34,10 +34,9 @@ export default function (app) {
    * @return {String}
    */
   app.route.discussion = (discussion, near) => {
-    const slug = discussion.slug();
     return app.route(near && near !== 1 ? 'discussion.near' : 'discussion', {
-      id: discussion.id() + (slug.trim() ? '-' + slug : ''),
-      near: near && near !== 1 ? near : undefined,
+      id: discussion.idWithSlug(),
+      near: near && near !== 1 ? near : undefined
     });
   };
 

--- a/js/src/forum/routes.js
+++ b/js/src/forum/routes.js
@@ -36,7 +36,7 @@ export default function (app) {
   app.route.discussion = (discussion, near) => {
     return app.route(near && near !== 1 ? 'discussion.near' : 'discussion', {
       id: discussion.idWithSlug(),
-      near: near && near !== 1 ? near : undefined
+      near: near && near !== 1 ? near : undefined,
     });
   };
 

--- a/src/Api/Serializer/BasicDiscussionSerializer.php
+++ b/src/Api/Serializer/BasicDiscussionSerializer.php
@@ -36,7 +36,7 @@ class BasicDiscussionSerializer extends AbstractSerializer
         return [
             'title' => $discussion->title,
             'slug'  => $discussion->slug,
-            'idWithSlug' => $discussion->id.trim($discussion->slug) ? '-'.$discussion->slug : ''
+            'idWithSlug' => $discussion->id.(trim($discussion->slug) ? '-'.$discussion->slug : '')
         ];
     }
 

--- a/src/Api/Serializer/BasicDiscussionSerializer.php
+++ b/src/Api/Serializer/BasicDiscussionSerializer.php
@@ -36,6 +36,7 @@ class BasicDiscussionSerializer extends AbstractSerializer
         return [
             'title' => $discussion->title,
             'slug'  => $discussion->slug,
+            'idWithSlug' => $discussion->id.trim($discussion->slug) ? '-'.$discussion->slug : ''
         ];
     }
 

--- a/src/Forum/Content/Discussion.php
+++ b/src/Forum/Content/Discussion.php
@@ -74,9 +74,7 @@ class Discussion
             unset($newQueryParams['id']);
             $queryString = http_build_query($newQueryParams);
 
-            $idWithSlug = $apiDocument->data->id.(trim($apiDocument->data->attributes->slug) ? '-'.$apiDocument->data->attributes->slug : '');
-
-            return $this->url->to('forum')->route('discussion', ['id' => $idWithSlug]).
+            return $this->url->to('forum')->route('discussion', ['id' => $apiDocument->data->attributes->idWithSlug]).
             ($queryString ? '?'.$queryString : '');
         };
 

--- a/views/frontend/content/index.blade.php
+++ b/views/frontend/content/index.blade.php
@@ -5,21 +5,19 @@
 
     <ul>
         @foreach ($apiDocument->data as $discussion)
-            <li>
-                <a href="{{ $url->to('forum')->route('discussion', [
-                    'id' => $discussion->id . (trim($discussion->attributes->slug) ? '-' . $discussion->attributes->slug : '')
-                ]) }}">
-                    {{ $discussion->attributes->title }}
-                </a>
-            </li>
+        <li>
+            <a href="{{ $url->to('forum')->route('discussion', ['id' => $discussion->attributes->idWithSlug]) }}">
+                {{ $discussion->attributes->title }}
+            </a>
+        </li>
         @endforeach
     </ul>
 
     @if (isset($apiDocument->links->prev))
-        <a href="{{ $url->to('forum')->route('index') }}?page={{ $page - 1 }}">&laquo; {{ $translator->trans('core.views.index.previous_page_button') }}</a>
+    <a href="{{ $url->to('forum')->route('index') }}?page={{ $page - 1 }}">&laquo; {{ $translator->trans('core.views.index.previous_page_button') }}</a>
     @endif
 
     @if (isset($apiDocument->links->next))
-        <a href="{{ $url->to('forum')->route('index') }}?page={{ $page + 1 }}">{{ $translator->trans('core.views.index.next_page_button') }} &raquo;</a>
+    <a href="{{ $url->to('forum')->route('index') }}?page={{ $page + 1 }}">{{ $translator->trans('core.views.index.next_page_button') }} &raquo;</a>
     @endif
 </div>

--- a/views/frontend/content/index.blade.php
+++ b/views/frontend/content/index.blade.php
@@ -14,10 +14,10 @@
     </ul>
 
     @if (isset($apiDocument->links->prev))
-    <a href="{{ $url->to('forum')->route('index') }}?page={{ $page - 1 }}">&laquo; {{ $translator->trans('core.views.index.previous_page_button') }}</a>
+        <a href="{{ $url->to('forum')->route('index') }}?page={{ $page - 1 }}">&laquo; {{ $translator->trans('core.views.index.previous_page_button') }}</a>
     @endif
 
     @if (isset($apiDocument->links->next))
-    <a href="{{ $url->to('forum')->route('index') }}?page={{ $page + 1 }}">{{ $translator->trans('core.views.index.next_page_button') }} &raquo;</a>
+        <a href="{{ $url->to('forum')->route('index') }}?page={{ $page + 1 }}">{{ $translator->trans('core.views.index.next_page_button') }} &raquo;</a>
     @endif
 </div>


### PR DESCRIPTION
**Fixes #1360**

**Changes proposed in this pull request:**
- Moved all discussion idWithSlug generation logic to backend.

**Reviewers should focus on:**
- Should we still send the raw slug itself to the frontend?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
