### PR TITLE
Fix ui of deleting discussion from user discussions page

### DIFF
--- a/js/src/forum/components/DiscussionsUserPage.js
+++ b/js/src/forum/components/DiscussionsUserPage.js
@@ -22,6 +22,8 @@ export default class DiscussionsUserPage extends UserPage {
     });
 
     this.state.refresh();
+
+    app.current.set('discussions', this.state);
   }
 
   content() {

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -6,6 +6,7 @@ import Separator from '../../common/components/Separator';
 import RenameDiscussionModal from '../components/RenameDiscussionModal';
 import ItemList from '../../common/utils/ItemList';
 import extractText from '../../common/utils/extractText';
+import DiscussionsUserPage from '../components/DiscussionsUserPage';
 
 /**
  * The `DiscussionControls` utility constructs a list of buttons for a
@@ -227,7 +228,13 @@ export default {
         app.history.back();
       }
 
-      return this.delete().then(() => app.discussions.removeDiscussion(this));
+      return this.delete().then(() => {
+        app.discussions.removeDiscussion(this);
+
+        if (app.current.matches(DiscussionsUserPage)) {
+          app.current.get('discussions').removeDiscussion(this);
+        }
+      });
     }
   },
 


### PR DESCRIPTION
**Fixes #2233**

**Changes proposed in this pull request:**
If we are on a discussions user page when we delete a discussion, it should be removed from that page's discussion list.

**Reviewers should focus on:**
Seems relatively trivial to be honest. Tested locally.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
