### PR TITLE
Move Discussion List State into its own class

### DIFF
--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -77,8 +77,8 @@ export default class ForumApplication extends Application {
    * @inheritdoc
    */
   cache = {
-    discussionList: new DiscussionListState()
-  }
+    discussionList: new DiscussionListState(),
+  };
 
   constructor() {
     super();

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -78,10 +78,12 @@ export default class ForumApplication extends Application {
 
     routes(this);
 
-    this.discussionList = new DiscussionListState({ forumApp: this });
+    this.discussions = new DiscussionListState({ forumApp: this });
 
-    // Deprecated, remove in beta 15. BC layer.
-    this.cache.discussionList = this.discussionList;
+    /**
+     * @deprecated beta 14, remove in beta 15.
+     */
+    this.cache.discussionList = this.discussions;
   }
 
   /**

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -73,11 +73,6 @@ export default class ForumApplication extends Application {
    */
   search = new GlobalSearchState();
 
-  /*
-   * @inheritdoc
-   */
-  discussionList;
-
   constructor() {
     super();
 

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -76,14 +76,15 @@ export default class ForumApplication extends Application {
   /*
    * @inheritdoc
    */
-  cache = {
-    discussionList: new DiscussionListState(),
-  };
+  discussionList = new DiscussionListState();
 
   constructor() {
     super();
 
     routes(this);
+
+    // Deprecated, remove in beta 15. BC layer.
+    this.cache.discussionList = this.discussionList;
   }
 
   /**

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -73,6 +73,13 @@ export default class ForumApplication extends Application {
    */
   search = new GlobalSearchState();
 
+  /*
+   * @inheritdoc
+   */
+  cache = {
+    discussionList: new DiscussionListState()
+  }
+
   constructor() {
     super();
 
@@ -104,7 +111,6 @@ export default class ForumApplication extends Application {
 
     this.pane = new Pane(document.getElementById('app'));
     this.composer = m.mount(document.getElementById('composer'), Composer.component());
-    this.cache.discussionList = new DiscussionListState();
 
     m.route.mode = 'pathname';
     super.mount(this.forum.attribute('basePath'));

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -78,6 +78,12 @@ export default class ForumApplication extends Application {
 
     routes(this);
 
+    /**
+     * An object which controls the state of the cached discussion list, which
+     * is used in the index page and the slideout pane.
+     *
+     * @type {DiscussionListState}
+     */
     this.discussions = new DiscussionListState({ forumApp: this });
 
     /**

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -15,6 +15,7 @@ import Application from '../common/Application';
 import Navigation from '../common/components/Navigation';
 import NotificationListState from './states/NotificationListState';
 import GlobalSearchState from './states/GlobalSearchState';
+import DiscussionListState from './state/DiscussionListState';
 
 export default class ForumApplication extends Application {
   /**
@@ -103,6 +104,8 @@ export default class ForumApplication extends Application {
 
     this.pane = new Pane(document.getElementById('app'));
     this.composer = m.mount(document.getElementById('composer'), Composer.component());
+    this.cache.discussionList = new DiscussionListState();
+    this.cache.discussionList.refresh();
 
     m.route.mode = 'pathname';
     super.mount(this.forum.attribute('basePath'));

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -105,7 +105,6 @@ export default class ForumApplication extends Application {
     this.pane = new Pane(document.getElementById('app'));
     this.composer = m.mount(document.getElementById('composer'), Composer.component());
     this.cache.discussionList = new DiscussionListState();
-    this.cache.discussionList.refresh();
 
     m.route.mode = 'pathname';
     super.mount(this.forum.attribute('basePath'));

--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -76,12 +76,14 @@ export default class ForumApplication extends Application {
   /*
    * @inheritdoc
    */
-  discussionList = new DiscussionListState();
+  discussionList;
 
   constructor() {
     super();
 
     routes(this);
+
+    this.discussionList = new DiscussionListState({ forumApp: this });
 
     // Deprecated, remove in beta 15. BC layer.
     this.cache.discussionList = this.discussionList;

--- a/js/src/forum/components/DiscussionComposer.js
+++ b/js/src/forum/components/DiscussionComposer.js
@@ -98,7 +98,7 @@ export default class DiscussionComposer extends ComposerBody {
       .save(data)
       .then((discussion) => {
         app.composer.hide();
-        app.cache.discussionList.refresh();
+        app.discussions.refresh();
         m.route(app.route.discussion(discussion));
       }, this.loaded.bind(this));
   }

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -34,7 +34,7 @@ export default class DiscussionList extends Component {
       });
     }
 
-    if (state.hasDiscussions() && !state.isLoading()) {
+    if (!state.hasDiscussions() && !state.isLoading()) {
       const text = app.translator.trans('core.forum.discussion_list.empty_text');
       return <div className="DiscussionList">{Placeholder.component({ text })}</div>;
     }

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -40,7 +40,7 @@ export default class DiscussionList extends Component {
     }
 
     return (
-      <div className={'DiscussionList' + (state.params.q ? ' DiscussionList--searchResults' : '')}>
+      <div className={'DiscussionList' + (state.isSearchResults() ? ' DiscussionList--searchResults' : '')}>
         <ul className="DiscussionList-discussions">
           {state.discussions.map((discussion) => {
             return (

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -11,10 +11,11 @@ import Placeholder from '../../common/components/Placeholder';
  *
  * - `params` A map of parameters used to construct a refined parameter object
  *   to send along in the API request to get discussion results.
+ * - `state` A DiscussionListState object that represents the discussion lists's state.
  */
 export default class DiscussionList extends Component {
   init() {
-    this.state = this.props.state || new DiscussionListState();
+    this.state = this.props.state;
   }
 
   view() {

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -34,7 +34,7 @@ export default class DiscussionList extends Component {
       });
     }
 
-    if (!state.hasDiscussions() && !state.isLoading()) {
+    if (state.empty()) {
       const text = app.translator.trans('core.forum.discussion_list.empty_text');
       return <div className="DiscussionList">{Placeholder.component({ text })}</div>;
     }

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -21,10 +21,10 @@ export default class DiscussionList extends Component {
   view() {
     const state = this.state;
 
-    const params = state.params;
+    const params = state.getParams();
     let loading;
 
-    if (state.loading) {
+    if (state.isLoading()) {
       loading = LoadingIndicator.component();
     } else if (state.moreResults) {
       loading = Button.component({
@@ -34,7 +34,7 @@ export default class DiscussionList extends Component {
       });
     }
 
-    if (state.discussions.length === 0 && !state.loading) {
+    if (state.hasDiscussions() && !state.isLoading()) {
       const text = app.translator.trans('core.forum.discussion_list.empty_text');
       return <div className="DiscussionList">{Placeholder.component({ text })}</div>;
     }

--- a/js/src/forum/components/DiscussionList.js
+++ b/js/src/forum/components/DiscussionList.js
@@ -14,53 +14,34 @@ import Placeholder from '../../common/components/Placeholder';
  */
 export default class DiscussionList extends Component {
   init() {
-    /**
-     * Whether or not discussion results are loading.
-     *
-     * @type {Boolean}
-     */
-    this.loading = true;
-
-    /**
-     * Whether or not there are more results that can be loaded.
-     *
-     * @type {Boolean}
-     */
-    this.moreResults = false;
-
-    /**
-     * The discussions in the discussion list.
-     *
-     * @type {Discussion[]}
-     */
-    this.discussions = [];
-
-    this.refresh();
+    this.state = this.props.state || new DiscussionListState();
   }
 
   view() {
-    const params = this.props.params;
+    const state = this.state;
+
+    const params = state.params;
     let loading;
 
-    if (this.loading) {
+    if (state.loading) {
       loading = LoadingIndicator.component();
-    } else if (this.moreResults) {
+    } else if (state.moreResults) {
       loading = Button.component({
         children: app.translator.trans('core.forum.discussion_list.load_more_button'),
         className: 'Button',
-        onclick: this.loadMore.bind(this),
+        onclick: state.loadMore.bind(state),
       });
     }
 
-    if (this.discussions.length === 0 && !this.loading) {
+    if (state.discussions.length === 0 && !state.loading) {
       const text = app.translator.trans('core.forum.discussion_list.empty_text');
       return <div className="DiscussionList">{Placeholder.component({ text })}</div>;
     }
 
     return (
-      <div className={'DiscussionList' + (this.props.params.q ? ' DiscussionList--searchResults' : '')}>
+      <div className={'DiscussionList' + (state.params.q ? ' DiscussionList--searchResults' : '')}>
         <ul className="DiscussionList-discussions">
-          {this.discussions.map((discussion) => {
+          {state.discussions.map((discussion) => {
             return (
               <li key={discussion.id()} data-id={discussion.id()}>
                 {DiscussionListItem.component({ discussion, params })}
@@ -71,141 +52,5 @@ export default class DiscussionList extends Component {
         <div className="DiscussionList-loadMore">{loading}</div>
       </div>
     );
-  }
-
-  /**
-   * Get the parameters that should be passed in the API request to get
-   * discussion results.
-   *
-   * @return {Object}
-   * @api
-   */
-  requestParams() {
-    const params = { include: ['user', 'lastPostedUser'], filter: {} };
-
-    params.sort = this.sortMap()[this.props.params.sort];
-
-    if (this.props.params.q) {
-      params.filter.q = this.props.params.q;
-
-      params.include.push('mostRelevantPost', 'mostRelevantPost.user');
-    }
-
-    return params;
-  }
-
-  /**
-   * Get a map of sort keys (which appear in the URL, and are used for
-   * translation) to the API sort value that they represent.
-   *
-   * @return {Object}
-   */
-  sortMap() {
-    const map = {};
-
-    if (this.props.params.q) {
-      map.relevance = '';
-    }
-    map.latest = '-lastPostedAt';
-    map.top = '-commentCount';
-    map.newest = '-createdAt';
-    map.oldest = 'createdAt';
-
-    return map;
-  }
-
-  /**
-   * Clear and reload the discussion list.
-   *
-   * @public
-   */
-  refresh(clear = true) {
-    if (clear) {
-      this.loading = true;
-      this.discussions = [];
-    }
-
-    return this.loadResults().then(
-      (results) => {
-        this.discussions = [];
-        this.parseResults(results);
-      },
-      () => {
-        this.loading = false;
-        m.redraw();
-      }
-    );
-  }
-
-  /**
-   * Load a new page of discussion results.
-   *
-   * @param {Integer} offset The index to start the page at.
-   * @return {Promise}
-   */
-  loadResults(offset) {
-    const preloadedDiscussions = app.preloadedApiDocument();
-
-    if (preloadedDiscussions) {
-      return m.deferred().resolve(preloadedDiscussions).promise;
-    }
-
-    const params = this.requestParams();
-    params.page = { offset };
-    params.include = params.include.join(',');
-
-    return app.store.find('discussions', params);
-  }
-
-  /**
-   * Load the next page of discussion results.
-   *
-   * @public
-   */
-  loadMore() {
-    this.loading = true;
-
-    this.loadResults(this.discussions.length).then(this.parseResults.bind(this));
-  }
-
-  /**
-   * Parse results and append them to the discussion list.
-   *
-   * @param {Discussion[]} results
-   * @return {Discussion[]}
-   */
-  parseResults(results) {
-    [].push.apply(this.discussions, results);
-
-    this.loading = false;
-    this.moreResults = !!results.payload.links.next;
-
-    m.lazyRedraw();
-
-    return results;
-  }
-
-  /**
-   * Remove a discussion from the list if it is present.
-   *
-   * @param {Discussion} discussion
-   * @public
-   */
-  removeDiscussion(discussion) {
-    const index = this.discussions.indexOf(discussion);
-
-    if (index !== -1) {
-      this.discussions.splice(index, 1);
-    }
-  }
-
-  /**
-   * Add a discussion to the top of the list.
-   *
-   * @param {Discussion} discussion
-   * @public
-   */
-  addDiscussion(discussion) {
-    this.discussions.unshift(discussion);
   }
 }

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -38,7 +38,7 @@ export default class DiscussionPage extends Page {
     // page, then we don't want Mithril to redraw the whole page – if it did,
     // then the pane would which would be slow and would cause problems with
     // event handlers.
-    if (app.cache.discussionList) {
+    if (app.cache.discussionList.hasDiscussions()) {
       app.pane.enable();
       app.pane.hide();
 
@@ -91,7 +91,7 @@ export default class DiscussionPage extends Page {
 
     return (
       <div className="DiscussionPage">
-        {app.cache.discussionList ? (
+        {app.cache.discussionList.hasDiscussions() ? (
           <div className="DiscussionPage-list" config={this.configPane.bind(this)}>
             {!$('.App-navigation').is(':visible') && <DiscussionList state={app.cache.discussionList} />}
           </div>

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -38,7 +38,7 @@ export default class DiscussionPage extends Page {
     // page, then we don't want Mithril to redraw the whole page – if it did,
     // then the pane would which would be slow and would cause problems with
     // event handlers.
-    if (app.cache.discussionList.hasDiscussions()) {
+    if (app.discussions.hasDiscussions()) {
       app.pane.enable();
       app.pane.hide();
 
@@ -91,9 +91,9 @@ export default class DiscussionPage extends Page {
 
     return (
       <div className="DiscussionPage">
-        {app.cache.discussionList.hasDiscussions() ? (
+        {app.discussions.hasDiscussions() ? (
           <div className="DiscussionPage-list" config={this.configPane.bind(this)}>
-            {!$('.App-navigation').is(':visible') && <DiscussionList state={app.cache.discussionList} />}
+            {!$('.App-navigation').is(':visible') && <DiscussionList state={app.discussions} />}
           </div>
         ) : (
           ''

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -36,7 +36,7 @@ export default class DiscussionPage extends Page {
     // If the discussion list has been loaded, then we'll enable the pane (and
     // hide it by default). Also, if we've just come from another discussion
     // page, then we don't want Mithril to redraw the whole page – if it did,
-    // then the pane would which would be slow and would cause problems with
+    // then the pane would redraw which would be slow and would cause problems with
     // event handlers.
     if (app.discussions.hasDiscussions()) {
       app.pane.enable();

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -7,6 +7,7 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
+import DiscussionList from './DiscussionList';
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -92,7 +93,7 @@ export default class DiscussionPage extends Page {
       <div className="DiscussionPage">
         {app.cache.discussionList ? (
           <div className="DiscussionPage-list" config={this.configPane.bind(this)}>
-            {!$('.App-navigation').is(':visible') ? app.cache.discussionList.render() : ''}
+            {!$('.App-navigation').is(':visible') && <DiscussionList state={app.cache.discussionList} />}
           </div>
         ) : (
           ''

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -50,6 +50,7 @@ export default class DiscussionPage extends Page {
     app.history.push('discussion');
 
     this.bodyClass = 'App--discussion';
+    this.discussionListClass = DiscussionList;
   }
 
   onunload(e) {

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -2,6 +2,7 @@ import { extend } from '../../common/extend';
 import Page from './Page';
 import ItemList from '../../common/utils/ItemList';
 import listItems from '../../common/helpers/listItems';
+import DiscussionListState from '../state/DiscussionListState';
 import DiscussionList from './DiscussionList';
 import WelcomeHero from './WelcomeHero';
 import DiscussionComposer from './DiscussionComposer';
@@ -45,7 +46,7 @@ export default class IndexPage extends Page {
       // will clear the cache and set up a new discussion list component with
       // the new parameters.
       Object.keys(params).some((key) => {
-        if (app.cache.discussionList.props.params[key] !== params[key]) {
+        if (app.cache.discussionList.params[key] !== params[key]) {
           app.cache.discussionList = null;
           return true;
         }
@@ -53,7 +54,7 @@ export default class IndexPage extends Page {
     }
 
     if (!app.cache.discussionList) {
-      app.cache.discussionList = new DiscussionList({ params });
+      app.cache.discussionList = new DiscussionListState({ params });
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
@@ -81,7 +82,7 @@ export default class IndexPage extends Page {
                 <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
                 <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
               </div>
-              {app.cache.discussionList.render()}
+              {<DiscussionList state={app.cache.discussionList} />}
             </div>
           </div>
         </div>

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -2,7 +2,6 @@ import { extend } from '../../common/extend';
 import Page from './Page';
 import ItemList from '../../common/utils/ItemList';
 import listItems from '../../common/helpers/listItems';
-import DiscussionListState from '../state/DiscussionListState';
 import DiscussionList from './DiscussionList';
 import WelcomeHero from './WelcomeHero';
 import DiscussionComposer from './DiscussionComposer';
@@ -22,6 +21,7 @@ export default class IndexPage extends Page {
 
   init() {
     super.init();
+    console.log(app.cache.discussionList)
 
     // If the user is returning from a discussion page, then take note of which
     // discussion they have just visited. After the view is rendered, we will
@@ -35,7 +35,7 @@ export default class IndexPage extends Page {
     // probably want to refresh the results. We will clear the discussion list
     // cache so that results are reloaded.
     if (app.previous instanceof IndexPage) {
-      app.cache.discussionList = null;
+      app.cache.discussionList.refresh(true, true);
     }
 
     const params = app.search.params();
@@ -47,14 +47,15 @@ export default class IndexPage extends Page {
       // the new parameters.
       Object.keys(params).some((key) => {
         if (app.cache.discussionList.params[key] !== params[key]) {
-          app.cache.discussionList = null;
+          app.cache.discussionList.refresh(true, true);
           return true;
         }
       });
     }
 
     if (!app.cache.discussionList) {
-      app.cache.discussionList = new DiscussionListState({ params });
+      app.cache.discussionList.setParams(params);
+      app.cache.discussionList.refresh();
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -37,19 +37,7 @@ export default class IndexPage extends Page {
       app.discussions.clear();
     }
 
-    const params = app.search.params();
-
-    // Compare the requested parameters (sort, search query) to the ones that
-    // are currently present in the cached discussion list. If they differ, we
-    // will clear the cache and update the parameters.
-    let clear = false;
-    if (app.discussions.hasDiscussions()) {
-      clear = Object.keys(params).some((key) => app.discussions.getParams()[key] !== params[key]);
-    }
-
-    if (!app.discussions.hasDiscussions() || clear) {
-      app.discussions.refresh(params);
-    }
+    app.discussions.refreshParams(app.search.params());
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
 

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -44,11 +44,7 @@ export default class IndexPage extends Page {
     // will clear the cache and update the parameters.
     let clear = false;
     if (app.discussions.hasDiscussions()) {
-      clear = Object.keys(params).some((key) => {
-        if (app.discussions.getParams()[key] !== params[key]) {
-          return true;
-        }
-      });
+      clear = Object.keys(params).some((key) => app.discussions.getParams()[key] !== params[key]);
     }
 
     if (!app.discussions.hasDiscussions() || clear) {

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -80,7 +80,9 @@ export default class IndexPage extends Page {
                 <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
                 <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
               </div>
-              {<DiscussionList state={app.cache.discussionList} />}
+              {app.discussionList.getComponentClass().component({
+                state: app.discussionList,
+              })}
             </div>
           </div>
         </div>

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -52,7 +52,6 @@ export default class IndexPage extends Page {
       });
     }
 
-    // If we just cleared the discussion list, reset the params.
     if (!app.cache.discussionList.hasDiscussions()) {
       app.cache.discussionList.setParams(params);
       app.cache.discussionList.refresh();

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -42,8 +42,7 @@ export default class IndexPage extends Page {
     if (app.cache.discussionList.hasDiscussions()) {
       // Compare the requested parameters (sort, search query) to the ones that
       // are currently present in the cached discussion list. If they differ, we
-      // will clear the cache and set up a new discussion list component with
-      // the new parameters.
+      // will clear the cache update the parameters.
       Object.keys(params).some((key) => {
         if (app.cache.discussionList.getParams()[key] !== params[key]) {
           app.cache.discussionList.clear();

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -39,19 +39,19 @@ export default class IndexPage extends Page {
 
     const params = app.search.params();
 
+    // Compare the requested parameters (sort, search query) to the ones that
+    // are currently present in the cached discussion list. If they differ, we
+    // will clear the cache and update the parameters.
+    let clear = false;
     if (app.cache.discussionList.hasDiscussions()) {
-      // Compare the requested parameters (sort, search query) to the ones that
-      // are currently present in the cached discussion list. If they differ, we
-      // will clear the cache update the parameters.
-      Object.keys(params).some((key) => {
+      clear = Object.keys(params).some((key) => {
         if (app.cache.discussionList.getParams()[key] !== params[key]) {
-          app.cache.discussionList.clear();
           return true;
         }
       });
     }
 
-    if (!app.cache.discussionList.hasDiscussions()) {
+    if (!app.cache.discussionList.hasDiscussions() || clear) {
       app.cache.discussionList.refresh(true, params);
     }
 

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -80,9 +80,7 @@ export default class IndexPage extends Page {
                 <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
                 <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
               </div>
-              {app.discussions.getComponentClass().component({
-                state: app.discussions,
-              })}
+              <DiscussionList state={app.discussions} />
             </div>
           </div>
         </div>

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -52,7 +52,7 @@ export default class IndexPage extends Page {
     }
 
     if (!app.cache.discussionList.hasDiscussions()) {
-      app.cache.discussionList.setParams(params);
+      app.cache.discussionList.refresh(true, params);
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -52,7 +52,7 @@ export default class IndexPage extends Page {
     }
 
     if (!app.cache.discussionList.hasDiscussions() || clear) {
-      app.cache.discussionList.refresh(true, params);
+      app.cache.discussionList.refresh(params);
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -34,7 +34,7 @@ export default class IndexPage extends Page {
     // probably want to refresh the results. We will clear the discussion list
     // cache so that results are reloaded.
     if (app.previous instanceof IndexPage) {
-      app.cache.discussionList.clear();
+      app.discussions.clear();
     }
 
     const params = app.search.params();
@@ -43,16 +43,16 @@ export default class IndexPage extends Page {
     // are currently present in the cached discussion list. If they differ, we
     // will clear the cache and update the parameters.
     let clear = false;
-    if (app.cache.discussionList.hasDiscussions()) {
+    if (app.discussions.hasDiscussions()) {
       clear = Object.keys(params).some((key) => {
-        if (app.cache.discussionList.getParams()[key] !== params[key]) {
+        if (app.discussions.getParams()[key] !== params[key]) {
           return true;
         }
       });
     }
 
-    if (!app.cache.discussionList.hasDiscussions() || clear) {
-      app.cache.discussionList.refresh(params);
+    if (!app.discussions.hasDiscussions() || clear) {
+      app.discussions.refresh(params);
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
@@ -80,8 +80,8 @@ export default class IndexPage extends Page {
                 <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
                 <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
               </div>
-              {app.discussionList.getComponentClass().component({
-                state: app.discussionList,
+              {app.discussions.getComponentClass().component({
+                state: app.discussions,
               })}
             </div>
           </div>
@@ -213,7 +213,7 @@ export default class IndexPage extends Page {
    */
   viewItems() {
     const items = new ItemList();
-    const sortMap = app.cache.discussionList.sortMap();
+    const sortMap = app.discussions.sortMap();
 
     const sortOptions = {};
     for (const i in sortMap) {
@@ -258,7 +258,7 @@ export default class IndexPage extends Page {
         icon: 'fas fa-sync',
         className: 'Button Button--icon',
         onclick: () => {
-          app.cache.discussionList.refresh();
+          app.discussions.refresh();
           if (app.session.user) {
             app.store.find('users', app.session.user.id());
             m.redraw();

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -53,7 +53,6 @@ export default class IndexPage extends Page {
 
     if (!app.cache.discussionList.hasDiscussions()) {
       app.cache.discussionList.setParams(params);
-      app.cache.discussionList.refresh();
     }
 
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -45,7 +45,7 @@ export default class IndexPage extends Page {
       // will clear the cache and set up a new discussion list component with
       // the new parameters.
       Object.keys(params).some((key) => {
-        if (app.cache.discussionList.params[key] !== params[key]) {
+        if (app.cache.discussionList.getParams()[key] !== params[key]) {
           app.cache.discussionList.clear();
           return true;
         }

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -34,25 +34,26 @@ export default class IndexPage extends Page {
     // probably want to refresh the results. We will clear the discussion list
     // cache so that results are reloaded.
     if (app.previous instanceof IndexPage) {
-      app.cache.discussionList.refresh(true, true);
+      app.cache.discussionList.clear();
     }
 
     const params = app.search.params();
 
-    if (app.cache.discussionList) {
+    if (app.cache.discussionList.hasDiscussions()) {
       // Compare the requested parameters (sort, search query) to the ones that
       // are currently present in the cached discussion list. If they differ, we
       // will clear the cache and set up a new discussion list component with
       // the new parameters.
       Object.keys(params).some((key) => {
         if (app.cache.discussionList.params[key] !== params[key]) {
-          app.cache.discussionList.refresh(true, true);
+          app.cache.discussionList.clear();
           return true;
         }
       });
     }
 
-    if (!app.cache.discussionList) {
+    // If we just cleared the discussion list, reset the params.
+    if (!app.cache.discussionList.hasDiscussions()) {
       app.cache.discussionList.setParams(params);
       app.cache.discussionList.refresh();
     }

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -21,7 +21,6 @@ export default class IndexPage extends Page {
 
   init() {
     super.init();
-    console.log(app.cache.discussionList)
 
     // If the user is returning from a discussion page, then take note of which
     // discussion they have just visited. After the view is rendered, we will

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -52,6 +52,8 @@ export default class DiscussionListState {
    */
   setParams(params) {
     this.params = params;
+
+    this.refresh();
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -65,22 +65,27 @@ export default class DiscussionListState {
   }
 
   /**
+   * If there are no cached discussions or the new params differ from the
+   * old ones, update params and refresh the discussion list from the database.
+   */
+  refreshParams(newParams) {
+    if (!this.hasDiscussions() || Object.keys(newParams).some((key) => this.getParams()[key] !== params[key])) {
+      this.params = newParams;
+
+      this.refresh();
+    }
+  }
+
+  /**
    * Clear and reload the discussion list.
    */
-  refresh(params, { clear = true } = {}) {
+  refresh() {
     this.loading = true;
 
-    if (clear) {
-      this.clear();
-    }
-
-    if (params) {
-      this.params = params;
-    }
+    this.clear();
 
     return this.loadResults().then(
       (results) => {
-        this.discussions = [];
         this.parseResults(results);
       },
       () => {

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -1,6 +1,8 @@
 export default class DiscussionListState {
-  constructor({ params = {} } = {}) {
+  constructor({ params = {}, forumApp = app } = {}) {
     this.params = params;
+
+    this.app = forumApp;
 
     this.discussions = [];
 
@@ -94,7 +96,7 @@ export default class DiscussionListState {
    * @param offset The index to start the page at.
    */
   loadResults(offset) {
-    const preloadedDiscussions = app.preloadedApiDocument();
+    const preloadedDiscussions = this.app.preloadedApiDocument();
 
     if (preloadedDiscussions) {
       return Promise.resolve(preloadedDiscussions);
@@ -104,7 +106,7 @@ export default class DiscussionListState {
     params.page = { offset };
     params.include = params.include.join(',');
 
-    return app.store.find('discussions', params);
+    return this.app.store.find('discussions', params);
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -72,7 +72,7 @@ export default class DiscussionListState {
     }
 
     if (params) {
-      this.params = params
+      this.params = params;
     }
 
     return this.loadResults().then(

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -1,0 +1,134 @@
+import Discussion from '../../common/models/Discussion';
+
+export default class DiscussionListState {
+  constructor({ params = {} } = {}) {
+    this.params = params;
+
+    this.discussions = [];
+
+    this.moreResults = false;
+
+    this.loading = true;
+
+    this.refresh();
+  }
+
+  /**
+   * Get the parameters that should be passed in the API request to get
+   * discussion results.
+   *
+   * @api
+   */
+  requestParams() {
+    const params = { include: ['user', 'lastPostedUser'], filter: {} };
+
+    params.sort = this.sortMap()[this.params.sort];
+
+    if (this.params.q) {
+      params.filter.q = this.params.q;
+
+      params.include.push('mostRelevantPost', 'mostRelevantPost.user');
+    }
+
+    return params;
+  }
+
+  /**
+   * Get a map of sort keys (which appear in the URL, and are used for
+   * translation) to the API sort value that they represent.
+   */
+  sortMap() {
+    const map = {};
+
+    if (this.params.q) {
+      map.relevance = '';
+    }
+    map.latest = '-lastPostedAt';
+    map.top = '-commentCount';
+    map.newest = '-createdAt';
+    map.oldest = 'createdAt';
+
+    return map;
+  }
+
+  /**
+   * Clear and reload the discussion list.
+   */
+  refresh(clear = true) {
+    if (clear) {
+      this.loading = true;
+      this.discussions = [];
+    }
+
+    return this.loadResults().then(
+      (results) => {
+        this.discussions = [];
+        this.parseResults(results);
+      },
+      () => {
+        this.loading = false;
+        m.redraw();
+      }
+    );
+  }
+
+  /**
+   * Load a new page of discussion results.
+   *
+   * @param offset The index to start the page at.
+   */
+  loadResults(offset) {
+    const preloadedDiscussions = app.preloadedApiDocument();
+
+    if (preloadedDiscussions) {
+      return Promise.resolve(preloadedDiscussions);
+    }
+
+    const params = this.requestParams();
+    params.page = { offset };
+    params.include = params.include.join(',');
+
+    return app.store.find('discussions', params);
+  }
+
+  /**
+   * Load the next page of discussion results.
+   */
+  loadMore() {
+    this.loading = true;
+
+    this.loadResults(this.discussions.length).then(this.parseResults.bind(this));
+  }
+
+  /**
+   * Parse results and append them to the discussion list.
+   */
+  parseResults(results) {
+    this.discussions.push(...results);
+
+    this.loading = false;
+    this.moreResults = !!results.payload.links.next;
+
+    m.redraw();
+
+    return results;
+  }
+
+  /**
+   * Remove a discussion from the list if it is present.
+   */
+  removeDiscussion(discussion) {
+    const index = this.discussions.indexOf(discussion);
+
+    if (index !== -1) {
+      this.discussions.splice(index, 1);
+    }
+  }
+
+  /**
+   * Add a discussion to the top of the list.
+   */
+  addDiscussion(discussion) {
+    this.discussions.unshift(discussion);
+  }
+}

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -75,7 +75,7 @@ export default class DiscussionListState {
   /**
    * Clear and reload the discussion list.
    */
-  refresh(clear = true, params) {
+  refresh(params, { clear = true } = {}) {
     this.loading = true;
 
     if (clear) {

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -66,6 +66,7 @@ export default class DiscussionListState {
    */
   clear() {
     this.discussions = [];
+    m.redraw();
   }
 
   /**
@@ -74,7 +75,7 @@ export default class DiscussionListState {
   refresh(clear = true) {
     if (clear) {
       this.loading = true;
-      this.clear();
+      this.discussions = [];
     }
 
     return this.loadResults().then(
@@ -140,6 +141,8 @@ export default class DiscussionListState {
     if (index !== -1) {
       this.discussions.splice(index, 1);
     }
+
+    m.redraw();
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -13,6 +13,10 @@ export default class DiscussionListState {
     this.refresh();
   }
 
+  setParams(params) {
+    this.params = params;
+  }
+
   /**
    * Get the parameters that should be passed in the API request to get
    * discussion results.
@@ -54,10 +58,14 @@ export default class DiscussionListState {
   /**
    * Clear and reload the discussion list.
    */
-  refresh(clear = true) {
+  refresh(clear = true, clearParams = false) {
     if (clear) {
       this.loading = true;
       this.discussions = [];
+    }
+
+    if (clearParams) {
+      this.params = {};
     }
 
     return this.loadResults().then(
@@ -107,7 +115,7 @@ export default class DiscussionListState {
     this.discussions.push(...results);
 
     this.loading = false;
-    this.moreResults = !!results.payload.links.next;
+    this.moreResults = !!results.payload.links && !!results.payload.links.next;
 
     m.redraw();
 

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -180,4 +180,11 @@ export default class DiscussionListState {
   isSearchResults() {
     return !!this.params.q;
   }
+
+  /**
+   * Have the search results come up empty?
+   */
+  empty() {
+    return !this.hasDiscussions() && !this.isLoading();
+  }
 }

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -15,10 +15,6 @@ export default class DiscussionListState {
     this.componentClass = componentClass;
   }
 
-  getComponentClass() {
-    return this.componentClass;
-  }
-
   /**
    * Get the parameters that should be passed in the API request to get
    * discussion results.
@@ -162,6 +158,13 @@ export default class DiscussionListState {
   }
 
   /**
+   * Get the class of the component to be used for this state's discussion list.
+   */
+  getComponentClass() {
+    return this.componentClass;
+  }
+
+  /**
    * Are there discussions stored in the discussion list state?
    */
   hasDiscussions() {
@@ -173,5 +176,12 @@ export default class DiscussionListState {
    */
   isLoading() {
     return this.loading;
+  }
+
+  /**
+   * In the last request, has the user searched for a discussion?
+   */
+  isSearchResults() {
+    return !!this.params.q;
   }
 }

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -69,7 +69,7 @@ export default class DiscussionListState {
     this.loading = true;
 
     if (clear) {
-      this.discussions = [];
+      this.clear();
     }
 
     if (params) {

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -8,13 +8,7 @@ export default class DiscussionListState {
 
     this.moreResults = false;
 
-    this.loading = true;
-
-    this.refresh();
-  }
-
-  setParams(params) {
-    this.params = params;
+    this.loading = false;
   }
 
   /**
@@ -56,16 +50,26 @@ export default class DiscussionListState {
   }
 
   /**
+   * Set the search parameters.
+   */
+  setParams(params) {
+    this.params = params;
+  }
+
+  /**
+   * Clear cached discussions.
+   */
+  clear() {
+    this.discussions = [];
+  }
+
+  /**
    * Clear and reload the discussion list.
    */
-  refresh(clear = true, clearParams = false) {
+  refresh(clear = true) {
     if (clear) {
       this.loading = true;
-      this.discussions = [];
-    }
-
-    if (clearParams) {
-      this.params = {};
+      this.clear();
     }
 
     return this.loadResults().then(
@@ -138,5 +142,12 @@ export default class DiscussionListState {
    */
   addDiscussion(discussion) {
     this.discussions.unshift(discussion);
+  }
+
+  /**
+   * Are there discussions stored in the discussion list state?
+   */
+  hasDiscussions() {
+    return this.discussions.length > 0;
   }
 }

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -1,5 +1,7 @@
+import DiscussionList from '../components/DiscussionList';
+
 export default class DiscussionListState {
-  constructor({ params = {}, forumApp = app } = {}) {
+  constructor({ params = {}, forumApp = app, componentClass = DiscussionList } = {}) {
     this.params = params;
 
     this.app = forumApp;
@@ -9,6 +11,12 @@ export default class DiscussionListState {
     this.moreResults = false;
 
     this.loading = false;
+
+    this.componentClass = componentClass;
+  }
+
+  getComponentClass() {
+    return this.componentClass;
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -48,15 +48,6 @@ export default class DiscussionListState {
   }
 
   /**
-   * Set the search parameters.
-   */
-  setParams(params) {
-    this.params = params;
-
-    this.refresh();
-  }
-
-  /**
    * Get the search parameters.
    */
   getParams() {
@@ -74,10 +65,14 @@ export default class DiscussionListState {
   /**
    * Clear and reload the discussion list.
    */
-  refresh(clear = true) {
+  refresh(clear = true, params) {
     if (clear) {
       this.loading = true;
       this.discussions = [];
+    }
+
+    if (params) {
+      this.params = params
     }
 
     return this.loadResults().then(

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -79,10 +79,12 @@ export default class DiscussionListState {
   /**
    * Clear and reload the discussion list.
    */
-  refresh() {
+  refresh({ clear = true } = {}) {
     this.loading = true;
 
-    this.clear();
+    if (clear) {
+      this.clear();
+    }
 
     return this.loadResults().then(
       (results) => {

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -1,5 +1,3 @@
-import Discussion from '../../common/models/Discussion';
-
 export default class DiscussionListState {
   constructor({ params = {} } = {}) {
     this.params = params;
@@ -54,6 +52,13 @@ export default class DiscussionListState {
    */
   setParams(params) {
     this.params = params;
+  }
+
+  /**
+   * Get the search parameters.
+   */
+  getParams() {
+    return this.params;
   }
 
   /**
@@ -149,5 +154,12 @@ export default class DiscussionListState {
    */
   hasDiscussions() {
     return this.discussions.length > 0;
+  }
+
+  /**
+   * Are discussions currently being loaded?
+   */
+  isLoading() {
+    return this.loading;
   }
 }

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -1,7 +1,5 @@
-import DiscussionList from '../components/DiscussionList';
-
 export default class DiscussionListState {
-  constructor({ params = {}, forumApp = app, componentClass = DiscussionList } = {}) {
+  constructor({ params = {}, forumApp = app } = {}) {
     this.params = params;
 
     this.app = forumApp;
@@ -11,8 +9,6 @@ export default class DiscussionListState {
     this.moreResults = false;
 
     this.loading = false;
-
-    this.componentClass = componentClass;
   }
 
   /**
@@ -155,13 +151,6 @@ export default class DiscussionListState {
   addDiscussion(discussion) {
     this.discussions.unshift(discussion);
     m.redraw();
-  }
-
-  /**
-   * Get the class of the component to be used for this state's discussion list.
-   */
-  getComponentClass() {
-    return this.componentClass;
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -150,6 +150,7 @@ export default class DiscussionListState {
    */
   addDiscussion(discussion) {
     this.discussions.unshift(discussion);
+    m.redraw();
   }
 
   /**

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -69,7 +69,7 @@ export default class DiscussionListState {
    * old ones, update params and refresh the discussion list from the database.
    */
   refreshParams(newParams) {
-    if (!this.hasDiscussions() || Object.keys(newParams).some((key) => this.getParams()[key] !== params[key])) {
+    if (!this.hasDiscussions() || Object.keys(newParams).some((key) => this.getParams()[key] !== newParams[key])) {
       this.params = newParams;
 
       this.refresh();

--- a/js/src/forum/state/DiscussionListState.js
+++ b/js/src/forum/state/DiscussionListState.js
@@ -66,8 +66,9 @@ export default class DiscussionListState {
    * Clear and reload the discussion list.
    */
   refresh(clear = true, params) {
+    this.loading = true;
+
     if (clear) {
-      this.loading = true;
       this.discussions = [];
     }
 

--- a/js/src/forum/states/GlobalSearchState.js
+++ b/js/src/forum/states/GlobalSearchState.js
@@ -60,7 +60,7 @@ export default class GlobalSearchState extends SearchState {
   changeSort(sort) {
     const params = this.params();
 
-    if (sort === Object.keys(app.cache.discussionList.sortMap())[0]) {
+    if (sort === Object.keys(app.discussions.sortMap())[0]) {
       delete params.sort;
     } else {
       params.sort = sort;

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -229,10 +229,7 @@ export default {
         app.history.back();
       }
 
-      return this.delete().then(() => {
-        app.cache.discussionList.removeDiscussion(this);
-        m.redraw();
-      });
+      return this.delete().then(() => app.cache.discussionList.removeDiscussion(this));
     }
   },
 

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -230,11 +230,8 @@ export default {
       }
 
       return this.delete().then(() => {
-        // If there is a discussion list in the cache, remove this discussion.
-        if (app.cache.discussionList) {
-          app.cache.discussionList.removeDiscussion(this);
-          m.redraw();
-        }
+        app.cache.discussionList.removeDiscussion(this);
+        m.redraw();
       });
     }
   },

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -229,7 +229,7 @@ export default {
         app.history.back();
       }
 
-      return this.delete().then(() => app.cache.discussionList.removeDiscussion(this));
+      return this.delete().then(() => app.discussions.removeDiscussion(this));
     }
   },
 

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -181,7 +181,7 @@ export default {
         // If this was the last post in the discussion, then we will assume that
         // the whole discussion was deleted too.
         if (!discussion.postIds().length) {
-          app.cache.discussionList.removeDiscussion(discussion);
+          app.discussions.removeDiscussion(discussion);
 
           if (app.viewingDiscussion(discussion)) {
             app.history.back();

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -181,10 +181,7 @@ export default {
         // If this was the last post in the discussion, then we will assume that
         // the whole discussion was deleted too.
         if (!discussion.postIds().length) {
-          // If there is a discussion list in the cache, remove this discussion.
-          if (app.cache.discussionList) {
-            app.cache.discussionList.removeDiscussion(discussion);
-          }
+          app.cache.discussionList.removeDiscussion(discussion);
 
           if (app.viewingDiscussion(discussion)) {
             app.history.back();


### PR DESCRIPTION
**Fixes Part Of #2144**

**Changes proposed in this pull request:**

- Separate the state of the discussion list out into it's own class (copied over David's code from the mithril/ts rewrite).
- Always keep an instance of discussion list state active; refresh instead of setting it null

**Reviewers should focus on:**
Anything I missed?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).


EDIT THIS BEFORE MERGING: https://github.com/flarum/core/pull/2151#pullrequestreview-417226123