### PR TITLE
Revert "Use lifecycle interface for frontend extender"

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Admin;
 
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
@@ -116,7 +118,7 @@ class AdminServiceProvider extends AbstractServiceProvider
         $events = $this->app->make('events');
 
         $events->listen(
-            ClearingCache::class,
+            [Enabled::class, Disabled::class, ClearingCache::class],
             function () {
                 $recompile = new RecompileFrontendAssets(
                     $this->app->make('flarum.assets.admin'),

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Forum;
 
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
 use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ErrorHandling\Registry;
@@ -132,7 +134,7 @@ class ForumServiceProvider extends AbstractServiceProvider
         $events = $this->app->make('events');
 
         $events->listen(
-            ClearingCache::class,
+            [Enabled::class, Disabled::class, ClearingCache::class],
             function () {
                 $recompile = new RecompileFrontendAssets(
                     $this->app->make('flarum.assets.forum'),


### PR DESCRIPTION
Reverts flarum/core#2211, see rationale in https://github.com/flarum/core/pull/2211#issuecomment-695212398