### PR TITLE
Fix composer header hidden by mobile browser

### DIFF
--- a/js/src/forum/components/Composer.js
+++ b/js/src/forum/components/Composer.js
@@ -270,7 +270,7 @@ export default class Composer extends Component {
     this.animateHeightChange().then(() => this.focus());
 
     if (app.screen() === 'phone') {
-      this.$().css('top', $(window).scrollTop());
+      this.$().css('top', 0);
       this.showBackdrop();
     }
   }

--- a/less/forum/Composer.less
+++ b/less/forum/Composer.less
@@ -114,7 +114,7 @@
     background: @body-bg;
 
     &:not(.minimized) {
-      position: absolute;
+      position: fixed;
       top: 0;
       height: 350px !important;
       padding-top: @header-height-phone;


### PR DESCRIPTION
**Fixes #1670**

**Changes proposed in this pull request:**
Fixes the position of the composer to the screen, you can test this in https://beta.flarum.site, just make sure you add the relevant CSS from the admin section.
```css
@media (max-width: 767px) {
    .Composer:not(.minimized) {
        position: fixed;
    }
}
```

**Reviewers should focus on:**
My only concern is that looking at git blame, the composer's position was made absolute in 2015 to fix a bug with iOs 8/9, but there doesn't seem to be any mention of what that bug exactly was, so I cannot tell if this could potentially bring back that bug.

Relevant commit: https://github.com/flarum/core/commit/e6e2cdd3e98be6268f4dd7fb370d366f565ae72e

**Screenshot**
The issue has images of the bug fixed by this PR.

**Confirmed**
- ~[ ] Frontend changes: tested on a local Flarum installation.~
- ~[ ] Backend changes: tests are green (run `composer test`).~
