### PR TITLE
Extract PostStream state

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -32,20 +32,7 @@ export default class DiscussionPage extends Page {
      */
     this.near = m.route.param('near') || 0;
 
-    const preloadedDiscussion = app.preloadedApiDocument();
-    if (preloadedDiscussion) {
-      // We must wrap this in a setTimeout because if we are mounting this
-      // component for the first time on page load, then any calls to m.redraw
-      // will be ineffective and thus any configs (scroll code) will be run
-      // before stuff is drawn to the page.
-      setTimeout(this.show.bind(this, preloadedDiscussion), 0);
-    } else {
-      const params = this.requestParams();
-
-      app.store.find('discussions', m.route.param('id').split('-')[0], params).then(this.show.bind(this));
-    }
-
-    m.lazyRedraw();
+    this.load();
 
     // If the discussion list has been loaded, then we'll enable the pane (and
     // hide it by default). Also, if we've just come from another discussion
@@ -138,6 +125,26 @@ export default class DiscussionPage extends Page {
     if (this.discussion) {
       app.setTitle(this.discussion.title());
     }
+  }
+
+  /**
+   * Load the discussion from the API or use the preloaded one.
+   */
+  load() {
+    const preloadedDiscussion = app.preloadedApiDocument();
+    if (preloadedDiscussion) {
+      // We must wrap this in a setTimeout because if we are mounting this
+      // component for the first time on page load, then any calls to m.redraw
+      // will be ineffective and thus any configs (scroll code) will be run
+      // before stuff is drawn to the page.
+      setTimeout(this.show.bind(this, preloadedDiscussion), 0);
+    } else {
+      const params = this.requestParams();
+
+      app.store.find('discussions', m.route.param('id').split('-')[0], params).then(this.show.bind(this));
+    }
+
+    m.lazyRedraw();
   }
 
   /**

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -109,7 +109,7 @@ export default class DiscussionPage extends Page {
                     <ul>{listItems(this.sidebarItems().toArray())}</ul>
                   </nav>
                   <div className="DiscussionPage-stream">
-                    {PostStream.component({ state: this.stream, positionHandler: this.positionChanged.bind(this) })}
+                    {PostStream.component({ discussion, state: this.stream, positionHandler: this.positionChanged.bind(this) })}
                   </div>
                 </div>,
               ]
@@ -267,6 +267,7 @@ export default class DiscussionPage extends Page {
     items.add(
       'scrubber',
       PostStreamScrubber.component({
+        discussion: this.discussion,
         state: this.stream,
         className: 'App-titleControl',
       }),

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -8,7 +8,7 @@ import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
 import DiscussionList from './DiscussionList';
-import PostStreamState from '../state/PostStreamState';
+import PostStreamState from '../states/PostStreamState';
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -90,24 +90,6 @@ export default class DiscussionPage extends Page {
   view() {
     const discussion = this.discussion;
 
-    let content;
-
-    if (discussion) {
-      const stream = new PostStream({ state: this.stream });
-      stream.on('positionChanged', this.positionChanged.bind(this));
-      content = [
-        DiscussionHero.component({ discussion }),
-        <div className="container">
-          <nav className="DiscussionPage-nav">
-            <ul>{listItems(this.sidebarItems().toArray())}</ul>
-          </nav>
-          <div className="DiscussionPage-stream">{stream.render()}</div>
-        </div>,
-      ];
-    } else {
-      content = LoadingIndicator.component({ className: 'LoadingIndicator--block' });
-    }
-
     return (
       <div className="DiscussionPage">
         {app.discussions.hasDiscussions() ? (
@@ -118,7 +100,17 @@ export default class DiscussionPage extends Page {
           ''
         )}
 
-        <div className="DiscussionPage-discussion">{content}</div>
+        <div className="DiscussionPage-discussion">{discussion ? [
+          DiscussionHero.component({ discussion }),
+          <div className="container">
+            <nav className="DiscussionPage-nav">
+              <ul>{listItems(this.sidebarItems().toArray())}</ul>
+            </nav>
+            <div className="DiscussionPage-stream">
+              {PostStream.component({state: this.state, positionHandler: this.positionChanged.bind(this)})}
+            </div>
+          </div>,
+        ] : LoadingIndicator.component({ className: 'LoadingIndicator--block' })}</div>
       </div>
     );
   }

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -109,7 +109,12 @@ export default class DiscussionPage extends Page {
                     <ul>{listItems(this.sidebarItems().toArray())}</ul>
                   </nav>
                   <div className="DiscussionPage-stream">
-                    {PostStream.component({ discussion, stream: this.stream, onPositionChange: this.positionChanged.bind(this) })}
+                    {PostStream.component({
+                      discussion,
+                      stream: this.stream,
+                      targetPost: this.stream.targetPost,
+                      onPositionChange: this.positionChanged.bind(this),
+                    })}
                   </div>
                 </div>,
               ]

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -109,7 +109,7 @@ export default class DiscussionPage extends Page {
                     <ul>{listItems(this.sidebarItems().toArray())}</ul>
                   </nav>
                   <div className="DiscussionPage-stream">
-                    {PostStream.component({ discussion, state: this.stream, positionHandler: this.positionChanged.bind(this) })}
+                    {PostStream.component({ discussion, stream: this.stream, onPositionChange: this.positionChanged.bind(this) })}
                   </div>
                 </div>,
               ]
@@ -268,7 +268,7 @@ export default class DiscussionPage extends Page {
       'scrubber',
       PostStreamScrubber.component({
         discussion: this.discussion,
-        state: this.stream,
+        stream: this.stream,
         className: 'App-titleControl',
       }),
       -100

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -198,7 +198,6 @@ export default class DiscussionPage extends Page {
     // posts we want to display. Tell the stream to scroll down and highlight
     // the specific post that was routed to.
     this.stream = new PostStreamState(discussion, includedPosts);
-    this.stream.on('positionChanged', this.positionChanged.bind(this));
     this.stream.goToNumber(m.route.param('near') || (includedPosts[0] && includedPosts[0].number()), true);
 
     app.current.set('discussion', discussion);

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -28,7 +28,7 @@ export default class DiscussionPage extends Page {
     /**
      * The number of the first post that is currently visible in the viewport.
      *
-     * @type {Integer}
+     * @type {number}
      */
     this.near = m.route.param('near') || 0;
 

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -267,7 +267,6 @@ export default class DiscussionPage extends Page {
     items.add(
       'scrubber',
       PostStreamScrubber.component({
-        discussion: this.discussion,
         stream: this.stream,
         className: 'App-titleControl',
       }),

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -220,7 +220,7 @@ export default class PostStream extends Component {
 
     this.state.index = index;
     this.state.visible(visible);
-    this.state.description = period ? dayjs(period).format('MMMM YYYY') : '';
+    if (period) this.state.description = dayjs(period).format('MMMM YYYY');
   }
 
   /**
@@ -344,12 +344,13 @@ export default class PostStream extends Component {
 
     return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
       const index = $item.data('index');
-      this.updateScrubber();
       m.redraw(true);
       const scroll = index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
       $(window).scrollTop(scroll);
       this.calculatePosition();
+      this.updateScrubber();
       this.state.unpause();
+      m.redraw();
     });
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -3,6 +3,7 @@ import ScrollListener from '../../common/utils/ScrollListener';
 import PostLoading from './LoadingPost';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
+import anchorScroll from '../../common/utils/anchorScroll';
 
 /**
  * The `PostStream` component displays an infinitely-scrollable wall of posts in
@@ -339,6 +340,9 @@ export default class PostStream extends Component {
     }
 
     return $container.promise().then(() => {
+      this.state.loadPromise.then(() => {
+        anchorScroll($item[0], () => m.redraw(true));
+      });
       this.state.unpause();
       this.calculatePosition();
       this.updateScrubber();

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -45,7 +45,7 @@ export default class PostStream extends Component {
     let lastTime;
 
     this.state.visibleEnd = this.state.sanitizeIndex(this.state.visibleEnd);
-    this.state.viewingEnd = this.state.visibleEnd === this.state.count();
+    const viewingEnd = this.state.viewingEnd();
 
     const posts = this.state.posts();
     const postIds = this.state.discussion.postIds();
@@ -94,7 +94,7 @@ export default class PostStream extends Component {
       );
     });
 
-    if (!this.state.viewingEnd && posts[this.state.visibleEnd - this.state.visibleStart - 1]) {
+    if (!viewingEnd && posts[this.state.visibleEnd - this.state.visibleStart - 1]) {
       items.push(
         <div className="PostStream-loadMore" key="loadMore">
           <Button className="Button" onclick={this.state.loadNext.bind(this)}>
@@ -106,7 +106,7 @@ export default class PostStream extends Component {
 
     // If we're viewing the end of the discussion, the user can reply, and
     // is not already doing so, then show a 'write a reply' placeholder.
-    if (this.state.viewingEnd && (!app.session.user || this.state.discussion.canReply())) {
+    if (viewingEnd && (!app.session.user || this.state.discussion.canReply())) {
       items.push(
         <div className="PostStream-item" key="reply">
           {ReplyPlaceholder.component({ discussion: this.state.discussion })}

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -104,24 +104,18 @@ export default class PostStream extends Component {
   config(isInitialized, context) {
     console.log('redrawing');
     if (this.state.needsScroll) {
-      let scrollPromise;
       this.state.needsScroll = false;
       const locationType = this.state.locationType;
       if (this[locationType] != this.state[locationType]) {
         if (locationType == 'number') {
-          scrollPromise = this.scrollToNumber(this.state.number, this.state.noAnimationScroll);
+          this.scrollToNumber(this.state.number, this.state.noAnimationScroll);
         } else if (locationType == 'index') {
           const index = this.state.sanitizeIndex(Math.floor(this.state.index));
           const backwards = index == this.state.count() - 1;
           anchorScroll(this.$('.PostStream-item:' + (backwards ? 'last' : 'first')), () => m.redraw(true));
-          scrollPromise = this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
+          this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
         }
         this[locationType] = this.state[locationType];
-        scrollPromise.then(() => {
-          this.state.unpause();
-          m.redraw();
-          this.calculatePosition();
-        });
       }
     }
 
@@ -333,7 +327,11 @@ export default class PostStream extends Component {
       }
     }
 
-    return $container.promise();
+    return $container.promise().then(() => {
+      this.state.unpause();
+      m.redraw();
+      this.calculatePosition();
+    });
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -81,7 +81,7 @@ export default class PostStream extends Component {
     if (!viewingEnd && posts[this.state.visibleEnd - this.state.visibleStart - 1]) {
       items.push(
         <div className="PostStream-loadMore" key="loadMore">
-          <Button className="Button" onclick={this.state.loadNext.bind(this)}>
+          <Button className="Button" onclick={this.state.loadNext}>
             {app.translator.trans('core.forum.post_stream.load_more_button')}
           </Button>
         </div>
@@ -112,7 +112,6 @@ export default class PostStream extends Component {
         } else if (locationType == 'index') {
           const index = this.state.sanitizeIndex(Math.floor(this.state.index));
           const backwards = index == this.state.count() - 1;
-          anchorScroll(this.$('.PostStream-item:' + (backwards ? 'last' : 'first')), () => m.redraw(true));
           this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
         }
         this[locationType] = this.state[locationType];
@@ -342,7 +341,6 @@ export default class PostStream extends Component {
 
     return $container.promise().then(() => {
       this.state.unpause();
-      m.redraw();
       this.calculatePosition();
       this.updateScrubber();
     });

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -137,7 +137,9 @@ export default class PostStream extends Component {
    * @param {Integer} top
    */
   onscroll(top = window.pageYOffset) {
+    console.log('scrolling');
     if (this.state.paused) return;
+    console.log('scrolling and unpaused');
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
     const viewportTop = top + marginTop;

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -208,16 +208,15 @@ export default class PostStream extends Component {
       const coversQuarterOfViewport = (height - visibleTop) / viewportHeight > 0.25;
       if (index === undefined && (threeQuartersVisible || coversQuarterOfViewport)) {
         index = parseFloat($this.data('index')) + visibleTop / height;
+        // If this item has a time associated with it, then set the
+        // scrollbar's current period to a formatted version of this time.
+        const time = $this.data('time');
+        if (time) period = time;
       }
 
       if (visiblePost > 0) {
         visible += visiblePost / height;
       }
-
-      // If this item has a time associated with it, then set the
-      // scrollbar's current period to a formatted version of this time.
-      const time = $this.data('time');
-      if (time) period = time;
     });
 
     const indexChanged = Math.floor(this.state.index) != Math.floor(index);

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -279,6 +279,20 @@ export default class PostStream extends Component {
     return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
   }
 
+  scrollToLast() {
+    return $('html,body')
+      .stop(true)
+      .animate(
+        {
+          scrollTop: $(document).height() - $(window).height(),
+        },
+        'fast',
+        () => {
+          this.flashItem(this.$('.PostStream-item:last-child'));
+        }
+      );
+  }
+
   /**
    * Scroll down to a certain post by number and 'flash' it.
    *
@@ -306,7 +320,11 @@ export default class PostStream extends Component {
     console.log('scrollToIndex');
     const $item = this.$(`.PostStream-item[data-index=${index}]`);
 
-    return this.scrollToItem($item, noAnimation, true, bottom);
+    return this.scrollToItem($item, noAnimation, true, bottom).done(() => {
+      if (index == this.state.count() - 1) {
+        return this.scrollToLast();
+      }
+    });
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -2,7 +2,6 @@ import Component from '../../common/Component';
 import ScrollListener from '../../common/utils/ScrollListener';
 import PostLoading from './LoadingPost';
 import anchorScroll from '../../common/utils/anchorScroll';
-import evented from '../../common/utils/evented';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
 
@@ -12,10 +11,9 @@ import Button from '../../common/components/Button';
  *
  * ### Props
  *
- * - `discussion`
- * - `includedPosts`
+ * - `state`
  */
-class PostStream extends Component {
+export default class PostStream extends Component {
   init() {
     this.state = this.props.state;
 
@@ -199,7 +197,7 @@ class PostStream extends Component {
     });
 
     if (startNumber) {
-      this.trigger('positionChanged', startNumber || 1, endNumber);
+      this.props.positionHandler(startNumber || 1, endNumber);
     }
   }
 
@@ -301,14 +299,3 @@ class PostStream extends Component {
     $item.addClass('flash').one('animationend webkitAnimationEnd', () => $item.removeClass('flash'));
   }
 }
-
-/**
- * The number of posts to load per page.
- *
- * @type {Integer}
- */
-PostStream.loadCount = 20;
-
-Object.assign(PostStream.prototype, evented);
-
-export default PostStream;

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -102,6 +102,7 @@ export default class PostStream extends Component {
   }
 
   config(isInitialized, context) {
+    console.log('redrawing');
     if (this.state.needsScroll) {
       let scrollPromise;
       this.state.needsScroll = false;

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -101,7 +101,6 @@ export default class PostStream extends Component {
   }
 
   config(isInitialized, context) {
-    console.log('redrawing', this.state.visibleStart, this.state.visibleEnd);
     if (this.state.needsScroll) {
       this.state.needsScroll = false;
       const locationType = this.state.locationType;
@@ -261,16 +260,6 @@ export default class PostStream extends Component {
   }
 
   /**
-   * Get the distance from the top of the viewport to the point at which we
-   * would consider a post to be the first one visible.
-   *
-   * @return {Integer}
-   */
-  getMarginTop() {
-    return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
-  }
-
-  /**
    * Scroll down to a certain post by number and 'flash' it.
    *
    * @param {Integer} number
@@ -278,7 +267,6 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToNumber(number, noAnimation) {
-    console.log('scrollToNumber');
     const $item = this.$(`.PostStream-item[data-number=${number}]`);
 
     return this.scrollToItem($item, noAnimation).then(this.flashItem.bind(this, $item));
@@ -294,7 +282,6 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToIndex(index, noAnimation, bottom) {
-    console.log('scrollToIndex');
     const $item = this.$(`.PostStream-item[data-index=${index}]`);
 
     return this.scrollToItem($item, noAnimation, true, bottom).then(() => {
@@ -316,7 +303,6 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToItem($item, noAnimation, force, bottom) {
-    console.log('scrollToItem');
     const $container = $('html, body').stop(true);
 
     if ($item.length) {
@@ -340,7 +326,6 @@ export default class PostStream extends Component {
     }
 
     return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
-      console.log("loaded and scrolled");
       this.updateScrubber();
       this.state.index = $item.data('index');
       m.redraw(true);
@@ -358,5 +343,15 @@ export default class PostStream extends Component {
    */
   flashItem($item) {
     $item.addClass('flash').one('animationend webkitAnimationEnd', () => $item.removeClass('flash'));
+  }
+
+  /**
+   * Get the distance from the top of the viewport to the point at which we
+   * would consider a post to be the first one visible.
+   *
+   * @return {Integer}
+   */
+  getMarginTop() {
+    return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
   }
 }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -349,7 +349,7 @@ export default class PostStream extends Component {
       $(window).scrollTop(scroll);
       this.calculatePosition();
       this.updateScrubber();
-      this.state.unpause();
+      this.state.paused = false;
       m.redraw();
     });
   }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -105,16 +105,14 @@ export default class PostStream extends Component {
     if (this.state.needsScroll) {
       this.state.needsScroll = false;
       const locationType = this.state.locationType;
-      if (this[locationType] != this.state[locationType]) {
-        if (locationType == 'number') {
-          this.scrollToNumber(this.state.number, this.state.noAnimationScroll);
-        } else if (locationType == 'index') {
-          const index = this.state.sanitizeIndex(this.state.index);
-          const backwards = index == this.state.count() - 1;
-          this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
-        }
-        this[locationType] = this.state[locationType];
+      if (locationType == 'number') {
+        this.scrollToNumber(this.state.number, this.state.noAnimationScroll);
+      } else if (locationType == 'index') {
+        const index = this.state.sanitizeIndex(this.state.index);
+        const backwards = index == this.state.count() - 1;
+        this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
       }
+      this[locationType] = this.state[locationType];
     }
 
     if (isInitialized) return;
@@ -210,6 +208,11 @@ export default class PostStream extends Component {
       if (visiblePost > 0) {
         visible += visiblePost / height;
       }
+
+      // If this item has a time associated with it, then set the
+      // scrollbar's current period to a formatted version of this time.
+      const time = $this.data('time');
+      if (time) period = time;
     });
 
     this.state.index = index + 1;
@@ -337,14 +340,14 @@ export default class PostStream extends Component {
     }
 
     return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
-      this.state.index = $item.data('index');
+      console.log("loaded and scrolled");
       this.updateScrubber();
+      this.state.index = $item.data('index');
       m.redraw(true);
       const scroll = this.state.index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
       $(window).scrollTop(scroll);
       this.calculatePosition();
       this.state.paused = false;
-      m.redraw();
     });
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -261,6 +261,16 @@ export default class PostStream extends Component {
   }
 
   /**
+   * Get the distance from the top of the viewport to the point at which we
+   * would consider a post to be the first one visible.
+   *
+   * @return {Integer}
+   */
+  getMarginTop() {
+    return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
+  }
+
+  /**
    * Scroll down to a certain post by number and 'flash' it.
    *
    * @param {Integer} number
@@ -344,15 +354,5 @@ export default class PostStream extends Component {
    */
   flashItem($item) {
     $item.addClass('flash').one('animationend webkitAnimationEnd', () => $item.removeClass('flash'));
-  }
-
-  /**
-   * Get the distance from the top of the viewport to the point at which we
-   * would consider a post to be the first one visible.
-   *
-   * @return {Integer}
-   */
-  getMarginTop() {
-    return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
   }
 }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -110,7 +110,7 @@ export default class PostStream extends Component {
         if (locationType == 'number') {
           this.scrollToNumber(this.state.number, this.state.noAnimationScroll);
         } else if (locationType == 'index') {
-          const index = this.state.sanitizeIndex(Math.floor(this.state.index));
+          const index = this.state.sanitizeIndex(this.state.index);
           const backwards = index == this.state.count() - 1;
           this.scrollToIndex(index, this.state.noAnimationScroll, backwards);
         }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -290,7 +290,7 @@ export default class PostStream extends Component {
     console.log('scrollToNumber');
     const $item = this.$(`.PostStream-item[data-number=${number}]`);
 
-    return this.scrollToItem($item, noAnimation).done(this.flashItem.bind(this, $item));
+    return this.scrollToItem($item, noAnimation).then(this.flashItem.bind(this, $item));
   }
 
   /**
@@ -306,7 +306,7 @@ export default class PostStream extends Component {
     console.log('scrollToIndex');
     const $item = this.$(`.PostStream-item[data-index=${index}]`);
 
-    return this.scrollToItem($item, noAnimation, true, bottom).done(() => {
+    return this.scrollToItem($item, noAnimation, true, bottom).then(() => {
       if (index == this.state.count() - 1) {
         this.flashItem(this.$('.PostStream-item:last-child'));
       }
@@ -348,18 +348,18 @@ export default class PostStream extends Component {
       }
     }
 
-    return $container.promise().then(() => {
+    return Promise.all([
+      $container.promise(),
       this.state.loadPromise
-        .then(() => {
-          m.redraw(true);
-          $(window).scrollTop($(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop());
-        })
-        .then(() => {
-          this.calculatePosition();
-          if (this.state.locationType == 'number') this.updateScrubber();
-        })
-        .then(() => this.state.unpause());
-    });
+    ]).then(() => {
+        m.redraw(true);
+        return $(window).scrollTop($(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop());
+      })
+      .then(() => {
+        //if (this.state.locationType == 'number') this.updateScrubber();
+        return this.calculatePosition();
+      })
+      .then(() => this.state.unpause());
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -44,9 +44,7 @@ export default class PostStream extends Component {
 
     let lastTime;
 
-    this.state.visibleEnd = this.state.sanitizeIndex(this.state.visibleEnd);
     const viewingEnd = this.state.viewingEnd();
-
     const posts = this.state.posts();
     const postIds = this.state.discussion.postIds();
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -281,6 +281,7 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToNumber(number, noAnimation) {
+    console.log('scrollToNumber');
     const $item = this.$(`.PostStream-item[data-number=${number}]`);
 
     return this.scrollToItem($item, noAnimation).done(this.flashItem.bind(this, $item));
@@ -296,6 +297,7 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToIndex(index, noAnimation, bottom) {
+    console.log('scrollToIndex');
     const $item = this.$(`.PostStream-item[data-index=${index}]`);
 
     return this.scrollToItem($item, noAnimation, true, bottom);
@@ -313,6 +315,7 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToItem($item, noAnimation, force, bottom) {
+    console.log('scrollToItem');
     const $container = $('html, body').stop(true);
 
     if ($item.length) {

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -23,9 +23,6 @@ export default class PostStream extends Component {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
-    this.state.on('scrollToLast', () => {
-      this.scrollToLast();
-    });
     this.state.on('scrollToNumber', (number, noAnimation) => {
       this.scrollToNumber(number, noAnimation);
     });
@@ -274,20 +271,6 @@ export default class PostStream extends Component {
     const $item = this.$(`.PostStream-item[data-number=${number}]`);
 
     return this.scrollToItem($item, noAnimation).done(this.flashItem.bind(this, $item));
-  }
-
-  scrollToLast() {
-    $('html,body')
-      .stop(true)
-      .animate(
-        {
-          scrollTop: $(document).height() - $(window).height(),
-        },
-        'fast',
-        () => {
-          this.flashItem(this.$('.PostStream-item:last-child'));
-        }
-      );
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -341,7 +341,7 @@ export default class PostStream extends Component {
 
     return $container.promise().then(() => {
       this.state.loadPromise.then(() => {
-        anchorScroll($item[0], () => m.redraw(true));
+        anchorScroll(`.PostStream-item[data-index=${$item.data('index')}]`, () => m.redraw(true));
       });
       this.state.unpause();
       this.calculatePosition();

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -215,7 +215,7 @@ export default class PostStream extends Component {
     });
 
     this.state.index = index + 1;
-    this.state.visible(visible);
+    this.state.visible = visible;
     if (period) this.state.description = dayjs(period).format('MMMM YYYY');
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -11,10 +11,12 @@ import Button from '../../common/components/Button';
  *
  * ### Props
  *
+ * - `discussion`
  * - `state`
  */
 export default class PostStream extends Component {
   init() {
+    this.discussion = this.props.discussion;
     this.state = this.props.state;
 
     this.scrollListener = new ScrollListener(this.onscroll.bind(this));
@@ -46,7 +48,7 @@ export default class PostStream extends Component {
 
     const viewingEnd = this.state.viewingEnd();
     const posts = this.state.posts();
-    const postIds = this.state.discussion.postIds();
+    const postIds = this.discussion.postIds();
 
     const items = posts.map((post, i) => {
       let content;
@@ -104,10 +106,10 @@ export default class PostStream extends Component {
 
     // If we're viewing the end of the discussion, the user can reply, and
     // is not already doing so, then show a 'write a reply' placeholder.
-    if (viewingEnd && (!app.session.user || this.state.discussion.canReply())) {
+    if (viewingEnd && (!app.session.user || this.discussion.canReply())) {
       items.push(
         <div className="PostStream-item" key="reply">
-          {ReplyPlaceholder.component({ discussion: this.state.discussion })}
+          {ReplyPlaceholder.component({ discussion: this.discussion })}
         </div>
       );
     }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -23,9 +23,6 @@ export default class PostStream extends Component {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
-    this.state.on('unpaused', () => {
-      this.scrollListener.update();
-    });
     this.state.on('scrollToLast', () => {
       this.scrollToLast();
     });

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -175,7 +175,7 @@ export default class PostStream extends Component {
     // seen if the browser were scrolled right up to the top of the page,
     // and the viewport had a height of 0.
     const $items = this.$('.PostStream-item[data-index]');
-    let index;
+    let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';
 
@@ -203,14 +203,8 @@ export default class PostStream extends Component {
       const visibleBottom = Math.min(height, viewportTop + viewportHeight - top);
       const visiblePost = visibleBottom - visibleTop;
 
-      const threeQuartersVisible = visibleTop / height < 0.75;
-      const coversQuarterOfViewport = (height - visibleTop) / viewportHeight > 0.25;
-      if (index === undefined && (threeQuartersVisible || coversQuarterOfViewport)) {
-        index = parseFloat($this.data('index')) + (visibleTop / height) * (1 / 0.75);
-        // If this item has a time associated with it, then set the
-        // scrollbar's current period to a formatted version of this time.
-        const time = $this.data('time');
-        if (time) period = time;
+      if (top <= viewportTop) {
+        index = parseFloat($this.data('index')) + visibleTop / height;
       }
 
       if (visiblePost > 0) {
@@ -218,7 +212,7 @@ export default class PostStream extends Component {
       }
     });
 
-    this.state.index = index;
+    this.state.index = index + 1;
     this.state.visible(visible);
     if (period) this.state.description = dayjs(period).format('MMMM YYYY');
   }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -136,7 +136,7 @@ export default class PostStream extends Component {
    *
    * @param {Integer} top
    */
-  onscroll(top) {
+  onscroll(top = window.pageYOffset) {
     if (this.state.paused) return;
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
@@ -163,6 +163,14 @@ export default class PostStream extends Component {
     // viewport) to 100ms.
     clearTimeout(this.calculatePositionTimeout);
     this.calculatePositionTimeout = setTimeout(this.calculatePosition.bind(this), 100);
+
+    this.updateScrubber(top);
+  }
+
+  updateScrubber(top = window.pageYOffset) {
+    const marginTop = this.getMarginTop();
+    const viewportHeight = $(window).height() - marginTop;
+    const viewportTop = top + marginTop;
 
     // Before looping through all of the posts, we reset the scrollbar
     // properties to a 'default' state. These values reflect what would be

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -102,7 +102,7 @@ export default class PostStream extends Component {
   }
 
   config(isInitialized, context) {
-    console.log('redrawing');
+    console.log('redrawing', this.state.visibleStart, this.state.visibleEnd);
     if (this.state.needsScroll) {
       this.state.needsScroll = false;
       const locationType = this.state.locationType;
@@ -279,20 +279,6 @@ export default class PostStream extends Component {
     return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
   }
 
-  scrollToLast() {
-    return $('html,body')
-      .stop(true)
-      .animate(
-        {
-          scrollTop: $(document).height() - $(window).height(),
-        },
-        'fast',
-        () => {
-          this.flashItem(this.$('.PostStream-item:last-child'));
-        }
-      );
-  }
-
   /**
    * Scroll down to a certain post by number and 'flash' it.
    *
@@ -322,7 +308,7 @@ export default class PostStream extends Component {
 
     return this.scrollToItem($item, noAnimation, true, bottom).done(() => {
       if (index == this.state.count() - 1) {
-        return this.scrollToLast();
+        this.flashItem(this.$('.PostStream-item:last-child'));
       }
     });
   }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -365,7 +365,8 @@ export default class PostStream extends Component {
     return $container.promise().then(() => {
       this.state.loadPromise
         .then(() => {
-          anchorScroll(`.PostStream-item[data-index=${$item.data('index')}]`, () => m.redraw(true));
+          m.redraw(true);
+          $(window).scrollTop($(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop());
         })
         .then(() => {
           this.calculatePosition();

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -81,7 +81,7 @@ export default class PostStream extends Component {
     if (!viewingEnd && posts[this.state.visibleEnd - this.state.visibleStart - 1]) {
       items.push(
         <div className="PostStream-loadMore" key="loadMore">
-          <Button className="Button" onclick={this.state.loadNext}>
+          <Button className="Button" onclick={this.state.loadNext.bind(this.state)}>
             {app.translator.trans('core.forum.post_stream.load_more_button')}
           </Button>
         </div>

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -339,6 +339,7 @@ export default class PostStream extends Component {
       this.state.unpause();
       m.redraw();
       this.calculatePosition();
+      this.updateScrubber();
     });
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -1,7 +1,6 @@
 import Component from '../../common/Component';
 import ScrollListener from '../../common/utils/ScrollListener';
 import PostLoading from './LoadingPost';
-import anchorScroll from '../../common/utils/anchorScroll';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -327,9 +327,9 @@ export default class PostStream extends Component {
 
     return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
       this.updateScrubber();
-      this.state.index = $item.data('index');
+      const index = $item.data('index');
       m.redraw(true);
-      const scroll = this.state.index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
+      const scroll = index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
       $(window).scrollTop(scroll);
       this.calculatePosition();
       this.state.paused = false;

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -342,15 +342,15 @@ export default class PostStream extends Component {
       }
     }
 
-    return Promise.all([$container.promise(), this.state.loadPromise])
-      .then(() => {
-        m.redraw(true);
-        return $(window).scrollTop($(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop());
-      })
-      .then(() => {
-        return this.calculatePosition();
-      })
-      .then(() => this.state.unpause());
+    return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
+      const index = $item.data('index');
+      this.updateScrubber();
+      m.redraw(true);
+      const scroll = index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
+      $(window).scrollTop(scroll);
+      this.calculatePosition();
+      this.state.unpause();
+    });
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -3,7 +3,6 @@ import ScrollListener from '../../common/utils/ScrollListener';
 import PostLoading from './LoadingPost';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
-import anchorScroll from '../../common/utils/anchorScroll';
 
 /**
  * The `PostStream` component displays an infinitely-scrollable wall of posts in
@@ -219,13 +218,9 @@ export default class PostStream extends Component {
       }
     });
 
-    const indexChanged = Math.floor(this.state.index) != Math.floor(index);
     this.state.index = index;
-    this.state.visible = visible;
+    this.state.visible(visible);
     this.state.description = period ? dayjs(period).format('MMMM YYYY') : '';
-    if (indexChanged) {
-      m.redraw();
-    }
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -206,7 +206,7 @@ export default class PostStream extends Component {
       const threeQuartersVisible = visibleTop / height < 0.75;
       const coversQuarterOfViewport = (height - visibleTop) / viewportHeight > 0.25;
       if (index === undefined && (threeQuartersVisible || coversQuarterOfViewport)) {
-        index = parseFloat($this.data('index')) + visibleTop / height;
+        index = parseFloat($this.data('index')) + (visibleTop / height) * (1 / 0.75);
         // If this item has a time associated with it, then set the
         // scrollbar's current period to a formatted version of this time.
         const time = $this.data('time');
@@ -343,12 +343,12 @@ export default class PostStream extends Component {
     }
 
     return Promise.all([$container.promise(), this.state.loadPromise]).then(() => {
-      const index = $item.data('index');
+      this.state.index = $item.data('index');
+      this.updateScrubber();
       m.redraw(true);
-      const scroll = index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
+      const scroll = this.state.index == 0 ? 0 : $(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop();
       $(window).scrollTop(scroll);
       this.calculatePosition();
-      this.updateScrubber();
       this.state.paused = false;
       m.redraw();
     });

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -12,6 +12,7 @@ import Button from '../../common/components/Button';
  *
  * - `discussion`
  * - `stream`
+ * - `targetPost`
  * - `onPositionChange`
  */
 export default class PostStream extends Component {
@@ -102,14 +103,7 @@ export default class PostStream extends Component {
   }
 
   config(isInitialized, context) {
-    this.stream.scrollEffect((type, position, animate) => {
-      if (type === 'number') {
-        this.scrollToNumber(position, animate);
-      } else if (type === 'index') {
-        const backwards = position === this.stream.count() - 1;
-        this.scrollToIndex(position, animate, backwards);
-      }
-    });
+    this.triggerScroll();
 
     if (isInitialized) return;
 
@@ -121,6 +115,30 @@ export default class PostStream extends Component {
       this.scrollListener.stop();
       clearTimeout(this.calculatePositionTimeout);
     };
+  }
+
+  /**
+   * Start scrolling, if appropriate, to a newly-targeted post.
+   */
+  triggerScroll() {
+    if (!this.props.targetPost) return;
+
+    const oldTarget = this.prevTarget;
+    const newTarget = this.props.targetPost;
+
+    if (oldTarget) {
+      if ('number' in oldTarget && oldTarget.number === newTarget.number) return;
+      if ('index' in oldTarget && oldTarget.index === newTarget.index) return;
+    }
+
+    if ('number' in newTarget) {
+      this.scrollToNumber(newTarget.number, this.stream.noAnimationScroll);
+    } else if ('index' in newTarget) {
+      const backwards = newTarget.index === this.stream.count() - 1;
+      this.scrollToIndex(newTarget.index, this.stream.noAnimationScroll, backwards);
+    }
+
+    this.prevTarget = newTarget;
   }
 
   /**

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -348,15 +348,12 @@ export default class PostStream extends Component {
       }
     }
 
-    return Promise.all([
-      $container.promise(),
-      this.state.loadPromise
-    ]).then(() => {
+    return Promise.all([$container.promise(), this.state.loadPromise])
+      .then(() => {
         m.redraw(true);
         return $(window).scrollTop($(`.PostStream-item[data-index=${$item.data('index')}]`).offset().top - this.getMarginTop());
       })
       .then(() => {
-        //if (this.state.locationType == 'number') this.updateScrubber();
         return this.calculatePosition();
       })
       .then(() => this.state.unpause());

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -108,7 +108,7 @@ export default class PostStream extends Component {
       );
     }
 
-    return <div className="PostStream js-PostStream">{items}</div>;
+    return <div className="PostStream">{items}</div>;
   }
 
   config(isInitialized, context) {
@@ -163,7 +163,7 @@ export default class PostStream extends Component {
     // properties to a 'default' state. These values reflect what would be
     // seen if the browser were scrolled right up to the top of the page,
     // and the viewport had a height of 0.
-    const $items = $('.js-PostStream > .PostStream-item[data-index]');
+    const $items = this.$('.PostStream-item[data-index]');
     let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -25,7 +25,7 @@ export default class PostStreamScrubber extends Component {
     const unreadPercent = count ? Math.min(count - this.state.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {
-      index: <span className="Scrubber-index">{formatNumber(Math.min(Math.ceil(index + visible), count))}</span>,
+      index: <span className="Scrubber-index">{formatNumber(this.state.sanitizeIndex(index + this.state.visible))}</span>,
       count: <span className="Scrubber-count">{formatNumber(count)}</span>,
     });
 

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -25,7 +25,7 @@ export default class PostStreamScrubber extends Component {
     const unreadPercent = count ? Math.min(count - this.state.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {
-      index: <span className="Scrubber-index">{formatNumber(this.state.sanitizeIndex(index + this.state.visible))}</span>,
+      index: <span className="Scrubber-index">{formatNumber(this.state.sanitizeIndex(index + 1))}</span>,
       count: <span className="Scrubber-count">{formatNumber(count)}</span>,
     });
 

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -134,8 +134,8 @@ export default class PostStreamScrubber extends Component {
   }
 
   config(isInitialized, context) {
+    this.state.loadPromise.then(() => this.updateScrubberValues({ animate: true, forceHeightChange: true }));
     if (isInitialized) return;
-    this.state.loadPromise.then(() => this.updateScrubberValues({ animate: true }));
 
     context.onunload = this.ondestroy.bind(this);
 
@@ -277,28 +277,27 @@ export default class PostStreamScrubber extends Component {
    * @param {Boolean} animate
    */
   updateScrubberValues(options = {}) {
-    if (!options.fromScroll) console.log("hello")
     const index = this.state.index;
     const count = this.state.count();
     const visible = this.state.visible() || 1;
     const percentPerPost = this.percentPerPost();
 
     const $scrubber = this.$();
-    $scrubber.find(`.Scrubber-index`).text(formatNumber(this.state.sanitizeIndex(index + 1)));
+    $scrubber.find(`.Scrubber-index`).text(formatNumber(this.state.sanitizeIndex(index)));
     $scrubber.find(`.Scrubber-description`).text(this.state.description);
     $scrubber.toggleClass('disabled', this.state.disabled());
 
     const heights = {};
-    heights.before = Math.max(0, percentPerPost.index * Math.min(index, count - visible));
+    heights.before = Math.max(0, percentPerPost.index * Math.min(index - 1, count - visible));
     heights.handle = Math.min(100 - heights.before, percentPerPost.visible * visible);
     heights.after = 100 - heights.before - heights.handle;
 
-    console.log(heights.before + heights.after);
-
+    console.log("scrolling?");
     if (!(options.fromScroll && this.state.paused) && (!this.adjustingHeight || options.forceHeightChange)) {
       const func = options.animate ? 'animate' : 'css';
       this.adjustingHeight = true;
       const animationPromises = [];
+      console.log("scrolling", heights.before, index)
       for (const part in heights) {
         const $part = $scrubber.find(`.Scrubber-${part}`);
         animationPromises.push(

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -10,11 +10,12 @@ import formatNumber from '../../common/utils/formatNumber';
  *
  * ### Props
  *
- * - `stream`
+ * - `state`
  * - `className`
  */
 export default class PostStreamScrubber extends Component {
   init() {
+    this.state = this.props.state;
     this.handlers = {};
 
     /**
@@ -40,7 +41,7 @@ export default class PostStreamScrubber extends Component {
 
     // When the post stream begins loading posts at a certain index, we want our
     // scrubber scrollbar to jump to that position.
-    this.props.stream.on('unpaused', (this.handlers.streamWasUnpaused = this.streamWasUnpaused.bind(this)));
+    this.state.on('unpaused', (this.handlers.streamWasUnpaused = this.streamWasUnpaused.bind(this)));
 
     // Define a handler to update the state of the scrollbar to reflect the
     // current scroll position of the page.
@@ -56,7 +57,7 @@ export default class PostStreamScrubber extends Component {
   view() {
     const retain = this.subtree.retain();
     const count = this.count();
-    const unreadCount = this.props.stream.discussion.unreadCount();
+    const unreadCount = this.state.discussion.unreadCount();
     const unreadPercent = count ? Math.min(count - this.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {
@@ -121,7 +122,7 @@ export default class PostStreamScrubber extends Component {
    * Go to the first post in the discussion.
    */
   goToFirst() {
-    this.props.stream.goToFirst();
+    this.state.goToFirst();
     this.index = 0;
     this.renderScrollbar(true);
   }
@@ -130,7 +131,7 @@ export default class PostStreamScrubber extends Component {
    * Go to the last post in the discussion.
    */
   goToLast() {
-    this.props.stream.goToLast();
+    this.state.goToLast();
     this.index = this.count();
     this.renderScrollbar(true);
   }
@@ -141,7 +142,7 @@ export default class PostStreamScrubber extends Component {
    * @return {Integer}
    */
   count() {
-    return this.props.stream.count();
+    return this.state.count();
   }
 
   /**
@@ -169,9 +170,7 @@ export default class PostStreamScrubber extends Component {
    * @param {Integer} top
    */
   onscroll(top) {
-    const stream = this.props.stream;
-
-    if (stream.paused || !stream.$()) return;
+    if (this.state.paused || !$('.js-PostStream')) return;
 
     this.update(top);
     this.renderScrollbar();
@@ -184,9 +183,7 @@ export default class PostStreamScrubber extends Component {
    * @param {Integer} scrollTop
    */
   update(scrollTop) {
-    const stream = this.props.stream;
-
-    const marginTop = stream.getMarginTop();
+    const marginTop = $('#header').outerHeight() + parseInt($('.js-PostStream').css('margin-top'), 10);
     const viewportTop = scrollTop + marginTop;
     const viewportHeight = $(window).height() - marginTop;
 
@@ -194,7 +191,7 @@ export default class PostStreamScrubber extends Component {
     // properties to a 'default' state. These values reflect what would be
     // seen if the browser were scrolled right up to the top of the page,
     // and the viewport had a height of 0.
-    const $items = stream.$('> .PostStream-item[data-index]');
+    const $items = $('.js-PostStream > .PostStream-item[data-index]');
     let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';
@@ -292,7 +289,7 @@ export default class PostStreamScrubber extends Component {
   ondestroy() {
     this.scrollListener.stop();
 
-    this.props.stream.off('unpaused', this.handlers.streamWasUnpaused);
+    this.state.off('unpaused', this.handlers.streamWasUnpaused);
 
     $(window).off('resize', this.handlers.onresize);
 
@@ -384,7 +381,7 @@ export default class PostStreamScrubber extends Component {
     this.mouseStart = e.clientY || e.originalEvent.touches[0].clientY;
     this.indexStart = this.index;
     this.dragging = true;
-    this.props.stream.paused = true;
+    this.state.paused = true;
     $('body').css('cursor', 'move');
   }
 
@@ -417,7 +414,7 @@ export default class PostStreamScrubber extends Component {
     // If the index we've landed on is in a gap, then tell the stream-
     // content that we want to load those posts.
     const intIndex = Math.floor(this.index);
-    this.props.stream.goToIndex(intIndex);
+    this.state.goToIndex(intIndex);
     this.renderScrollbar(true);
   }
 
@@ -439,7 +436,7 @@ export default class PostStreamScrubber extends Component {
     //    content component to jump to that index.
     let offsetIndex = offsetPercent / this.percentPerPost().index;
     offsetIndex = Math.max(0, Math.min(this.count() - 1, offsetIndex));
-    this.props.stream.goToIndex(Math.floor(offsetIndex));
+    this.state.goToIndex(Math.floor(offsetIndex));
     this.index = offsetIndex;
     this.renderScrollbar(true);
 

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -50,8 +50,13 @@ export default class PostStreamScrubber extends Component {
     const handleHeight = Math.min(100 - beforeHeight, percentPerPost.visible * visible);
     const afterHeight = 100 - beforeHeight - handleHeight;
 
+    const classNames = ['PostStreamScrubber', 'Dropdown'];
+    if (this.state.allVisible) classNames.push('disabled');
+    if (this.dragging) classNames.push('dragging');
+    if (this.props.className) classNames.push(this.props.className);
+
     return (
-      <div className={'PostStreamScrubber Dropdown ' + (this.state.allVisible() ? 'disabled ' : '') + (this.props.className || '')}>
+      <div className={classNames.join(' ')}>
         <button className="Button Dropdown-toggle" data-toggle="dropdown">
           {viewing} {icon('fas fa-sort')}
         </button>

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -51,7 +51,7 @@ export default class PostStreamScrubber extends Component {
     const afterHeight = 100 - beforeHeight - handleHeight;
 
     const classNames = ['PostStreamScrubber', 'Dropdown'];
-    if (this.state.allVisible) classNames.push('disabled');
+    if (this.state.allVisible()) classNames.push('disabled');
     if (this.dragging) classNames.push('dragging');
     if (this.props.className) classNames.push(this.props.className);
 

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -144,7 +144,7 @@ export default class PostStreamScrubber extends Component {
   updateScrubberValues(options = {}) {
     const index = this.state.index;
     const count = this.state.count();
-    const visible = this.state.visible() || 1;
+    const visible = this.state.visible || 1;
     const percentPerPost = this.percentPerPost();
 
     const $scrubber = this.$();
@@ -297,7 +297,7 @@ export default class PostStreamScrubber extends Component {
    */
   percentPerPost() {
     const count = this.state.count() || 1;
-    const visible = this.state.visible() || 1;
+    const visible = this.state.visible || 1;
 
     // To stop the handle of the scrollbar from getting too small when there
     // are many posts, we define a minimum percentage height for the handle

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -10,11 +10,13 @@ import formatNumber from '../../common/utils/formatNumber';
  *
  * ### Props
  *
+ * - `discussion`
  * - `state`
  * - `className`
  */
 export default class PostStreamScrubber extends Component {
   init() {
+    this.discussion = this.props.discusssion;
     this.state = this.props.state;
     this.handlers = {};
 
@@ -57,7 +59,7 @@ export default class PostStreamScrubber extends Component {
   view() {
     const retain = this.subtree.retain();
     const count = this.count();
-    const unreadCount = this.state.discussion.unreadCount();
+    const unreadCount = this.discussion.unreadCount();
     const unreadPercent = count ? Math.min(count - this.index, unreadCount) / count : 0;
 
     const viewing = app.translator.transChoice('core.forum.post_scrubber.viewing_text', count, {

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -261,7 +261,6 @@ export default class PostStreamScrubber extends Component {
     let offsetIndex = offsetPercent / this.percentPerPost().index;
     offsetIndex = Math.max(0, Math.min(this.state.count() - 1, offsetIndex));
     this.state.goToIndex(Math.floor(offsetIndex));
-    this.state.index = offsetIndex;
 
     this.$().removeClass('open');
   }

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -148,8 +148,8 @@ export default class PostStreamScrubber extends Component {
     const percentPerPost = this.percentPerPost();
 
     const $scrubber = this.$();
-    $scrubber.find(`.Scrubber-index`).text(formatNumber(this.state.sanitizeIndex(Math.max(1, index))));
-    $scrubber.find(`.Scrubber-description`).text(this.state.description);
+    $scrubber.find('.Scrubber-index').text(formatNumber(this.state.sanitizeIndex(Math.max(1, index))));
+    $scrubber.find('.Scrubber-description').text(this.state.description);
     $scrubber.toggleClass('disabled', this.state.disabled());
 
     const heights = {};

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -54,7 +54,7 @@ export default class PostStreamScrubber extends Component {
     const afterHeight = 100 - beforeHeight - handleHeight;
 
     const classNames = ['PostStreamScrubber', 'Dropdown'];
-    if (this.state.allVisible()) classNames.push('disabled');
+    if (this.state.disabled()) classNames.push('disabled');
     if (this.dragging) classNames.push('dragging');
     if (this.props.className) classNames.push(this.props.className);
 
@@ -291,6 +291,6 @@ export default class PostStreamScrubber extends Component {
       this.$(`.Scrubber-${part}`).css('height', heights[part] + '%');
     }
 
-    this.$().toggleClass('disabled', this.state.allVisible());
+    this.$().toggleClass('disabled', this.state.disabled());
   }
 }

--- a/js/src/forum/components/PostStreamScrubber.js
+++ b/js/src/forum/components/PostStreamScrubber.js
@@ -277,20 +277,23 @@ export default class PostStreamScrubber extends Component {
    * @param {Boolean} animate
    */
   updateScrubberValues(options = {}) {
+    if (!options.fromScroll) console.log("hello")
     const index = this.state.index;
     const count = this.state.count();
     const visible = this.state.visible() || 1;
     const percentPerPost = this.percentPerPost();
 
     const $scrubber = this.$();
-    $scrubber.find(`.Scrubber-index`).html(formatNumber(this.state.sanitizeIndex(index + 1)));
+    $scrubber.find(`.Scrubber-index`).text(formatNumber(this.state.sanitizeIndex(index + 1)));
+    $scrubber.find(`.Scrubber-description`).text(this.state.description);
+    $scrubber.toggleClass('disabled', this.state.disabled());
 
     const heights = {};
     heights.before = Math.max(0, percentPerPost.index * Math.min(index, count - visible));
     heights.handle = Math.min(100 - heights.before, percentPerPost.visible * visible);
     heights.after = 100 - heights.before - heights.handle;
 
-    console.log(heights.after);
+    console.log(heights.before + heights.after);
 
     if (!(options.fromScroll && this.state.paused) && (!this.adjustingHeight || options.forceHeightChange)) {
       const func = options.animate ? 'animate' : 'css';
@@ -311,7 +314,5 @@ export default class PostStreamScrubber extends Component {
       }
       Promise.all(animationPromises).then(() => (this.adjustingHeight = false));
     }
-
-    $scrubber.toggleClass('disabled', this.state.disabled());
   }
 }

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -21,6 +21,27 @@ class PostStreamState {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
+    /**
+     * The index of the post that is currently at the top of the viewport.
+     *
+     * @type {Number}
+     */
+    this.index = 0;
+
+    /**
+     * The number of posts that are currently visible in the viewport.
+     *
+     * @type {Number}
+     */
+    this.visible = 1;
+
+    /**
+     * The description to render on the scrubber.
+     *
+     * @type {String}
+     */
+    this.description = '';
+
     this.show(includedPosts);
   }
 
@@ -146,6 +167,16 @@ class PostStreamState {
    */
   count() {
     return this.discussion.postIds().length;
+  }
+
+  /**
+   * Check whether or not the scrubber should be disabled, i.e. if all of the
+   * posts are visible in the viewport.
+   *
+   * @return {Boolean}
+   */
+  allVisible() {
+    return this.visible >= this.count();
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -128,6 +128,28 @@ class PostStreamState {
   }
 
   /**
+   * Execute a callback when necessary because the scroll position changed.
+   *
+   * The callback will be called with three arguments:
+   *  - the "type" of position to jump to ("number" or "index")
+   *  - the corresponding position
+   *  - whether scrolling should be animated
+   *
+   * @param callback
+   */
+  scrollEffect(callback) {
+    if (!this.needsScroll) return;
+
+    if (this.locationType === 'number') {
+      callback('number', this.number, !this.noAnimationScroll);
+    } else {
+      callback('index', this.sanitizeIndex(this.index), !this.noAnimationScroll);
+    }
+
+    this.needsScroll = false;
+  }
+
+  /**
    * Clear the stream and load posts near a certain number. Returns a promise.
    * If the post with the given number is already loaded, the promise will be
    * resolved immediately.

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -29,7 +29,7 @@ class PostStreamState {
      *
      * @type {Number}
      */
-    this.visible = m.prop(1);
+    this.visible = 1;
 
     /**
      * The description to render on the scrubber.
@@ -328,7 +328,7 @@ class PostStreamState {
    * @return {Boolean}
    */
   disabled() {
-    return this.visible() >= this.count();
+    return this.visible >= this.count();
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -1,4 +1,3 @@
-import evented from '../../common/utils/evented';
 import anchorScroll from '../../common/utils/anchorScroll';
 
 class PostStreamState {
@@ -21,12 +20,9 @@ class PostStreamState {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
-    /**
-     * The index of the post that is currently at the top of the viewport.
-     *
-     * @type {Number}
-     */
+    this.locationType = null;
     this.index = 0;
+    this.number = 1;
 
     /**
      * The number of posts that are currently visible in the viewport.
@@ -66,15 +62,14 @@ class PostStreamState {
 
     m.redraw(true);
 
-    return promise
-      .then(() => {
-        m.redraw(true);
+    this.locationType = 'number';
+    this.number = number;
+    this.needsScroll = true;
+    this.noAnimationScroll = noAnimation;
 
-        this.trigger('scrollToNumber', number, noAnimation);
-      })
-      .then(() => {
-        this.paused = false;
-      });
+    m.redraw();
+
+    return promise;
   }
 
   /**
@@ -86,20 +81,21 @@ class PostStreamState {
    * @param {Boolean} noAnimation
    * @return {Promise}
    */
-  goToIndex(index, backwards, noAnimation) {
+  goToIndex(index, noAnimation) {
     this.paused = true;
 
     const promise = this.loadNearIndex(index);
 
     m.redraw(true);
 
-    return promise
-      .then(() => {
-        this.trigger('scrollToIndex', index, noAnimation, backwards);
-      })
-      .then(() => {
-        this.paused = false;
-      });
+    this.locationType = 'index';
+    this.index = index;
+    this.needsScroll = true;
+    this.noAnimationScroll = noAnimation;
+
+    m.redraw();
+
+    return promise;
   }
 
   /**
@@ -117,7 +113,7 @@ class PostStreamState {
    * @return {Promise}
    */
   goToLast() {
-    return this.goToIndex(this.count() - 1, true);
+    return this.goToIndex(this.count() - 1);
   }
 
   /**
@@ -375,7 +371,5 @@ class PostStreamState {
  * @type {Integer}
  */
 PostStreamState.loadCount = 20;
-
-Object.assign(PostStreamState.prototype, evented);
 
 export default PostStreamState;

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -29,7 +29,7 @@ class PostStreamState {
      *
      * @type {Number}
      */
-    this.visible = 1;
+    this.visible = m.prop(1);
 
     /**
      * The description to render on the scrubber.
@@ -173,7 +173,7 @@ class PostStreamState {
    * @return {Boolean}
    */
   allVisible() {
-    return this.visible >= this.count();
+    return this.visible() >= this.count();
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -61,8 +61,6 @@ class PostStreamState {
 
     const promise = this.loadNearNumber(number);
 
-    m.redraw(true);
-
     this.locationType = 'number';
     this.number = number;
     this.needsScroll = true;
@@ -88,8 +86,7 @@ class PostStreamState {
 
     const promise = this.loadNearIndex(index);
 
-    m.redraw(true);
-
+    console.log('promiseGenerated');
     this.locationType = 'index';
     this.index = index;
     this.needsScroll = true;
@@ -115,6 +112,7 @@ class PostStreamState {
    * @return {Promise}
    */
   goToLast() {
+    m.redraw(true);
     return this.goToIndex(this.count() - 1);
   }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -204,7 +204,7 @@ class PostStreamState {
 
     this.visibleEnd = this.count();
 
-    return this.loadRange(this.visibleStart, this.visibleEnd).then(() => m.redraw());
+    return this.loadRange(this.visibleStart, this.visibleEnd);
   }
 
   /**
@@ -264,7 +264,6 @@ class PostStreamState {
    */
   loadPage(start, end, backwards) {
     console.log('loadPage');
-    const redraw = () => {};
 
     this.loadPageTimeouts[start] = setTimeout(
       () => {
@@ -332,7 +331,8 @@ class PostStreamState {
         filter: { discussion: this.discussion.id() },
         page: { near: number },
       })
-      .then(this.show.bind(this));
+      .then(this.show.bind(this))
+      .then(() => m.redraw());
   }
 
   /**
@@ -354,7 +354,9 @@ class PostStreamState {
 
     this.reset(start, end);
 
-    return this.loadRange(start, end).then(this.show.bind(this));
+    return this.loadRange(start, end)
+      .then(this.show.bind(this))
+      .then(() => m.redraw());
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -50,6 +50,7 @@ class PostStreamState {
    * @return {Promise}
    */
   goToNumber(number, noAnimation) {
+    console.log('goToNumber', number);
     // If we want to go to the reply preview, then we will go to the end of the
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
@@ -82,6 +83,7 @@ class PostStreamState {
    * @return {Promise}
    */
   goToIndex(index, noAnimation) {
+    console.log('goToIndex', index);
     this.paused = true;
 
     const promise = this.loadNearIndex(index);
@@ -211,6 +213,7 @@ class PostStreamState {
    * Load the next page of posts.
    */
   loadNext() {
+    console.log('loadNext');
     const start = this.visibleEnd;
     const end = (this.visibleEnd = this.sanitizeIndex(this.visibleEnd + this.constructor.loadCount));
 
@@ -234,6 +237,7 @@ class PostStreamState {
    * Load the previous page of posts.
    */
   loadPrevious() {
+    console.log('loadPrevious');
     const end = this.visibleStart;
     const start = (this.visibleStart = this.sanitizeIndex(this.visibleStart - this.constructor.loadCount));
 
@@ -261,20 +265,16 @@ class PostStreamState {
    * @param {Boolean} backwards
    */
   loadPage(start, end, backwards) {
-    const redraw = () => {
-      if (start < this.visibleStart || end > this.visibleEnd) return;
-
-      const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
-      anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
-
-      this.paused = false;
-    };
-    redraw();
+    console.log('loadPage');
+    const redraw = () => {};
 
     this.loadPageTimeouts[start] = setTimeout(
       () => {
         this.loadRange(start, end).then(() => {
-          redraw();
+          if (start >= this.visibleStart && end <= this.visibleEnd) {
+            const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
+            anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
+          }
           this.pagesLoading--;
         });
         this.loadPageTimeouts[start] = null;
@@ -322,6 +322,7 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearNumber(number) {
+    console.log('loadNearNumber', number);
     if (this.posts().some((post) => post && Number(post.number()) === Number(number))) {
       return m.deferred().resolve().promise;
     }
@@ -345,6 +346,7 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearIndex(index) {
+    console.log('loadNearIndex', index);
     if (index >= this.visibleStart && index <= this.visibleEnd) {
       return m.deferred().resolve().promise;
     }

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -58,7 +58,7 @@ class PostStreamState {
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
       return this.goToLast().then(() => {
-        this.trigger('scrollToLast');
+        this.trigger('scrollToIndex', this.count());
       });
     }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -75,7 +75,7 @@ class PostStreamState {
         this.trigger('scrollToNumber', number, noAnimation);
       })
       .then(() => {
-        this.unpause();
+        this.paused = false;
       });
   }
 
@@ -100,7 +100,7 @@ class PostStreamState {
         this.trigger('scrollToIndex', index, noAnimation, backwards);
       })
       .then(() => {
-        this.unpause();
+        this.paused = false;
       });
   }
 
@@ -273,7 +273,7 @@ class PostStreamState {
       const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
       anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
 
-      this.unpause();
+      this.paused = false;
     };
     redraw();
 
@@ -368,7 +368,6 @@ class PostStreamState {
    */
   unpause() {
     this.paused = false;
-    this.trigger('unpaused');
   }
 }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -76,7 +76,7 @@ class PostStreamState {
   /**
    * Load and scroll to a post with a certain number.
    *
-   * @param {Integer|String} number The post number to go to. If 'reply', go to
+   * @param {number|String} number The post number to go to. If 'reply', go to
    *     the last post and scroll the reply preview into view.
    * @param {Boolean} noAnimation
    * @return {Promise}
@@ -97,7 +97,7 @@ class PostStreamState {
     this.number = number;
 
     // In this case, the redraw is only called after the response has been loaded
-    // because we need to know the indeces of the post range before we can
+    // because we need to know the indices of the post range before we can
     // start scrolling to items. Calling redraw early causes issues.
     // Since this is only used for external navigation to the post stream, the delay
     // before the stream is moved is not an issue.
@@ -107,9 +107,7 @@ class PostStreamState {
   /**
    * Load and scroll to a certain index within the discussion.
    *
-   * @param {Integer} index
-   * @param {Boolean} backwards Whether or not to load backwards from the given
-   *     index.
+   * @param {number} index
    * @param {Boolean} noAnimation
    * @return {Promise}
    */
@@ -134,7 +132,7 @@ class PostStreamState {
    * If the post with the given number is already loaded, the promise will be
    * resolved immediately.
    *
-   * @param {Integer} number
+   * @param {number} number
    * @return {Promise}
    */
   loadNearNumber(number) {
@@ -157,7 +155,7 @@ class PostStreamState {
    * surrounding the given index will be loaded. Returns a promise. If the given
    * index is already loaded, the promise will be resolved immediately.
    *
-   * @param {Integer} index
+   * @param {number} index
    * @return {Promise}
    */
   loadNearIndex(index) {
@@ -222,8 +220,8 @@ class PostStreamState {
   /**
    * Load a page of posts into the stream and redraw.
    *
-   * @param {Integer} start
-   * @param {Integer} end
+   * @param {number} start
+   * @param {number} end
    * @param {Boolean} backwards
    */
   loadPage(start, end, backwards) {
@@ -250,8 +248,8 @@ class PostStreamState {
    * Load and inject the specified range of posts into the stream, without
    * clearing it.
    *
-   * @param {Integer} start
-   * @param {Integer} end
+   * @param {number} start
+   * @param {number} end
    * @return {Promise}
    */
   loadRange(start, end) {
@@ -288,8 +286,8 @@ class PostStreamState {
    * Reset the stream so that a specific range of posts is displayed. If a range
    * is not specified, the first page of posts will be displayed.
    *
-   * @param {Integer} [start]
-   * @param {Integer} [end]
+   * @param {number} [start]
+   * @param {number} [end]
    */
   reset(start, end) {
     this.visibleStart = start || 0;
@@ -315,7 +313,7 @@ class PostStreamState {
   /**
    * Get the total number of posts in the discussion.
    *
-   * @return {Integer}
+   * @return {number}
    */
   count() {
     return this.discussion.postIds().length;
@@ -344,7 +342,7 @@ class PostStreamState {
    * Make sure that the given index is not outside of the possible range of
    * indexes in the discussion.
    *
-   * @param {Integer} index
+   * @param {number} index
    */
   sanitizeIndex(index) {
     return Math.max(0, Math.min(this.count(), Math.floor(index)));
@@ -354,7 +352,7 @@ class PostStreamState {
 /**
  * The number of posts to load per page.
  *
- * @type {Integer}
+ * @type {number}
  */
 PostStreamState.loadCount = 20;
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -65,9 +65,12 @@ class PostStreamState {
     this.locationType = 'number';
     this.number = number;
 
-    m.redraw();
-
-    return this.loadPromise;
+    // In this case, the redraw is only called after the response has been loaded
+    // because we need to know the indeces of the post range before we can
+    // start scrolling to items. Calling redraw early causes issues.
+    // Since this is only used for external navigation to the post stream, the delay
+    // before the stream is moved is not an issue.
+    return this.loadPromise.then(() => m.redraw());
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -332,7 +332,7 @@ class PostStreamState {
         page: { near: number },
       })
       .then(this.show.bind(this))
-      .then(() => m.redraw());
+      .then(() => anchorScroll($(`.PostStream-item[data-number="${number}"]`), () => m.redraw(true)));
   }
 
   /**
@@ -356,7 +356,7 @@ class PostStreamState {
 
     return this.loadRange(start, end)
       .then(this.show.bind(this))
-      .then(() => m.redraw());
+      .then(() => anchorScroll($(`.PostStream-item[data-index="${index}"]`), () => m.redraw(true)));
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -125,7 +125,6 @@ class PostStreamState {
   show(posts) {
     this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
     this.visibleEnd = this.sanitizeIndex(this.visibleStart + posts.length);
-    this.description = posts.length ? dayjs(posts[Math.floor(posts.length / 2)].createdAt()).format('MMMM YYYY') : '';
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -108,7 +108,7 @@ class PostStreamState {
    */
   show(posts) {
     this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
-    this.visibleEnd = this.visibleStart + posts.length;
+    this.visibleEnd = this.sanitizeIndex(this.visibleStart + posts.length);
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -82,7 +82,6 @@ class PostStreamState {
    * @return {Promise}
    */
   goToNumber(number, noAnimation) {
-    console.log('goToNumber', number);
     // If we want to go to the reply preview, then we will go to the end of the
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
@@ -115,7 +114,6 @@ class PostStreamState {
    * @return {Promise}
    */
   goToIndex(index, noAnimation) {
-    console.log('goToIndex', index);
     this.paused = true;
 
     this.loadPromise = this.loadNearIndex(index);
@@ -140,7 +138,6 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearNumber(number) {
-    console.log('loadNearNumber', number);
     if (this.posts().some((post) => post && Number(post.number()) === Number(number))) {
       return m.deferred().resolve().promise;
     }
@@ -164,9 +161,7 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearIndex(index) {
-    console.log('loadNearIndex', index);
     if (index >= this.visibleStart && index <= this.visibleEnd) {
-      console.log("doing the thing")
       return m.deferred().resolve().promise;
     }
 
@@ -182,7 +177,6 @@ class PostStreamState {
    * Load the next page of posts.
    */
   loadNext() {
-    console.log('loadNext');
     const start = this.visibleEnd;
     const end = (this.visibleEnd = this.sanitizeIndex(this.visibleEnd + this.constructor.loadCount));
 
@@ -206,7 +200,6 @@ class PostStreamState {
    * Load the previous page of posts.
    */
   loadPrevious() {
-    console.log('loadPrevious');
     const end = this.visibleStart;
     const start = (this.visibleStart = this.sanitizeIndex(this.visibleStart - this.constructor.loadCount));
 
@@ -234,14 +227,12 @@ class PostStreamState {
    * @param {Boolean} backwards
    */
   loadPage(start, end, backwards) {
-    console.log('loadPage');
     m.redraw();
 
     this.loadPageTimeouts[start] = setTimeout(
       () => {
         this.loadRange(start, end).then(() => {
           if (start >= this.visibleStart && end <= this.visibleEnd) {
-            console.log('anchoring!');
             const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
             anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
           }

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -81,7 +81,7 @@ class PostStreamState {
    * @param {Boolean} noAnimation
    * @return {Promise}
    */
-  goToNumber(number, noAnimation) {
+  goToNumber(number, noAnimation = false) {
     // If we want to go to the reply preview, then we will go to the end of the
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
@@ -111,7 +111,7 @@ class PostStreamState {
    * @param {Boolean} noAnimation
    * @return {Promise}
    */
-  goToIndex(index, noAnimation) {
+  goToIndex(index, noAnimation = false) {
     this.paused = true;
 
     this.loadPromise = this.loadNearIndex(index);

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -234,6 +234,7 @@ class PostStreamState {
    */
   loadPage(start, end, backwards) {
     console.log('loadPage');
+    m.redraw();
 
     this.loadPageTimeouts[start] = setTimeout(
       () => {

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -20,8 +20,10 @@ class PostStreamState {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
+    this.show(includedPosts);
+
     this.locationType = null;
-    this.index = 0;
+    this.index = (this.visibleEnd - this.visibleStart) / 2;
     this.number = 1;
 
     /**
@@ -37,8 +39,6 @@ class PostStreamState {
      * @type {String}
      */
     this.description = '';
-
-    this.show(includedPosts);
   }
 
   /**
@@ -270,6 +270,7 @@ class PostStreamState {
       () => {
         this.loadRange(start, end).then(() => {
           if (start >= this.visibleStart && end <= this.visibleEnd) {
+            console.log('anchoring!');
             const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
             anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
           }

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -57,18 +57,17 @@ class PostStreamState {
       return this.goToLast();
     }
 
+    this.loadPromise = this.loadNearNumber(number);
+
     this.paused = true;
-
-    const promise = this.loadNearNumber(number);
-
-    this.locationType = 'number';
-    this.number = number;
     this.needsScroll = true;
     this.noAnimationScroll = noAnimation;
+    this.locationType = 'number';
+    this.number = number;
 
     m.redraw();
 
-    return promise;
+    return this.loadPromise;
   }
 
   /**
@@ -84,17 +83,17 @@ class PostStreamState {
     console.log('goToIndex', index);
     this.paused = true;
 
-    const promise = this.loadNearIndex(index);
+    this.loadPromise = this.loadNearIndex(index);
 
-    console.log('promiseGenerated');
-    this.locationType = 'index';
-    this.index = index;
+    this.paused = true;
     this.needsScroll = true;
     this.noAnimationScroll = noAnimation;
+    this.locationType = 'index';
+    this.index = index;
 
     m.redraw();
 
-    return promise;
+    return this.loadPromise;
   }
 
   /**
@@ -112,7 +111,6 @@ class PostStreamState {
    * @return {Promise}
    */
   goToLast() {
-    m.redraw(true);
     return this.goToIndex(this.count() - 1);
   }
 
@@ -190,7 +188,7 @@ class PostStreamState {
    * @protected
    */
   sanitizeIndex(index) {
-    return Math.max(0, Math.min(this.count(), index));
+    return Math.max(0, Math.min(this.count(), Math.floor(index)));
   }
 
   /**
@@ -331,8 +329,7 @@ class PostStreamState {
         filter: { discussion: this.discussion.id() },
         page: { near: number },
       })
-      .then(this.show.bind(this))
-      .then(() => anchorScroll($(`.PostStream-item[data-number="${number}"]`), () => m.redraw(true)));
+      .then(this.show.bind(this));
   }
 
   /**
@@ -354,9 +351,7 @@ class PostStreamState {
 
     this.reset(start, end);
 
-    return this.loadRange(start, end)
-      .then(this.show.bind(this))
-      .then(() => anchorScroll($(`.PostStream-item[data-index="${index}"]`), () => m.redraw(true)));
+    return this.loadRange(start, end).then(this.show.bind(this));
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -221,7 +221,7 @@ class PostStreamState {
    * @param {number} end
    * @param {Boolean} backwards
    */
-  loadPage(start, end, backwards) {
+  loadPage(start, end, backwards = false) {
     m.redraw();
 
     this.loadPageTimeouts[start] = setTimeout(

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -1,0 +1,344 @@
+import evented from '../../common/utils/evented';
+import anchorScroll from '../../common/utils/anchorScroll';
+
+class PostStreamState {
+  constructor(discussion, includedPosts = []) {
+    /**
+     * The discussion to display the post stream for.
+     *
+     * @type {Discussion}
+     */
+    this.discussion = discussion;
+
+    /**
+     * Whether or not the infinite-scrolling auto-load functionality is
+     * disabled.
+     *
+     * @type {Boolean}
+     */
+    this.paused = false;
+
+    this.loadPageTimeouts = {};
+    this.pagesLoading = 0;
+
+    this.show(includedPosts);
+  }
+
+  /**
+   * Load and scroll to a post with a certain number.
+   *
+   * @param {Integer|String} number The post number to go to. If 'reply', go to
+   *     the last post and scroll the reply preview into view.
+   * @param {Boolean} noAnimation
+   * @return {Promise}
+   */
+  goToNumber(number, noAnimation) {
+    // If we want to go to the reply preview, then we will go to the end of the
+    // discussion and then scroll to the very bottom of the page.
+    if (number === 'reply') {
+      return this.goToLast().then(() => {
+        this.trigger('scrollToLast');
+      });
+    }
+
+    this.paused = true;
+
+    const promise = this.loadNearNumber(number);
+
+    m.redraw(true);
+
+    return promise
+      .then(() => {
+        m.redraw(true);
+
+        this.trigger('scrollToNumber', number, noAnimation);
+      })
+      .then(() => {
+        this.unpause();
+      });
+  }
+
+  /**
+   * Load and scroll to a certain index within the discussion.
+   *
+   * @param {Integer} index
+   * @param {Boolean} backwards Whether or not to load backwards from the given
+   *     index.
+   * @param {Boolean} noAnimation
+   * @return {Promise}
+   */
+  goToIndex(index, backwards, noAnimation) {
+    this.paused = true;
+
+    const promise = this.loadNearIndex(index);
+
+    m.redraw(true);
+
+    return promise
+      .then(() => {
+        this.trigger('scrollToIndex', index, noAnimation, backwards);
+      })
+      .then(() => {
+        this.unpause();
+      });
+  }
+
+  /**
+   * Load and scroll up to the first post in the discussion.
+   *
+   * @return {Promise}
+   */
+  goToFirst() {
+    return this.goToIndex(0);
+  }
+
+  /**
+   * Load and scroll down to the last post in the discussion.
+   *
+   * @return {Promise}
+   */
+  goToLast() {
+    return this.goToIndex(this.count() - 1, true);
+  }
+
+  /**
+   * Set up the stream with the given array of posts.
+   *
+   * @param {Post[]} posts
+   */
+  show(posts) {
+    this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
+    this.visibleEnd = this.visibleStart + posts.length;
+  }
+
+  /**
+   * Reset the stream so that a specific range of posts is displayed. If a range
+   * is not specified, the first page of posts will be displayed.
+   *
+   * @param {Integer} [start]
+   * @param {Integer} [end]
+   */
+  reset(start, end) {
+    this.visibleStart = start || 0;
+    this.visibleEnd = this.sanitizeIndex(end || this.constructor.loadCount);
+  }
+
+  /**
+   * Get the visible page of posts.
+   *
+   * @return {Post[]}
+   */
+  posts() {
+    return this.discussion
+      .postIds()
+      .slice(this.visibleStart, this.visibleEnd)
+      .map((id) => {
+        const post = app.store.getById('posts', id);
+
+        return post && post.discussion() && typeof post.canEdit() !== 'undefined' ? post : null;
+      });
+  }
+
+  /**
+   * Get the total number of posts in the discussion.
+   *
+   * @return {Integer}
+   */
+  count() {
+    return this.discussion.postIds().length;
+  }
+
+  /**
+   * Make sure that the given index is not outside of the possible range of
+   * indexes in the discussion.
+   *
+   * @param {Integer} index
+   * @protected
+   */
+  sanitizeIndex(index) {
+    return Math.max(0, Math.min(this.count(), index));
+  }
+
+  /**
+   * Update the stream so that it loads and includes the latest posts in the
+   * discussion, if the end is being viewed.
+   *
+   * @public
+   */
+  update() {
+    if (!this.viewingEnd) return m.deferred().resolve().promise;
+
+    this.visibleEnd = this.count();
+
+    return this.loadRange(this.visibleStart, this.visibleEnd).then(() => m.redraw());
+  }
+
+  /**
+   * Load the next page of posts.
+   */
+  loadNext() {
+    const start = this.visibleEnd;
+    const end = (this.visibleEnd = this.sanitizeIndex(this.visibleEnd + this.constructor.loadCount));
+
+    // Unload the posts which are two pages back from the page we're currently
+    // loading.
+    const twoPagesAway = start - this.constructor.loadCount * 2;
+    if (twoPagesAway > this.visibleStart && twoPagesAway >= 0) {
+      this.visibleStart = twoPagesAway + this.constructor.loadCount + 1;
+
+      if (this.loadPageTimeouts[twoPagesAway]) {
+        clearTimeout(this.loadPageTimeouts[twoPagesAway]);
+        this.loadPageTimeouts[twoPagesAway] = null;
+        this.pagesLoading--;
+      }
+    }
+
+    this.loadPage(start, end);
+  }
+
+  /**
+   * Load the previous page of posts.
+   */
+  loadPrevious() {
+    const end = this.visibleStart;
+    const start = (this.visibleStart = this.sanitizeIndex(this.visibleStart - this.constructor.loadCount));
+
+    // Unload the posts which are two pages back from the page we're currently
+    // loading.
+    const twoPagesAway = start + this.constructor.loadCount * 2;
+    if (twoPagesAway < this.visibleEnd && twoPagesAway <= this.count()) {
+      this.visibleEnd = twoPagesAway;
+
+      if (this.loadPageTimeouts[twoPagesAway]) {
+        clearTimeout(this.loadPageTimeouts[twoPagesAway]);
+        this.loadPageTimeouts[twoPagesAway] = null;
+        this.pagesLoading--;
+      }
+    }
+
+    this.loadPage(start, end, true);
+  }
+
+  /**
+   * Load a page of posts into the stream and redraw.
+   *
+   * @param {Integer} start
+   * @param {Integer} end
+   * @param {Boolean} backwards
+   */
+  loadPage(start, end, backwards) {
+    const redraw = () => {
+      if (start < this.visibleStart || end > this.visibleEnd) return;
+
+      const anchorIndex = backwards ? this.visibleEnd - 1 : this.visibleStart;
+      anchorScroll(`.PostStream-item[data-index="${anchorIndex}"]`, () => m.redraw(true));
+
+      this.unpause();
+    };
+    redraw();
+
+    this.loadPageTimeouts[start] = setTimeout(
+      () => {
+        this.loadRange(start, end).then(() => {
+          redraw();
+          this.pagesLoading--;
+        });
+        this.loadPageTimeouts[start] = null;
+      },
+      this.pagesLoading ? 1000 : 0
+    );
+
+    this.pagesLoading++;
+  }
+
+  /**
+   * Load and inject the specified range of posts into the stream, without
+   * clearing it.
+   *
+   * @param {Integer} start
+   * @param {Integer} end
+   * @return {Promise}
+   */
+  loadRange(start, end) {
+    const loadIds = [];
+    const loaded = [];
+
+    this.discussion
+      .postIds()
+      .slice(start, end)
+      .forEach((id) => {
+        const post = app.store.getById('posts', id);
+
+        if (post && post.discussion() && typeof post.canEdit() !== 'undefined') {
+          loaded.push(post);
+        } else {
+          loadIds.push(id);
+        }
+      });
+
+    return loadIds.length ? app.store.find('posts', loadIds) : m.deferred().resolve(loaded).promise;
+  }
+
+  /**
+   * Clear the stream and load posts near a certain number. Returns a promise.
+   * If the post with the given number is already loaded, the promise will be
+   * resolved immediately.
+   *
+   * @param {Integer} number
+   * @return {Promise}
+   */
+  loadNearNumber(number) {
+    if (this.posts().some((post) => post && Number(post.number()) === Number(number))) {
+      return m.deferred().resolve().promise;
+    }
+
+    this.reset();
+
+    return app.store
+      .find('posts', {
+        filter: { discussion: this.discussion.id() },
+        page: { near: number },
+      })
+      .then(this.show.bind(this));
+  }
+
+  /**
+   * Clear the stream and load posts near a certain index. A page of posts
+   * surrounding the given index will be loaded. Returns a promise. If the given
+   * index is already loaded, the promise will be resolved immediately.
+   *
+   * @param {Integer} index
+   * @return {Promise}
+   */
+  loadNearIndex(index) {
+    if (index >= this.visibleStart && index <= this.visibleEnd) {
+      return m.deferred().resolve().promise;
+    }
+
+    const start = this.sanitizeIndex(index - this.constructor.loadCount / 2);
+    const end = start + this.constructor.loadCount;
+
+    this.reset(start, end);
+
+    return this.loadRange(start, end).then(this.show.bind(this));
+  }
+
+  /**
+   * Resume the stream's ability to auto-load posts on scroll.
+   */
+  unpause() {
+    this.paused = false;
+    this.trigger('unpaused');
+  }
+}
+
+/**
+ * The number of posts to load per page.
+ *
+ * @type {Integer}
+ */
+PostStreamState.loadCount = 20;
+
+Object.assign(PostStreamState.prototype, evented);
+
+export default PostStreamState;

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -20,7 +20,6 @@ class PostStreamState {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
-    this.locationType = null;
     this.index = 0;
     this.number = 1;
 
@@ -92,9 +91,8 @@ class PostStreamState {
 
     this.loadPromise = this.loadNearNumber(number);
 
-    this.needsScroll = true;
+    this.targetPost = { number };
     this.noAnimationScroll = noAnimation;
-    this.locationType = 'number';
     this.number = number;
 
     // In this case, the redraw is only called after the response has been loaded
@@ -117,36 +115,13 @@ class PostStreamState {
 
     this.loadPromise = this.loadNearIndex(index);
 
-    this.needsScroll = true;
+    this.targetPost = { index };
     this.noAnimationScroll = noAnimation;
-    this.locationType = 'index';
     this.index = index;
 
     m.redraw();
 
     return this.loadPromise;
-  }
-
-  /**
-   * Execute a callback when necessary because the scroll position changed.
-   *
-   * The callback will be called with three arguments:
-   *  - the "type" of position to jump to ("number" or "index")
-   *  - the corresponding position
-   *  - whether scrolling should be animated
-   *
-   * @param callback
-   */
-  scrollEffect(callback) {
-    if (!this.needsScroll) return;
-
-    if (this.locationType === 'number') {
-      callback('number', this.number, !this.noAnimationScroll);
-    } else {
-      callback('index', this.sanitizeIndex(this.index), !this.noAnimationScroll);
-    }
-
-    this.needsScroll = false;
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -166,6 +166,7 @@ class PostStreamState {
   loadNearIndex(index) {
     console.log('loadNearIndex', index);
     if (index >= this.visibleStart && index <= this.visibleEnd) {
+      console.log("doing the thing")
       return m.deferred().resolve().promise;
     }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -20,10 +20,8 @@ class PostStreamState {
     this.loadPageTimeouts = {};
     this.pagesLoading = 0;
 
-    this.show(includedPosts);
-
     this.locationType = null;
-    this.index = (this.visibleEnd - this.visibleStart) / 2;
+    this.index = 0;
     this.number = 1;
 
     /**
@@ -39,6 +37,8 @@ class PostStreamState {
      * @type {String}
      */
     this.description = '';
+
+    this.show(includedPosts);
   }
 
   /**
@@ -125,6 +125,7 @@ class PostStreamState {
   show(posts) {
     this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
     this.visibleEnd = this.sanitizeIndex(this.visibleStart + posts.length);
+    this.index = (this.visibleEnd - this.visibleStart) / 2;
   }
 
   /**
@@ -137,6 +138,7 @@ class PostStreamState {
   reset(start, end) {
     this.visibleStart = start || 0;
     this.visibleEnd = this.sanitizeIndex(end || this.constructor.loadCount);
+    this.index = (this.visibleEnd - this.visibleStart) / 2;
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -70,7 +70,7 @@ class PostStreamState {
    * @return {Promise}
    */
   goToLast() {
-    return this.goToIndex(this.count() - 1);
+    return this.goToIndex(this.count() - 1, true);
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -88,9 +88,10 @@ class PostStreamState {
       return this.goToLast();
     }
 
+    this.paused = true;
+
     this.loadPromise = this.loadNearNumber(number);
 
-    this.paused = true;
     this.needsScroll = true;
     this.noAnimationScroll = noAnimation;
     this.locationType = 'number';
@@ -116,7 +117,6 @@ class PostStreamState {
 
     this.loadPromise = this.loadNearIndex(index);
 
-    this.paused = true;
     this.needsScroll = true;
     this.noAnimationScroll = noAnimation;
     this.locationType = 'index';

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -57,9 +57,7 @@ class PostStreamState {
     // If we want to go to the reply preview, then we will go to the end of the
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
-      return this.goToLast().then(() => {
-        this.trigger('scrollToIndex', this.count());
-      });
+      return this.goToLast();
     }
 
     this.paused = true;

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -125,7 +125,8 @@ class PostStreamState {
   show(posts) {
     this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
     this.visibleEnd = this.sanitizeIndex(this.visibleStart + posts.length);
-    this.index = (this.visibleEnd - this.visibleStart) / 2;
+    this.index = (this.visibleEnd + this.visibleStart) / 2;
+    this.description = posts.length ? dayjs(posts[Math.floor(posts.length / 2)].createdAt()).format('MMMM YYYY') : '';
   }
 
   /**
@@ -138,7 +139,6 @@ class PostStreamState {
   reset(start, end) {
     this.visibleStart = start || 0;
     this.visibleEnd = this.sanitizeIndex(end || this.constructor.loadCount);
-    this.index = (this.visibleEnd - this.visibleStart) / 2;
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -125,7 +125,6 @@ class PostStreamState {
   show(posts) {
     this.visibleStart = posts.length ? this.discussion.postIds().indexOf(posts[0].id()) : 0;
     this.visibleEnd = this.sanitizeIndex(this.visibleStart + posts.length);
-    this.index = (this.visibleEnd + this.visibleStart) / 2;
     this.description = posts.length ? dayjs(posts[Math.floor(posts.length / 2)].createdAt()).format('MMMM YYYY') : '';
   }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -149,6 +149,15 @@ class PostStreamState {
   }
 
   /**
+   * Are we currently viewing the end of the discussion?
+   *
+   * @return {boolean}
+   */
+  viewingEnd() {
+    return this.visibleEnd === this.count();
+  }
+
+  /**
    * Make sure that the given index is not outside of the possible range of
    * indexes in the discussion.
    *
@@ -166,7 +175,7 @@ class PostStreamState {
    * @public
    */
   update() {
-    if (!this.viewingEnd) return m.deferred().resolve().promise;
+    if (!this.viewingEnd()) return m.deferred().resolve().promise;
 
     this.visibleEnd = this.count();
 

--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -21,13 +21,13 @@
 }
 .Scrubber-before, .Scrubber-after {
   border-left: 1px solid @control-bg;
-  transition: height 0.15s ease-out;
+  transition: height 0.15s linear;
 }
-.Scrubber-before, .Scrubber-after {
+.Scrubber-handle {
   border-left: 1px solid @control-bg;
-  transition: height 0.15s ease-out;
+  transition: height 0.25s ease-in;
 }
-.dragging .Scrubber-before, .dragging .Scrubber-after {
+.dragging .Scrubber-before, .dragging .Scrubber-after, .dragging .Scrubber-handle {
   transition: none;
 }
 .Scrubber-unread {

--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -21,6 +21,14 @@
 }
 .Scrubber-before, .Scrubber-after {
   border-left: 1px solid @control-bg;
+  transition: height 0.15s ease-out;
+}
+.Scrubber-before, .Scrubber-after {
+  border-left: 1px solid @control-bg;
+  transition: height 0.15s ease-out;
+}
+.dragging .Scrubber-before, .dragging .Scrubber-after {
+  transition: none;
 }
 .Scrubber-unread {
   position: absolute;

--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -7,8 +7,7 @@
       font-size: 14px;
       margin-right: 2px;
     }
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       text-decoration: none;
       color: @link-color;
     }
@@ -20,20 +19,14 @@
   min-height: 50px; // JavaScript sets a max-height
   position: relative;
 }
-.Scrubber-before,
-.Scrubber-after {
+.Scrubber-before, .Scrubber-after {
   border-left: 1px solid @control-bg;
 }
 .Scrubber-unread {
   position: absolute;
   border-left: 1px solid lighten(@muted-color, 10%);
   width: 100%;
-  background-image: linear-gradient(
-    to right,
-    @control-bg,
-    fade(@control-bg, 0) 10px,
-    fade(@control-bg, 0)
-  );
+  background-image: linear-gradient(to right, @control-bg, fade(@control-bg, 0) 10px, fade(@control-bg, 0));
   display: flex;
   align-items: center;
   color: @muted-color;

--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -7,7 +7,8 @@
       font-size: 14px;
       margin-right: 2px;
     }
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       text-decoration: none;
       color: @link-color;
     }
@@ -19,22 +20,20 @@
   min-height: 50px; // JavaScript sets a max-height
   position: relative;
 }
-.Scrubber-before, .Scrubber-after {
+.Scrubber-before,
+.Scrubber-after {
   border-left: 1px solid @control-bg;
-  transition: height 0.15s linear;
-}
-.Scrubber-handle {
-  border-left: 1px solid @control-bg;
-  transition: height 0.25s ease-in;
-}
-.dragging .Scrubber-before, .dragging .Scrubber-after, .dragging .Scrubber-handle {
-  transition: none;
 }
 .Scrubber-unread {
   position: absolute;
   border-left: 1px solid lighten(@muted-color, 10%);
   width: 100%;
-  background-image: linear-gradient(to right, @control-bg, fade(@control-bg, 0) 10px, fade(@control-bg, 0));
+  background-image: linear-gradient(
+    to right,
+    @control-bg,
+    fade(@control-bg, 0) 10px,
+    fade(@control-bg, 0)
+  );
   display: flex;
   align-items: center;
   color: @muted-color;


### PR DESCRIPTION
**Fixes Part of #1821, #2144**
Fixes #2001 
Fixes #2086

**Changes proposed in this pull request:**
Extract PostStream state out of PostStream, PostStreamScrubber.

**Reviewers should focus on:**
- Can we get rid of the positionChanged event sent out in PostStream?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).