### PR TITLE
Make queue error handler compatible with Laravel 6

### DIFF
--- a/src/Queue/ExceptionHandler.php
+++ b/src/Queue/ExceptionHandler.php
@@ -59,4 +59,15 @@ class ExceptionHandler implements ExceptionHandling
     {
         // TODO: Implement renderForConsole() method.
     }
+
+    /**
+     * Determine if the exception should be reported.
+     *
+     * @param  \Exception $e
+     * @return bool
+     */
+    public function shouldReport(Exception $e)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
**Relates to #2055**

The method was added to the contract, so we need to add it to our implementation as well.
This must have been an oversight in the upgrade to Laravel 5.8, if I remember correctly.