### PR TITLE
Fix Buggy Modals

### DIFF
--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -54,7 +54,6 @@ export default class ModalManager extends Component {
     m.redraw(true);
 
     this.$().modal({backdrop: this.component.isDismissible() ? true : 'static'}).modal('show');
-    this.onready();
   }
 
   /**

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -177,7 +177,7 @@
 
 @media @tablet-up {
   .Modal {
-    margin: 30px auto;
+    margin: 120px auto;
   }
   .Modal-close {
     position: absolute;

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -177,7 +177,7 @@
 
 @media @tablet-up {
   .Modal {
-    margin: 120px auto;
+    margin: 30px auto;
   }
   .Modal-close {
     position: absolute;


### PR DESCRIPTION
**Fixes #1504**
**Fixes #1813**

**Changes proposed in this pull request:**

First commit was proposing to change margin values for `@tablet-up` breakpoint as seen on [Bootstrap stylesheets](https://github.com/twbs/bootstrap/blob/68b0d231a13201eb14acd3dc84e51543d16e5f7e/dist/css/bootstrap.css#L6053). Evethough it fixes the issue, i wasn't happy with it and did some further research. Eventually, i noticed that we're calling `onready()` method of `ModalManager` component twice [Line 33 & 57]. First call waits for transitions to be complete and the second one seems useless. Made some conversation with @datitisev on Discord and now we're here.

**Reviewers should focus on:**

* Did i miss something?

I know this one is hard to catch since it seems sporadic but try to test it with developer tools docked to bottom of the browser (make it bigger until you succeed).

Note that zooming out from the page before clicking on the "Choose Tags" button also fixes the issue ([as stated by @sometao](https://discuss.flarum.org/d/22788-opening-choose-tags-from-the-new-post-form-is-buggy/11)) ~~so it should be something related with viewport heights~~.

I look forward to your reviews and I need to fix this since it effects some of my modal related extensions.

**Screenshot**

https://vimeo.com/399523797

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).