### PR TITLE
Added excerpt method to Discussion, and meta description to description page.

### DIFF
--- a/src/Api/Serializer/BasicDiscussionSerializer.php
+++ b/src/Api/Serializer/BasicDiscussionSerializer.php
@@ -36,6 +36,7 @@ class BasicDiscussionSerializer extends AbstractSerializer
         return [
             'title' => $discussion->title,
             'slug'  => $discussion->slug,
+            'excerpt' => $discussion->excerpt(),
         ];
     }
 

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -454,4 +454,18 @@ class Discussion extends AbstractModel
         $this->attributes['title'] = $title;
         $this->slug = Str::slug($title);
     }
+
+    /**
+     * Generates a brief excerpt based off of the first post
+     *
+     * @param int length (Defaults to 160)
+     * @return string
+     */
+    public function excerpt($length = 160)
+    {
+        $relevantPost = $this->mostRelevantPost ?: $this->firstPost ?: $this->comments->first();
+        $content = trim(preg_replace('/\s+/', ' ', strip_tags($relevantPost->formatContent())));
+        $excerpt = substr($content, 0, $length);
+        return mb_strlen($content) > $length ? mb_substr($excerpt, 0, strrpos($excerpt, ' ')).'...' : $excerpt;
+    }
 }

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -470,6 +470,7 @@ class Discussion extends AbstractModel
 
         $content = trim(preg_replace('/\s+/', ' ', strip_tags($relevantPost->formatContent())));
         $excerpt = substr($content, 0, $length);
+
         return mb_strlen($content) > $length ? mb_substr($excerpt, 0, strrpos($excerpt, ' ')).'...' : $excerpt;
     }
 }

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -464,6 +464,10 @@ class Discussion extends AbstractModel
     public function excerpt($length = 160)
     {
         $relevantPost = $this->mostRelevantPost ?: $this->firstPost ?: $this->comments->first();
+        if ($relevantPost === null) {
+            return '';
+        }
+
         $content = trim(preg_replace('/\s+/', ' ', strip_tags($relevantPost->formatContent())));
         $excerpt = substr($content, 0, $length);
         return mb_strlen($content) > $length ? mb_substr($excerpt, 0, strrpos($excerpt, ' ')).'...' : $excerpt;

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -456,7 +456,7 @@ class Discussion extends AbstractModel
     }
 
     /**
-     * Generates a brief excerpt based off of the first post
+     * Generates a brief excerpt based off of the first post.
      *
      * @param int length (Defaults to 160)
      * @return string

--- a/src/Forum/Content/Discussion.php
+++ b/src/Forum/Content/Discussion.php
@@ -89,6 +89,7 @@ class Discussion
         }
 
         $document->title = $apiDocument->data->attributes->title;
+        $document->meta['description'] = $apiDocument->data->attributes->excerpt;
         $document->canonicalUrl = $url([]);
         $document->content = $this->view->make('flarum.forum::frontend.content.discussion', compact('apiDocument', 'page', 'getResource', 'posts', 'url'));
         $document->payload['apiDocument'] = $apiDocument;


### PR DESCRIPTION
**Cleans up #1948**

**Changes proposed in this pull request:**
- Added length-configurable exerpt method to discussion (could be used in projects like flarum summaries)
- Added meta description to description page 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).