### PR TITLE
Don't use body as tooltip container, allow notification area overflow

### DIFF
--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -30,6 +30,7 @@ export default class Badge extends Component {
   config(isInitialized) {
     if (isInitialized) return;
 
-    if (this.props.label) this.$().tooltip({ container: 'body' });
+    if (this.props.label) this.$().tooltip();
   }
+
 }

--- a/js/src/common/components/Badge.js
+++ b/js/src/common/components/Badge.js
@@ -32,5 +32,4 @@ export default class Badge extends Component {
 
     if (this.props.label) this.$().tooltip();
   }
-
 }

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -1,5 +1,6 @@
 
 .NotificationList {
+  overflow: hidden;
   & .loading-indicator {
     height: 100px;
   }

--- a/less/forum/NotificationsDropdown.less
+++ b/less/forum/NotificationsDropdown.less
@@ -1,7 +1,6 @@
 .NotificationsDropdown {
   .Dropdown-menu {
     padding: 0;
-    overflow: hidden;
 
     .NotificationList-content {
       max-height: 70vh;


### PR DESCRIPTION
**Fixes #2118**

**Changes proposed in this pull request:**
Badge tooltips are using container: 'body', so they can overflow the
notification area. When the user navigates back while a badge tooltip is
showing, the tooltip remains visible.

This commit removes the body container attribute and instead allows the
notificationDropDown to overflow, so badge tooltips aren't cut off.
Instead, this adds overflow: hidden to NotificationList (one down in hierarchy).

**Reviewers should focus on:**
Notification Drop Down UI in combination with badge tooltips and things that may overflow but shouldn't.

**Screenshot**
Video of Bug 1 that is fixed by this: https://puu.sh/FvEHo/ff5810b7f5.mp4 (video by @davwheat, see bug report)
Video of Bug 2 that is fixed by this: https://imgur.com/a/AQOA7t7

**Confirmed**

- [x ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).