### PR TITLE
Fix calculation of post position on page

### DIFF
--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -476,7 +476,7 @@ class PostStream extends Component {
       const top = $item.offset().top;
       const height = $item.outerHeight(true);
 
-      if (top + height > scrollTop) {
+      if (top + height > scrollTop + 2) {
         if (!startNumber) {
           startNumber = endNumber = $item.data('number');
         }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -475,7 +475,10 @@ class PostStream extends Component {
       const $item = $(this);
       const top = $item.offset().top;
       const height = $item.outerHeight(true);
-
+      
+      // jQuery offset() and outHeight() may return value in decimals.
+      // Instead of 5, may return 5.8. TO offset this, we add +2 to the
+      // value of scrollTop.
       if (top + height > scrollTop + 2) {
         if (!startNumber) {
           startNumber = endNumber = $item.data('number');


### PR DESCRIPTION
**Fixes #2086**

**Changes proposed in this pull request:**
Changes Formula for calculating the current post, which is used to scroll to the post. Current implementation scrolled to the previous post, and not the linked post.

**Reviewers should focus on:**
Open this link: https://discuss.flarum.org/d/9033-telegram-login-and-notifications-by-flagrow/16 . Note the address bar . The address bar should not change to /15

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

btw: I think I screwed up my previous pull requests. Hope I am doing it right this time. Would love to get some guidance if I am doing it wrong.