### PR TITLE
Simplify uploads, avoid Application contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "illuminate/support": "5.7.*",
         "illuminate/validation": "5.7.*",
         "illuminate/view": "5.7.*",
-        "intervention/image": "^2.3.0",
+        "intervention/image": "^2.5.0",
         "laminas/laminas-diactoros": "^1.8.4",
         "laminas/laminas-httphandlerrunner": "^1.0",
         "laminas/laminas-stratigility": "^3.0",

--- a/src/Api/Controller/DeleteFaviconController.php
+++ b/src/Api/Controller/DeleteFaviconController.php
@@ -9,12 +9,10 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\Foundation\Application;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AssertPermissionTrait;
 use Laminas\Diactoros\Response\EmptyResponse;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DeleteFaviconController extends AbstractDeleteController
@@ -27,17 +25,18 @@ class DeleteFaviconController extends AbstractDeleteController
     protected $settings;
 
     /**
-     * @var Application
+     * @var FilesystemInterface
      */
-    protected $app;
+    protected $uploadDir;
 
     /**
      * @param SettingsRepositoryInterface $settings
+     * @param FilesystemInterface $uploadDir
      */
-    public function __construct(SettingsRepositoryInterface $settings, Application $app)
+    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
     {
         $this->settings = $settings;
-        $this->app = $app;
+        $this->uploadDir = $uploadDir;
     }
 
     /**
@@ -51,10 +50,8 @@ class DeleteFaviconController extends AbstractDeleteController
 
         $this->settings->set('favicon_path', null);
 
-        $uploadDir = new Filesystem(new Local($this->app->publicPath().'/assets'));
-
-        if ($uploadDir->has($path)) {
-            $uploadDir->delete($path);
+        if ($this->uploadDir->has($path)) {
+            $this->uploadDir->delete($path);
         }
 
         return new EmptyResponse(204);

--- a/src/Api/Controller/DeleteLogoController.php
+++ b/src/Api/Controller/DeleteLogoController.php
@@ -9,12 +9,10 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\Foundation\Application;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AssertPermissionTrait;
 use Laminas\Diactoros\Response\EmptyResponse;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DeleteLogoController extends AbstractDeleteController
@@ -27,17 +25,18 @@ class DeleteLogoController extends AbstractDeleteController
     protected $settings;
 
     /**
-     * @var Application
+     * @var FilesystemInterface
      */
-    protected $app;
+    protected $uploadDir;
 
     /**
      * @param SettingsRepositoryInterface $settings
+     * @param FilesystemInterface $uploadDir
      */
-    public function __construct(SettingsRepositoryInterface $settings, Application $app)
+    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
     {
         $this->settings = $settings;
-        $this->app = $app;
+        $this->uploadDir = $uploadDir;
     }
 
     /**
@@ -51,10 +50,8 @@ class DeleteLogoController extends AbstractDeleteController
 
         $this->settings->set('logo_path', null);
 
-        $uploadDir = new Filesystem(new Local($this->app->publicPath().'/assets'));
-
-        if ($uploadDir->has($path)) {
-            $uploadDir->delete($path);
+        if ($this->uploadDir->has($path)) {
+            $this->uploadDir->delete($path);
         }
 
         return new EmptyResponse(204);

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -9,15 +9,12 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\Foundation\Application;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AssertPermissionTrait;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
-use League\Flysystem\MountManager;
+use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -31,17 +28,18 @@ class UploadLogoController extends ShowForumController
     protected $settings;
 
     /**
-     * @var Application
+     * @var FilesystemInterface
      */
-    protected $app;
+    protected $uploadDir;
 
     /**
      * @param SettingsRepositoryInterface $settings
+     * @param FilesystemInterface $uploadDir
      */
-    public function __construct(SettingsRepositoryInterface $settings, Application $app)
+    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
     {
         $this->settings = $settings;
-        $this->app = $app;
+        $this->uploadDir = $uploadDir;
     }
 
     /**
@@ -53,28 +51,19 @@ class UploadLogoController extends ShowForumController
 
         $file = Arr::get($request->getUploadedFiles(), 'logo');
 
-        $tmpFile = tempnam($this->app->storagePath().'/tmp', 'logo');
-        $file->moveTo($tmpFile);
-
         $manager = new ImageManager;
 
-        $encodedImage = $manager->make($tmpFile)->heighten(60, function ($constraint) {
+        $encodedImage = $manager->make($file->getStream())->heighten(60, function ($constraint) {
             $constraint->upsize();
         })->encode('png');
-        file_put_contents($tmpFile, $encodedImage);
 
-        $mount = new MountManager([
-            'source' => new Filesystem(new Local(pathinfo($tmpFile, PATHINFO_DIRNAME))),
-            'target' => new Filesystem(new Local($this->app->publicPath().'/assets')),
-        ]);
-
-        if (($path = $this->settings->get('logo_path')) && $mount->has($file = "target://$path")) {
-            $mount->delete($file);
+        if (($path = $this->settings->get('logo_path')) && $this->uploadDir->has($path)) {
+            $this->uploadDir->delete($path);
         }
 
         $uploadName = 'logo-'.Str::lower(Str::random(8)).'.png';
 
-        $mount->move('source://'.pathinfo($tmpFile, PATHINFO_BASENAME), "target://$uploadName");
+        $this->uploadDir->write($uploadName, $encodedImage);
 
         $this->settings->set('logo_path', $uploadName);
 

--- a/src/Settings/SettingsServiceProvider.php
+++ b/src/Settings/SettingsServiceProvider.php
@@ -9,8 +9,15 @@
 
 namespace Flarum\Settings;
 
+use Flarum\Api\Controller\DeleteFaviconController;
+use Flarum\Api\Controller\DeleteLogoController;
+use Flarum\Api\Controller\UploadFaviconController;
+use Flarum\Api\Controller\UploadLogoController;
 use Flarum\Foundation\AbstractServiceProvider;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Database\ConnectionInterface;
+use League\Flysystem\FilesystemInterface;
 
 class SettingsServiceProvider extends AbstractServiceProvider
 {
@@ -28,5 +35,18 @@ class SettingsServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->alias(SettingsRepositoryInterface::class, 'flarum.settings');
+
+        $assets = function (Container $app) {
+            return $app->make(Factory::class)->disk('flarum-assets')->getDriver();
+        };
+
+        $this->app->when([
+            DeleteFaviconController::class,
+            DeleteLogoController::class,
+            UploadFaviconController::class,
+            UploadLogoController::class,
+        ])
+            ->needs(FilesystemInterface::class)
+            ->give($assets);
     }
 }

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -10,14 +10,76 @@
 namespace Flarum\User;
 
 use Flarum\Foundation\AbstractValidator;
+use Flarum\Foundation\ValidationException;
+use Psr\Http\Message\UploadedFileInterface;
+use Symfony\Component\Mime\MimeTypes;
 
 class AvatarValidator extends AbstractValidator
 {
-    protected $rules = [
-        'avatar' => [
-            'required',
-            'mimes:jpeg,png,bmp,gif',
-            'max:2048'
-        ]
-    ];
+    /**
+     * Throw an exception if a model is not valid.
+     *
+     * @param array $attributes
+     */
+    public function assertValid(array $attributes)
+    {
+        $this->assertFileRequired($attributes['avatar']);
+        $this->assertFileMimes($attributes['avatar']);
+        $this->assertFileSize($attributes['avatar']);
+    }
+
+    protected function assertFileRequired(UploadedFileInterface $file)
+    {
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            $this->raise('required');
+        }
+    }
+
+    protected function assertFileMimes(UploadedFileInterface $file)
+    {
+        $allowedTypes = $this->getAllowedTypes();
+
+        // Block PHP files masquerading as images
+        $phpExtensions = ['php', 'php3', 'php4', 'php5', 'phtml'];
+        $fileExtension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
+
+        if (in_array(trim(strtolower($fileExtension)), $phpExtensions)) {
+            $this->raise('mimes', [':values' => implode(', ', $allowedTypes)]);
+        }
+
+        $guessedExtension = MimeTypes::getDefault()->getExtensions($file->getClientMediaType())[0] ?? null;
+
+        if (! in_array($guessedExtension, $allowedTypes)) {
+            $this->raise('mimes', [':values' => implode(', ', $allowedTypes)]);
+        }
+    }
+
+    protected function assertFileSize(UploadedFileInterface $file)
+    {
+        $maxSize = $this->getMaxSize();
+
+        if ($file->getSize() / 1024 > $maxSize) {
+            $this->raise('max.file', [':max' => $maxSize]);
+        }
+    }
+
+    protected function raise($error, array $parameters = [])
+    {
+        $message = $this->translator->trans(
+            "validation.$error",
+            $parameters + [':attribute' => 'avatar']
+        );
+
+        throw new ValidationException(['avatar' => $message]);
+    }
+
+    protected function getMaxSize()
+    {
+        return 2048;
+    }
+
+    protected function getAllowedTypes()
+    {
+        return ['jpeg', 'png', 'bmp', 'gif'];
+    }
 }

--- a/src/User/Command/UploadAvatarHandler.php
+++ b/src/User/Command/UploadAvatarHandler.php
@@ -18,7 +18,6 @@ use Flarum\User\Event\AvatarSaving;
 use Flarum\User\UserRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Intervention\Image\ImageManager;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadAvatarHandler
 {
@@ -65,6 +64,7 @@ class UploadAvatarHandler
      * @param UploadAvatar $command
      * @return \Flarum\User\User
      * @throws \Flarum\User\Exception\PermissionDeniedException
+     * @throws \Flarum\Foundation\ValidationException
      */
     public function handle(UploadAvatar $command)
     {
@@ -82,15 +82,6 @@ class UploadAvatarHandler
         $file->moveTo($tmpFile);
 
         try {
-            $file = new UploadedFile(
-                $tmpFile,
-                $file->getClientFilename(),
-                $file->getClientMediaType(),
-                $file->getSize(),
-                $file->getError(),
-                true
-            );
-
             $this->validator->assertValid(['avatar' => $file]);
 
             $image = (new ImageManager)->make($tmpFile);


### PR DESCRIPTION
**Prepares for #2055**

Laravel 5.8 further increased the size of the `Application` contract. Reimplementing all these methods just becomes pointless. The problem has been recognized over at Laravel, but not yet fully solved. So, instead of reimplementing all these methods, we should instead try to avoid using this contract.

This is one part of reducing the usages - in the various places where we dealt with accepting / deleting file uploads, we injected our `Application` class just to build a path. Instead, let's inject filesystem instances, which are configured to point to a certain directory elsewhere (in service providers). Additional benefit: this makes it easier to inject e.g. a S3 filesystem where scaling capabilities are needed / local filesystems are not writable.

Additional changes:
- No longer use the `MountManager` for these uploads. It only added complexity (by moving temporary files around) and will not be available in the next major release of Flysystem.
- Stop copying files to a temporary location before moving them again.
- For the avatar upload, write custom validation logic instead of wrapping a PSR-7 file object in a Symfony file object just to be compatible with Laravel's validation layer.
- Upgrade `intervention/image` to support passing PSR upload streams. (Very likely, users have already updated to this newer version, as the old constraint allowed it, but we should be explicit for correctness' sake.)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
