### PR TITLE
Add change setting command

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Console;
 
+use Flarum\Database\Console\ChangeSettingCommand;
 use Flarum\Database\Console\GenerateMigrationCommand;
 use Flarum\Database\Console\MigrateCommand;
 use Flarum\Database\Console\ResetCommand;
@@ -25,6 +26,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
         $this->app->singleton('flarum.console.commands', function () {
             return [
                 CacheClearCommand::class,
+                ChangeSettingCommand::class,
                 GenerateMigrationCommand::class,
                 MigrateCommand::class,
                 ResetCommand::class,

--- a/src/Database/Console/ChangeSettingCommand.php
+++ b/src/Database/Console/ChangeSettingCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Database\Console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ChangeSettingCommand extends AbstractCommand
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @param SettingsRepositoryInterface $settings
+     */
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('setting:change')
+            ->setDescription('Change a setting programatically')
+            ->addArgument(
+                'setting',
+                InputArgument::REQUIRED,
+                'The name of the setting to change.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $setting = $this->input->getArgument('setting');
+        $this->info('Configuring setting: '.$setting);
+
+        $newValue = $this->askForSettingValue();
+        $this->settings->set($setting, $newValue);
+
+        $this->info('Done');
+    }
+
+    protected function askForSettingValue()
+    {
+        while (true) {
+            $value = $this->ask('New Value:');
+
+            json_decode($value);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                break;
+            } else {
+                $this->error('Value must be a valid json string.');
+            }
+        }
+    }
+}

--- a/src/Database/Console/ChangeSettingCommand.php
+++ b/src/Database/Console/ChangeSettingCommand.php
@@ -51,7 +51,7 @@ class ChangeSettingCommand extends AbstractCommand
     protected function fire()
     {
         $setting = $this->input->getArgument('setting');
-        $this->info('Configuring setting: '.$setting);
+        $this->info('Configuring setting: ' . $setting);
 
         $newValue = $this->askForSettingValue();
         $this->settings->set($setting, $newValue);
@@ -62,12 +62,10 @@ class ChangeSettingCommand extends AbstractCommand
     protected function askForSettingValue()
     {
         while (true) {
-            $value = $this->ask('New Value:');
-
-            json_decode($value);
+            $value =  json_decode($this->ask('New Value:'), true);
 
             if (json_last_error() === JSON_ERROR_NONE) {
-                break;
+                return $value;
             } else {
                 $this->error('Value must be a valid json string.');
             }

--- a/src/Database/Console/ChangeSettingCommand.php
+++ b/src/Database/Console/ChangeSettingCommand.php
@@ -51,7 +51,7 @@ class ChangeSettingCommand extends AbstractCommand
     protected function fire()
     {
         $setting = $this->input->getArgument('setting');
-        $this->info('Configuring setting: ' . $setting);
+        $this->info('Configuring setting: '.$setting);
 
         $newValue = $this->askForSettingValue();
         $this->settings->set($setting, $newValue);
@@ -62,7 +62,7 @@ class ChangeSettingCommand extends AbstractCommand
     protected function askForSettingValue()
     {
         while (true) {
-            $value =  json_decode($this->ask('New Value:'), true);
+            $value = json_decode($this->ask('New Value:'), true);
 
             if (json_last_error() === JSON_ERROR_NONE) {
                 return $value;


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
Add console command to change a setting in the database by providing a json encoded string. Depends on #2068 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
