### PR TITLE
Don't store PostUser instance in CommentPost

### DIFF
--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -33,11 +33,7 @@ export default class CommentPost extends Post {
 
     // Create an instance of the component that displays the post's author so
     // that we can force the post to rerender when the user card is shown.
-    this.postUser = new PostUser({ post: this.props.post });
-    this.subtree.check(
-      () => this.postUser.cardVisible,
-      () => this.isEditing()
-    );
+    this.subtree.check(() => this.isEditing());
   }
 
   content() {
@@ -131,7 +127,7 @@ export default class CommentPost extends Post {
     const post = this.props.post;
     const props = { post };
 
-    items.add('user', this.postUser.render(), 100);
+    items.add('user', PostUser.component({ post: this.props.post }), 100);
     items.add('meta', PostMeta.component(props));
 
     if (post.isEdited() && !post.isHidden()) {

--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -31,8 +31,6 @@ export default class CommentPost extends Post {
      */
     this.revealContent = false;
 
-    // Create an instance of the component that displays the post's author so
-    // that we can force the post to rerender when the user card is shown.
     this.subtree.check(() => this.isEditing());
   }
 

--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -125,13 +125,12 @@ export default class CommentPost extends Post {
   headerItems() {
     const items = new ItemList();
     const post = this.props.post;
-    const props = { post };
 
-    items.add('user', PostUser.component({ post: this.props.post }), 100);
-    items.add('meta', PostMeta.component(props));
+    items.add('user', PostUser.component({ post }), 100);
+    items.add('meta', PostMeta.component({ post }));
 
     if (post.isEdited() && !post.isHidden()) {
-      items.add('edited', PostEdited.component(props));
+      items.add('edited', PostEdited.component({ post }));
     }
 
     // If the post is hidden, add a button that allows toggling the visibility

--- a/js/src/forum/components/PostUser.js
+++ b/js/src/forum/components/PostUser.js
@@ -13,15 +13,6 @@ import listItems from '../../common/helpers/listItems';
  * - `post`
  */
 export default class PostUser extends Component {
-  init() {
-    /**
-     * Whether or not the user hover card is visible.
-     *
-     * @type {Boolean}
-     */
-    this.cardVisible = false;
-  }
-
   view() {
     const post = this.props.post;
     const user = post.user();
@@ -38,7 +29,7 @@ export default class PostUser extends Component {
 
     let card = '';
 
-    if (!post.isHidden() && this.cardVisible) {
+    if (!post.isHidden()) {
       card = UserCard.component({
         user,
         className: 'UserCard--popover',
@@ -81,10 +72,6 @@ export default class PostUser extends Component {
    * Show the user card.
    */
   showCard() {
-    this.cardVisible = true;
-
-    m.redraw();
-
     setTimeout(() => this.$('.UserCard').addClass('in'));
   }
 
@@ -92,11 +79,6 @@ export default class PostUser extends Component {
    * Hide the user card.
    */
   hideCard() {
-    this.$('.UserCard')
-      .removeClass('in')
-      .one('transitionend webkitTransitionEnd oTransitionEnd', () => {
-        this.cardVisible = false;
-        m.redraw();
-      });
+    this.$('.UserCard').removeClass('in');
   }
 }


### PR DESCRIPTION
**Refs #1821 #2144**

**Changes proposed in this pull request:**
- Don't store PostUser instance in commentPost
- Eliminate unnecessary cardVisible attribute of PostUser

**Reviewers should focus on:**
I am concerned about the `this.subtree.check(() => this.isEditing());` in `CommentPost.js`: I'm assuming we're dropping that in Mithril 2.0, but when I do so here, there's a delay when editing before the preview starts to show (for some reason, config isn't immediately called).

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
