### PR TITLE
Revert https://github.com/flarum/core/pull/1536

### DIFF
--- a/src/User/UserPolicy.php
+++ b/src/User/UserPolicy.php
@@ -36,7 +36,7 @@ class UserPolicy extends AbstractPolicy
      */
     public function find(User $actor, Builder $query)
     {
-        if ($actor->cannot('viewUserList')) {
+        if ($actor->cannot('viewDiscussions')) {
             if ($actor->isGuest()) {
                 $query->whereRaw('FALSE');
             } else {

--- a/tests/integration/api/users/UpdateTest.php
+++ b/tests/integration/api/users/UpdateTest.php
@@ -35,6 +35,7 @@ class UpdateTest extends TestCase
             ],
             'group_permission' => [
                 ['permission' => 'viewUserList', 'group_id' => 3],
+                ['permission' => 'viewDiscussions', 'group_id' => 3]
             ]
         ]);
     }


### PR DESCRIPTION
**Refs #1680**. The rest will be fixed in https://github.com/flarum/core/pull/2212, but we can get this particular bug fixed in time for the next release.

Essentially, among our permission scheme, we have the `viewDiscussions` and `viewUserList` permissions. The first actually serves as a generic access permission for the entire forum, while the second is intended for the LIST users API. IE, `viewUserList` controls whether the list of users can be searched. This is further explained in https://github.com/flarum/core/issues/1680#issuecomment-444286686.

This PR fixes the second part of that comment, so that people stop seeing errors when refreshing the page after going to a user profile. This means that the `viewUserList` permission can now be used as intended, and unnecessary user searching can be restricted.

The rest (renaming permissions) will be done in https://github.com/flarum/core/pull/2212, but we need to discuss (and agree upon) a permission naming convention first.