### PR TITLE
Fix clear search

### DIFF
--- a/js/src/forum/states/GlobalSearchState.js
+++ b/js/src/forum/states/GlobalSearchState.js
@@ -2,9 +2,8 @@ import setRouteWithForcedRefresh from '../../common/utils/setRouteWithForcedRefr
 import SearchState from './SearchState';
 
 export default class GlobalSearchState extends SearchState {
-  constructor(cachedSearches = [], searchRoute = 'index') {
+  constructor(cachedSearches = []) {
     super(cachedSearches);
-    this.searchRoute = searchRoute;
   }
 
   getValue() {
@@ -91,6 +90,6 @@ export default class GlobalSearchState extends SearchState {
     const params = this.params();
     delete params.q;
 
-    setRouteWithForcedRefresh(app.route(this.searchRoute, params));
+    setRouteWithForcedRefresh(app.route(app.current.get('routeName'), params));
   }
 }


### PR DESCRIPTION
Clear search added "tag" as a query parameter, same as this one: https://github.com/flarum/core/issues/2267
I also removed the `searchRoute` property, since it's not used anywhere anymore.


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.


