### PR TITLE
Mithril 2 modal fixes

### DIFF
--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -27,6 +27,10 @@ export default class Modal extends Component {
     this.attrs.onshow(() => this.onready());
   }
 
+  onremove() {
+    this.attrs.onhide();
+  }
+
   view() {
     if (this.alertAttrs) {
       this.alertAttrs.dismissible = false;

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -31,7 +31,7 @@ export default class Modal extends Component {
     // If the global modal state currently contains a modal,
     // we've just opened up a new one, and accordingly,
     // we don't need to show a hide animation.
-    if (!app.modal.modal) {
+    if (!this.attrs.state.modal) {
       this.attrs.onhide();
     }
   }
@@ -112,7 +112,7 @@ export default class Modal extends Component {
    * Hide the modal.
    */
   hide() {
-    app.modal.close();
+    this.attrs.state.close();
   }
 
   /**

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -24,7 +24,7 @@ export default class Modal extends Component {
   oncreate(vnode) {
     super.oncreate(vnode);
 
-    this.attrs.onshow(() => this.onready());
+    this.attrs.animateShow(() => this.onready());
   }
 
   onbeforeremove() {
@@ -32,7 +32,7 @@ export default class Modal extends Component {
     // we've just opened up a new one, and accordingly,
     // we don't need to show a hide animation.
     if (!this.attrs.state.modal) {
-      this.attrs.onhide();
+      this.attrs.animateHide();
     }
   }
 

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -27,8 +27,13 @@ export default class Modal extends Component {
     this.attrs.onshow(() => this.onready());
   }
 
-  onremove() {
-    this.attrs.onhide();
+  onbeforeremove() {
+    // If the global modal state currently contains a modal,
+    // we've just opened up a new one, and accordingly,
+    // we don't need to show a hide animation.
+    if (!app.modal.modal) {
+      this.attrs.onhide();
+    }
   }
 
   view() {
@@ -107,7 +112,7 @@ export default class Modal extends Component {
    * Hide the modal.
    */
   hide() {
-    this.attrs.onhide();
+    app.modal.close();
   }
 
   /**

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -16,12 +16,6 @@ export default class ModalManager extends Component {
     );
   }
 
-  onupdate() {
-    if (this.$('.Modal') && !this.attrs.state.modal) {
-      this.animateHide();
-    }
-  }
-
   oncreate(vnode) {
     super.oncreate(vnode);
 

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -14,8 +14,8 @@ export default class ModalManager extends Component {
         {modal
           ? modal.componentClass.component({
               ...modal.attrs,
-              onshow: this.animateShow.bind(this),
-              onhide: this.animateHide.bind(this),
+              animateShow: this.animateShow.bind(this),
+              animateHide: this.animateHide.bind(this),
               state: this.attrs.state,
             })
           : ''}

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -11,7 +11,14 @@ export default class ModalManager extends Component {
 
     return (
       <div className="ModalManager modal fade">
-        {modal ? modal.componentClass.component({ ...modal.attrs, onshow: this.animateShow.bind(this), onhide: this.animateHide.bind(this) }) : ''}
+        {modal
+          ? modal.componentClass.component({
+              ...modal.attrs,
+              onshow: this.animateShow.bind(this),
+              onhide: this.animateHide.bind(this),
+              state: this.attrs.state,
+            })
+          : ''}
       </div>
     );
   }

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -28,6 +28,13 @@ export default class ModalManager extends Component {
   animateShow(readyCallback) {
     const dismissible = !!this.attrs.state.modal.componentClass.isDismissible;
 
+    // If we are opening this modal while another modal is already open,
+    // the shown event will not run, because the modal is already open.
+    // So, we need to manually trigger the readyCallback.
+    if (this.$().hasClass('in')) {
+      readyCallback();
+    }
+
     this.$()
       .one('shown.bs.modal', readyCallback)
       .modal({

--- a/js/src/common/components/ModalManager.js
+++ b/js/src/common/components/ModalManager.js
@@ -40,6 +40,7 @@ export default class ModalManager extends Component {
     // So, we need to manually trigger the readyCallback.
     if (this.$().hasClass('in')) {
       readyCallback();
+      return;
     }
 
     this.$()


### PR DESCRIPTION
This PR:

- Reverts the hacky #2263 
- Makes `this.hide` call the global `modal.close`, fixing #2303 
- Uses `onbeforeremove` for closing animation instead of `onremove`, and only when we actually need to close the modal
- Ensures that `readyCallback` is called on modals opened from other modals.