### PR TITLE
SubtreeRetainer: fix onbeforeupdate needsRebuild

### DIFF
--- a/js/src/common/utils/SubtreeRetainer.js
+++ b/js/src/common/utils/SubtreeRetainer.js
@@ -28,6 +28,9 @@ export default class SubtreeRetainer {
   constructor(...callbacks) {
     this.callbacks = callbacks;
     this.data = {};
+    // Build the initial data, so it is available when calling
+    // needsRebuild from the onbeforeupdate hook.
+    this.needsRebuild();
   }
 
   /**

--- a/js/src/common/utils/SubtreeRetainer.js
+++ b/js/src/common/utils/SubtreeRetainer.js
@@ -63,6 +63,8 @@ export default class SubtreeRetainer {
    */
   check(...callbacks) {
     this.callbacks = this.callbacks.concat(callbacks);
+    // Update the data cache when new checks are added.
+    this.needsRebuild();
   }
 
   /**


### PR DESCRIPTION
Previously the subtree retainer check was done in the beginning of the view function. 
Now being moved to the onbeforeupdate function, it's missing the initial call to set the data and returns `true` on the first call.

- [x] Frontend changes: tested on a local Flarum installation.

