### PR TITLE
Instances of models should not matter when checking permissions

### DIFF
--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -103,7 +103,7 @@ class UserServiceProvider extends AbstractServiceProvider
             // If no policy covered this permission query, we will only grant
             // the permission if the actor's groups have it. Otherwise, we will
             // not allow the user to perform this action.
-            if ($actor->isAdmin() || (! $model && $actor->hasPermission($ability))) {
+            if ($actor->isAdmin() || $actor->hasPermission($ability)) {
                 return true;
             }
 


### PR DESCRIPTION
**Ref #2092 **

**Changes proposed in this pull request:**
> So right now, the permission system has, essentially 4 layers, checked in the following order.
> 
> 1. Run through all relevant policies. If non-null returned, return that. Else, continue.
> 2. If the user is in a group that has the given permission and the permsission is not being evaluated on an instance of a model, return true. Else, continue.
> 3. If the user is in the admin group, return true. Else, continue.
> 4. Return false.
> 
> My proposed changes to the actual process are:
> 
> 1. Have an order of precedence for step (1), that being forceDeny, forceAllow, deny, allow. This solves the issue of dependence on extension boot order,
> 2. Don't disqualify step 2 if the permission is being evaluated on an instance of a model. I'm not really sure why that was there in the first place.
- From https://github.com/flarum/core/issues/2092#issuecomment-614233346

This PR does (2) above, by not disqualifying a user's group having a permission if the permission check is called on an instance. This system isn't intuitive, and was set up in a commit titled "fix permissions being incorrectly granted" (which tells us nothing) back from 2015. Looking at the history at the time, this logic was called BEFORE policies were called, which might explain the changes. Now that policies are considered first, this is no longer necessary.
https://github.com/flarum/core/commit/90def3f0db033244c1aa455727b9c1eb50694933

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
