### PR TITLE
Refactor formatter extender

### DIFF
--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -24,9 +24,9 @@ class Formatter implements ExtenderInterface, LifecycleInterface
      * or otherwise change the formatter. Please see documentation for the s9e text formatter library for more
      * information on how to use this.
      *
-     * @param callable $callable
+     * @param callable|string $callback
      *
-     * The callable can be a closure or invokable class, and should accept:
+     * The callback can be a closure or invokable class, and should accept:
      * - \s9e\TextFormatter\Configurator $configurator
      */
     public function configure($callback)
@@ -40,14 +40,14 @@ class Formatter implements ExtenderInterface, LifecycleInterface
      * Prepare the system for parsing. This can be used to modify the text that will be parsed, or to modify the parser.
      * Please note that the text to be parsed must be returned, regardless of whether it's changed.
      *
-     * @param callable $callable
+     * @param callable|string $callback
      *
-     * The callable can be a closure or invokable class, and should accept:
+     * The callback can be a closure or invokable class, and should accept:
      * - \s9e\TextFormatter\Parser $parser
      * - mixed $context
      * - string $text: The text to be parsed.
      *
-     * The callable should return:
+     * The callback should return:
      * - string $text: The text to be parsed.
      */
     public function parse($callback)
@@ -61,15 +61,15 @@ class Formatter implements ExtenderInterface, LifecycleInterface
      * Prepare the system for rendering. This can be used to modify the xml that will be rendered, or to modify the renderer.
      * Please note that the xml to be rendered must be returned, regardless of whether it's changed.
      *
-     * @param callable $callable
+     * @param callable|string $callback
      *
-     * The callable can be a closure or invokable class, and should accept:
+     * The callback can be a closure or invokable class, and should accept:
      * - \s9e\TextFormatter\Rendered $renderer
      * - mixed $context
      * - string $xml: The xml to be rendered.
      * - ServerRequestInterface $request
      *
-     * The callable should return:
+     * The callback should return:
      * - string $xml: The xml to be rendered.
      */
     public function render($callback)

--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -19,6 +19,16 @@ class Formatter implements ExtenderInterface, LifecycleInterface
     private $parsingCallbacks = [];
     private $renderingCallbacks = [];
 
+    /**
+     * Configure the formatter. This can be used to add support for custom markdown/bbcode/etc tags,
+     * or otherwise change the formatter. Please see documentation for the s9e text formatter library for more
+     * information on how to use this.
+     *
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \s9e\TextFormatter\Configurator $configurator
+     */
     public function configure($callback)
     {
         $this->configurationCallbacks[] = $callback;
@@ -26,6 +36,20 @@ class Formatter implements ExtenderInterface, LifecycleInterface
         return $this;
     }
 
+    /**
+     * Prepare the system for parsing. This can be used to modify the text that will be parsed, or to modify the parser.
+     * Please note that the text to be parsed must be returned, regardless of whether it's changed.
+     *
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \s9e\TextFormatter\Parser $parser
+     * - mixed $context
+     * - string $text: The text to be parsed.
+     *
+     * The callable should return:
+     * - string $text: The text to be parsed.
+     */
     public function parse($callback)
     {
         $this->parsingCallbacks[] = $callback;
@@ -33,6 +57,21 @@ class Formatter implements ExtenderInterface, LifecycleInterface
         return $this;
     }
 
+    /**
+     * Prepare the system for rendering. This can be used to modify the xml that will be rendered, or to modify the renderer.
+     * Please note that the xml to be rendered must be returned, regardless of whether it's changed.
+     *
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \s9e\TextFormatter\Rendered $renderer
+     * - mixed $context
+     * - string $xml: The xml to be rendered.
+     * - ServerRequestInterface $request
+     *
+     * The callable should return:
+     * - string $xml: The xml to be rendered.
+     */
     public function render($callback)
     {
         $this->renderingCallbacks[] = $callback;

--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -10,10 +10,9 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
-use Flarum\Formatter\Event\Configuring;
 use Flarum\Formatter\Formatter as ActualFormatter;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Events\Dispatcher;
+use s9e\TextFormatter\Configurator;
 
 class Formatter implements ExtenderInterface, LifecycleInterface
 {
@@ -44,29 +43,33 @@ class Formatter implements ExtenderInterface, LifecycleInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        foreach ($this->configurationCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
+        $container->extend('flarum.formatter', function ($formatter, $container) {
+            foreach ($this->configurationCallbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $container->make($callback);
+                }
+
+                $formatter->addConfigurationCallback($callback);
             }
 
-            ActualFormatter::addConfigurationCallback($callback);
-        }
+            foreach ($this->parsingCallbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $container->make($callback);
+                }
 
-        foreach ($this->parsingCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
+                $formatter->addParsingCallback($callback);
             }
 
-            ActualFormatter::addParsingCallback($callback);
-        }
+            foreach ($this->renderingCallbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $container->make($callback);
+                }
 
-        foreach ($this->renderingCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
+                $formatter->addRenderingCallback($callback);
             }
 
-            ActualFormatter::addRenderingCallback($callback);
-        }
+            return $formatter;
+        });
     }
 
     public function onEnable(Container $container, Extension $extension)

--- a/src/Extend/Formatter.php
+++ b/src/Extend/Formatter.php
@@ -12,7 +12,6 @@ namespace Flarum\Extend;
 use Flarum\Extension\Extension;
 use Flarum\Formatter\Formatter as ActualFormatter;
 use Illuminate\Contracts\Container\Container;
-use s9e\TextFormatter\Configurator;
 
 class Formatter implements ExtenderInterface, LifecycleInterface
 {

--- a/src/Formatter/Event/Configuring.php
+++ b/src/Formatter/Event/Configuring.php
@@ -12,7 +12,7 @@ namespace Flarum\Formatter\Event;
 use s9e\TextFormatter\Configurator;
 
 /**
- * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ * @deprecated beta 15, removed beta 16. Use the Formatter extender instead.
  */
 class Configuring
 {

--- a/src/Formatter/Event/Configuring.php
+++ b/src/Formatter/Event/Configuring.php
@@ -11,6 +11,9 @@ namespace Flarum\Formatter\Event;
 
 use s9e\TextFormatter\Configurator;
 
+/**
+ * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ */
 class Configuring
 {
     /**

--- a/src/Formatter/Event/Parsing.php
+++ b/src/Formatter/Event/Parsing.php
@@ -12,7 +12,7 @@ namespace Flarum\Formatter\Event;
 use s9e\TextFormatter\Parser;
 
 /**
- * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ * @deprecated beta 15, removed beta 16. Use the Formatter extender instead.
  */
 class Parsing
 {

--- a/src/Formatter/Event/Parsing.php
+++ b/src/Formatter/Event/Parsing.php
@@ -11,6 +11,9 @@ namespace Flarum\Formatter\Event;
 
 use s9e\TextFormatter\Parser;
 
+/**
+ * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ */
 class Parsing
 {
     /**

--- a/src/Formatter/Event/Rendering.php
+++ b/src/Formatter/Event/Rendering.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Renderer;
 
 /**
- * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ * @deprecated beta 15, removed beta 16. Use the Formatter extender instead.
  */
 class Rendering
 {

--- a/src/Formatter/Event/Rendering.php
+++ b/src/Formatter/Event/Rendering.php
@@ -12,6 +12,9 @@ namespace Flarum\Formatter\Event;
 use Psr\Http\Message\ServerRequestInterface;
 use s9e\TextFormatter\Renderer;
 
+/**
+ * @deprecated beta 13, removed beta 14. Use the Formatter extender instead.
+ */
 class Rendering
 {
     /**

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -79,7 +79,7 @@ class Formatter
     {
         $parser = $this->getParser($context);
 
-        // Deprecated in beta 13, remove in beta 14
+        // Deprecated in beta 15, remove in beta 16
         $this->events->dispatch(new Parsing($parser, $context, $text));
 
         foreach ($this->parsingCallbacks as $callback) {
@@ -101,7 +101,7 @@ class Formatter
     {
         $renderer = $this->getRenderer();
 
-        // Deprecated in beta 13, remove in beta 14
+        // Deprecated in beta 15, remove in beta 16
         $this->events->dispatch(new Rendering($renderer, $context, $xml, $request));
 
         foreach ($this->renderingCallbacks as $callback) {
@@ -153,7 +153,7 @@ class Formatter
         $configurator->Autolink;
         $configurator->tags->onDuplicate('replace');
 
-        // Deprecated in beta 13, remove in beta 14
+        // Deprecated in beta 15, remove in beta 16
         $this->events->dispatch(new Configuring($configurator));
 
         foreach ($this->configurationCallbacks as $callback) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -26,21 +26,6 @@ class Formatter
 
     protected $renderingCallbacks = [];
 
-    public function addConfigurationCallback($callback)
-    {
-        $this->configurationCallbacks[] = $callback;
-    }
-
-    public function addParsingCallback($callback)
-    {
-        $this->parsingCallbacks[] = $callback;
-    }
-
-    public function addRenderingCallback($callback)
-    {
-        $this->renderingCallbacks[] = $callback;
-    }
-
     /**
      * @var Repository
      */
@@ -66,6 +51,21 @@ class Formatter
         $this->cache = $cache;
         $this->events = $events;
         $this->cacheDir = $cacheDir;
+    }
+
+    public function addConfigurationCallback($callback)
+    {
+        $this->configurationCallbacks[] = $callback;
+    }
+
+    public function addParsingCallback($callback)
+    {
+        $this->parsingCallbacks[] = $callback;
+    }
+
+    public function addRenderingCallback($callback)
+    {
+        $this->renderingCallbacks[] = $callback;
     }
 
     /**

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -83,7 +83,7 @@ class Formatter
         $this->events->dispatch(new Parsing($parser, $context, $text));
 
         foreach ($this->parsingCallbacks as $callback) {
-            $callback($parser, $context, $text);
+            $text = $callback($parser, $context, $text);
         }
 
         return $parser->parse($text);
@@ -105,7 +105,7 @@ class Formatter
         $this->events->dispatch(new Rendering($renderer, $context, $xml, $request));
 
         foreach ($this->renderingCallbacks as $callback) {
-            $callback($renderer, $context, $xml, $request);
+            $xml = $callback($renderer, $context, $xml, $request);
         }
 
         return $renderer->render($xml);

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -20,6 +20,27 @@ use s9e\TextFormatter\Unparser;
 
 class Formatter
 {
+    protected static $configurationCallbacks = [];
+
+    protected static $parsingCallbacks = [];
+
+    protected static $renderingCallbacks = [];
+
+    public static function addConfigurationCallback($callback)
+    {
+        static::$configurationCallbacks[] = $callback;
+    }
+
+    public static function addParsingCallback($callback)
+    {
+        static::$parsingCallbacks[] = $callback;
+    }
+
+    public static function addRenderingCallback($callback)
+    {
+        static::$renderingCallbacks[] = $callback;
+    }
+
     /**
      * @var Repository
      */
@@ -58,7 +79,12 @@ class Formatter
     {
         $parser = $this->getParser($context);
 
+        // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Parsing($parser, $context, $text));
+
+        foreach (static::$parsingCallbacks as $callback) {
+            $callback($parser, $context, $text);
+        }
 
         return $parser->parse($text);
     }
@@ -75,7 +101,12 @@ class Formatter
     {
         $renderer = $this->getRenderer();
 
+        // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Rendering($renderer, $context, $xml, $request));
+
+        foreach (static::$renderingCallbacks as $callback) {
+            $callback($renderer, $context, $xml, $request);
+        }
 
         return $renderer->render($xml);
     }
@@ -122,7 +153,12 @@ class Formatter
         $configurator->Autolink;
         $configurator->tags->onDuplicate('replace');
 
+        // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Configuring($configurator));
+
+        foreach (static::$configurationCallbacks as $callback) {
+            $callback($configurator);
+        }
 
         $this->configureExternalLinks($configurator);
 

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -20,25 +20,25 @@ use s9e\TextFormatter\Unparser;
 
 class Formatter
 {
-    protected static $configurationCallbacks = [];
+    protected $configurationCallbacks = [];
 
-    protected static $parsingCallbacks = [];
+    protected $parsingCallbacks = [];
 
-    protected static $renderingCallbacks = [];
+    protected $renderingCallbacks = [];
 
-    public static function addConfigurationCallback($callback)
+    public function addConfigurationCallback($callback)
     {
-        static::$configurationCallbacks[] = $callback;
+        $this->configurationCallbacks[] = $callback;
     }
 
-    public static function addParsingCallback($callback)
+    public function addParsingCallback($callback)
     {
-        static::$parsingCallbacks[] = $callback;
+        $this->parsingCallbacks[] = $callback;
     }
 
-    public static function addRenderingCallback($callback)
+    public function addRenderingCallback($callback)
     {
-        static::$renderingCallbacks[] = $callback;
+        $this->renderingCallbacks[] = $callback;
     }
 
     /**
@@ -82,7 +82,7 @@ class Formatter
         // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Parsing($parser, $context, $text));
 
-        foreach (static::$parsingCallbacks as $callback) {
+        foreach ($this->parsingCallbacks as $callback) {
             $callback($parser, $context, $text);
         }
 
@@ -104,7 +104,7 @@ class Formatter
         // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Rendering($renderer, $context, $xml, $request));
 
-        foreach (static::$renderingCallbacks as $callback) {
+        foreach ($this->renderingCallbacks as $callback) {
             $callback($renderer, $context, $xml, $request);
         }
 
@@ -156,7 +156,7 @@ class Formatter
         // Deprecated in beta 13, remove in beta 14
         $this->events->dispatch(new Configuring($configurator));
 
-        foreach (static::$configurationCallbacks as $callback) {
+        foreach ($this->configurationCallbacks as $callback) {
             $callback($configurator);
         }
 

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -74,8 +74,8 @@ class FormatterTest extends TestCase
      */
     public function custom_formatter_parsing_works_if_added_with_closure()
     {
-        $this->extend((new Extend\Formatter)->parse(function ($parser, $context, &$text) {
-            $text = 'ReplacedText<a>';
+        $this->extend((new Extend\Formatter)->parse(function ($parser, $context, $text) {
+            return 'ReplacedText<a>';
         }));
 
         $this->assertEquals('<t>ReplacedText&lt;a&gt;</t>', $this->getFormatter()->parse('Text<a>'));
@@ -104,8 +104,8 @@ class FormatterTest extends TestCase
      */
     public function custom_formatter_rendering_works_if_added_with_closure()
     {
-        $this->extend((new Extend\Formatter)->render(function ($renderer, $context, &$xml, $request) {
-            $xml = '<html>ReplacedText</html>';
+        $this->extend((new Extend\Formatter)->render(function ($renderer, $context, $xml, $request) {
+            return '<html>ReplacedText</html>';
         }));
 
         $this->assertEquals('ReplacedText', $this->getFormatter()->render('<html>Text</html>'));
@@ -132,16 +132,16 @@ class InvokableConfig
 
 class InvokableParsing
 {
-    public function __invoke($parser, $context, &$text)
+    public function __invoke($parser, $context, $text)
     {
-        $text = 'ReplacedText<a>';
+        return 'ReplacedText<a>';
     }
 }
 
 class InvokableRendering
 {
-    public function __invoke($renderer, $context, &$xml, $request)
+    public function __invoke($renderer, $context, $xml, $request)
     {
-        $xml = '<html>ReplacedText</html>';
+        return '<html>ReplacedText</html>';
     }
 }

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -19,6 +19,7 @@ class FormatterTest extends TestCase
     {
         $formatter = $this->app()->getContainer()->make(Formatter::class);
         $formatter->flush();
+
         return $formatter;
     }
 

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -17,7 +17,9 @@ class FormatterTest extends TestCase
 {
     protected function getFormatter()
     {
-        return $this->app()->getContainer()->make(Formatter::class);
+        $formatter = $this->app()->getContainer()->make(Formatter::class);
+        $formatter->flush();
+        return $formatter;
     }
 
     /**
@@ -26,7 +28,6 @@ class FormatterTest extends TestCase
     public function custom_formatter_config_doesnt_work_by_default()
     {
         $formatter = $this->getFormatter();
-        $formatter->flush();
 
         $this->assertEquals('<t>[B]something[/B]</t>', $formatter->parse('[B]something[/B]'));
     }
@@ -40,9 +41,7 @@ class FormatterTest extends TestCase
             $config->BBCodes->addFromRepository('B');
         }));
 
-        // Needed so that the config is refreshed, this is usually handled by lifecyclehooks.
         $formatter = $this->getFormatter();
-        $formatter->flush();
 
         $this->assertEquals('<b>something</b>', $formatter->render($formatter->parse('[B]something[/B]')));
     }
@@ -54,9 +53,7 @@ class FormatterTest extends TestCase
     {
         $this->extend((new Extend\Formatter)->configure(InvokableConfig::class));
 
-        // Needed so that the config is refreshed, this is usually handled by lifecyclehooks.
         $formatter = $this->getFormatter();
-        $formatter->flush();
 
         $this->assertEquals('<b>something</b>', $formatter->render($formatter->parse('[B]something[/B]')));
     }

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\Formatter\Formatter;
+use Flarum\Tests\integration\TestCase;
+use s9e\TextFormatter\Configurator;
+use s9e\TextFormatter\Parser;
+use s9e\TextFormatter\Renderer;
+
+class FormatterTest extends TestCase
+{
+    protected function getFormatter()
+    {
+        return $this->app()->getContainer()->make(Formatter::class);
+    }
+    /**
+     * @test
+     */
+    public function custom_formatter_config_doesnt_work_by_default()
+    {
+        $formatter = $this->getFormatter();
+        $formatter->flush();
+
+        $this->assertEquals('<t>[B]something[/B]</t>', $formatter->parse('[B]something[/B]'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_config_works_if_added_with_closure()
+    {
+        $this->extend((new Extend\Formatter)->configure(function ($config) {
+            $config->BBCodes->addFromRepository('B');
+        }));
+
+        // Needed so that the config is refreshed, this is usually handled by lifecyclehooks.
+        $formatter = $this->getFormatter();
+        $formatter->flush();
+
+        $this->assertEquals('<b>something</b>', $formatter->render($formatter->parse('[B]something[/B]')));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_config_works_if_added_with_invokable_class()
+    {
+        $this->extend((new Extend\Formatter)->configure(InvokableConfig::class));
+
+        // Needed so that the config is refreshed, this is usually handled by lifecyclehooks.
+        $formatter = $this->getFormatter();
+        $formatter->flush();
+
+        $this->assertEquals('<b>something</b>', $formatter->render($formatter->parse('[B]something[/B]')));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_parsing_doesnt_work_by_default()
+    {
+        $this->assertEquals('<t>Text&lt;a&gt;</t>', $this->getFormatter()->parse('Text<a>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_parsing_works_if_added_with_closure()
+    {
+        $this->extend((new Extend\Formatter)->parse(function ($parser, $context, &$text) {
+            $text = 'ReplacedText<a>';
+        }));
+
+        $this->assertEquals('<t>ReplacedText&lt;a&gt;</t>', $this->getFormatter()->parse('Text<a>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_parsing_works_if_added_with_invokable_class()
+    {
+        $this->extend((new Extend\Formatter)->parse(InvokableParsing::class));
+
+        $this->assertEquals('<t>ReplacedText&lt;a&gt;</t>', $this->getFormatter()->parse('Text<a>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_rendering_doesnt_work_by_default()
+    {
+        $this->assertEquals('Text', $this->getFormatter()->render('<p>Text</p>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_rendering_works_if_added_with_closure()
+    {
+        $this->extend((new Extend\Formatter)->render(function ($renderer, $context, &$xml, $request) {
+            $xml = '<html>ReplacedText</html>';
+        }));
+
+        $this->assertEquals('ReplacedText', $this->getFormatter()->render('<html>Text</html>'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_formatter_rendering_works_if_added_with_invokable_class()
+    {
+        $this->extend((new Extend\Formatter)->render(InvokableRendering::class));
+
+        $this->assertEquals('ReplacedText', $this->getFormatter()->render('<html>Text</html>'));
+    }
+}
+
+class InvokableConfig
+{
+    public function __invoke($config)
+    {
+        $config->BBCodes->addFromRepository('B');
+    }
+}
+
+class InvokableParsing
+{
+    public function __invoke($parser, $context, &$text)
+    {
+        $text = 'ReplacedText<a>';
+    }
+}
+
+class InvokableRendering
+{
+    public function __invoke($renderer, $context, &$xml, $request)
+    {
+        $xml = '<html>ReplacedText</html>';
+    }
+}

--- a/tests/integration/extenders/FormatterTest.php
+++ b/tests/integration/extenders/FormatterTest.php
@@ -12,9 +12,6 @@ namespace Flarum\Tests\integration\extenders;
 use Flarum\Extend;
 use Flarum\Formatter\Formatter;
 use Flarum\Tests\integration\TestCase;
-use s9e\TextFormatter\Configurator;
-use s9e\TextFormatter\Parser;
-use s9e\TextFormatter\Renderer;
 
 class FormatterTest extends TestCase
 {
@@ -22,6 +19,7 @@ class FormatterTest extends TestCase
     {
         return $this->app()->getContainer()->make(Formatter::class);
     }
+
     /**
      * @test
      */


### PR DESCRIPTION
**Fixes part of #1891**

**Changes proposed in this pull request:**
- Deprecated all events involved with Formatter
- Refactor ->configure() method on extender not to use events
- Add extender methods for ->render() and ->parse()
- Add integration tests for all of this

**Reviewers should focus on:**
How do we feel about the method naming for ->render() and ->parse()? I feel it could be better but all my other ideas were clunky.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
