### PR TITLE
allow higher customization for compiling assets

### DIFF
--- a/src/Frontend/Assets.php
+++ b/src/Frontend/Assets.php
@@ -102,7 +102,7 @@ class Assets
 
     public function makeJs(): JsCompiler
     {
-        $compiler = new JsCompiler($this->assetsDir, $this->name.'.js');
+        $compiler = $this->makeJsCompiler($this->name.'.js');
 
         $this->populate($compiler, 'js');
 
@@ -120,7 +120,7 @@ class Assets
 
     public function makeLocaleJs(string $locale): JsCompiler
     {
-        $compiler = new JsCompiler($this->assetsDir, $this->name.'-'.$locale.'.js');
+        $compiler = $this->makeJsCompiler($this->name.'-'.$locale.'.js');
 
         $this->populate($compiler, 'localeJs', $locale);
 
@@ -134,6 +134,11 @@ class Assets
         $this->populate($compiler, 'localeCss', $locale);
 
         return $compiler;
+    }
+
+    protected function makeJsCompiler(string $filename)
+    {
+        return new JsCompiler($this->assetsDir, $filename);
     }
 
     protected function makeLessCompiler(string $filename): LessCompiler


### PR DESCRIPTION
One of the issues with the compiler logic is that it's hard to override it in case you need a different file naming convention. The current filenaming convention causes the forum to have no styling whenever an extension is enabled/disabled (cache is cleared) and you are using a CDN and/or horizontally scaled hosting environments. In case of cache invalidation nodes separately recompile the files, which isn't sensible in itself, but with a CDN involved becomes disastrous.