### PR TITLE
Remove Mithril namespace export from shims.d.ts

### DIFF
--- a/js/shims.d.ts
+++ b/js/shims.d.ts
@@ -9,14 +9,6 @@ import * as _$ from 'jquery';
 import Application from './src/common/Application';
 
 /**
- * Export Mithril typings globally.
- *
- * This lets us use these typings without an extra import everywhere we use
- * Mithril in a TypeScript file.
- */
-export as namespace Mithril;
-
-/**
  * flarum/core exposes several extensions globally:
  *
  * - jQuery for convenient DOM manipulation


### PR DESCRIPTION
From using PhpStorm to try and see if the autocomplete works properly, it appears as it doesn't. The intention was to not have to import Mithril every time we wanted to type something with Mithril.*, but that doesn't seem to be possible - and it's not a big deal anyway.