### PR TITLE
Fix replies dropdown menu width

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -288,6 +288,7 @@
   margin-top: -5px;
   float: right;
   position: relative;
+  z-index: 1;
 
   .transition(opacity 0.2s);
 


### PR DESCRIPTION
**Fixes #1707**

**Changes proposed in this pull request:**
Changes relative positioning to the list item instead. No issues on smaller screens, it auto resizes.

**Screenshot**
![repliesList](https://user-images.githubusercontent.com/20267363/66607208-03172580-ebb4-11e9-9d38-a295e41706d7.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] Related core extension PRs: flarum/mentions#38
