### PR TITLE
Validator extender

### DIFF
--- a/src/Extend/Validator.php
+++ b/src/Extend/Validator.php
@@ -32,12 +32,14 @@ class Validator implements ExtenderInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        foreach ($this->configurationCallbacks as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
-            }
+        $container->resolving($this->validator, function ($validator, $container) {
+            foreach ($this->configurationCallbacks as $callback) {
+                if (is_string($callback)) {
+                    $callback = $container->make($callback);
+                }
 
-            AbstractValidator::addConfiguration($this->validator, $callback);
-        }
+                $validator->addConfiguration($callback);
+            }
+        });
     }
 }

--- a/src/Extend/Validator.php
+++ b/src/Extend/Validator.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Flarum\Foundation\AbstractValidator;
+use Illuminate\Contracts\Container\Container;
+
+class Validator implements ExtenderInterface
+{
+    private $configurationCallbacks = [];
+    private $validator;
+
+    public function __construct($validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function configure($callback)
+    {
+        $this->configurationCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        foreach ($this->configurationCallbacks as $callback) {
+            if (is_string($callback)) {
+                $callback = $container->make($callback);
+            }
+
+            AbstractValidator::addConfiguration($this->validator, $callback);
+        }
+    }
+}

--- a/src/Extend/Validator.php
+++ b/src/Extend/Validator.php
@@ -17,11 +17,24 @@ class Validator implements ExtenderInterface
     private $configurationCallbacks = [];
     private $validator;
 
-    public function __construct($validator)
+    /**
+     * @param string $validatorClass: The ::class attribute of the validator you are modifying.
+     *                                The validator should inherit from \Flarum\Foundation\AbstractValidator.
+     */
+    public function __construct($validatorClass)
     {
-        $this->validator = $validator;
+        $this->validator = $validatorClass;
     }
 
+    /**
+     * Configure the validator. This is often used to adjust validation rules, but can be
+     * used to make other changes to the validator as well.
+     *
+     * @param callable $callable
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \Illuminate\Validation\Validator $validator: The validator object that is being modified.
+     */
     public function configure($callback)
     {
         $this->configurationCallbacks[] = $callback;

--- a/src/Extend/Validator.php
+++ b/src/Extend/Validator.php
@@ -33,7 +33,8 @@ class Validator implements ExtenderInterface
      * @param callable $callable
      *
      * The callable can be a closure or invokable class, and should accept:
-     * - \Illuminate\Validation\Validator $validator: The validator object that is being modified.
+     * - \Flarum\Foundation\AbstractValidator $flarumValidator: The Flarum validator wrapper
+     * - \Illuminate\Validation\Validator $validator: The Laravel validator instance
      */
     public function configure($callback)
     {

--- a/src/Extend/Validator.php
+++ b/src/Extend/Validator.php
@@ -10,7 +10,6 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
-use Flarum\Foundation\AbstractValidator;
 use Illuminate\Contracts\Container\Container;
 
 class Validator implements ExtenderInterface

--- a/src/Foundation/AbstractValidator.php
+++ b/src/Foundation/AbstractValidator.php
@@ -21,6 +21,19 @@ abstract class AbstractValidator
     /**
      * @var array
      */
+    protected static $configuration = [];
+
+    public static function addConfiguration($validatorClass, $callable) {
+        if (!array_key_exists($validatorClass, static::$configuration)) {
+            static::$configuration[$validatorClass] = [];
+        }
+
+        static::$configuration[$validatorClass][] = $callable;
+    }
+
+    /**
+     * @var array
+     */
     protected $rules = [];
 
     /**
@@ -92,9 +105,16 @@ abstract class AbstractValidator
 
         $validator = $this->validator->make($attributes, $rules, $this->getMessages());
 
+        /**
+         * @deprecated in beta 13, removed in beta 14.
+         */
         $this->events->dispatch(
             new Validating($this, $validator)
         );
+
+        foreach (Arr::get(static::$configuration, static::class, []) as $callable) {
+            $callable($validator);
+        }
 
         return $validator;
     }

--- a/src/Foundation/AbstractValidator.php
+++ b/src/Foundation/AbstractValidator.php
@@ -103,7 +103,7 @@ abstract class AbstractValidator
         $validator = $this->validator->make($attributes, $rules, $this->getMessages());
 
         /**
-         * @deprecated in beta 13, removed in beta 14.
+         * @deprecated in beta 15, removed in beta 16.
          */
         $this->events->dispatch(
             new Validating($this, $validator)

--- a/src/Foundation/AbstractValidator.php
+++ b/src/Foundation/AbstractValidator.php
@@ -21,14 +21,11 @@ abstract class AbstractValidator
     /**
      * @var array
      */
-    protected static $configuration = [];
+    protected $configuration = [];
 
-    public static function addConfiguration($validatorClass, $callable) {
-        if (!array_key_exists($validatorClass, static::$configuration)) {
-            static::$configuration[$validatorClass] = [];
-        }
-
-        static::$configuration[$validatorClass][] = $callable;
+    public function addConfiguration($callable)
+    {
+        $this->configuration[] = $callable;
     }
 
     /**
@@ -112,7 +109,7 @@ abstract class AbstractValidator
             new Validating($this, $validator)
         );
 
-        foreach (Arr::get(static::$configuration, static::class, []) as $callable) {
+        foreach ($this->configuration as $callable) {
             $callable($validator);
         }
 

--- a/src/Foundation/AbstractValidator.php
+++ b/src/Foundation/AbstractValidator.php
@@ -110,7 +110,7 @@ abstract class AbstractValidator
         );
 
         foreach ($this->configuration as $callable) {
-            $callable($validator);
+            $callable($this, $validator);
         }
 
         return $validator;

--- a/src/Foundation/Event/Validating.php
+++ b/src/Foundation/Event/Validating.php
@@ -13,7 +13,7 @@ use Flarum\Foundation\AbstractValidator;
 use Illuminate\Validation\Validator;
 
 /**
- * @deprecated in Beta 13, remove in beta 14. Use the Validator extender instead.
+ * @deprecated in Beta 15, remove in beta 16. Use the Validator extender instead.
  * The `Validating` event is called when a validator instance for a
  * model is being built. This event can be used to add custom rules/extensions
  * to the validator for when validation takes place.

--- a/src/Foundation/Event/Validating.php
+++ b/src/Foundation/Event/Validating.php
@@ -13,6 +13,7 @@ use Flarum\Foundation\AbstractValidator;
 use Illuminate\Validation\Validator;
 
 /**
+ * @deprecated in Beta 13, remove in beta 14. Use the Validator extender instead.
  * The `Validating` event is called when a validator instance for a
  * model is being built. This event can be used to add custom rules/extensions
  * to the validator for when validation takes place.

--- a/tests/integration/extenders/ValidatorTest.php
+++ b/tests/integration/extenders/ValidatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\User\UserValidator;
+use Flarum\Group\GroupValidator;
+use Flarum\Tests\integration\TestCase;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+
+class ModelTest extends TestCase
+{
+    private function extendToRequireLongPassword() {
+        $this->extend((new Extend\Validator(UserValidator::class))->configure(function ($validator) {
+            $rules = $validator->getRules();
+            $passwordRules = Arr::get($rules, 'password', []);
+            if (count($passwordRules)) {
+                $rules['password'] = array_map(function ($rule) {
+                    if ($rule === 'min:8') {
+                        return 'min:20';
+                    }
+
+                    return $rule;
+                }, $passwordRules);
+
+                $validator->setRules($rules);
+            }
+        }));
+    }
+    /**
+     * @test
+     */
+    public function custom_validation_rule_does_not_exist_by_default()
+    {
+        $this->app()->getContainer()->make(UserValidator::class)->assertValid(['password' => 'simplePassword']);
+
+        // If we have gotten this far, no validation exception has been thrown, so the test is succesful.
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_validation_rule_exists_if_added()
+    {
+        $this->extendToRequireLongPassword();
+
+        $this->expectException(ValidationException::class);
+
+        $this->app()->getContainer()->make(UserValidator::class)->assertValid(['password' => 'simplePassword']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_validation_rule_doesnt_affect_other_validators()
+    {
+        $this->extendToRequireLongPassword();
+
+        $this->app()->getContainer()->make(GroupValidator::class)->assertValid(['password' => 'simplePassword']);
+
+        // If we have gotten this far, no validation exception has been thrown, so the test is succesful.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/integration/extenders/ValidatorTest.php
+++ b/tests/integration/extenders/ValidatorTest.php
@@ -10,15 +10,16 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
-use Flarum\User\UserValidator;
 use Flarum\Group\GroupValidator;
 use Flarum\Tests\integration\TestCase;
+use Flarum\User\UserValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
 class ModelTest extends TestCase
 {
-    private function extendToRequireLongPassword() {
+    private function extendToRequireLongPassword()
+    {
         $this->extend((new Extend\Validator(UserValidator::class))->configure(function ($validator) {
             $rules = $validator->getRules();
             $passwordRules = Arr::get($rules, 'password', []);
@@ -35,6 +36,7 @@ class ModelTest extends TestCase
             }
         }));
     }
+
     /**
      * @test
      */

--- a/tests/integration/extenders/ValidatorTest.php
+++ b/tests/integration/extenders/ValidatorTest.php
@@ -16,7 +16,7 @@ use Flarum\User\UserValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
-class ModelTest extends TestCase
+class ValidatorTest extends TestCase
 {
     private function extendToRequireLongPassword()
     {

--- a/tests/integration/extenders/ValidatorTest.php
+++ b/tests/integration/extenders/ValidatorTest.php
@@ -91,7 +91,7 @@ class CustomValidatorClass
             'password' => [
                 'required',
                 'min:20'
-        ]
+            ]
         ] + $validator->getRules());
     }
 }

--- a/tests/integration/extenders/ValidatorTest.php
+++ b/tests/integration/extenders/ValidatorTest.php
@@ -83,15 +83,15 @@ class ValidatorTest extends TestCase
     }
 }
 
-
 class CustomValidatorClass
 {
-    public function __invoke($flarumValidator, $validator) {
-            $validator->setRules([
-                'password' => [
-                    'required',
-                    'min:20'
-                ]
-            ] + $validator->getRules());
-        }
+    public function __invoke($flarumValidator, $validator)
+    {
+        $validator->setRules([
+            'password' => [
+                'required',
+                'min:20'
+        ]
+        ] + $validator->getRules());
+    }
 }


### PR DESCRIPTION
**Fixes part of #1891**

**Changes proposed in this pull request:**
- Add Validator extender with configure method
- Add integration tests
- Deprecate Validating event

**Reviewers should focus on:**
I slightly deviated from the previously discussed spec on this one, as I think that having a configure method that runs the validator through a callable gives us and developers more flexibility than simply the ability to add rules. Similarly, there are extensions that depend on this type of capabilities.

Should there be a dedicated method to run the ruleset through a callable as well? I'm not sure if that is necessary (this PR supports that), but it might be a nice shortcut.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
