### PR TITLE
Change default discussion comment count

### DIFF
--- a/migrations/2020_03_19_134512_change_discussions_default_comment_count.php
+++ b/migrations/2020_03_19_134512_change_discussions_default_comment_count.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->integer('comment_count')->default(1)->change();
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->integer('comment_count')->default(0)->change();
+        });
+    }
+];


### PR DESCRIPTION
This allows new public discussions to be immediately visible by users.


**Fixes #2076**

**Changes proposed in this pull request:**
Add a migration to default discussion comment_count to 1 allowing discussions to be visible to users immediately, this fixes recent pusher issues.

**Reviewers should focus on:**
Is this the way we want to fix this issue?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
