### PR TITLE
Ensure consistent DB state for integration tests

### DIFF
--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -27,6 +27,29 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected $app;
 
+    // Used to run non-static setUp only once.
+    protected $initialized = false;
+
+    protected function setUp()
+    {
+        if (!$this->initialized) {
+            // Clear some essential tables. If it's used in more than 1 test classes, it should be here.
+            $this->prepareDatabase([
+                'users' => [],
+                'groups' => [],
+                'group_user' => [],
+                'group_permission' => [],
+                'discussions' => [],
+                'posts' => [],
+                'settings' => [],
+            ]);
+            // Unset app so that extenders can be resolved
+            $this->app = null;
+        }
+
+        $this->initialized = true;
+    }
+
     /**
      * @return \Flarum\Foundation\InstalledApp
      */
@@ -75,17 +98,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $this->server;
     }
 
-    protected $database;
+    protected static $database;
 
     protected function database(): ConnectionInterface
     {
-        if (is_null($this->database)) {
-            $this->database = $this->app()->getContainer()->make(
+        if (is_null(static::$database)) {
+            static::$database = $this->app()->getContainer()->make(
                 ConnectionInterface::class
             );
         }
 
-        return $this->database;
+        return static::$database;
     }
 
     protected function prepareDatabase(array $tableData)

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        if (!$this->initialized) {
+        if (! $this->initialized) {
             // Clear some essential tables. If it's used in more than 1 test classes, it should be here.
             $this->prepareDatabase([
                 'users' => [],

--- a/tests/integration/api/authentication/WithApiKeyTest.php
+++ b/tests/integration/api/authentication/WithApiKeyTest.php
@@ -28,6 +28,17 @@ class WithApiKeyTest extends TestCase
                 $this->adminUser(),
                 $this->normalUser(),
             ],
+            'groups' => [
+                $this->adminGroup(),
+                $this->memberGroup(),
+            ],
+            'group_user' => [
+                ['user_id' => 1, 'group_id' => 1],
+                ['user_id' => 2, 'group_id' => 3],
+            ],
+            'group_permission' => [
+                ['permission' => 'viewUserList', 'group_id' => 3],
+            ],
             'api_keys' => [],
         ]);
     }

--- a/tests/integration/api/discussions/ShowTest.php
+++ b/tests/integration/api/discussions/ShowTest.php
@@ -114,7 +114,7 @@ class ShowTest extends TestCase
     public function when_allowed_guests_can_see_hidden_posts()
     {
         /** @var Dispatcher $events */
-        $events = app(Dispatcher::class);
+        $events = $this->app()->getContainer()->make(Dispatcher::class);
 
         $events->listen(ScopeModelVisibility::class, function (ScopeModelVisibility $event) {
             if ($event->ability === 'hidePosts') {

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -31,6 +31,9 @@ class EventTest extends TestCase
             'users' => [
                 $this->adminUser(),
             ],
+            'group_user' => [
+                ['user_id' => 1, 'group_id' => 1],
+            ],
         ]);
 
         $bus = $this->app()->getContainer()->make(Dispatcher::class);

--- a/tests/integration/extenders/MailTest.php
+++ b/tests/integration/extenders/MailTest.php
@@ -29,6 +29,12 @@ class MailTest extends TestCase
             'users' => [
                 $this->adminUser(),
             ],
+            'groups' => [
+                $this->adminGroup(),
+            ],
+            'group_user' => [
+                ['user_id' => 1, 'group_id' => 1],
+            ],
         ]);
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Clear the database before each test class
- Cache the database connection instance to avoid 'Too Many Connections' 
- Adjust tests accordingly.

**Reviewers should focus on:**
- Is there a cleaner way to do this? I don't like that teardown is static but setup isnt.
- Can we truncate ALL tables instead of hardcoding the ones we want to truncate in?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
