### PR TITLE
Update Site.php

### DIFF
--- a/src/Foundation/Site.php
+++ b/src/Foundation/Site.php
@@ -25,26 +25,34 @@ class Site
                 'Paths array requires keys base, public and storage'
             );
         }
+        
+        if (! isset($paths['config'])) {
+            $paths['config'] = $paths['base'] . "/config.php";
+        }
+        
+        if (! isset($paths['extend'])) {
+            $paths['extend'] = $paths['base'] . "/extend.php";
+        }
 
         date_default_timezone_set('UTC');
 
-        if (static::hasConfigFile($paths['base'])) {
+        if (static::hasConfigFile($paths['config'])) {
             return (
-                new InstalledSite($paths, static::loadConfig($paths['base']))
-            )->extendWith(static::loadExtenders($paths['base']));
+                new InstalledSite($paths, static::loadConfig($paths['config']))
+            )->extendWith(static::loadExtenders($paths['extend']));
         } else {
             return new UninstalledSite($paths);
         }
     }
 
-    private static function hasConfigFile($basePath)
+    private static function hasConfigFile($configPath)
     {
-        return file_exists("$basePath/config.php");
+        return file_exists($configPath);
     }
 
-    private static function loadConfig($basePath): array
+    private static function loadConfig($configPath): array
     {
-        $config = include "$basePath/config.php";
+        $config = include $configPath;
 
         if (! is_array($config)) {
             throw new RuntimeException('config.php should return an array');
@@ -53,9 +61,8 @@ class Site
         return $config;
     }
 
-    private static function loadExtenders($basePath): array
+    private static function loadExtenders($extenderFile): array
     {
-        $extenderFile = "$basePath/extend.php";
 
         if (! file_exists($extenderFile)) {
             return [];


### PR DESCRIPTION
**Changes proposed in this pull request:**
Allows specify path of config.php and extend.php to make multi-site
In site.php:
```php
return Flarum\Foundation\Site::fromPaths([
    'base' => dirname(__DIR__),
    'config' => __DIR__ . '/config.php',
    'extend' => __DIR__ . '/extend.php',
    'public' => __DIR__.'/public',
    'storage' => __DIR__.'/storage',
]);
```

**Required changes:**
- [x] Related documentation PR:
  Add multi-site config page