### PR TITLE
Mark keys for Config required only with InstalledSite

### DIFF
--- a/src/Foundation/Site.php
+++ b/src/Foundation/Site.php
@@ -25,6 +25,8 @@ class Site
         date_default_timezone_set('UTC');
 
         if (! static::hasConfigFile($paths->base)) {
+            // Instantiate site instance for new installations,
+            // fallback to localhost for validation of Config for instance in CLI.
             return new UninstalledSite(
                 $paths,
                 Arr::get($_SERVER, 'REQUEST_URI', 'http://localhost')

--- a/src/Foundation/Site.php
+++ b/src/Foundation/Site.php
@@ -25,7 +25,10 @@ class Site
         date_default_timezone_set('UTC');
 
         if (! static::hasConfigFile($paths->base)) {
-            return new UninstalledSite($paths, $_SERVER['REQUEST_URI']);
+            return new UninstalledSite(
+                $paths,
+                Arr::get($_SERVER, 'REQUEST_URI', 'http://localhost')
+            );
         }
 
         return (


### PR DESCRIPTION
Fixes an issue with the $_SERVER object having no value in cli, this is used in the cli install command.