### PR TITLE
Allow upper case TLS and SSL for SMTP encryption

### DIFF
--- a/src/Mail/SmtpDriver.php
+++ b/src/Mail/SmtpDriver.php
@@ -33,7 +33,7 @@ class SmtpDriver implements DriverInterface
         return $validator->make($settings->all(), [
             'mail_host' => 'required',
             'mail_port' => 'nullable|integer',
-            'mail_encryption' => 'nullable|in:tls,ssl',
+            'mail_encryption' => 'nullable|in:tls,ssl,TLS,SSL',
             'mail_username' => 'nullable|string',
             'mail_password' => 'nullable|string',
         ])->errors();


### PR DESCRIPTION
If I remember correctly, the SMTP driver doesn't ACTUALLY care about case sensitivity for encryption names. This change should make setup a bit less confusing for people, since all-uppercase is a common convention for capitalized names.