### PR TITLE
Scroll to edited post or inform the user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #634**

**Changes proposed in this pull request:**
Pretty much copy/pasted from [ReplyComposer](https://github.com/flarum/core/blob/02ceed4fedb5eb62ae95c38306a62a3e18f22793/js/src/forum/components/ReplyComposer.js#L74).

> If we're currently viewing the discussion which post edit was made in, then we can scroll to the post. Otherwise, we'll create an alert message to inform the user that their edit has been made, containing a button which will transition to their edited post when clicked.

**Reviewers should focus on:**
* Translations.
* Did I miss something?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] Related core extension PRs: flarum/lang-english#163
