### PR TITLE
Fix Paths test failing on Windows

### DIFF
--- a/src/Foundation/Paths.php
+++ b/src/Foundation/Paths.php
@@ -34,7 +34,7 @@ class Paths
         }, $paths);
 
         // Assume a standard Composer directory structure unless specified
-        $this->paths['vendor'] = $this->vendor ?? $this->base.DIRECTORY_SEPARATOR.'vendor';
+        $this->paths['vendor'] = $this->vendor ?? $this->base.'/vendor';
     }
 
     public function __get($name): ?string

--- a/tests/unit/Foundation/PathsTest.php
+++ b/tests/unit/Foundation/PathsTest.php
@@ -48,7 +48,7 @@ class PathsTest extends TestCase
             'storage' => '/var/www/flarum/storage',
         ]);
 
-        $this->assertEquals('/var/www/flarum'.DIRECTORY_SEPARATOR.'vendor', $paths->vendor);
+        $this->assertEquals('/var/www/flarum/vendor', $paths->vendor);
     }
 
     /** @test */

--- a/tests/unit/Foundation/PathsTest.php
+++ b/tests/unit/Foundation/PathsTest.php
@@ -48,7 +48,7 @@ class PathsTest extends TestCase
             'storage' => '/var/www/flarum/storage',
         ]);
 
-        $this->assertEquals('/var/www/flarum/vendor', $paths->vendor);
+        $this->assertEquals('/var/www/flarum'.DIRECTORY_SEPARATOR.'vendor', $paths->vendor);
     }
 
     /** @test */


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
The PathsTest fails on windows because of the directory separator, it's a backslash in windows.

**Confirmed**

- ~[ ] Frontend changes: tested on a local Flarum installation.~
- [x] Backend changes: tests are green (run `composer test`).
