### PR TITLE
Fixes wrong IP address when using a reverse proxy

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -68,7 +68,7 @@ class AdminServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->bind('flarum.admin.proxy_middleware', function() {
+        $this->app->bind('flarum.admin.proxy_middleware', function () {
             $config = $this->app->get('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -69,7 +69,7 @@ class AdminServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->bind('flarum.admin.proxy_middleware', function () {
-            $config = $this->app->get('flarum.config');
+            $config = $this->app->make('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(
                 Arr::get($config, 'reverse_proxy.enabled', false),

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -67,7 +67,7 @@ class ApiServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->bind('flarum.api.proxy_middleware', function () {
-            $config = $this->app->get('flarum.config');
+            $config = $this->app->make('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(
                 Arr::get($config, 'reverse_proxy.enabled', false),

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -66,7 +66,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->bind('flarum.api.proxy_middleware', function() {
+        $this->app->bind('flarum.api.proxy_middleware', function () {
             $config = $this->app->get('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -22,6 +22,7 @@ use Flarum\Http\Middleware as HttpMiddleware;
 use Flarum\Http\RouteCollection;
 use Flarum\Http\RouteHandlerFactory;
 use Flarum\Http\UrlGenerator;
+use Illuminate\Support\Arr;
 use Laminas\Stratigility\MiddlewarePipe;
 
 class ApiServiceProvider extends AbstractServiceProvider
@@ -45,6 +46,7 @@ class ApiServiceProvider extends AbstractServiceProvider
         $this->app->singleton('flarum.api.middleware', function () {
             return [
                 'flarum.api.error_handler',
+                'flarum.api.proxy_middleware',
                 HttpMiddleware\ParseJsonBody::class,
                 Middleware\FakeHttpMethods::class,
                 HttpMiddleware\StartSession::class,
@@ -61,6 +63,15 @@ class ApiServiceProvider extends AbstractServiceProvider
                 $this->app->make(Registry::class),
                 new JsonApiFormatter($this->app['flarum']->inDebugMode()),
                 $this->app->tagged(Reporter::class)
+            );
+        });
+
+        $this->app->bind('flarum.api.proxy_middleware', function() {
+            $config = $this->app->get('flarum.config');
+
+            return new HttpMiddleware\ProxyAddress(
+                Arr::get($config, 'reverse_proxy.enabled', false),
+                Arr::get($config, 'reverse_proxy.allowed', ['127.0.0.1'])
             );
         });
 

--- a/src/Api/Controller/CreateDiscussionController.php
+++ b/src/Api/Controller/CreateDiscussionController.php
@@ -62,7 +62,7 @@ class CreateDiscussionController extends AbstractCreateController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
-        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
+        $ipAddress = $request->getAttribute('ipAddress');
 
         if (! $request->getAttribute('bypassFloodgate')) {
             $this->floodgate->assertNotFlooding($actor);

--- a/src/Api/Controller/CreatePostController.php
+++ b/src/Api/Controller/CreatePostController.php
@@ -63,7 +63,7 @@ class CreatePostController extends AbstractCreateController
         $actor = $request->getAttribute('actor');
         $data = Arr::get($request->getParsedBody(), 'data', []);
         $discussionId = Arr::get($data, 'relationships.discussion.data.id');
-        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
+        $ipAddress = $request->getAttribute('ipAddress');
 
         if (! $request->getAttribute('bypassFloodgate')) {
             $this->floodgate->assertNotFlooding($actor);

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -87,7 +87,6 @@ class ForumServiceProvider extends AbstractServiceProvider
             );
         });
 
-
         $this->app->singleton('flarum.forum.handler', function () {
             $pipe = new MiddlewarePipe;
 

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -79,7 +79,7 @@ class ForumServiceProvider extends AbstractServiceProvider
         });
 
         $this->app->bind('flarum.forum.proxy_middleware', function () {
-            $config = $this->app->get('flarum.config');
+            $config = $this->app->make('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(
                 Arr::get($config, 'reverse_proxy.enabled', false),

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -78,7 +78,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->bind('flarum.forum.proxy_middleware', function() {
+        $this->app->bind('flarum.forum.proxy_middleware', function () {
             $config = $this->app->get('flarum.config');
 
             return new HttpMiddleware\ProxyAddress(

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -59,12 +59,6 @@ class InstalledApp implements AppInterface
         $pipe = new MiddlewarePipe;
 
         $pipe->pipe(new BasePath($this->basePath()));
-        $pipe->pipe(
-            new ProxyAddress(
-                Arr::get($this->config, 'reverse_proxy.enabled', false),
-                Arr::get($this->config, 'reverse_proxy.allowed', ['127.0.0.1'])
-            )
-        );
         $pipe->pipe(new OriginalMessages);
         $pipe->pipe(
             new BasePathRouter([

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -11,11 +11,9 @@ namespace Flarum\Foundation;
 
 use Flarum\Foundation\Console\InfoCommand;
 use Flarum\Http\Middleware\DispatchRoute;
-use Flarum\Http\Middleware\ProxyAddress;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Support\Arr;
 use Laminas\Stratigility\Middleware\OriginalMessages;
 use Laminas\Stratigility\MiddlewarePipe;
 use Middlewares\BasePath;

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -11,9 +11,11 @@ namespace Flarum\Foundation;
 
 use Flarum\Foundation\Console\InfoCommand;
 use Flarum\Http\Middleware\DispatchRoute;
+use Flarum\Http\Middleware\ProxyAddress;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
 use Laminas\Stratigility\Middleware\OriginalMessages;
 use Laminas\Stratigility\MiddlewarePipe;
 use Middlewares\BasePath;
@@ -57,6 +59,11 @@ class InstalledApp implements AppInterface
         $pipe = new MiddlewarePipe;
 
         $pipe->pipe(new BasePath($this->basePath()));
+        $pipe->pipe(new ProxyAddress(
+                Arr::get($this->config, 'reverse_proxy.enabled', false),
+                Arr::get($this->config, 'reverse_proxy.allowed', ['127.0.0.1'])
+            )
+        );
         $pipe->pipe(new OriginalMessages);
         $pipe->pipe(
             new BasePathRouter([

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -59,7 +59,8 @@ class InstalledApp implements AppInterface
         $pipe = new MiddlewarePipe;
 
         $pipe->pipe(new BasePath($this->basePath()));
-        $pipe->pipe(new ProxyAddress(
+        $pipe->pipe(
+            new ProxyAddress(
                 Arr::get($this->config, 'reverse_proxy.enabled', false),
                 Arr::get($this->config, 'reverse_proxy.allowed', ['127.0.0.1'])
             )

--- a/src/Http/Exception/ProxyNotAllowedException.php
+++ b/src/Http/Exception/ProxyNotAllowedException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http\Exception;
+
+use Exception;
+use Flarum\Foundation\KnownError;
+
+class ProxyNotAllowedException extends Exception implements KnownError
+{
+    public function getType(): string
+    {
+        return 'reverse_proxy_not_allowed';
+    }
+}

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -61,7 +61,7 @@ class ProxyAddress implements Middleware
                 $ipAddress = Arr::get($serverParams, 'HTTP_CLIENT_IP', $ipAddress);
                 $ipAddress = Arr::get($serverParams, 'X_PROXYUSER_IP', $ipAddress);
             } else {
-                throw new ProxyNotAllowedException("The used proxy isn't allowed to connect!");
+                throw new ProxyNotAllowedException();
             }
         }
 

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -51,14 +51,15 @@ class ProxyAddress implements Middleware
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
+        $serverParams = $request->getServerParams();
+        $ipAddress = Arr::get($serverParams, 'REMOTE_ADDR', '127.0.0.1');
 
         if ($this->enabled) {
             if ($this->wildcardMatch($ipAddress)) {
                 // standard header for proxies, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
-                $ipAddress = Arr::get($request->getServerParams(), 'X_FORWARDED_FOR', $ipAddress);
-                $ipAddress = Arr::get($request->getServerParams(), 'HTTP_CLIENT_IP', $ipAddress);
-                $ipAddress = Arr::get($request->getServerParams(), 'X_PROXYUSER_IP', $ipAddress);
+                $ipAddress = Arr::get($serverParams, 'X_FORWARDED_FOR', $ipAddress);
+                $ipAddress = Arr::get($serverParams, 'HTTP_CLIENT_IP', $ipAddress);
+                $ipAddress = Arr::get($serverParams, 'X_PROXYUSER_IP', $ipAddress);
             } else {
                 throw new ProxyNotAllowedException("The used proxy isn't allowed to connect!");
             }

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -52,7 +52,7 @@ class ProxyAddress implements Middleware
             }
         }
 
-        $request->withAttribute('ipAddress', $ipAddress);
+        $request = $request->withAttribute('ipAddress', $ipAddress);
 
         return $handler->handle($request);
     }

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 class ProxyAddress implements Middleware
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected $enabled;
 
@@ -52,7 +52,7 @@ class ProxyAddress implements Middleware
             }
         }
 
-        $request->withAttribute("ipAddress", $ipAddress);
+        $request->withAttribute('ipAddress', $ipAddress);
 
         return $handler->handle($request);
     }

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http\Middleware;
+
+use Flarum\Http\Exception\ProxyNotAllowedException;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ProxyAddress implements Middleware
+{
+    /**
+     * @var boolean
+     */
+    protected $enabled;
+
+    /**
+     * @var array
+     */
+    protected $allowedAddresses;
+
+    /**
+     * @param bool $enabled
+     * @param array $allowedAddresses
+     */
+    public function __construct($enabled, $allowedAddresses)
+    {
+        $this->enabled = $enabled;
+        $this->allowedAddresses = $allowedAddresses;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
+
+        if ($this->enabled) {
+            if (in_array($ipAddress, $this->allowedAddresses)) {
+                // standard header for proxies, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+                $ipAddress = Arr::get($request->getServerParams(), 'X_FORWARDED_FOR', $ipAddress);
+                $ipAddress = Arr::get($request->getServerParams(), 'HTTP_CLIENT_IP', $ipAddress);
+            } else {
+                throw new ProxyNotAllowedException("The used proxy isn't allowed to connect!");
+            }
+        }
+
+        $request->withAttribute("ipAddress", $ipAddress);
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -38,10 +38,12 @@ class ProxyAddress implements Middleware
         $this->allowedAddresses = $allowedAddresses;
     }
 
-    private function wildcardMatch(string $ipAddress): bool {
+    private function wildcardMatch(string $ipAddress): bool
+    {
         foreach ($this->allowedAddresses as $allowedAddress) {
-            if (fnmatch($allowedAddress, $ipAddress))
+            if (fnmatch($allowedAddress, $ipAddress)) {
                 return true;
+            }
         }
 
         return false;

--- a/src/Http/Middleware/ProxyAddress.php
+++ b/src/Http/Middleware/ProxyAddress.php
@@ -58,6 +58,7 @@ class ProxyAddress implements Middleware
                 // standard header for proxies, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
                 $ipAddress = Arr::get($request->getServerParams(), 'X_FORWARDED_FOR', $ipAddress);
                 $ipAddress = Arr::get($request->getServerParams(), 'HTTP_CLIENT_IP', $ipAddress);
+                $ipAddress = Arr::get($request->getServerParams(), 'X_PROXYUSER_IP', $ipAddress);
             } else {
                 throw new ProxyNotAllowedException("The used proxy isn't allowed to connect!");
             }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Two new **optional** config values: 
- `reverse_proxy.enabled` will enable ip address finding of a user using a reverse proxy at `\Http\Middleware\ProxyAddress`
- `reverse_proxy.allowed` controls the allowed reverse proxy IPs used for checking.

Changed `Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');` to `$request->getAttribute('ipAddress');` to use the new attribute in the codebase.

**Reviewers should focus on:**
- The Middleware is added in` \Flarum\Foundation\InstalledApp` and im unsure if this is the correct/best position.

**Confirmed**

- [x] Backend changes: 2 failures (WritablePathsTest which is not related to the changes I made).

**Required changes:**

- [x] Related documentation PR: TODO (Would be good to document the optional config values.)