### PR TITLE
Fix number abbreviation when the number is n-thousand

### DIFF
--- a/js/src/common/utils/abbreviateNumber.ts
+++ b/js/src/common/utils/abbreviateNumber.ts
@@ -10,7 +10,7 @@ export default function abbreviateNumber(number: number): string {
   if (number >= 1000000) {
     return Math.floor(number / 1000000) + app.translator.trans('core.lib.number_suffix.mega_text');
   } else if (number >= 1000) {
-    return Math.floor(number / 1000) + app.translator.trans('core.lib.number_suffix.kilo_text');
+    return (number / 1000).toFixed(1) + app.translator.trans('core.lib.number_suffix.kilo_text');
   } else {
     return number.toString();
   }


### PR DESCRIPTION
**Changes proposed in this pull request:**

This commit fixes the method `abbreviateNumber` so that it behaves as stated in the JSDoc.

Previously, an input of `1234` would have produced `1K`. With this change, the output will be `1.2K`.

**Reviewers should focus on:**

/

**Screenshot**

/

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

