### PR TITLE
Use lifecycle interface for frontend extender

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -9,8 +9,6 @@
 
 namespace Flarum\Admin;
 
-use Flarum\Extension\Event\Disabled;
-use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
@@ -118,7 +116,7 @@ class AdminServiceProvider extends AbstractServiceProvider
         $events = $this->app->make('events');
 
         $events->listen(
-            [Enabled::class, Disabled::class, ClearingCache::class],
+            ClearingCache::class,
             function () {
                 $recompile = new RecompileFrontendAssets(
                     $this->app->make('flarum.assets.admin'),

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -80,7 +80,7 @@ class Frontend implements ExtenderInterface, LifecycleInterface
             return;
         }
 
-        $abstract = 'flarum.assets.'.$this->frontend;
+        $abstract = 'flarum.assets.' . $this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -104,7 +104,7 @@ class Frontend implements ExtenderInterface, LifecycleInterface
             }
         });
 
-        if (! $container->bound($abstract)) {
+        if (!$container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });
@@ -114,12 +114,8 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
             $events->listen(
                 ClearingCache::class,
-                function () use ($container, $abstract) {
-                    $recompile = new RecompileFrontendAssets(
-                        $container->make($abstract),
-                        $container->make(LocaleManager::class)
-                    );
-                    $recompile->flush();
+                function () use ($container) {
+                    $this->recompile($container);
                 }
             );
 
@@ -186,23 +182,24 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
     public function onEnable(Container $container, Extension $extension)
     {
-        if (! empty($this->js) || ! empty($this->css)) {
-            $recompile = new RecompileFrontendAssets(
-                $container->make('flarum.assets.'.$this->frontend),
-                $container->make(LocaleManager::class)
-            );
-            $recompile->flush();
+        if (!empty($this->js) || !empty($this->css)) {
+            $this->recompile($container);
         }
     }
 
     public function onDisable(Container $container, Extension $extension)
     {
-        if (! empty($this->js) || ! empty($this->css)) {
-            $recompile = new RecompileFrontendAssets(
-                $container->make('flarum.assets.'.$this->frontend),
-                $container->make(LocaleManager::class)
-            );
-            $recompile->flush();
+        if (!empty($this->js) || !empty($this->css)) {
+            $this->recompile($container);
         }
+    }
+
+    private function recompile($container)
+    {
+        $recompile = new RecompileFrontendAssets(
+            $container->make('flarum.assets.' . $this->frontend),
+            $container->make(LocaleManager::class)
+        );
+        $recompile->flush();
     }
 }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -80,7 +80,7 @@ class Frontend implements ExtenderInterface, LifecycleInterface
             return;
         }
 
-        $abstract = 'flarum.assets.' . $this->frontend;
+        $abstract = 'flarum.assets.'.$this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -104,7 +104,7 @@ class Frontend implements ExtenderInterface, LifecycleInterface
             }
         });
 
-        if (!$container->bound($abstract)) {
+        if (! $container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });
@@ -182,14 +182,14 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
     public function onEnable(Container $container, Extension $extension)
     {
-        if (!empty($this->js) || !empty($this->css)) {
+        if (! empty($this->js) || ! empty($this->css)) {
             $this->recompile($container);
         }
     }
 
     public function onDisable(Container $container, Extension $extension)
     {
-        if (!empty($this->js) || !empty($this->css)) {
+        if (! empty($this->js) || ! empty($this->css)) {
             $this->recompile($container);
         }
     }
@@ -197,7 +197,7 @@ class Frontend implements ExtenderInterface, LifecycleInterface
     private function recompile($container)
     {
         $recompile = new RecompileFrontendAssets(
-            $container->make('flarum.assets.' . $this->frontend),
+            $container->make('flarum.assets.'.$this->frontend),
             $container->make(LocaleManager::class)
         );
         $recompile->flush();

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -186,9 +186,9 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
     public function onEnable(Container $container, Extension $extension)
     {
-        if (!empty($this->js) || !empty($this->css)) {
+        if (! empty($this->js) || ! empty($this->css)) {
             $recompile = new RecompileFrontendAssets(
-                $container->make('flarum.assets.' . $this->frontend),
+                $container->make('flarum.assets.'.$this->frontend),
                 $container->make(LocaleManager::class)
             );
             $recompile->flush();
@@ -197,9 +197,9 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
     public function onDisable(Container $container, Extension $extension)
     {
-        if (!empty($this->js) || !empty($this->css)) {
+        if (! empty($this->js) || ! empty($this->css)) {
             $recompile = new RecompileFrontendAssets(
-                $container->make('flarum.assets.' . $this->frontend),
+                $container->make('flarum.assets.'.$this->frontend),
                 $container->make(LocaleManager::class)
             );
             $recompile->flush();

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -186,19 +186,23 @@ class Frontend implements ExtenderInterface, LifecycleInterface
 
     public function onEnable(Container $container, Extension $extension)
     {
-        $recompile = new RecompileFrontendAssets(
-            $container->make('flarum.assets.'.$this->frontend),
-            $container->make(LocaleManager::class)
-        );
-        $recompile->flush();
+        if (!empty($this->js) || !empty($this->css)) {
+            $recompile = new RecompileFrontendAssets(
+                $container->make('flarum.assets.' . $this->frontend),
+                $container->make(LocaleManager::class)
+            );
+            $recompile->flush();
+        }
     }
 
     public function onDisable(Container $container, Extension $extension)
     {
-        $recompile = new RecompileFrontendAssets(
-            $container->make('flarum.assets.'.$this->frontend),
-            $container->make(LocaleManager::class)
-        );
-        $recompile->flush();
+        if (!empty($this->js) || !empty($this->css)) {
+            $recompile = new RecompileFrontendAssets(
+                $container->make('flarum.assets.' . $this->frontend),
+                $container->make(LocaleManager::class)
+            );
+            $recompile->flush();
+        }
     }
 }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -9,8 +9,6 @@
 
 namespace Flarum\Forum;
 
-use Flarum\Extension\Event\Disabled;
-use Flarum\Extension\Event\Enabled;
 use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ErrorHandling\Registry;
@@ -134,7 +132,7 @@ class ForumServiceProvider extends AbstractServiceProvider
         $events = $this->app->make('events');
 
         $events->listen(
-            [Enabled::class, Disabled::class, ClearingCache::class],
+            ClearingCache::class,
             function () {
                 $recompile = new RecompileFrontendAssets(
                     $this->app->make('flarum.assets.forum'),


### PR DESCRIPTION
**Fixes #1935**

**Changes proposed in this pull request:**
- Use lifecycle hooks to recompile frontend assets on extension enable/disable
- Only recompile frontend assets if the extension included css or js

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
