### PR TITLE
Fixes #2157, Explicitly set SameSite value for cookies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": ">=7.2",
         "axy/sourcemap": "^0.1.4",
         "components/font-awesome": "5.9.*",
-        "dflydev/fig-cookies": "^1.0.2",
+        "dflydev/fig-cookies": "^2.0.1",
         "doctrine/dbal": "^2.7",
         "franzl/whoops-middleware": "^0.4.0",
         "illuminate/bus": "5.7.*",

--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -45,6 +45,13 @@ class CookieFactory
     protected $secure;
 
     /**
+     * Same Site cookie value
+     *
+     * @var string
+     */
+    protected $samesite;
+
+    /**
      * @param Application $app
      */
     public function __construct(Application $app)
@@ -57,6 +64,7 @@ class CookieFactory
         $this->path = $app->config('cookie.path', Arr::get($url, 'path') ?: '/');
         $this->domain = $app->config('cookie.domain');
         $this->secure = $app->config('cookie.secure', Arr::get($url, 'scheme') === 'https');
+        $this->samesite = $app->config('cookie.samesite', 'lax');
     }
 
     /**
@@ -86,11 +94,19 @@ class CookieFactory
             $cookie = $cookie->withDomain($this->domain);
         }
 
+        // Explicitly set SameSite value, use sensible default if no value provided
+        if ($this->samesite === 'strict') {
+            $cookie = $cookie->withSameSite(SameSite::strict());
+        } elseif ($this->samesite === 'none') {
+            $cookie = $cookie->withSameSite(SameSite::none());
+        } else {
+            $cookie = $cookie->withSameSite(SameSite::lax());
+        }
+
         return $cookie
             ->withPath($this->path)
             ->withSecure($this->secure)
-            ->withHttpOnly(true)
-            ->withSameSite(SameSite::lax());
+            ->withHttpOnly(true);
     }
 
     /**

--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -64,7 +64,7 @@ class CookieFactory
         $this->path = $app->config('cookie.path', Arr::get($url, 'path') ?: '/');
         $this->domain = $app->config('cookie.domain');
         $this->secure = $app->config('cookie.secure', Arr::get($url, 'scheme') === 'https');
-        $this->samesite = $app->config('cookie.samesite', 'lax');
+        $this->samesite = $app->config('cookie.samesite');
     }
 
     /**
@@ -95,7 +95,7 @@ class CookieFactory
         }
 
         // Explicitly set SameSite value, use sensible default if no value provided
-        $cookie = $cookie->withSameSite(forward_static_call([SameSite, $this->samesite ?? 'lax']));
+        $cookie = $cookie->withSameSite(SameSite::{$this->samesite ?? 'lax'}());
 
         return $cookie
             ->withPath($this->path)

--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Http;
 
+use Dflydev\FigCookies\Modifier\SameSite;
 use Dflydev\FigCookies\SetCookie;
 use Flarum\Foundation\Application;
 use Illuminate\Support\Arr;
@@ -88,7 +89,8 @@ class CookieFactory
         return $cookie
             ->withPath($this->path)
             ->withSecure($this->secure)
-            ->withHttpOnly(true);
+            ->withHttpOnly(true)
+            ->withSameSite(SameSite::lax());
     }
 
     /**

--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -95,13 +95,7 @@ class CookieFactory
         }
 
         // Explicitly set SameSite value, use sensible default if no value provided
-        if ($this->samesite === 'strict') {
-            $cookie = $cookie->withSameSite(SameSite::strict());
-        } elseif ($this->samesite === 'none') {
-            $cookie = $cookie->withSameSite(SameSite::none());
-        } else {
-            $cookie = $cookie->withSameSite(SameSite::lax());
-        }
+        $cookie = $cookie->withSameSite(forward_static_call([SameSite, $this->samesite ?? 'lax']));
 
         return $cookie
             ->withPath($this->path)

--- a/src/Http/CookieFactory.php
+++ b/src/Http/CookieFactory.php
@@ -45,7 +45,7 @@ class CookieFactory
     protected $secure;
 
     /**
-     * Same Site cookie value
+     * Same Site cookie value.
      *
      * @var string
      */


### PR DESCRIPTION
Also contains an update for the cookie library dependency

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2157 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Updates the cookie library and explicitly sets the same site value

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
* Is Lax the value we want to set? None requires HTTPs and Strict would prevent cookie use on a primary/sub-domain

**Confirmed**

~~- [ ] Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
