### PR TITLE
Remove depreciated code in QueueServiceProvider

### DIFF
--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -63,8 +63,7 @@ class QueueServiceProvider extends AbstractServiceProvider
             return new Worker(
                 new HackyManagerForWorker($app[Factory::class]),
                 $app['events'],
-                $app[ExceptionHandling::class],
-                function () { return false; }
+                $app[ExceptionHandling::class]
             );
         });
 

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -63,7 +63,8 @@ class QueueServiceProvider extends AbstractServiceProvider
             return new Worker(
                 new HackyManagerForWorker($app[Factory::class]),
                 $app['events'],
-                $app[ExceptionHandling::class]
+                $app[ExceptionHandling::class],
+                function () { return false; }
             );
         });
 

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -103,6 +103,22 @@ class QueueServiceProvider extends AbstractServiceProvider
         $this->app->alias(Factory::class, 'queue');
         $this->app->alias(Worker::class, 'queue.worker');
         $this->app->alias(Listener::class, 'queue.listener');
+
+        $this->registerCommands();
+    }
+
+    private function registerCommands()
+    {
+        $queue = $this->app->make(Queue::class);
+
+        // There is no need to have the queue commands when using the sync driver.
+        if ($queue instanceof SyncQueue) {
+            return;
+        }
+
+        $this->app->extend('flarum.console.commands', function ($existingCommands) {
+            return array_merge($existingCommands, $this->commands);
+        });
     }
 
     public function boot()

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Queue;
 
-use Flarum\Console\Event\Configuring;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
@@ -104,24 +103,6 @@ class QueueServiceProvider extends AbstractServiceProvider
         $this->app->alias(Factory::class, 'queue');
         $this->app->alias(Worker::class, 'queue.worker');
         $this->app->alias(Listener::class, 'queue.listener');
-
-        $this->registerCommands();
-    }
-
-    protected function registerCommands()
-    {
-        $this->app['events']->listen(Configuring::class, function (Configuring $event) {
-            $queue = $this->app->make(Queue::class);
-
-            // There is no need to have the queue commands when using the sync driver.
-            if ($queue instanceof SyncQueue) {
-                return;
-            }
-
-            foreach ($this->commands as $command) {
-                $event->addCommand($command);
-            }
-        });
     }
 
     public function boot()


### PR DESCRIPTION
Apparently the `Configuring` event was depreciated and eventually removed. But traces of it's references were not. This PR aims to removes them.