### PR TITLE
Don't scroll IndexPage oncreate if not on desktop

### DIFF
--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -91,12 +91,14 @@ export default class IndexPage extends Page {
 
     $('#app').css('min-height', $(window).height() + heroHeight);
 
-    // Scroll to the remembered position. We do this after a short delay so that
-    // it happens after the browser has done its own "back button" scrolling,
-    // which isn't right. https://github.com/flarum/core/issues/835
-    const scroll = () => $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
-    scroll();
-    setTimeout(scroll, 1);
+    if (app.screen() == 'desktop' || app.screen() == 'desktop-hd') {
+      // Scroll to the remembered position. We do this after a short delay so that
+      // it happens after the browser has done its own "back button" scrolling,
+      // which isn't right. https://github.com/flarum/core/issues/835
+      const scroll = () => $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
+      scroll();
+      setTimeout(scroll, 1);
+    }
 
     // If we've just returned from a discussion page, then the constructor will
     // have set the `lastDiscussion` property. If this is the case, we want to


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/2284**

**Changes proposed in this pull request:**
Only scroll IndexPage in oncreate if on desktop or larger.

**Reviewers should focus on:**
Do we still need this with the Mithril 2 update changes?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
