### PR TITLE
Revert to using state.needsScroll for triggering scrolls with PostStream

### DIFF
--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -121,15 +121,10 @@ export default class PostStream extends Component {
    * Start scrolling, if appropriate, to a newly-targeted post.
    */
   triggerScroll() {
-    if (!this.attrs.targetPost) return;
+    if (!this.attrs.targetPost || !this.stream.needsScroll) return;
 
-    const oldTarget = this.prevTarget;
     const newTarget = this.attrs.targetPost;
-
-    if (oldTarget) {
-      if ('number' in oldTarget && oldTarget.number === newTarget.number) return;
-      if ('index' in oldTarget && oldTarget.index === newTarget.index) return;
-    }
+    this.stream.needsScroll = false;
 
     if ('number' in newTarget) {
       this.scrollToNumber(newTarget.number, this.stream.noAnimationScroll);
@@ -137,8 +132,6 @@ export default class PostStream extends Component {
       const backwards = newTarget.index === this.stream.count() - 1;
       this.scrollToIndex(newTarget.index, this.stream.noAnimationScroll, backwards);
     }
-
-    this.prevTarget = newTarget;
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -91,6 +91,7 @@ class PostStreamState {
 
     this.loadPromise = this.loadNearNumber(number);
 
+    this.needsScroll = true;
     this.targetPost = { number };
     this.noAnimationScroll = noAnimation;
     this.number = number;
@@ -115,6 +116,7 @@ class PostStreamState {
 
     this.loadPromise = this.loadNearIndex(index);
 
+    this.needsScroll = true;
     this.targetPost = { index };
     this.noAnimationScroll = noAnimation;
     this.index = index;


### PR DESCRIPTION
While more pleasant from an FSM standpoint, comparing the current targetPost to the previous one does not work if goToNumber is called twice in a row for the same post. For instance, if a user clicks the mentions link to a post twice, post stream breaks.