### PR TITLE
Added Model extender, integration tests

### DIFF
--- a/src/Database/AbstractModel.php
+++ b/src/Database/AbstractModel.php
@@ -78,7 +78,7 @@ abstract class AbstractModel extends Eloquent
 
     public static function addCustomRelation(string $from, string $name, $relation)
     {
-        if (!array_key_exists($from, static::$customRelations)) {
+        if (! array_key_exists($from, static::$customRelations)) {
             static::$customRelations[$from] = [];
         }
 
@@ -87,7 +87,7 @@ abstract class AbstractModel extends Eloquent
 
     public static function addDateCallback(string $model, $callback)
     {
-        if (!array_key_exists($model, static::$dateCallbacks)) {
+        if (! array_key_exists($model, static::$dateCallbacks)) {
             static::$dateCallbacks[$model] = [];
         }
 
@@ -96,7 +96,7 @@ abstract class AbstractModel extends Eloquent
 
     public static function addDefaultAttributeCallback(string $model, $callback)
     {
-        if (!array_key_exists($model, static::$defaultAttributeCallbacks)) {
+        if (! array_key_exists($model, static::$defaultAttributeCallbacks)) {
             static::$defaultAttributeCallbacks[$model] = [];
         }
 

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -54,18 +54,6 @@ class DatabaseServiceProvider extends AbstractServiceProvider
 
         $this->app->alias(ConnectionInterface::class, 'db.connection');
         $this->app->alias(ConnectionInterface::class, 'flarum.db');
-
-        $this->app->singleton('flarum.model.customRelations', function () {
-            return [];
-        });
-
-        $this->app->singleton('flarum.model.dateCallbacks', function () {
-            return [];
-        });
-
-        $this->app->singleton('flarum.model.defaultAttributeCallbacks', function () {
-            return [];
-        });
     }
 
     /**
@@ -75,35 +63,5 @@ class DatabaseServiceProvider extends AbstractServiceProvider
     {
         AbstractModel::setConnectionResolver($this->app->make(ConnectionResolverInterface::class));
         AbstractModel::setEventDispatcher($this->app->make('events'));
-
-        foreach ($this->app->make('flarum.model.customRelations') as $modelClass => $callbacks) {
-            foreach ($callbacks as  $name => $relation) {
-                if (is_string($relation)) {
-                    $relation = $this->app->make($relation);
-                }
-
-                AbstractModel::addCustomRelation($modelClass, $name, $relation);
-            }
-        }
-
-        foreach ($this->app->make('flarum.model.dateCallbacks') as $modelClass => $callbacks) {
-            foreach ($callbacks as $callback) {
-                if (is_string($callback)) {
-                    $callback = $this->app->make($callback);
-                }
-
-                AbstractModel::addDateCallback($modelClass, $callback);
-            }
-        }
-
-        foreach ($this->app->make('flarum.model.defaultAttributeCallbacks') as $modelClass => $callbacks) {
-            foreach ($callbacks as $callback) {
-                if (is_string($callback)) {
-                    $callback = $this->app->make($callback);
-                }
-
-                AbstractModel::addDefaultAttributeCallback($modelClass, $callback);
-            }
-        }
     }
 }

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -54,6 +54,18 @@ class DatabaseServiceProvider extends AbstractServiceProvider
 
         $this->app->alias(ConnectionInterface::class, 'db.connection');
         $this->app->alias(ConnectionInterface::class, 'flarum.db');
+
+        $this->app->singleton('flarum.model.customRelations', function () {
+            return [];
+        });
+
+        $this->app->singleton('flarum.model.dateCallbacks', function () {
+            return [];
+        });
+
+        $this->app->singleton('flarum.model.defaultAttributeCallbacks', function () {
+            return [];
+        });
     }
 
     /**
@@ -63,5 +75,35 @@ class DatabaseServiceProvider extends AbstractServiceProvider
     {
         AbstractModel::setConnectionResolver($this->app->make(ConnectionResolverInterface::class));
         AbstractModel::setEventDispatcher($this->app->make('events'));
+
+        foreach ($this->app->make('flarum.model.customRelations') as $modelClass => $callbacks) {
+            foreach ($callbacks as  $name => $relation) {
+                if (is_string($relation)) {
+                    $relation = $this->app->make($relation);
+                }
+
+                AbstractModel::addCustomRelation($modelClass, $name, $relation);
+            }
+        }
+
+        foreach ($this->app->make('flarum.model.dateCallbacks') as $modelClass => $callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $this->app->make($callback);
+                }
+
+                AbstractModel::addDateCallback($modelClass, $callback);
+            }
+        }
+
+        foreach ($this->app->make('flarum.model.defaultAttributeCallbacks') as $modelClass => $callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $this->app->make($callback);
+                }
+
+                AbstractModel::addDefaultAttributeCallback($modelClass, $callback);
+            }
+        }
     }
 }

--- a/src/Event/ConfigureModelDates.php
+++ b/src/Event/ConfigureModelDates.php
@@ -12,6 +12,8 @@ namespace Flarum\Event;
 use Flarum\Database\AbstractModel;
 
 /**
+ * @deprecated in beta 13, removed in beta 14
+ *
  * The `ConfigureModelDates` event is called to retrieve a list of fields for a model
  * that should be converted into date objects.
  */

--- a/src/Event/ConfigureModelDefaultAttributes.php
+++ b/src/Event/ConfigureModelDefaultAttributes.php
@@ -11,6 +11,9 @@ namespace Flarum\Event;
 
 use Flarum\Database\AbstractModel;
 
+/**
+ * @deprecated in beta 13, removed in beta 14
+ */
 class ConfigureModelDefaultAttributes
 {
     /**

--- a/src/Event/GetModelRelationship.php
+++ b/src/Event/GetModelRelationship.php
@@ -12,6 +12,8 @@ namespace Flarum\Event;
 use Flarum\Database\AbstractModel;
 
 /**
+ * @deprecated beta 13, use the Model extender instead.
+ *
  * The `GetModelRelationship` event is called to retrieve Relation object for a
  * model. Listeners should return an Eloquent Relation object.
  */

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+
+class Model implements ExtenderInterface
+{
+    private $modelClass;
+    private $relationships = [];
+
+    public function __construct(string $modelClass)
+    {
+        $this->modelClass = $modelClass;
+    }
+
+    public function relationship(string $name, callable $callable)
+    {
+        $this->relationships[$name] = $callable;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $model = $container->make($this->modelClass);
+
+        foreach ($this->relationships as $name => $relationship) {
+            if (is_string($relationship)) {
+                $relationship = $container->make($relationship);
+            }
+
+            AbstractModel::addCustomRelation($this->modelClass, $name, $relationship);
+        }
+    }
+}

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -31,9 +31,14 @@ class Model implements ExtenderInterface
     /**
      * Modify which attributes of this model are treated as dates.
      *
-     * @param callable $callable: A callback, or class attribute of invokable class.
-     *                            It should take as input, and return, an array of
-     *                            attributes that should be treated as dates.
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \Flarum\User\User $user: the user in question.
+     * - array $dateAttributes: an array of attributes which are processed as dates.
+     *
+     * The callable should return:
+     * - array $dateAttributes: an array of attributes which are processed as dates.
      */
     public function configureDates(callable $callable)
     {
@@ -45,9 +50,14 @@ class Model implements ExtenderInterface
     /**
      * Modify default attribute values for this model.
      *
-     * @param callable $callable: A callback, or class attribute of invokable class.
-     *                            It should take as input, and return, an
-     *                            associative array of attributes => default values.
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \Flarum\User\User $user: the user in question.
+     * - array[string] $dateAttributes: an associative array of attributes => default values.
+     *
+     * The callable should return:
+     * - array[string] $dateAttributes: an associative array of attributes => default values.
      */
     public function configureDefaultAttributes(callable $callable)
     {
@@ -61,9 +71,14 @@ class Model implements ExtenderInterface
      *
      * @param string $name: the name of the relation. This doesn't have to match anything,
      *                      but has to be unique from other relation names for this model.
-     * @param callable $callable: A callable that takes as input an instance of this model, and
-     *                            returns a Laravel Relationship object. See relevant methods of
-     *                            models like \Flarum\User\User for examples of how relationships should be returned.
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - $instance: An instance of this model.
+     *
+     * The callable should return:
+     * - $relationship: A Laravel Relationship object. See relevant methods of models
+     *                  like \Flarum\User\User for examples of how relationships should be returned.
      */
     public function relationship(string $name, callable $callable)
     {

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -88,12 +88,11 @@ class Model implements ExtenderInterface
      * @param string $related: The ::class attribute of the model, which should extend \Flarum\Database\AbstractModel.
      * @param string $foreignKey: The foreign key attribute of the parent model.
      * @param string $ownerKey: The primary key attribute of the parent model.
-     * @param string $relation
      */
-    public function belongsTo(string $name, $related, $foreignKey = null, $ownerKey = null, $relation = null)
+    public function belongsTo(string $name, $related, $foreignKey = null, $ownerKey = null)
     {
-        return $this->relationship($name, function (AbstractModel $model) use ($related, $foreignKey, $ownerKey, $relation) {
-            return $model->belongsTo($related, $foreignKey, $ownerKey, $relation);
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $foreignKey, $ownerKey, $name) {
+            return $model->belongsTo($related, $foreignKey, $ownerKey, $name);
         });
     }
 
@@ -111,13 +110,12 @@ class Model implements ExtenderInterface
      * @param string $relatedPivotKey: The associated key attribute of the relation.
      * @param string $parentKey: The key name of the parent model.
      * @param string $relatedKey: The key name of the related model.
-     * @param string $relation
      */
     public function belongsToMany(string $name, $related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
-                                  $parentKey = null, $relatedKey = null, $relation = null)
+                                  $parentKey = null, $relatedKey = null)
     {
-        return $this->relationship($name, function (AbstractModel $model) use ($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relation) {
-            return $model->belongsToMany($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relation);
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $name) {
+            return $model->belongsToMany($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $name);
         });
     }
 

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Extend;
 
-use Flarum\Database\AbstractModel;
 use Flarum\Extension\Extension;
 use Illuminate\Contracts\Container\Container;
 

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -111,8 +111,15 @@ class Model implements ExtenderInterface
      * @param string $parentKey: The key name of the parent model.
      * @param string $relatedKey: The key name of the related model.
      */
-    public function belongsToMany(string $name, $related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
-                                  $parentKey = null, $relatedKey = null)
+    public function belongsToMany(
+        string $name,
+        $related,
+        $table = null,
+        $foreignPivotKey = null,
+        $relatedPivotKey = null,
+        $parentKey = null,
+        $relatedKey = null
+    )
     {
         return $this->relationship($name, function (AbstractModel $model) use ($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $name) {
             return $model->belongsToMany($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $name);

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -48,30 +48,16 @@ class Model implements ExtenderInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        $model = $container->make($this->modelClass);
+        $container->extend('flarum.model.customRelations', function ($existingRelations) {
+            return array_merge_recursive($existingRelations, [$this->modelClass => $this->relationships]);
+        });
 
-        foreach ($this->dateCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
-            }
+        $container->extend('flarum.model.dateCallbacks', function ($existingCallbacks) {
+            return array_merge_recursive($existingCallbacks, [$this->modelClass => $this->dateCallbacks]);
+        });
 
-            AbstractModel::addDateCallback($this->modelClass, $callback);
-        }
-
-        foreach ($this->defaultAttributeCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
-            }
-
-            AbstractModel::addDefaultAttributeCallback($this->modelClass, $callback);
-        }
-
-        foreach ($this->relationships as $name => $relationship) {
-            if (is_string($relationship)) {
-                $relationship = $container->make($relationship);
-            }
-
-            AbstractModel::addCustomRelation($this->modelClass, $name, $relationship);
-        }
+        $container->extend('flarum.model.defaultAttributeCallbacks', function ($existingCallbacks) {
+            return array_merge_recursive($existingCallbacks, [$this->modelClass => $this->defaultAttributeCallbacks]);
+        });
     }
 }

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -58,8 +58,9 @@ class Model implements ExtenderInterface
     /**
      * Add a relationship from this model to another model.
      *
-     * @param string $name: the name of the relation. This doesn't have to match anything,
-     *                      but has to be unique from other relation names for this model.
+     * @param string $name: The name of the relation. This doesn't have to be anything in particular,
+     *                      but has to be unique from other relation names for this model, and should
+     *                      work as the name of a method.
      * @param callable $callable
      *
      * The callable can be a closure or invokable class, and should accept:
@@ -74,6 +75,88 @@ class Model implements ExtenderInterface
         Arr::set(AbstractModel::$customRelations, "$this->modelClass.$name", $callable);
 
         return $this;
+    }
+
+    /**
+     * Establish a simple belongsTo relationship from this model to another model.
+     * This represents an inverse one-to-one or inverse one-to-many relationship.
+     * For more complex relationships, use the ->relationship method.
+     *
+     * @param string $name: The name of the relation. This doesn't have to be anything in particular,
+     *                      but has to be unique from other relation names for this model, and should
+     *                      work as the name of a method.
+     * @param string $related: The ::class attribute of the model, which should extend \Flarum\Database\AbstractModel.
+     * @param string $foreignKey: The foreign key attribute of the parent model.
+     * @param string $ownerKey: The primary key attribute of the parent model.
+     * @param string $relation
+     */
+    public function belongsTo(string $name, $related, $foreignKey = null, $ownerKey = null, $relation = null)
+    {
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $foreignKey, $ownerKey, $relation) {
+            return $model->belongsTo($related, $foreignKey, $ownerKey, $relation);
+        });
+    }
+
+    /**
+     * Establish a simple belongsToMany relationship from this model to another model.
+     * This represents a many-to-many relationship.
+     * For more complex relationships, use the ->relationship method.
+     *
+     * @param string $name: The name of the relation. This doesn't have to be anything in particular,
+     *                      but has to be unique from other relation names for this model, and should
+     *                      work as the name of a method.
+     * @param string $related: The ::class attribute of the model, which should extend \Flarum\Database\AbstractModel.
+     * @param string $table: The intermediate table for this relation
+     * @param string $foreignPivotKey: The foreign key attribute of the parent model.
+     * @param string $relatedPivotKey: The associated key attribute of the relation.
+     * @param string $parentKey: The key name of the parent model.
+     * @param string $relatedKey: The key name of the related model.
+     * @param string $relation
+     */
+    public function belongsToMany(string $name, $related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
+                                  $parentKey = null, $relatedKey = null, $relation = null)
+    {
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relation) {
+            return $model->belongsToMany($related, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relation);
+        });
+    }
+
+    /**
+     * Establish a simple hasOne relationship from this model to another model.
+     * This represents a one-to-one relationship.
+     * For more complex relationships, use the ->relationship method.
+     *
+     * @param string $name: The name of the relation. This doesn't have to be anything in particular,
+     *                      but has to be unique from other relation names for this model, and should
+     *                      work as the name of a method.
+     * @param string $related: The ::class attribute of the model, which should extend \Flarum\Database\AbstractModel.
+     * @param string $foreignKey: The foreign key attribute of the parent model.
+     * @param string $localKey: The primary key attribute of the parent model.
+     */
+    public function hasOne(string $name, $related, $foreignKey = null, $localKey = null)
+    {
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $foreignKey, $localKey) {
+            return $model->hasOne($related, $foreignKey, $localKey);
+        });
+    }
+
+    /**
+     * Establish a simple hasMany relationship from this model to another model.
+     * This represents a one-to-many relationship.
+     * For more complex relationships, use the ->relationship method.
+     *
+     * @param string $name: The name of the relation. This doesn't have to be anything in particular,
+     *                      but has to be unique from other relation names for this model, and should
+     *                      work as the name of a method.
+     * @param string $related: The ::class attribute of the model, which should extend \Flarum\Database\AbstractModel.
+     * @param string $foreignKey: The foreign key attribute of the parent model.
+     * @param string $localKey: The primary key attribute of the parent model.
+     */
+    public function hasMany(string $name, $related, $foreignKey = null, $localKey = null)
+    {
+        return $this->relationship($name, function (AbstractModel $model) use ($related, $foreignKey, $localKey) {
+            return $model->hasMany($related, $foreignKey, $localKey);
+        });
     }
 
     public function extend(Container $container, Extension $extension = null)

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -19,18 +19,36 @@ class Model implements ExtenderInterface
     private $defaultAttributeCallbacks = [];
     private $relationships = [];
 
+    /**
+     * @param string $modelClass The ::class attribute of the model you are modifying.
+     *                           This model should extend from \Flarum\Database\AbstractModel.
+     */
     public function __construct(string $modelClass)
     {
         $this->modelClass = $modelClass;
     }
 
-    public function configureDates(callable $callback)
+    /**
+     * Modify which attributes of this model are treated as dates.
+     *
+     * @param callable $callable: A callback, or class attribute of invokable class.
+     *                            It should take as input, and return, an array of
+     *                            attributes that should be treated as dates.
+     */
+    public function configureDates(callable $callable)
     {
-        $this->dateCallbacks[] = $callback;
+        $this->dateCallbacks[] = $callable;
 
         return $this;
     }
 
+    /**
+     * Modify default attribute values for this model.
+     *
+     * @param callable $callable: A callback, or class attribute of invokable class.
+     *                            It should take as input, and return, an
+     *                            associative array of attributes => default values.
+     */
     public function configureDefaultAttributes(callable $callable)
     {
         $this->defaultAttributeCallbacks[] = $callable;
@@ -38,6 +56,15 @@ class Model implements ExtenderInterface
         return $this;
     }
 
+    /**
+     * Add a relationship from this model to another model.
+     *
+     * @param string $name: the name of the relation. This doesn't have to match anything,
+     *                      but has to be unique from other relation names for this model.
+     * @param callable $callable: A callable that takes as input an instance of this model, and
+     *                            returns a Laravel Relationship object. See relevant methods of
+     *                            models like \Flarum\User\User for examples of how relationships should be returned.
+     */
     public function relationship(string $name, callable $callable)
     {
         $this->relationships[$name] = $callable;

--- a/src/Extend/Model.php
+++ b/src/Extend/Model.php
@@ -16,11 +16,27 @@ use Illuminate\Contracts\Container\Container;
 class Model implements ExtenderInterface
 {
     private $modelClass;
+    private $dateCallbacks = [];
+    private $defaultAttributeCallbacks = [];
     private $relationships = [];
 
     public function __construct(string $modelClass)
     {
         $this->modelClass = $modelClass;
+    }
+
+    public function configureDates(callable $callback)
+    {
+        $this->dateCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function configureDefaultAttributes(callable $callable)
+    {
+        $this->defaultAttributeCallbacks[] = $callable;
+
+        return $this;
     }
 
     public function relationship(string $name, callable $callable)
@@ -33,6 +49,22 @@ class Model implements ExtenderInterface
     public function extend(Container $container, Extension $extension = null)
     {
         $model = $container->make($this->modelClass);
+
+        foreach ($this->dateCallbacks as $callback) {
+            if (is_string($callback)) {
+                $callback = $container->make($callback);
+            }
+
+            AbstractModel::addDateCallback($this->modelClass, $callback);
+        }
+
+        foreach ($this->defaultAttributeCallbacks as $callback) {
+            if (is_string($callback)) {
+                $callback = $container->make($callback);
+            }
+
+            AbstractModel::addDefaultAttributeCallback($this->modelClass, $callback);
+        }
 
         foreach ($this->relationships as $name => $relationship) {
             if (is_string($relationship)) {

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -114,6 +114,8 @@ class ModelTest extends TestCase
     {
         $group = new Group;
 
+        $this->app();
+
         $this->assertNotEquals('Custom Default', $group->name_singular);
     }
 
@@ -156,9 +158,11 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function custom_date_doesnt_exist_if_not_set()
+    public function expected_date_attribute_exists_if_not_removed()
     {
         $post = new Post;
+
+        $this->app();
 
         $this->assertContains('hidden_at', $post->getDates());
     }
@@ -166,7 +170,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function custom_date_works_if_set()
+    public function date_type_attribute_can_be_removed_through_extender()
     {
         $this->extend((new Extend\Model(Post::class))->configureDates(function ($dates) {
             if (($key = array_search('hidden_at', $dates)) !== false) {

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -124,11 +124,7 @@ class ModelTest extends TestCase
      */
     public function custom_default_attribute_works_if_set()
     {
-        $this->extend((new Extend\Model(Group::class))->configureDefaultAttributes(function ($defaults) {
-            $defaults['name_singular'] = 'Custom Default';
-
-            return $defaults;
-        }));
+        $this->extend((new Extend\Model(Group::class))->default('name_singular', 'Custom Default'));
 
         $this->app();
 
@@ -140,13 +136,28 @@ class ModelTest extends TestCase
     /**
      * @test
      */
+    public function custom_default_attribute_evaluated_at_runtime_if_callable()
+    {
+        $time = Carbon::now();
+        $this->extend((new Extend\Model(Group::class))->default('name_singular', function () {
+            return Carbon::now();
+        }));
+
+        $this->app();
+
+        sleep(2);
+
+        $group = new Group;
+
+        $this->assertGreaterThanOrEqual($time->diffInSeconds($group->name_singular), 2);
+    }
+
+    /**
+     * @test
+     */
     public function custom_default_attribute_doesnt_work_if_set_on_unrelated_model()
     {
-        $this->extend((new Extend\Model(Group::class))->configureDefaultAttributes(function ($defaults) {
-            $defaults['name_singular'] = 'Custom Default';
-
-            return $defaults;
-        }));
+        $this->extend((new Extend\Model(Group::class))->default('name_singular', 'Custom Default'));
 
         $this->app();
 
@@ -158,52 +169,40 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function expected_date_attribute_exists_if_not_removed()
+    public function custom_date_attribute_doesnt_exist_by_default()
     {
         $post = new Post;
 
         $this->app();
 
-        $this->assertContains('hidden_at', $post->getDates());
+        $this->assertNotContains('custom', $post->getDates());
     }
 
     /**
      * @test
      */
-    public function date_type_attribute_can_be_removed_through_extender()
+    public function custom_date_attribute_can_be_set()
     {
-        $this->extend((new Extend\Model(Post::class))->configureDates(function ($dates) {
-            if (($key = array_search('hidden_at', $dates)) !== false) {
-                unset($dates[$key]);
-            }
-
-            return $dates;
-        }));
+        $this->extend((new Extend\Model(Post::class))->dateAttribute('custom'));
 
         $this->app();
 
         $post = new Post;
 
-        $this->assertNotContains('hidden_at', $post->getDates());
+        $this->assertContains('custom', $post->getDates());
     }
 
     /**
      * @test
      */
-    public function custom_date_doesnt_work_if_set_on_unrelated_model()
+    public function custom_date_attribute_doesnt_work_if_set_on_unrelated_model()
     {
-        $this->extend((new Extend\Model(Post::class))->configureDates(function ($dates) {
-            if (($key = array_search('hidden_at', $dates)) !== false) {
-                unset($dates[$key]);
-            }
-
-            return $dates;
-        }));
+        $this->extend((new Extend\Model(Post::class))->dateAttribute('custom'));
 
         $this->app();
 
         $discussion = new Discussion;
 
-        $this->assertContains('hidden_at', $discussion->getDates());
+        $this->assertNotContains('custom', $discussion->getDates());
     }
 }

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -12,6 +12,7 @@ namespace Flarum\Tests\integration\extenders;
 use Carbon\Carbon;
 use Flarum\Extend;
 use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
 use Flarum\User\User;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
@@ -89,5 +90,27 @@ class ModelTest extends TestCase
 
         $this->assertNotEquals([], $user->customRelation()->get()->toArray());
         $this->assertContains(json_encode(__CLASS__), json_encode($user->customRelation()->get()));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_relationship_does_not_exist_if_added_to_unrelated_model()
+    {
+        $this->extend((new Extend\Model(User::class))->relationship('customRelation', function (User $user) {
+            return $user->hasMany(Discussion::class, 'user_id');
+        }));
+
+        $this->prepDB();
+        $this->prepareDatabase([
+            'groups' => [
+                $this->adminGroup()
+            ]
+        ]);
+
+        $group = Group::find(1);
+
+        $this->expectException(\BadMethodCallException::class);
+        $group->customRelation();
     }
 }

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -28,17 +28,9 @@ class ModelTest extends TestCase
             'users' => [
                 $this->adminUser(),
                 $this->normalUser(),
-            ]
+            ],
+            'discussions' => []
         ]);
-    }
-
-    protected function tearDown()
-    {
-        if (! is_null($discussion = Discussion::find(1))) {
-            $discussion->delete();
-        }
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -10,13 +10,13 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Carbon\Carbon;
-use Flarum\Extend;
 use Flarum\Discussion\Discussion;
+use Flarum\Extend;
 use Flarum\Group\Group;
 use Flarum\Post\Post;
-use Flarum\User\User;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
+use Flarum\User\User;
 
 class ModelTest extends TestCase
 {
@@ -34,7 +34,7 @@ class ModelTest extends TestCase
 
     protected function tearDown()
     {
-        if (!is_null($discussion = Discussion::find(1))) {
+        if (! is_null($discussion = Discussion::find(1))) {
             $discussion->delete();
         }
 
@@ -132,6 +132,7 @@ class ModelTest extends TestCase
     {
         $this->extend((new Extend\Model(Group::class))->configureDefaultAttributes(function ($defaults) {
             $defaults['name_singular'] = 'Custom Default';
+
             return $defaults;
         }));
 
@@ -149,6 +150,7 @@ class ModelTest extends TestCase
     {
         $this->extend((new Extend\Model(Group::class))->configureDefaultAttributes(function ($defaults) {
             $defaults['name_singular'] = 'Custom Default';
+
             return $defaults;
         }));
 
@@ -198,6 +200,7 @@ class ModelTest extends TestCase
             if (($key = array_search('hidden_at', $dates)) !== false) {
                 unset($dates[$key]);
             }
+
             return $dates;
         }));
 

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -110,6 +110,48 @@ class ModelTest extends TestCase
     /**
      * @test
      */
+    public function custom_hasOne_relationship_exists_if_added()
+    {
+        $this->extend((new Extend\Model(User::class))->hasMany('customRelation', Discussion::class, 'user_id'));
+
+        $this->prepDB();
+
+        $user = User::find(1);
+
+        $this->assertEquals([], $user->customRelation()->get()->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_hasMany_relationship_exists_if_added()
+    {
+        $this->extend((new Extend\Model(User::class))->hasMany('customRelation', Discussion::class, 'user_id'));
+
+        $this->prepDB();
+
+        $user = User::find(1);
+
+        $this->assertEquals([], $user->customRelation()->get()->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_belongsTo_relationship_exists_if_added()
+    {
+        $this->extend((new Extend\Model(User::class))->belongsTo('customRelation', Discussion::class, 'user_id'));
+
+        $this->prepDB();
+
+        $user = User::find(1);
+
+        $this->assertEquals([], $user->customRelation()->get()->toArray());
+    }
+
+    /**
+     * @test
+     */
     public function custom_default_attribute_doesnt_exist_if_not_set()
     {
         $group = new Group;

--- a/tests/integration/extenders/ModelTest.php
+++ b/tests/integration/extenders/ModelTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Carbon\Carbon;
+use Flarum\Extend;
+use Flarum\Discussion\Discussion;
+use Flarum\User\User;
+use Flarum\Tests\integration\RetrievesAuthorizedUsers;
+use Flarum\Tests\integration\TestCase;
+
+class ModelTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function prepDb()
+    {
+        $this->prepareDatabase([
+            'users' => [
+                $this->adminUser(),
+                $this->normalUser(),
+            ]
+        ]);
+    }
+
+    protected function tearDown()
+    {
+        if (!is_null($discussion = Discussion::find(1))) {
+            $discussion->delete();
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function custom_relationship_does_not_exist_by_default()
+    {
+        $this->prepDB();
+
+        $user = User::find(1);
+
+        $this->expectException(\BadMethodCallException::class);
+        $user->customRelation();
+    }
+
+    /**
+     * @test
+     */
+    public function custom_relationship_exists_if_added()
+    {
+        $this->extend((new Extend\Model(User::class))->relationship('customRelation', function (User $user) {
+            return $user->hasMany(Discussion::class, 'user_id');
+        }));
+
+        $this->prepDB();
+
+        $user = User::find(1);
+
+        $this->assertEquals([], $user->customRelation()->get()->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_relationship_exists_and_can_return_instances_if_added()
+    {
+        $this->extend((new Extend\Model(User::class))->relationship('customRelation', function (User $user) {
+            return $user->hasMany(Discussion::class, 'user_id');
+        }));
+
+        $this->prepDB();
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1]
+            ]
+        ]);
+
+        $user = User::find(1);
+
+        $this->assertNotEquals([], $user->customRelation()->get()->toArray());
+        $this->assertContains(json_encode(__CLASS__), json_encode($user->customRelation()->get()));
+    }
+}


### PR DESCRIPTION
**Fixes part of #1891**

**Changes proposed in this pull request:**
- Add Model extender with relationship method (decided not to go with one method-per-relationship as this is simpler, more flexible, and easier to operate). Also added configureDates and configureDefaultAttributes methods, which also take callables.
- Deprecated GetModelRelationship, ConfigureModelDefaultAttributes, ConfigureModelDates events
- Added integration tests for model relationship extender

**Reviewers should focus on:**
Anything I'm missing?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).