### PR TITLE
Fix optional parameters in url generator

### DIFF
--- a/src/Http/RouteCollection.php
+++ b/src/Http/RouteCollection.php
@@ -88,7 +88,23 @@ class RouteCollection
     public function getPath($name, array $parameters = [])
     {
         if (isset($this->reverse[$name])) {
+            $curr_max_count = 0;
             $parts = $this->reverse[$name][0];
+
+            // For a given route name, we want to choose the option that best matches the given parameters.
+            // Each routing option is an array of parts. Each part is either a constant string
+            // (which we don't care about here), or an array where the first element is the parameter name
+            // and the second element is a regex into which the parameter value is inserted, if the parameter matches.
+            foreach ($this->reverse[$name] as $parts_option) {
+                for ($i = 0; $i < count($parts_option); $i++) {
+                    $part = $parts_option[$i];
+                    if (is_array($part) && in_array($part[0], array_keys($parameters)) && $i > $curr_max_count) {
+                        $curr_max_count = $i;
+                        $parts = $parts_option;
+                    }
+                }
+            }
+
             array_walk($parts, [$this, 'fixPathPart'], $parameters);
 
             return '/'.ltrim(implode('', $parts), '/');

--- a/tests/unit/Foundation/RouteCollectionTest.php
+++ b/tests/unit/Foundation/RouteCollectionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Foundation;
+
+use Flarum\Foundation\Paths;
+use Flarum\Http\RouteCollection;
+use Flarum\Tests\unit\TestCase;
+use InvalidArgumentException;
+use RuntimeException;
+
+class RouteCollectionTest extends TestCase
+{
+    /** @test */
+    public function it_errors_when_nonexistent_route_requested()
+    {
+        $collection = new RouteCollection();
+
+        $this->expectException(RuntimeException::class);
+
+        $collection->getPath('nonexistent');
+    }
+
+
+    /** @test */
+    public function it_properly_processes_a_simple_route_with_no_parameters()
+    {
+        $collection = new RouteCollection();
+        // We can use anything for the handler since we're only testing getPath
+        $collection->addRoute('GET', '/custom/route', 'custom', '');
+
+        $this->assertEquals('/custom/route', $collection->getPath('custom'));
+    }
+
+
+    /** @test */
+    public function it_properly_processes_a_route_with_all_parameters_required()
+    {
+        $collection = new RouteCollection();
+        // We can use anything for the handler since we're only testing getPath
+        $collection->addRoute('GET', '/custom/{route}/{has}/{parameters}', 'custom', '');
+
+        $this->assertEquals('/custom/something/something_else/anything_else', $collection->getPath('custom', [
+            'route' => 'something',
+            'has' => 'something_else',
+            'parameters' => 'anything_else'
+        ]));
+    }
+
+
+    /** @test */
+    public function it_works_if_optional_parameters_are_missing()
+    {
+        $collection = new RouteCollection();
+        // We can use anything for the handler since we're only testing getPath
+        $collection->addRoute('GET', '/custom/{route}[/{has}]', 'custom', '');
+
+        $this->assertEquals('/custom/something', $collection->getPath('custom', [
+            'route' => 'something'
+        ]));
+    }
+
+
+    /** @test */
+    public function it_works_with_optional_parameters()
+    {
+        $collection = new RouteCollection();
+        // We can use anything for the handler since we're only testing getPath
+        $collection->addRoute('GET', '/custom/{route}[/{has}]', 'custom', '');
+
+        $this->assertEquals('/custom/something/something_else', $collection->getPath('custom', [
+            'route' => 'something',
+            'has' => 'something_else'
+        ]));
+    }
+}

--- a/tests/unit/Foundation/RouteCollectionTest.php
+++ b/tests/unit/Foundation/RouteCollectionTest.php
@@ -9,10 +9,8 @@
 
 namespace Flarum\Tests\unit\Foundation;
 
-use Flarum\Foundation\Paths;
 use Flarum\Http\RouteCollection;
 use Flarum\Tests\unit\TestCase;
-use InvalidArgumentException;
 use RuntimeException;
 
 class RouteCollectionTest extends TestCase
@@ -27,7 +25,6 @@ class RouteCollectionTest extends TestCase
         $collection->getPath('nonexistent');
     }
 
-
     /** @test */
     public function it_properly_processes_a_simple_route_with_no_parameters()
     {
@@ -37,7 +34,6 @@ class RouteCollectionTest extends TestCase
 
         $this->assertEquals('/custom/route', $collection->getPath('custom'));
     }
-
 
     /** @test */
     public function it_properly_processes_a_route_with_all_parameters_required()
@@ -53,7 +49,6 @@ class RouteCollectionTest extends TestCase
         ]));
     }
 
-
     /** @test */
     public function it_works_if_optional_parameters_are_missing()
     {
@@ -65,7 +60,6 @@ class RouteCollectionTest extends TestCase
             'route' => 'something'
         ]));
     }
-
 
     /** @test */
     public function it_works_with_optional_parameters()


### PR DESCRIPTION
**Fixes #1972**

**Changes proposed in this pull request:**
- Select the most fitting paths option instead of the first one to support using url generator with optional parameters
- Add unit tests for this functionality

**Reviewers should focus on:**
- Any shortcomings in the algorithm I used?
- Any code style recommendations? The variable naming I feel a bit iffy on

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x[ Backend changes: tests are green (run `composer test`).
