### PR TITLE
Fix header contents moving when opening modal

### DIFF
--- a/less/common/App.less
+++ b/less/common/App.less
@@ -236,15 +236,11 @@
   .App-header {
     padding: 8px;
     height: @header-height;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;
     z-index: @zindex-header;
-
-    .affix & {
-      position: fixed;
-    }
 
     & when (@config-colored-header = true) {
       .light-contents(@header-color, @header-control-bg, @header-control-color);

--- a/views/frontend/admin.blade.php
+++ b/views/frontend/admin.blade.php
@@ -4,7 +4,7 @@
 
     <div id="drawer" class="App-drawer">
 
-        <header id="header" class="App-header">
+        <header id="header" class="App-header navbar-fixed-top">
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <h1 class="Header-title">

--- a/views/frontend/forum.blade.php
+++ b/views/frontend/forum.blade.php
@@ -6,7 +6,7 @@
 
     <div id="drawer" class="App-drawer">
 
-        <header id="header" class="App-header">
+        <header id="header" class="App-header navbar-fixed-top">
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <h1 class="Header-title">


### PR DESCRIPTION
**Fixes the following minor bug:**

Header contents move on desktop when modal is opened.

Steps:
1. https://discuss.flarum.org
2. scroll a little down
3. open a modal (f.e. Login Modal)
-> Header contents move back and forth when opening and closing the modal. (Chrome)

Reason: Scrollbar is disabled when modal is open. A padding-right is applied to the body to account for that. When header position is fixed, it does not apply the padding. 

**Changes proposed in this pull request:**
Bootstrap modal has a builtin class navbar-fixed-top that fixes that issue.

**Reviewers should focus on:**
Changed the header css class to position:fixed for @tablet-up.  

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

