### PR TITLE
fix search input value disappearing on page reload

### DIFF
--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -24,7 +24,7 @@ export default class Search extends Component {
      *
      * @type {Function}
      */
-    this.value = m.prop('');
+    this.value = m.prop();
 
     /**
      * Whether or not the search input has focus.


### PR DESCRIPTION
**Fixes the following bug:**
going to https://discuss.flarum.org/?q=abc
the search input shows no value if accessed through the link, or when searching something and reloading the page.

**Changes proposed in this pull request:**
remove the empty string in m.prop, so the below code in the view function can run.
```js
   // Initialize search input value in the view rather than the constructor so
    // that we have access to app.current.
    if (typeof this.value() === 'undefined') {
      this.value(currentSearch || '');
    }
```

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

