### PR TITLE
Ensure that modal hide animates

### DIFF
--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -33,6 +33,9 @@ export default class Modal extends Component {
     // we don't need to show a hide animation.
     if (!this.attrs.state.modal) {
       this.attrs.animateHide();
+      // Here, we ensure that the animation has time to complete.
+      // See https://mithril.js.org/lifecycle-methods.html#onbeforeremove
+      return new Promise((resolve) => setTimeout(resolve, 1000));
     }
   }
 


### PR DESCRIPTION
We will return a promise with arbitrary time until fulfillment to ensure that mithril doesn't remove the modal DOM before it has time to animate away.