### PR TITLE
Add AskQuestionTrait for console commands

### DIFF
--- a/src/Console/AskQuestionTrait.php
+++ b/src/Console/AskQuestionTrait.php
@@ -46,7 +46,7 @@ trait AskQuestionTrait
     protected function confirm($question)
     {
         while (true) {
-            $confirmation = $this->ask($question . ' (y/N)');
+            $confirmation = $this->ask($question.' (y/N)');
 
             if (strtolower($confirmation) === 'y') {
                 return true;

--- a/src/Console/AskQuestionTrait.php
+++ b/src/Console/AskQuestionTrait.php
@@ -47,7 +47,7 @@ trait AskQuestionTrait
     protected function confirm($question)
     {
         while (true) {
-            $confirmation = $this->ask($question.' (y/N)');
+            $confirmation = $this->ask($question.' (y/n)');
 
             if (strtolower($confirmation) === 'y') {
                 return true;

--- a/src/Console/AskQuestionTrait.php
+++ b/src/Console/AskQuestionTrait.php
@@ -42,4 +42,19 @@ trait AskQuestionTrait
 
         return $this->questionHelper()->ask($this->input, $this->output, $question);
     }
+
+    protected function confirm($question)
+    {
+        while (true) {
+            $confirmation = $this->ask($question . ' (y/N)');
+
+            if (strtolower($confirmation) === 'y') {
+                return true;
+            } elseif (strtolower($confirmation) === 'n') {
+                return false;
+            } else {
+                $this->error('Invalid Response');
+            }
+        }
+    }
 }

--- a/src/Console/AskQuestionTrait.php
+++ b/src/Console/AskQuestionTrait.php
@@ -24,6 +24,7 @@ trait AskQuestionTrait
         if (is_null($this->questionHelper)) {
             $this->questionHelper = new QuestionHelper;
         }
+
         return $this->questionHelper;
     }
 

--- a/src/Console/AskQuestionTrait.php
+++ b/src/Console/AskQuestionTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Console;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
+
+trait AskQuestionTrait
+{
+    /**
+     * @var QuestionHelper
+     */
+    protected $questionHelper;
+
+    protected function questionHelper()
+    {
+        if (is_null($this->questionHelper)) {
+            $this->questionHelper = new QuestionHelper;
+        }
+        return $this->questionHelper;
+    }
+
+    protected function ask($question, $default = null)
+    {
+        $question = new Question("<question>$question</question> ", $default);
+
+        return $this->questionHelper()->ask($this->input, $this->output, $question);
+    }
+
+    protected function secret($question)
+    {
+        $question = new Question("<question>$question</question> ");
+
+        $question->setHidden(true)->setHiddenFallback(true);
+
+        return $this->questionHelper()->ask($this->input, $this->output, $question);
+    }
+}


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Various console commands are likely to need to ask for input within the command. So:
- The ->ask() and ->secret() utilities have been added in a new trait, so that they are accessible to console commands.
- A ->confirm() utility has been added to require a user to confirm something (y/N)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).