### PR TITLE
Remove unwanted semicolon in assets files

### DIFF
--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -65,7 +65,7 @@ class JsCompiler extends RevisionCompiler
      */
     protected function format(string $string): string
     {
-        return preg_replace('~//# sourceMappingURL.*$~m', '', $string).";\n";
+        return preg_replace('~//# sourceMappingURL.*$~m', '', $string)."\n";
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2120**

**Changes proposed in this pull request:**
Removes an unnecessary / unwanted semicolon that is generated in ```/assets/forum-<hash>.js``` and ```/assets/admin-<hash>.js```.

As mentioned by @clarkwinkelmann the problem is found here:
https://github.com/flarum/core/blob/d492579638fb52dafbfe65f1f36a95eb6047f7f3/src/Frontend/Compiler/JsCompiler.php#L72

I simply removed the extra semicolon. No errors showing.
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Confirmed**

~~- [ ] Frontend changes: tested on a local Flarum installation.~~
~~- [ ] Backend changes: tests are green (run `composer test`).~~
