### PR TITLE
Fixed Broken Badges in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
 <a href="https://github.com/flarum/core/actions?query=workflow%3ATests"><img src="https://github.com/flarum/core/workflows/Tests/badge.svg" alt="PHP Tests"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/dt/flarum/core" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/v/flarum/core" alt="Latest Version"></a>
+<a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/github/v/release/flarum/core?sort=semver" alt="Latest Version"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/l/flarum/core" alt="License"></a>
 <a href="https://github.styleci.io/repos/28257573"><img src="https://github.styleci.io/repos/28257573/shield?style=flat" alt="StyleCI"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <p align="center">
 <a href="https://github.com/flarum/core/actions?query=workflow%3ATests"><img src="https://github.com/flarum/core/workflows/Tests/badge.svg" alt="PHP Tests"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/v/unstable.svg" alt="Latest Version"></a>
-<a href="https://packagist.org/packages/flarum/core"><img src="https://poser.pugx.org/flarum/core/license.svg" alt="License"></a>
+<a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/dt/flarum/core" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/v/flarum/core" alt="Latest Version"></a>
+<a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/l/flarum/core" alt="License"></a>
 <a href="https://github.styleci.io/repos/28257573"><img src="https://github.styleci.io/repos/28257573/shield?style=flat" alt="StyleCI"></a>
 </p>
 


### PR DESCRIPTION
Hi Flarum Team,

I just noticed that all the badges provided by Poser are broken because their website server is no more available. So, I updated all the broken badges in the ReadMe.md file with the badges provided by the shields.io website which is a reliable and my favorite tool for adding badges to Readme.md files.

Badges updated:
1. Total Downloads
2. Latest Version
3. License

**Changes proposed in this pull request:**
Updated Broken Badges in ReadMe.md file of **flarum/core** repository
**Reviewers should focus on:**
I have updated the ReadMe.md file kindly review it only.

**Screenshot**
Before:
![image](https://user-images.githubusercontent.com/40134208/95014617-aa168c00-0665-11eb-8bd5-c92a439d8c01.png)

After:

![image](https://user-images.githubusercontent.com/40134208/95014650-d3cfb300-0665-11eb-9eb0-10922fc7cfb4.png)

Kindly review and merge my Pull Request.

Thanks & Regards,
Abhishek Verma
