### PR TITLE
Fix AvatarChanged event

### DIFF
--- a/src/User/AvatarUploader.php
+++ b/src/User/AvatarUploader.php
@@ -44,7 +44,7 @@ class AvatarUploader
 
     /**
      * Handle the removal of the old avatar file after a successful user save
-     * We don't place this in remove() because otherwise we would call changeAvatarPath 2 times when uploading
+     * We don't place this in remove() because otherwise we would call changeAvatarPath 2 times when uploading.
      * @param User $user
      */
     protected function removeFileAfterSave(User $user)

--- a/src/User/AvatarUploader.php
+++ b/src/User/AvatarUploader.php
@@ -36,13 +36,18 @@ class AvatarUploader
 
         $avatarPath = Str::random().'.png';
 
-        $this->remove($user);
+        $this->removeFileAfterSave($user);
         $user->changeAvatarPath($avatarPath);
 
         $this->uploadDir->put($avatarPath, $encodedImage);
     }
 
-    public function remove(User $user)
+    /**
+     * Handle the removal of the old avatar file after a successful user save
+     * We don't place this in remove() because otherwise we would call changeAvatarPath 2 times when uploading
+     * @param User $user
+     */
+    protected function removeFileAfterSave(User $user)
     {
         $avatarPath = $user->getOriginal('avatar_url');
 
@@ -51,6 +56,14 @@ class AvatarUploader
                 $this->uploadDir->delete($avatarPath);
             }
         });
+    }
+
+    /**
+     * @param User $user
+     */
+    public function remove(User $user)
+    {
+        $this->removeFileAfterSave($user);
 
         $user->changeAvatarPath(null);
     }

--- a/src/User/Command/UploadAvatarHandler.php
+++ b/src/User/Command/UploadAvatarHandler.php
@@ -80,6 +80,8 @@ class UploadAvatarHandler
 
         $user->save();
 
+        $this->dispatchEventsFor($user, $actor);
+
         return $user;
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

The `AvatarChanged` event is triggered on avatar delete, but not on avatar change due to a missing call to `dispatchEventsFor`.

I guess it's another of those events nobody tried to use before myself.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).