### PR TITLE
Fix SMTP username and password shouldn't be required

### DIFF
--- a/src/Mail/SmtpDriver.php
+++ b/src/Mail/SmtpDriver.php
@@ -34,8 +34,8 @@ class SmtpDriver implements DriverInterface
             'mail_host' => 'required',
             'mail_port' => 'nullable|integer',
             'mail_encryption' => 'nullable|in:tls,ssl',
-            'mail_username' => 'required',
-            'mail_password' => 'required',
+            'mail_username' => 'nullable|string',
+            'mail_password' => 'nullable|string',
         ])->errors();
     }
 


### PR DESCRIPTION
**Fixes [#2253](https://github.com/flarum/core/issues/2253)**

**Changes proposed in this pull request:**
Some SMTP servers do not require a password and possibly not a username either. The library handles username-less and password-less correctly so we shouldn't require them in the interface

**Reviewers should focus on:**
Nothing

**Screenshot**
The issue has images of the bug fixed by this PR.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
