### PR TITLE
Use drivers for display names, add display name extender

### DIFF
--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -21,6 +21,7 @@ export default class BasicsPage extends Page {
       'default_route',
       'welcome_title',
       'welcome_message',
+      'display_name_driver',
     ];
     this.values = {};
 
@@ -32,6 +33,14 @@ export default class BasicsPage extends Page {
     for (const i in locales) {
       this.localeOptions[i] = `${locales[i]} (${i})`;
     }
+
+    this.displayNameOptions = {};
+    const displayNameDrivers = app.data.displayNameDrivers;
+    for (const i in displayNameDrivers) {
+      this.displayNameOptions[i] = `${displayNameDrivers[i]} (${i})`;
+    }
+
+    if (!this.values.display_name_driver() && displayNameDrivers.includes('username')) this.values.display_name_driver('username');
 
     if (typeof this.values.show_language_selector() !== 'number') this.values.show_language_selector(1);
   }
@@ -113,6 +122,19 @@ export default class BasicsPage extends Page {
                 </div>,
               ],
             })}
+
+            {Object.keys(this.displayNameOptions).length > 1
+              ? FieldSet.component({
+                  label: app.translator.trans('core.admin.basics.display_name_heading'),
+                  children: [
+                    Select.component({
+                      options: this.displayNameOptions,
+                      value: this.values.display_name_driver(),
+                      onchange: this.values.display_name_driver,
+                    }),
+                  ],
+                })
+              : ''}
 
             {Button.component({
               type: 'submit',

--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -36,9 +36,9 @@ export default class BasicsPage extends Page {
 
     this.displayNameOptions = {};
     const displayNameDrivers = app.data.displayNameDrivers;
-    for (const i in displayNameDrivers) {
-      this.displayNameOptions[displayNameDrivers[i]] = `${displayNameDrivers[i]} (${i})`;
-    }
+    displayNameDrivers.forEach(function (identifier) {
+      this.displayNameOptions[identifier] = identifier;
+    }, this);
 
     if (!this.values.display_name_driver() && displayNameDrivers.includes('username')) this.values.display_name_driver('username');
 

--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -127,6 +127,7 @@ export default class BasicsPage extends Page {
               ? FieldSet.component({
                   label: app.translator.trans('core.admin.basics.display_name_heading'),
                   children: [
+                    <div className="helpText">{app.translator.trans('core.admin.basics.display_name_text')}</div>,
                     Select.component({
                       options: this.displayNameOptions,
                       value: this.values.display_name_driver(),

--- a/js/src/admin/components/BasicsPage.js
+++ b/js/src/admin/components/BasicsPage.js
@@ -37,7 +37,7 @@ export default class BasicsPage extends Page {
     this.displayNameOptions = {};
     const displayNameDrivers = app.data.displayNameDrivers;
     for (const i in displayNameDrivers) {
-      this.displayNameOptions[i] = `${displayNameDrivers[i]} (${i})`;
+      this.displayNameOptions[displayNameDrivers[i]] = `${displayNameDrivers[i]} (${i})`;
     }
 
     if (!this.values.display_name_driver() && displayNameDrivers.includes('username')) this.values.display_name_driver('username');

--- a/src/Admin/Content/AdminPayload.php
+++ b/src/Admin/Content/AdminPayload.php
@@ -14,12 +14,18 @@ use Flarum\Frontend\Document;
 use Flarum\Group\Permission;
 use Flarum\Settings\Event\Deserializing;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class AdminPayload
 {
+    /**
+     * @var Container;
+     */
+    protected $container;
+
     /**
      * @var SettingsRepositoryInterface
      */
@@ -36,13 +42,20 @@ class AdminPayload
     protected $db;
 
     /**
+     * @param Container $container
      * @param SettingsRepositoryInterface $settings
      * @param ExtensionManager $extensions
      * @param ConnectionInterface $db
      * @param Dispatcher $events
      */
-    public function __construct(SettingsRepositoryInterface $settings, ExtensionManager $extensions, ConnectionInterface $db, Dispatcher $events)
-    {
+    public function __construct(
+        Container $container,
+        SettingsRepositoryInterface $settings,
+        ExtensionManager $extensions,
+        ConnectionInterface $db,
+        Dispatcher $events
+    ) {
+        $this->container = $container;
         $this->settings = $settings;
         $this->extensions = $extensions;
         $this->db = $db;
@@ -60,6 +73,8 @@ class AdminPayload
         $document->payload['settings'] = $settings;
         $document->payload['permissions'] = Permission::map();
         $document->payload['extensions'] = $this->extensions->getExtensions()->toArray();
+
+        $document->payload['displayNameDrivers'] = array_keys($this->container->make('flarum.user.display_name.supported_drivers'));
 
         $document->payload['phpVersion'] = PHP_VERSION;
         $document->payload['mysqlVersion'] = $this->db->selectOne('select version() as version')->version;

--- a/src/Extend/User.php
+++ b/src/Extend/User.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+
+class User implements ExtenderInterface
+{
+    private $displayNameDrivers = [];
+
+    /**
+     * Add a mail driver.
+     *
+     * @param string $identifier Identifier for display name driver. E.g. 'username' for UserNameDriver
+     * @param string $driver ::class attribute of driver class, which must implement Flarum\User\DisplayName\DriverInterface
+     */
+    public function displayNameDriver(string $identifier, $driver)
+    {
+        $this->drivers[$identifier] = $driver;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $container->extend('flarum.user.display_name.supported_drivers', function ($existingDrivers) {
+            return array_merge($existingDrivers, $this->drivers);
+        });
+    }
+}

--- a/src/User/DisplayName/DriverInterface.php
+++ b/src/User/DisplayName/DriverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\DisplayName;
+
+use Flarum\User\User;
+
+/**
+ * An interface for a display name driver.
+ *
+ * @public
+ */
+interface DriverInterface
+{
+    /**
+     * Return a display name for a user.
+     */
+    public function displayName(User $user): string;
+}

--- a/src/User/DisplayName/UsernameDriver.php
+++ b/src/User/DisplayName/UsernameDriver.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\DisplayName;
+
+use Flarum\User\User;
+
+/**
+ * The default driver, which returns the user's username.
+ */
+class UsernameDriver implements DriverInterface
+{
+    public function displayName(User $user): string
+    {
+        return $user->username;
+    }
+}

--- a/src/User/Event/GetDisplayName.php
+++ b/src/User/Event/GetDisplayName.php
@@ -11,6 +11,9 @@ namespace Flarum\User\Event;
 
 use Flarum\User\User;
 
+/**
+ * @deprecated beta 14, removed beta 15.
+ */
 class GetDisplayName
 {
     /**

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -23,6 +23,7 @@ use Flarum\Http\AccessToken;
 use Flarum\Http\UrlGenerator;
 use Flarum\Notification\Notification;
 use Flarum\Post\Post;
+use Flarum\User\DisplayName\DriverInterface;
 use Flarum\User\Event\Activated;
 use Flarum\User\Event\AvatarChanged;
 use Flarum\User\Event\CheckingPassword;
@@ -92,6 +93,13 @@ class User extends AbstractModel
      * @var array
      */
     protected static $preferences = [];
+
+    /**
+     * A driver for getting display names.
+     *
+     * @var DriverInterface
+     */
+    protected static $displayNameDriver;
 
     /**
      * The hasher with which to hash passwords.
@@ -170,6 +178,16 @@ class User extends AbstractModel
     public static function setGate($gate)
     {
         static::$gate = $gate;
+    }
+
+    /**
+     * Set the display name driver.
+     *
+     * @param DriverInterface $driver
+     */
+    public static function setDisplayNameDriver(DriverInterface $driver)
+    {
+        static::$displayNameDriver = $driver;
     }
 
     /**
@@ -309,7 +327,8 @@ class User extends AbstractModel
      */
     public function getDisplayNameAttribute()
     {
-        return static::$dispatcher->until(new GetDisplayName($this)) ?: $this->username;
+        // Event is deprecated in beta 14, remove in beta 15.
+        return static::$dispatcher->until(new GetDisplayName($this)) ?: static::$displayNameDriver->displayName($this);
     }
 
     /**

--- a/tests/integration/extenders/UserTest.php
+++ b/tests/integration/extenders/UserTest.php
@@ -10,9 +10,9 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
-use Flarum\User\DisplayName\DriverInterface;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
+use Flarum\User\DisplayName\DriverInterface;
 use Flarum\User\User;
 
 class UserTest extends TestCase

--- a/tests/integration/extenders/UserTest.php
+++ b/tests/integration/extenders/UserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\User\DisplayName\DriverInterface;
+use Flarum\Tests\integration\RetrievesAuthorizedUsers;
+use Flarum\Tests\integration\TestCase;
+use Flarum\User\User;
+
+class UserTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function prepDb()
+    {
+        $this->prepareDatabase([
+            'users' => [
+                $this->adminUser(),
+            ], 'settings' => [
+                ['key' => 'display_name_driver', 'value' => 'custom'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function username_display_name_driver_used_by_default()
+    {
+        $this->prepDb();
+
+        $user = User::find(1);
+
+        $this->assertEquals('admin', $user->displayName);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_custom_display_name_driver()
+    {
+        $this->extend(
+            (new Extend\User)
+                ->displayNameDriver('custom', CustomDisplayNameDriver::class)
+        );
+
+        $this->prepDb();
+
+        $user = User::find(1);
+
+        $this->assertEquals('admin@machine.local$$$suffix', $user->displayName);
+    }
+}
+
+class CustomDisplayNameDriver implements DriverInterface
+{
+    public function displayName(User $user): string
+    {
+        return $user->email.'$$$suffix';
+    }
+}


### PR DESCRIPTION
**Part of #2091, #1891 **

**Changes proposed in this pull request:**
- Deprecate GetDisplayName event
- Use drivers for display name
- Add extender for adding display name driver
- Add integration tests for extender
- Add frontend ui for 

**Reviewers should focus on:**
- Is there a better place to put the driver UI than the basics page?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).