### PR TITLE
Make scrubber handle have transparent background

### DIFF
--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -2,7 +2,7 @@
   & a {
     margin-left: -1px;
     color: @muted-color;
-    
+
     & .fa {
       font-size: 14px;
       margin-right: 2px;
@@ -39,7 +39,7 @@
 .Scrubber-handle {
   position: relative;
   z-index: 1;
-  background: @body-bg;
+  background: transparent;
   width: 100%;
   padding: 5px 0;
 }


### PR DESCRIPTION
Currently, the scrubber handle's background color is set to the forum's background color. This isn't ideal, because if a non-uniform-colored background is used, it looks awkward. By setting it to transparent, we lose nothing, but make it look better with gradient/picture based backgrounds