### PR TITLE
Fix notification bubble colors on mobile

### DIFF
--- a/less/common/Navigation.less
+++ b/less/common/Navigation.less
@@ -49,12 +49,12 @@
     content: ' ';
     display: block;
     position: absolute;
-    background: @primary-color;
+    background: @header-color;
     top: 10px;
     right: 3px;
     width: 14px;
     height: 14px;
     border-radius: 7px;
-    border: 2px solid @body-bg;
+    border: 2px solid @header-bg;
   }
 }


### PR DESCRIPTION
**Fixes #1983**

**Changes proposed in this pull request:**
Adapt nofitication bubble colors to header colors on mobile.

**Reviewers should focus on:**
- Should bars and the dot have the same color?

**Screenshot**
![](https://i.ibb.co/BgnmM87/notif.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
