### PR TITLE
Added alt attribute to avatar's img tag

### DIFF
--- a/js/src/common/helpers/avatar.js
+++ b/js/src/common/helpers/avatar.js
@@ -25,7 +25,7 @@ export default function avatar(user, attrs = {}) {
     if (hasTitle) attrs.title = attrs.title || username;
 
     if (avatarUrl) {
-      return <img {...attrs} src={avatarUrl} alt={username} />;
+      return <img {...attrs} src={avatarUrl} alt="" />;
     }
 
     content = username.charAt(0).toUpperCase();

--- a/js/src/common/helpers/avatar.js
+++ b/js/src/common/helpers/avatar.js
@@ -25,7 +25,7 @@ export default function avatar(user, attrs = {}) {
     if (hasTitle) attrs.title = attrs.title || username;
 
     if (avatarUrl) {
-      return <img {...attrs} src={avatarUrl} />;
+      return <img {...attrs} src={avatarUrl} alt={username} />;
     }
 
     content = username.charAt(0).toUpperCase();


### PR DESCRIPTION
Fixes #2256 

**Changes proposed in this pull request:**

Adds an `alt` attribute in the `img` tag and value is set to the author's username. Improves SEO and makes site more accessible.

**Screenshot**

![Screenshot from 2020-08-21 01-37-21](https://user-images.githubusercontent.com/16922883/90820384-ea88a780-e34e-11ea-80ed-80e943a72eab.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).