### PR TITLE
Fix extensions page layout

### DIFF
--- a/less/admin/ExtensionsPage.less
+++ b/less/admin/ExtensionsPage.less
@@ -28,7 +28,9 @@
   .clearfix();
 
   > li {
+    -webkit-column-break-inside: avoid;
     break-inside: avoid-column;
+    page-break-inside: avoid;
     text-align: left;
     position: relative;
     border-radius: 4px;


### PR DESCRIPTION
**Fixes #2029**

**Changes proposed in this pull request:**
`break-inside: avoid-column;` is [not supported on Firefox](https://caniuse.com/#feat=mdn-css_properties_break-inside_multicol_context_column), yet they have `page-break-inside` property to prevent breaks in **columns**, as well as pages. Also, `-webkit-column-break-inside` should be used for WebKit-based browsers (like Safari). See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/break-inside) for further information.

**Reviewers should focus on:**
There are also couple of work-arounds I've found on [StackOverflow](https://stackoverflow.com/a/7785711) but it seems like the `page-break-inside` property fixes our issue without needing any of them.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
