### PR TITLE
Don't store checkbox instances in NotificationGrid

### DIFF
--- a/js/src/common/components/Checkbox.js
+++ b/js/src/common/components/Checkbox.js
@@ -15,8 +15,6 @@ import icon from '../helpers/icon';
  * - `children` A text label to display next to the checkbox.
  */
 export default class Checkbox extends Component {
-  init() {}
-
   view() {
     let className = 'Checkbox ' + (this.props.state ? 'on' : 'off') + ' ' + (this.props.className || '');
     if (this.props.loading) className += ' loading';

--- a/js/src/common/components/Checkbox.js
+++ b/js/src/common/components/Checkbox.js
@@ -10,23 +10,16 @@ import icon from '../helpers/icon';
  * - `state` Whether or not the checkbox is checked.
  * - `className` The class name for the root element.
  * - `disabled` Whether or not the checkbox is disabled.
+ * - `loading` Whether or not the checkbox is loading.
  * - `onchange` A callback to run when the checkbox is checked/unchecked.
  * - `children` A text label to display next to the checkbox.
  */
 export default class Checkbox extends Component {
-  init() {
-    /**
-     * Whether or not the checkbox's value is in the process of being saved.
-     *
-     * @type {Boolean}
-     * @public
-     */
-    this.loading = false;
-  }
+  init() {}
 
   view() {
     let className = 'Checkbox ' + (this.props.state ? 'on' : 'off') + ' ' + (this.props.className || '');
-    if (this.loading) className += ' loading';
+    if (this.props.loading) className += ' loading';
     if (this.props.disabled) className += ' disabled';
 
     return (
@@ -45,7 +38,7 @@ export default class Checkbox extends Component {
    * @protected
    */
   getDisplay() {
-    return this.loading ? LoadingIndicator.component({ size: 'tiny' }) : icon(this.props.state ? 'fas fa-check' : 'fas fa-times');
+    return this.props.loading ? LoadingIndicator.component({ size: 'tiny' }) : icon(this.props.state ? 'fas fa-check' : 'fas fa-times');
   }
 
   /**

--- a/js/src/common/components/Switch.js
+++ b/js/src/common/components/Switch.js
@@ -12,6 +12,6 @@ export default class Switch extends Checkbox {
   }
 
   getDisplay() {
-    return this.loading ? super.getDisplay() : '';
+    return this.props.loading ? super.getDisplay() : '';
   }
 }

--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -25,7 +25,7 @@ export default class NotificationGrid extends Component {
      *
      * @type {Object}
      */
-    this.loadingState = {};
+    this.loading = {};
 
     /**
      * Information about the available notification types.
@@ -62,7 +62,7 @@ export default class NotificationGrid extends Component {
                   <td className="NotificationGrid-checkbox">
                     {Checkbox.component({
                       state: !!this.props.user.preferences()[key],
-                      loading: this.loadingState[key],
+                      loading: this.loading[key],
                       disabled: !(key in this.props.user.preferences()),
                       onchange: () => this.toggle([key]),
                     })}
@@ -107,14 +107,14 @@ export default class NotificationGrid extends Component {
     const enabled = !preferences[keys[0]];
 
     keys.forEach((key) => {
-      this.loadingState[key] = true;
+      this.loading[key] = true;
       preferences[key] = enabled;
     });
 
     m.redraw();
 
     user.save({ preferences }).then(() => {
-      keys.forEach((key) => (this.loadingState[key] = false));
+      keys.forEach((key) => (this.loading[key] = false));
 
       m.redraw();
     });

--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -36,6 +36,8 @@ export default class NotificationGrid extends Component {
   }
 
   view() {
+    const preferences = this.props.user.preferences();
+
     return (
       <table className="NotificationGrid">
         <thead>
@@ -61,9 +63,9 @@ export default class NotificationGrid extends Component {
                 return (
                   <td className="NotificationGrid-checkbox">
                     {Checkbox.component({
-                      state: !!this.props.user.preferences()[key],
+                      state: !!preferences[key],
                       loading: this.loading[key],
-                      disabled: !(key in this.props.user.preferences()),
+                      disabled: !(key in preferences),
                       onchange: () => this.toggle([key]),
                     })}
                   </td>

--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -55,16 +55,18 @@ export default class NotificationGrid extends Component {
               <td className="NotificationGrid-groupToggle" onclick={this.toggleType.bind(this, type.name)}>
                 {icon(type.icon)} {type.label}
               </td>
-              {this.methods.map((method) => (
-                <td className="NotificationGrid-checkbox">
+              {this.methods.map((method) => {
+                const key = this.preferenceKey(type.name, method.name);
+
+                return <td className="NotificationGrid-checkbox">
                   {Checkbox.component({
-                    state: !!this.props.user.preferences()[this.preferenceKey(type.name, method.name)],
-                    loading: this.loadingState[this.preferenceKey(type.name, method.name)],
-                    disabled: !(this.preferenceKey(type.name, method.name) in this.props.user.preferences()),
-                    onchange: () => this.toggle([this.preferenceKey(type.name, method.name)]),
+                    state: !!this.props.user.preferences()[key],
+                    loading: this.loadingState[key],
+                    disabled: !(key in this.props.user.preferences()),
+                    onchange: () => this.toggle([key]),
                   })}
-                </td>
-              ))}
+                </td>;
+              })}
             </tr>
           ))}
         </tbody>

--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -58,14 +58,16 @@ export default class NotificationGrid extends Component {
               {this.methods.map((method) => {
                 const key = this.preferenceKey(type.name, method.name);
 
-                return <td className="NotificationGrid-checkbox">
-                  {Checkbox.component({
-                    state: !!this.props.user.preferences()[key],
-                    loading: this.loadingState[key],
-                    disabled: !(key in this.props.user.preferences()),
-                    onchange: () => this.toggle([key]),
-                  })}
-                </td>;
+                return (
+                  <td className="NotificationGrid-checkbox">
+                    {Checkbox.component({
+                      state: !!this.props.user.preferences()[key],
+                      loading: this.loadingState[key],
+                      disabled: !(key in this.props.user.preferences()),
+                      onchange: () => this.toggle([key]),
+                    })}
+                  </td>
+                );
               })}
             </tr>
           ))}

--- a/js/src/forum/components/NotificationGrid.js
+++ b/js/src/forum/components/NotificationGrid.js
@@ -36,7 +36,6 @@ export default class NotificationGrid extends Component {
   }
 
   view() {
-    console.log('hi');
     return (
       <table className="NotificationGrid">
         <thead>

--- a/js/src/forum/components/SettingsPage.js
+++ b/js/src/forum/components/SettingsPage.js
@@ -116,11 +116,11 @@ export default class SettingsPage extends UserPage {
    */
   preferenceSaver(key) {
     return (value, component) => {
-      if (component) component.loading = true;
+      if (component) component.props.loading = true;
       m.redraw();
 
       this.user.savePreferences({ [key]: value }).then(() => {
-        if (component) component.loading = false;
+        if (component) component.props.loading = false;
         m.redraw();
       });
     };

--- a/js/src/forum/components/SettingsPage.js
+++ b/js/src/forum/components/SettingsPage.js
@@ -109,6 +109,8 @@ export default class SettingsPage extends UserPage {
   }
 
   /**
+   * @deprecated beta 14, remove in beta 15.
+   *
    * Generate a callback that will save a value to the given preference.
    *
    * @param {String} key
@@ -140,9 +142,15 @@ export default class SettingsPage extends UserPage {
         children: app.translator.trans('core.forum.settings.privacy_disclose_online_label'),
         state: this.user.preferences().discloseOnline,
         onchange: (value, component) => {
-          this.user.pushAttributes({ lastSeenAt: null });
-          this.preferenceSaver('discloseOnline')(value, component);
+          this.discloseOnlineLoading = true;
+          m.redraw();
+
+          this.user.savePreferences({ discloseOnline: value }).then(() => {
+            this.discloseOnlineLoading = false;
+            m.redraw();
+          });
         },
+        loading: this.discloseOnlineLoading,
       })
     );
 

--- a/js/src/forum/components/SettingsPage.js
+++ b/js/src/forum/components/SettingsPage.js
@@ -141,9 +141,8 @@ export default class SettingsPage extends UserPage {
       Switch.component({
         children: app.translator.trans('core.forum.settings.privacy_disclose_online_label'),
         state: this.user.preferences().discloseOnline,
-        onchange: (value, component) => {
+        onchange: (value) => {
           this.discloseOnlineLoading = true;
-          m.redraw();
 
           this.user.savePreferences({ discloseOnline: value }).then(() => {
             this.discloseOnlineLoading = false;


### PR DESCRIPTION
**Refs #1821 #2144**

**Changes proposed in this pull request:**
- Don't store checkbox instances in NotificationGrid
- Use props for Checkbox/Switch loading state instead of attribute so it can be passed in / modified

**Reviewers should focus on:**
- The code in `view` is very repetetive. Can we somehow put the key into a variable?
- I don't like that preferenceSaver is directly changing the component's props like that. But I also don't think it's a priority (we're not storing an instance of the component), and I don't know exactly what to do with it (we could have a register of all the fields / preferences as an extensible method, create an array of loadingState in `init` of SettingsPage, but that would still require extensions that add preferences to include a reference to that loadingState, breaking their loading indicators) 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
