### PR TITLE
Minor improvements to onNewRoute

### DIFF
--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -31,9 +31,7 @@ export default class Page extends Component {
    */
   onNewRoute() {
     app.previous = app.current;
-    app.current = new PageState(this.constructor);
-
-    app.current.set('routeName', this.attrs.routeName);
+    app.current = new PageState(this.constructor, { routeName: this.attrs.routeName });
   }
 
   oncreate(vnode) {

--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -10,9 +10,6 @@ export default class Page extends Component {
   oninit(vnode) {
     super.oninit(vnode);
 
-    app.previous = app.current;
-    app.current = new PageState(this.constructor);
-
     this.onNewRoute();
 
     app.drawer.hide();
@@ -33,6 +30,9 @@ export default class Page extends Component {
    * adjust the current route name.
    */
   onNewRoute() {
+    app.previous = app.current;
+    app.current = new PageState(this.constructor);
+
     app.current.set('routeName', this.attrs.routeName);
   }
 

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -99,6 +99,7 @@ export default class DiscussionPage extends Page {
     super.onbeforeupdate(vnode);
 
     if (m.route.get() !== this.prevRoute) {
+      this.onNewRoute();
       this.prevRoute = m.route.get();
 
       // If we have routed to the same discussion as we were viewing previously,

--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -34,6 +34,8 @@ export default class UserPage extends Page {
   onbeforeupdate() {
     const currUsername = m.route.param('username');
     if (currUsername !== this.prevUsername) {
+      this.onNewRoute();
+
       this.prevUsername = currUsername;
 
       this.loadUser(currUsername);


### PR DESCRIPTION
In this PR:

- We move calls to create/modify `app.previous` and `app.current` from `oninit` to `onNewRoute` (inspired by https://github.com/flarum/core/pull/2319#discussion_r497053049)
- We call onNewRoute in `onbeforeupdate` for DiscussionPage and UserPage as well as in IndexPage (so that several visits to DiscussionPage in a row don't count as one "PageState".

This also sets us up for possible changes like https://github.com/flarum/core/pull/2275#issuecomment-701032151