### PR TITLE
Inject Url Generator and Translator Interface into notification mailer

### DIFF
--- a/src/Notification/NotificationMailer.php
+++ b/src/Notification/NotificationMailer.php
@@ -9,9 +9,11 @@
 
 namespace Flarum\Notification;
 
+use Flarum\Http\UrlGenerator;
 use Flarum\User\User;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Mail\Message;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class NotificationMailer
 {
@@ -21,11 +23,25 @@ class NotificationMailer
     protected $mailer;
 
     /**
-     * @param Mailer $mailer
+     * @var TranslatorInterface
      */
-    public function __construct(Mailer $mailer)
+    protected $translator;
+
+    /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    /**
+     * @param Mailer $mailer
+     * @param TranslatorInterface $translator
+     * @param UrlGenerator $url
+     */
+    public function __construct(Mailer $mailer, TranslatorInterface $translator, UrlGenerator $url)
     {
         $this->mailer = $mailer;
+        $this->translator = $translator;
+        $this->url = $url;
     }
 
     /**
@@ -34,9 +50,11 @@ class NotificationMailer
      */
     public function send(MailableInterface $blueprint, User $user)
     {
+        $translator = $this->translator;
+        $url = $this->url;
         $this->mailer->send(
             $blueprint->getEmailView(),
-            compact('blueprint', 'user'),
+            compact('blueprint', 'user', 'translator', 'url'),
             function (Message $message) use ($blueprint, $user) {
                 $message->to($user->email, $user->username)
                         ->subject($blueprint->getEmailSubject());


### PR DESCRIPTION
**Allows Fix For #1934**

Allows us to get rid of https://github.com/flarum/mentions/blob/e054158ae5917d4edadb3c996e4c9ae992ab78e0/views/emails/postMentioned.blade.php#L5
moving one step closer to deprecating helpers

**Changes proposed in this pull request:**
- Inject an instance of translator into notification views
- Inject an instance of UrlGenerator into notification views

**Reviewers should focus on:**
What else should we inject? SettingsRepository came to mind, as well as possibly an optional associative array of arguments provided when calling `$mailer->send` One important thing to note is that we want to avoid an anti-pattern of business logic in the email views, so I'd stick to the essentials for now.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
