### PR TITLE
fix insertAfter and insertBefore middleware extender functions

### DIFF
--- a/src/Extend/Middleware.php
+++ b/src/Extend/Middleware.php
@@ -49,14 +49,14 @@ class Middleware implements ExtenderInterface
 
     public function insertBefore($originalMiddleware, $newMiddleware)
     {
-        $this->replaceMiddlewares[$originalMiddleware] = $newMiddleware;
+        $this->insertBeforeMiddlewares[$originalMiddleware] = $newMiddleware;
 
         return $this;
     }
 
     public function insertAfter($originalMiddleware, $newMiddleware)
     {
-        $this->replaceMiddlewares[$originalMiddleware] = $newMiddleware;
+        $this->insertAfterMiddlewares[$originalMiddleware] = $newMiddleware;
 
         return $this;
     }

--- a/src/Extend/Middleware.php
+++ b/src/Extend/Middleware.php
@@ -81,7 +81,7 @@ class Middleware implements ExtenderInterface
             foreach ($this->insertBeforeMiddlewares as $originalMiddleware => $newMiddleware) {
                 array_splice(
                     $existingMiddleware,
-                    array_search($originalMiddleware, $existingMiddleware),
+                    array_search($originalMiddleware, $existingMiddleware) + 1,
                     0,
                     $newMiddleware
                 );
@@ -90,7 +90,7 @@ class Middleware implements ExtenderInterface
             foreach ($this->insertAfterMiddlewares as $originalMiddleware => $newMiddleware) {
                 array_splice(
                     $existingMiddleware,
-                    array_search($originalMiddleware, $existingMiddleware) + 1,
+                    array_search($originalMiddleware, $existingMiddleware),
                     0,
                     $newMiddleware
                 );

--- a/tests/integration/extenders/MiddlewareTest.php
+++ b/tests/integration/extenders/MiddlewareTest.php
@@ -88,13 +88,14 @@ class MiddlewareTest extends TestCase
     /**
      * @test
      */
-    public function can_insert_before_middleware() {
+    public function can_insert_before_middleware()
+    {
         $this->add_first_middleware();
         $this->extend(
             (new Extend\Middleware('forum'))->insertBefore(FirstTestMiddleware::class, SecondTestMiddleware::class)
         );
 
-        $response =  $this->send($this->request('GET', '/'));
+        $response = $this->send($this->request('GET', '/'));
         $headers = $response->getHeaders();
         $newMiddlewarePosition = array_search('X-Second-Test-Middleware', array_keys($headers));
         $originalMiddlewarePosition = array_search('X-First-Test-Middleware', array_keys($headers));
@@ -106,13 +107,14 @@ class MiddlewareTest extends TestCase
     /**
      * @test
      */
-    public function can_insert_after_middleware() {
+    public function can_insert_after_middleware()
+    {
         $this->add_first_middleware();
         $this->extend(
             (new Extend\Middleware('forum'))->insertAfter(FirstTestMiddleware::class, SecondTestMiddleware::class)
         );
 
-        $response =  $this->send($this->request('GET', '/'));
+        $response = $this->send($this->request('GET', '/'));
         $headers = $response->getHeaders();
         $newMiddlewarePosition = array_search('X-Second-Test-Middleware', array_keys($headers));
         $originalMiddlewarePosition = array_search('X-First-Test-Middleware', array_keys($headers));

--- a/tests/integration/extenders/MiddlewareTest.php
+++ b/tests/integration/extenders/MiddlewareTest.php
@@ -84,6 +84,42 @@ class MiddlewareTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertArrayNotHasKey('X-First-Test-Middleware', $response->getHeaders());
     }
+
+    /**
+     * @test
+     */
+    public function can_insert_before_middleware() {
+        $this->add_first_middleware();
+        $this->extend(
+            (new Extend\Middleware('forum'))->insertBefore(FirstTestMiddleware::class, SecondTestMiddleware::class)
+        );
+
+        $response =  $this->send($this->request('GET', '/'));
+        $headers = $response->getHeaders();
+        $newMiddlewarePosition = array_search('X-Second-Test-Middleware', array_keys($headers));
+        $originalMiddlewarePosition = array_search('X-First-Test-Middleware', array_keys($headers));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertLessThan($originalMiddlewarePosition, $newMiddlewarePosition);
+    }
+
+    /**
+     * @test
+     */
+    public function can_insert_after_middleware() {
+        $this->add_first_middleware();
+        $this->extend(
+            (new Extend\Middleware('forum'))->insertAfter(FirstTestMiddleware::class, SecondTestMiddleware::class)
+        );
+
+        $response =  $this->send($this->request('GET', '/'));
+        $headers = $response->getHeaders();
+        $newMiddlewarePosition = array_search('X-Second-Test-Middleware', array_keys($headers));
+        $originalMiddlewarePosition = array_search('X-First-Test-Middleware', array_keys($headers));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertGreaterThan($originalMiddlewarePosition, $newMiddlewarePosition);
+    }
 }
 
 class FirstTestMiddleware implements MiddlewareInterface


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Fixes `insertBefore` and `insertAfter` functions of the Middleware extender.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Confirmed**
- [x] Backend changes: tests are green (run `composer test`).
