### PR TITLE
User Extender (prepareGroups functionality)

### DIFF
--- a/src/Event/PrepareUserGroups.php
+++ b/src/Event/PrepareUserGroups.php
@@ -12,6 +12,7 @@ namespace Flarum\Event;
 use Flarum\User\User;
 
 /**
+ * @deprecated beta 13, remove in beta 14. Use the User extender instead.
  * The `PrepareUserGroups` event.
  */
 class PrepareUserGroups

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -10,7 +10,6 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
-use Flarum\User\User as ActualUser;
 use Illuminate\Contracts\Container\Container;
 
 class User implements ExtenderInterface

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -54,18 +54,12 @@ class User implements ExtenderInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        // Display name config
         $container->extend('flarum.user.display_name.supported_drivers', function ($existingDrivers) {
             return array_merge($existingDrivers, $this->displayNameDrivers);
         });
 
-        // Group processor config
-        foreach ($this->groupProcessors as $callback) {
-            if (is_string($callback)) {
-                $callback = $container->make($callback);
-            }
-
-            ActualUser::addGroupProcessor($callback);
-        }
+        $container->extend('flarum.user.groupProcessors', function ($existingRelations) {
+            return array_merge($existingRelations, $this->groupProcessors);
+        });
     }
 }

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -57,7 +57,7 @@ class User implements ExtenderInterface
             return array_merge($existingDrivers, $this->displayNameDrivers);
         });
 
-        $container->extend('flarum.user.groupProcessors', function ($existingRelations) {
+        $container->extend('flarum.user.group_processors', function ($existingRelations) {
             return array_merge($existingRelations, $this->groupProcessors);
         });
     }

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -10,14 +10,16 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
+use Flarum\User\User as ActualUser;
 use Illuminate\Contracts\Container\Container;
 
 class User implements ExtenderInterface
 {
     private $displayNameDrivers = [];
+    private $groupProcessors = [];
 
     /**
-     * Add a mail driver.
+     * Add a display name driver.
      *
      * @param string $identifier Identifier for display name driver. E.g. 'username' for UserNameDriver
      * @param string $driver ::class attribute of driver class, which must implement Flarum\User\DisplayName\DriverInterface
@@ -29,10 +31,41 @@ class User implements ExtenderInterface
         return $this;
     }
 
+
+    /**
+     * Add a callback to dynamically process a user's list of groups.
+     * This can be used to add or remove groups to a user.
+     *
+     * The callable can be a closure or invokable class, and should accept:
+     * - \Flarum\User\User $user: the user in question
+     * - array $groupIds: an array of ids for the groups the user belongs to
+     *
+     * The callable should return:
+     * - array $groupIds: an array of ids for the groups the user belongs to
+     *
+     * @param callable $callback
+     */
+    public function addGroupProcessor($callback)
+    {
+        $this->groupProcessors[] = $callback;
+
+        return $this;
+    }
+
     public function extend(Container $container, Extension $extension = null)
     {
+        // Display name config
         $container->extend('flarum.user.display_name.supported_drivers', function ($existingDrivers) {
             return array_merge($existingDrivers, $this->displayNameDrivers);
         });
+
+        // Group processor config
+        foreach ($this->groupProcessors as $callback) {
+            if (is_string($callback)) {
+                $callback = $container->make($callback);
+            }
+
+            ActualUser::addGroupProcessor($callback);
+        }
     }
 }

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -44,7 +44,7 @@ class User implements ExtenderInterface
      * The callable should return:
      * - array $groupIds: an array of ids for the groups the user belongs to.
      */
-    public function addGroupProcessor(callable $callable)
+    public function permissionGroups(callable $callable)
     {
         $this->groupProcessors[] = $callable;
 

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -30,7 +30,6 @@ class User implements ExtenderInterface
         return $this;
     }
 
-
     /**
      * Dynamically process a user's list of groups when calculating permissions.
      * This can be used to give a user permissions for groups they aren't actually in, based on context.

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -32,21 +32,22 @@ class User implements ExtenderInterface
 
 
     /**
-     * Add a callback to dynamically process a user's list of groups.
-     * This can be used to add or remove groups to a user.
+     * Dynamically process a user's list of groups when calculating permissions.
+     * This can be used to give a user permissions for groups they aren't actually in, based on context.
+     * It will not change the group badges displayed for the user.
+     *
+     * @param callable $callable
      *
      * The callable can be a closure or invokable class, and should accept:
-     * - \Flarum\User\User $user: the user in question
-     * - array $groupIds: an array of ids for the groups the user belongs to
+     * - \Flarum\User\User $user: the user in question.
+     * - array $groupIds: an array of ids for the groups the user belongs to.
      *
      * The callable should return:
-     * - array $groupIds: an array of ids for the groups the user belongs to
-     *
-     * @param callable $callback
+     * - array $groupIds: an array of ids for the groups the user belongs to.
      */
-    public function addGroupProcessor($callback)
+    public function addGroupProcessor(callable $callable)
     {
-        $this->groupProcessors[] = $callback;
+        $this->groupProcessors[] = $callable;
 
         return $this;
     }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -32,7 +32,7 @@ class UserServiceProvider extends AbstractServiceProvider
         $this->registerAvatarsFilesystem();
         $this->registerDisplayNameDrivers();
 
-        $this->app->singleton('flarum.user.groupProcessors', function () {
+        $this->app->singleton('flarum.user.group_processors', function () {
             return [];
         });
     }
@@ -76,7 +76,7 @@ class UserServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        foreach ($this->app->make('flarum.user.groupProcessors') as $callback) {
+        foreach ($this->app->make('flarum.user.group_processors') as $callback) {
             if (is_string($callback)) {
                 $callback = $this->app->make($callback);
             }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -31,6 +31,10 @@ class UserServiceProvider extends AbstractServiceProvider
     {
         $this->registerAvatarsFilesystem();
         $this->registerDisplayNameDrivers();
+
+        $this->app->singleton('flarum.user.groupProcessors', function () {
+            return [];
+        });
     }
 
     protected function registerDisplayNameDrivers()
@@ -72,6 +76,14 @@ class UserServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
+        foreach ($this->app->make('flarum.user.groupProcessors') as $callback) {
+            if (is_string($callback)) {
+                $callback = $this->app->make($callback);
+            }
+
+            User::addGroupProcessor($callback);
+        }
+
         User::setHasher($this->app->make('hash'));
         User::setGate($this->app->make(Gate::class));
         User::setDisplayNameDriver($this->app->make('flarum.user.display_name.driver'));

--- a/tests/integration/extenders/UserTest.php
+++ b/tests/integration/extenders/UserTest.php
@@ -26,6 +26,7 @@ class UserTest extends TestCase
                 $this->adminUser(),
             ], 'settings' => [
                 ['key' => 'display_name_driver', 'value' => 'custom'],
+                $this->normalUser(),
             ],
         ]);
     }
@@ -57,6 +58,34 @@ class UserTest extends TestCase
         $user = User::find(1);
 
         $this->assertEquals('admin@machine.local$$$suffix', $user->displayName);
+    }
+
+    /**
+     * @test
+     */
+    public function user_has_permissions_for_expected_groups_if_no_processors_added()
+    {
+        $this->prepDb();
+        $user = User::find(2);
+
+        $this->assertContains('viewUserList', $user->getPermissions());
+    }
+
+    /**
+     * @test
+     */
+    public function processor_can_restrict_user_groups()
+    {
+        $this->extend((new Extend\User)->addGroupProcessor(function (User $user, array $groupIds) {
+            return array_filter($groupIds, function ($id) {
+                return $id != 3;
+            });
+        }));
+
+        $this->prepDb();
+        $user = User::find(2);
+
+        $this->assertNotContains('viewUserList', $user->getPermissions());
     }
 }
 

--- a/tests/integration/extenders/UserTest.php
+++ b/tests/integration/extenders/UserTest.php
@@ -24,9 +24,10 @@ class UserTest extends TestCase
         $this->prepareDatabase([
             'users' => [
                 $this->adminUser(),
-            ], 'settings' => [
-                ['key' => 'display_name_driver', 'value' => 'custom'],
                 $this->normalUser(),
+            ],
+            'settings' => [
+                ['key' => 'display_name_driver', 'value' => 'custom'],
             ],
         ]);
     }

--- a/tests/integration/extenders/UserTest.php
+++ b/tests/integration/extenders/UserTest.php
@@ -77,7 +77,7 @@ class UserTest extends TestCase
      */
     public function processor_can_restrict_user_groups()
     {
-        $this->extend((new Extend\User)->addGroupProcessor(function (User $user, array $groupIds) {
+        $this->extend((new Extend\User)->permissionGroups(function (User $user, array $groupIds) {
             return array_filter($groupIds, function ($id) {
                 return $id != 3;
             });


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
- Added User extender with addGroupProcessor method
- Added integration tests
- Deprecated PrepareUserGroups

**Reviewers should focus on:**
Are we ok with the naming?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).