### PR TITLE
Fix issue where posts API doesn't return the right amount of posts

### DIFF
--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -108,12 +108,13 @@ class ListPostsController extends AbstractListController
      */
     private function getPostIds(ServerRequestInterface $request)
     {
+        $actor = $request->getAttribute('actor');
         $filter = $this->extractFilter($request);
         $sort = $this->extractSort($request);
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);
 
-        $query = $this->posts->query();
+        $query = $this->posts->query()->whereVisibleTo($actor);
 
         $this->applyFilters($query, $filter);
 


### PR DESCRIPTION
**Fixes #2071**

**Changes proposed in this pull request:**
Check for permissions when getting the post Ids. 

- [x] Tested locally