### PR TITLE
Added event extender (used for domain events)

### DIFF
--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -21,10 +21,8 @@ class Event implements ExtenderInterface
      * Add a listener to a domain event dispatched by flarum or a flarum extension.
      *
      * The listener can either be:
-     *  - a callback function
-     *  - a The class attribute of class with a public `handle` method, which accepts an instance of the event as a parameter
-     *  - An array where the first element is the class attribute of the listener class, and the second element is
-     *    a string with the name of the method that will handle the event. This method should accept an instance of the event as a parameter.
+     *  - a callback function or
+     *  - the class attribute of a class with a public `handle` method, which accepts an instance of the event as a parameter
      *
      * @param string $event
      * @param callable $listener

--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Events\Dispatcher;
+
+class Event implements ExtenderInterface
+{
+    private $listeners = [];
+
+    /**
+     * Add a listener to a domain event dispatched by flarum or an extension to flarum
+     *
+     * @param string $event
+     * @param callable $listener
+     */
+    public function listen(string $event, $listener)
+    {
+        $this->listeners[] = [$event, $listener];
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $events = $container->make(Dispatcher::class);
+
+        foreach ($this->listeners as $listener) {
+            if (is_string($listener[1])) {
+                $listener[1] = $container->make($listener[1]);
+            }
+
+            $events->listen($listener[0], $listener[1]);
+        }
+    }
+}

--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -20,6 +20,12 @@ class Event implements ExtenderInterface
     /**
      * Add a listener to a domain event dispatched by flarum or a flarum extension.
      *
+     * The listener can either be:
+     *  - a callback function
+     *  - a The class attribute of class with a public `handle` method, which accepts an instance of the event as a parameter
+     *  - An array where the first element is the class attribute of the listener class, and the second element is
+     *    a string with the name of the method that will handle the event. This method should accept an instance of the event as a parameter.
+     *
      * @param string $event
      * @param callable $listener
      */

--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -18,7 +18,7 @@ class Event implements ExtenderInterface
     private $listeners = [];
 
     /**
-     * Add a listener to a domain event dispatched by flarum or an extension to flarum
+     * Add a listener to a domain event dispatched by flarum or a flarum extension.
      *
      * @param string $event
      * @param callable $listener
@@ -35,10 +35,6 @@ class Event implements ExtenderInterface
         $events = $container->make(Dispatcher::class);
 
         foreach ($this->listeners as $listener) {
-            if (is_string($listener[1])) {
-                $listener[1] = $container->make($listener[1]);
-            }
-
             $events->listen($listener[0], $listener[1]);
         }
     }

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -56,10 +56,23 @@ class EventTest extends TestCase
     /**
      * @test
      */
-    public function custom_listener_works_with_invokable_class_and_can_inject_stuff()
+    public function custom_listener_works_with_class_with_handle_method_and_can_inject_stuff()
     {
         // Because it injects a translator, this also tests that stuff can be injected into this callback.
         $this->extend((new Extend\Event)->listen(Created::class, CustomListener::class));
+
+        $group = $this->buildGroup();
+
+        $this->assertEquals($group->name_singular, 'core.group.admin');
+    }
+
+    /**
+     * @test
+     */
+    public function custom_listener_works_with_class_with_custom_method_and_can_inject_stuff()
+    {
+        // Because it injects a translator, this also tests that stuff can be injected into this callback.
+        $this->extend((new Extend\Event)->listen(Created::class, [CustomListener::class, 'customHandle']));
 
         $group = $this->buildGroup();
 
@@ -76,7 +89,12 @@ class CustomListener
         $this->translator = $translator;
     }
 
-    public function __invoke(Created $event)
+    public function handle(Created $event)
+    {
+        $event->group->name_singular = $this->translator->trans('core.group.admin');
+    }
+
+    public function customHandle(Created $event)
     {
         $event->group->name_singular = $this->translator->trans('core.group.admin');
     }

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -14,6 +14,7 @@ use Flarum\Group\Group;
 use Flarum\Group\Event\Created;
 use Flarum\Tests\integration\TestCase;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Translation\Translator;
 
 class EventTest extends TestCase
 {
@@ -56,22 +57,26 @@ class EventTest extends TestCase
      */
     public function custom_listener_works_with_invokable_class_and_can_inject_stuff()
     {
+        // Because it injects a translator, this also tests that stuff can be injected into this callback.
         $this->extend((new Extend\Event)->listen(Created::class, CustomListener::class));
 
         $group = $this->buildGroup();
 
-        $this->assertEquals($group->name_singular, 'modified group');
+        $this->assertEquals($group->name_singular, 'core.group.admin');
     }
 }
 
 class CustomListener
 {
-    public function __construct()
+    protected $translator;
+
+    public function __construct(Translator $translator)
     {
+        $this->translator = $translator;
     }
 
     public function __invoke(Created $event)
     {
-        $event->group->name_singular = 'modified group';
+        $event->group->name_singular = $this->translator->trans('core.group.admin');
     }
 }

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -66,19 +66,6 @@ class EventTest extends TestCase
 
         $this->assertEquals($group->name_singular, 'core.group.admin');
     }
-
-    /**
-     * @test
-     */
-    public function custom_listener_works_with_class_with_custom_method_and_can_inject_stuff()
-    {
-        // Because it injects a translator, this also tests that stuff can be injected into this callback.
-        $this->extend((new Extend\Event)->listen(Created::class, [CustomListener::class, 'customHandle']));
-
-        $group = $this->buildGroup();
-
-        $this->assertEquals($group->name_singular, 'core.group.admin');
-    }
 }
 
 class CustomListener
@@ -91,11 +78,6 @@ class CustomListener
     }
 
     public function handle(Created $event)
-    {
-        $event->group->name_singular = $this->translator->trans('core.group.admin');
-    }
-
-    public function customHandle(Created $event)
     {
         $event->group->name_singular = $this->translator->trans('core.group.admin');
     }

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -29,6 +29,7 @@ class EventTest extends TestCase
 
         return $group;
     }
+
     /**
      * @test
      */

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -10,15 +10,16 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
-use Flarum\Group\Group;
 use Flarum\Group\Event\Created;
+use Flarum\Group\Group;
 use Flarum\Tests\integration\TestCase;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Translation\Translator;
 
 class EventTest extends TestCase
 {
-    protected function buildGroup() {
+    protected function buildGroup()
+    {
         $events = $this->app()->getContainer()->make(Dispatcher::class);
 
         $group = Group::build('test group', 'test groups', '#000000', 'fas fa-crown');

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\Group\Group;
+use Flarum\Group\Event\Created;
+use Flarum\Tests\integration\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class EventTest extends TestCase
+{
+    protected function buildGroup() {
+        $events = $this->app()->getContainer()->make(Dispatcher::class);
+
+        $group = Group::build('test group', 'test groups', '#000000', 'fas fa-crown');
+        $group->save();
+
+        $events->dispatch(new Created($group));
+
+        return $group;
+    }
+    /**
+     * @test
+     */
+    public function custom_listener_doesnt_work_by_default()
+    {
+        $group = $this->buildGroup();
+
+        $this->assertEquals($group->name_singular, 'test group');
+    }
+
+    /**
+     * @test
+     */
+    public function custom_listener_works_with_closure()
+    {
+        $this->extend((new Extend\Event)->listen(Created::class, function (Created $event) {
+            $event->group->name_singular = 'modified group';
+        }));
+
+        $group = $this->buildGroup();
+
+        $this->assertEquals($group->name_singular, 'modified group');
+    }
+
+    /**
+     * @test
+     */
+    public function custom_listener_works_with_invokable_class_and_can_inject_stuff()
+    {
+        $this->extend((new Extend\Event)->listen(Created::class, CustomListener::class));
+
+        $group = $this->buildGroup();
+
+        $this->assertEquals($group->name_singular, 'modified group');
+    }
+}
+
+class CustomListener
+{
+    public function __construct()
+    {
+    }
+
+    public function __invoke(Created $event)
+    {
+        $event->group->name_singular = 'modified group';
+    }
+}


### PR DESCRIPTION
**Fixes Part of #1891**

**Changes proposed in this pull request:**
Added event extender (accepts the event class string and a callable), and integration tests for the event extender

**Reviewers should focus on:**
Anything I missed?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
