### PR TITLE
Replace $app->url() with url-generated link to index

### DIFF
--- a/views/error/not_found.blade.php
+++ b/views/error/not_found.blade.php
@@ -5,7 +5,7 @@
     {{ $message }}
   </p>
   <p>
-    <a href="{{ $url->to('forum')->route('index') }}">
+    <a href="{{ $url->to('forum')->base() }}">
       {{ $translator->trans('core.views.error.not_found_return_link', ['{forum}' => $settings->get('forum_title')]) }}
     </a>
   </p>

--- a/views/error/not_found.blade.php
+++ b/views/error/not_found.blade.php
@@ -5,7 +5,7 @@
     {{ $message }}
   </p>
   <p>
-    <a href="{{ $app->url() }}">
+    <a href="{{ $url->to('forum')->route('index') }}">
       {{ $translator->trans('core.views.error.not_found_return_link', ['{forum}' => $settings->get('forum_title')]) }}
     </a>
   </p>


### PR DESCRIPTION
The `url` method of Container was removed in #2142.  Works locally.