### PR TITLE
Fix opening modals from other modals.

### DIFF
--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -27,10 +27,6 @@ export default class Modal extends Component {
     this.attrs.onshow(() => this.onready());
   }
 
-  onremove() {
-    this.attrs.onhide();
-  }
-
   view() {
     if (this.alertAttrs) {
       this.alertAttrs.dismissible = false;

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -17,7 +17,7 @@ export default class ModalManager extends Component {
   }
 
   onupdate() {
-    if (this.$('Modal') && !this.attrs.state.modal) {
+    if (this.$('.Modal') && !this.attrs.state.modal) {
       this.animateHide();
     }
   }

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -16,6 +16,12 @@ export default class ModalManager extends Component {
     );
   }
 
+  onupdate() {
+    if (this.$('Modal') && !this.attrs.state.modal) {
+      this.animateHide();
+    }
+  }
+
   oncreate(vnode) {
     super.oncreate(vnode);
 


### PR DESCRIPTION
**DO NOT MERGE WHEN APPROVED, REROUTE TO MASTER AFTER THE REWRITE IS MERGED**

While seemingly correct, an onremove method in Modal that triggers animateHide is problematic, because if one modal is opened from another, the one currently open will be removed from the DOM, triggering animateHide, and closing the new modal.

To compensate, an onupdate method now closes a modal if one is open but shouldn't be; this supports the functionality of the old method when the modal is closed not from the modal instance itself (e.g. app.modal.close())

This is not ideal, but necessary. We should consider eventually expanding the modal system to support showing multiple modals at the same time (stacked over each other). Then, we can move this back to individual modals.
