### PR TITLE
Fix mobile controls gesture on discussion deletion/restoration

### DIFF
--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -50,6 +50,7 @@ export default class DiscussionListItem extends Component {
         'DiscussionListItem',
         this.active() ? 'active' : '',
         this.attrs.discussion.isHidden() ? 'DiscussionListItem--hidden' : '',
+        'ontouchstart' in window ? 'Slidable' : '',
       ]),
     };
   }
@@ -136,7 +137,7 @@ export default class DiscussionListItem extends Component {
     // This allows the user to drag the row to either side of the screen to
     // reveal controls.
     if ('ontouchstart' in window) {
-      const slidableInstance = slidable(this.$().addClass('Slidable'));
+      const slidableInstance = slidable(this.$());
 
       this.$('.DiscussionListItem-controls').on('hidden.bs.dropdown', () => slidableInstance.reset());
     }


### PR DESCRIPTION
**Fixes #1427**

**Changes proposed in this pull request:**
Because the `Slidable` class was always added on creation, it was lost every time the class list changed (in this case when the discussion was hidden/unhidden which added/removed `DiscussionListItem--hidden` class). So by determining the `Slidable` class's presence in `elementAttrs()` method, it guarantees it always properly set. 

**Reviewers should focus on:**
..

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
