### PR TITLE
Pass a translator instance to getEmailSubject on MailableInterface

### DIFF
--- a/src/Notification/MailableInterface.php
+++ b/src/Notification/MailableInterface.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Notification;
 
+use Symfony\Component\Translation\TranslatorInterface;
+
 interface MailableInterface
 {
     /**
@@ -23,5 +25,5 @@ interface MailableInterface
      *
      * @return string
      */
-    public function getEmailSubject();
+    public function getEmailSubject(TranslatorInterface $translator);
 }

--- a/src/Notification/MailableInterface.php
+++ b/src/Notification/MailableInterface.php
@@ -25,5 +25,7 @@ interface MailableInterface
      *
      * @return string
      */
-    public function getEmailSubject(TranslatorInterface $translator);
+    // TODO: This is temporarily commented out to avoid BC breaks between beta 13 and beta 14.
+    // It should be uncommented before beta 15.
+    // public function getEmailSubject(TranslatorInterface $translator);
 }

--- a/src/Notification/NotificationMailer.php
+++ b/src/Notification/NotificationMailer.php
@@ -12,6 +12,7 @@ namespace Flarum\Notification;
 use Flarum\User\User;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Mail\Message;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class NotificationMailer
 {
@@ -21,11 +22,18 @@ class NotificationMailer
     protected $mailer;
 
     /**
-     * @param Mailer $mailer
+     * @var TranslatorInterface
      */
-    public function __construct(Mailer $mailer)
+    protected $translator;
+
+    /**
+     * @param Mailer $mailer
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(Mailer $mailer, TranslatorInterface $translator)
     {
         $this->mailer = $mailer;
+        $this->translator = $translator;
     }
 
     /**
@@ -39,7 +47,7 @@ class NotificationMailer
             compact('blueprint', 'user'),
             function (Message $message) use ($blueprint, $user) {
                 $message->to($user->email, $user->username)
-                        ->subject($blueprint->getEmailSubject());
+                        ->subject($blueprint->getEmailSubject($this->translator));
             }
         );
     }


### PR DESCRIPTION
As per #2169, the notification views have access to the translator interface. The email subject, however, does not. That makes it the last significant piece where english is hardcoded. This PR revises the MailableInterface to pass a TranslatorInterface instance to getEmailSubject. It is a breaking change, but I think it is one that is worth it. The only way to do this without a breaking change would be to:

1. Create a TranslatedMailableInterface, deprecate MailableInterface
2. Remove MailableInterface
3. Deprecate TranslatedMailableInterface, make a new MailableInterface which is a copy-paste of TranslatedMailableInterface
4. Remove TranslatatedMailableInterface

Alternatively, a translator instance could be passed into every instantiation of a blueprint, but imo that is not nearly as clean (since all email subjects should be translated).