### PR TITLE
Add Authenticated Test Case utility

### DIFF
--- a/tests/integration/AuthenticatedTestCase.php
+++ b/tests/integration/AuthenticatedTestCase.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Api\ApiKey;
+use Illuminate\Support\Str;
+use Psr\Http\Message\ServerRequestInterface;
+
+abstract class AuthenticatedTestCase extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function genKey(int $user_id = null): ApiKey
+    {
+        return ApiKey::unguarded(function () use ($user_id) {
+            return ApiKey::query()->firstOrCreate([
+                'key'        => Str::random(),
+                'user_id'    => $user_id,
+                'created_at' => Carbon::now()
+            ]);
+        });
+    }
+
+    /**
+     * Build an authenticated HTTP request that can be passed through middleware.
+     *
+     * This method simplifies building HTTP request for use in our HTTP-level
+     * integration tests. It provides options for all features repeatedly being
+     * used in those tests.
+     *
+     * @param string $method
+     * @param string $path
+     * @param array $options
+     *   An array of optional request properties.
+     *   Currently supported:
+     *   - "json" should point to a JSON-serializable object that will be
+     *     serialized and used as request body. The corresponding Content-Type
+     *     header will be set automatically.
+     *   - "cookiesFrom" should hold a response object from a previous HTTP
+     *     interaction. All cookies returned from the server in that response
+     *     (via the "Set-Cookie" header) will be copied to the cookie params of
+     *     the new request.
+     * @param bool $useAdmin Should the request be sent with admin permissions?
+     * @return ServerRequestInterface
+     */
+    protected function authenticatedRequest(string $method, string $path, array $options = [], bool $useAdmin = true): ServerRequestInterface
+    {
+        $request = $this->request($method, $path, $options);
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->adminUser(),
+                $this->normalUser(),
+            ],
+        ]);
+
+        if (! isset($this->key)) {
+            $this->key = $this->genKey();
+        }
+
+        $userId = $useAdmin ? 1 : 2;
+
+        return $request->withAddedHeader('Authorization', "Token {$this->key->key}; userId=$userId");
+    }
+}

--- a/tests/integration/AuthenticatedTestCase.php
+++ b/tests/integration/AuthenticatedTestCase.php
@@ -48,10 +48,11 @@ abstract class AuthenticatedTestCase extends TestCase
      *     interaction. All cookies returned from the server in that response
      *     (via the "Set-Cookie" header) will be copied to the cookie params of
      *     the new request.
-     * @param bool $useAdmin Should the request be sent with admin permissions?
+     * @param int $userId Which user should be emulated? User ID 1 will return a
+     * user with admin perms unless this has been modified in your test case.
      * @return ServerRequestInterface
      */
-    protected function authenticatedRequest(string $method, string $path, array $options = [], bool $useAdmin = true): ServerRequestInterface
+    protected function authenticatedRequest(string $method, string $path, array $options = [], int $userId = 1): ServerRequestInterface
     {
         $request = $this->request($method, $path, $options);
 
@@ -62,11 +63,9 @@ abstract class AuthenticatedTestCase extends TestCase
             ],
         ]);
 
-        if (! isset($this->key)) {
+        if (!isset($this->key)) {
             $this->key = $this->genKey();
         }
-
-        $userId = $useAdmin ? 1 : 2;
 
         return $request->withAddedHeader('Authorization', "Token {$this->key->key}; userId=$userId");
     }


### PR DESCRIPTION
**Organized Workaround for  #2035**

Provides a superclass for integration tests that require authentication on requests. Supports both admin and non-admin permissions. Compliant with https://github.com/flarum/core/pull/2036#issuecomment-595734221. Makes integration tests a LOT more easier. Also, probable base for moving the Controller integration tests onto using requests, not directly calling the controller.