### PR TITLE
Abstract away onNewRoute and routeHasChanged

### DIFF
--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -12,15 +12,18 @@ export default class Page extends Component {
 
     this.onNewRoute();
 
-    app.drawer.hide();
-    app.modal.close();
-
     /**
      * A class name to apply to the body while the route is active.
      *
      * @type {String}
      */
     this.bodyClass = '';
+
+    this.currentPath = m.route.get();
+  }
+
+  routeHasChanged() {
+    return this.currentPath !== m.route.get();
   }
 
   /**
@@ -30,8 +33,21 @@ export default class Page extends Component {
    * adjust the current route name.
    */
   onNewRoute() {
+    this.currentPath = m.route.get();
+
     app.previous = app.current;
     app.current = new PageState(this.constructor, { routeName: this.attrs.routeName });
+
+    app.drawer.hide();
+    app.modal.close();
+  }
+
+  onbeforeupdate(vnode, old) {
+    super.onbeforeupdate(vnode, old);
+
+    if (this.routeHasChanged()) {
+      this.onNewRoute();
+    }
   }
 
   oncreate(vnode) {

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -29,16 +29,6 @@ export default class IndexPage extends Page {
       this.lastDiscussion = app.previous.get('discussion');
     }
 
-    // If the user is coming from the discussion list, then they have either
-    // just switched one of the parameters (filter, sort, search) or they
-    // probably want to refresh the results. We will clear the discussion list
-    // cache so that results are reloaded.
-    if (app.previous.matches(IndexPage)) {
-      app.discussions.clear();
-    }
-
-    app.discussions.refreshParams(app.search.params());
-
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
 
     this.bodyClass = 'App--index';
@@ -47,7 +37,13 @@ export default class IndexPage extends Page {
   onNewRoute() {
     super.onNewRoute();
 
-    app.discussions.clear();
+    // If the user is coming from the discussion list, then they have either
+    // just switched one of the parameters (filter, sort, search) or they
+    // probably want to refresh the results. We will clear the discussion list
+    // cache so that results are reloaded.
+    if (app.previous.matches(IndexPage)) {
+      app.discussions.clear();
+    }
 
     app.discussions.refreshParams(app.search.params());
 

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -42,26 +42,16 @@ export default class IndexPage extends Page {
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
 
     this.bodyClass = 'App--index';
-
-    this.currentPath = m.route.get();
   }
 
-  onbeforeupdate(vnode) {
-    super.onbeforeupdate(vnode);
+  onNewRoute() {
+    super.onNewRoute();
 
-    const curPath = m.route.get();
+    app.discussions.clear();
 
-    if (this.currentPath !== curPath) {
-      this.onNewRoute();
+    app.discussions.refreshParams(app.search.params());
 
-      app.discussions.clear();
-
-      app.discussions.refreshParams(app.search.params());
-
-      this.currentPath = curPath;
-
-      this.setTitle();
-    }
+    this.setTitle();
   }
 
   view() {

--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -27,14 +27,14 @@ export default class UserPage extends Page {
     this.user = null;
 
     this.bodyClass = 'App--user';
-
-    this.currUsername = m.route.param('username');
   }
 
   onNewRoute() {
     super.onNewRoute();
 
-    this.loadUser(m.route.param('username'));
+    if (m.route.param('username')) {
+      this.loadUser(m.route.param('username'));
+    }
   }
 
   view() {

--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -28,18 +28,13 @@ export default class UserPage extends Page {
 
     this.bodyClass = 'App--user';
 
-    this.prevUsername = m.route.param('username');
+    this.currUsername = m.route.param('username');
   }
 
-  onbeforeupdate() {
-    const currUsername = m.route.param('username');
-    if (currUsername !== this.prevUsername) {
-      this.onNewRoute();
+  onNewRoute() {
+    super.onNewRoute();
 
-      this.prevUsername = currUsername;
-
-      this.loadUser(currUsername);
-    }
+    this.loadUser(m.route.param('username'));
   }
 
   view() {


### PR DESCRIPTION
This provides a cleaner interface for dealing with pages that handle multiple routes. We also move `modal` and `drawer` close calls to ensure those happen on route change with the same component.