### PR TITLE
Return the proper error code when wrong password when changing email

### DIFF
--- a/src/Api/Controller/UpdateUserController.php
+++ b/src/Api/Controller/UpdateUserController.php
@@ -12,7 +12,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\Command\EditUser;
-use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\Exception\NotAuthenticatedException;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -62,7 +62,7 @@ class UpdateUserController extends AbstractShowController
             $password = Arr::get($request->getParsedBody(), 'meta.password');
 
             if (! $actor->checkPassword($password)) {
-                throw new PermissionDeniedException;
+                throw new NotAuthenticatedException;
             }
         }
 


### PR DESCRIPTION
Right now, frontend looks for error code 401 to display a 'wrong password' alert (https://github.com/flarum/core/blob/998e32c2080a0b977110d965f9885f1120f2bf3e/js/src/forum/components/ChangeEmailModal.js#L124), but the backend returns 403. This PR makes it return 401.