### PR TITLE
Fix PostStream Reply Scroll

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -82,7 +82,6 @@ export default class DiscussionPage extends Page {
                     {PostStream.component({
                       discussion,
                       stream: this.stream,
-                      targetPost: this.stream.targetPost,
                       onPositionChange: this.positionChanged.bind(this),
                     })}
                   </div>

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -312,12 +312,12 @@ export default class PostStream extends Component {
    * @return {jQuery.Deferred}
    */
   scrollToIndex(index, animate, reply) {
+    const $item = reply ? $('.PostStream-item:last-child') : this.$(`.PostStream-item[data-index=${index}]`);
+
+    this.scrollToItem($item, animate, true, reply);
+
     if (reply) {
-      const $placeholder = this.$('.PostStream-item:last-child');
-      this.scrollToItem($placeholder, animate, true, true);
-      this.flashItem($placeholder);
-    } else {
-      this.scrollToItem(this.$(`.PostStream-item[data-index=${index}]`), animate, true);
+      this.flashItem($item);
     }
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -359,7 +359,7 @@ export default class PostStream extends Component {
       // We manually set the index because we want to display the index of the
       // exact post we've scrolled to, not just that of the first post within viewport.
       this.updateScrubber();
-      this.stream.index = index;
+      this.stream.index = index || this.stream.index;
     };
 
     // If we don't update this before the scroll, the scrubber will start

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -129,15 +129,15 @@ export default class PostStream extends Component {
    * Start scrolling, if appropriate, to a newly-targeted post.
    */
   triggerScroll() {
-    if (!this.attrs.targetPost || !this.stream.needsScroll) return;
+    if (!this.stream.needsScroll) return;
 
-    const newTarget = this.attrs.targetPost;
+    const target = this.stream.targetPost;
     this.stream.needsScroll = false;
 
-    if ('number' in newTarget) {
-      this.scrollToNumber(newTarget.number, this.stream.animateScroll);
-    } else if ('index' in newTarget) {
-      this.scrollToIndex(newTarget.index, this.stream.animateScroll, newTarget.reply);
+    if ('number' in target) {
+      this.scrollToNumber(target.number, this.stream.animateScroll);
+    } else if ('index' in target) {
+      this.scrollToIndex(target.index, this.stream.animateScroll, target.reply);
     }
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -359,7 +359,7 @@ export default class PostStream extends Component {
       // We manually set the index because we want to display the index of the
       // exact post we've scrolled to, not just that of the first post within viewport.
       this.updateScrubber();
-      this.stream.index = index || this.stream.index;
+     if (index !== undefined) this.stream.index = index + 1;
     };
 
     // If we don't update this before the scroll, the scrubber will start

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -342,7 +342,7 @@ export default class PostStream extends Component {
       const scrollBottom = scrollTop + $(window).height();
 
       // If the item is already in the viewport, we may not need to scroll.
-      // If we're scrolling to the reply placeholder, we'll make sure it's
+      // If we're scrolling to the reply placeholder, we'll make sure its
       // bottom will line up with the top of the composer.
       if (force || itemTop < scrollTop || itemBottom > scrollBottom) {
         const top = reply ? itemBottom - $(window).height() + app.composer.computedHeight() : $item.is(':first-child') ? 0 : itemTop;
@@ -370,13 +370,14 @@ export default class PostStream extends Component {
     return Promise.all([$container.promise(), this.stream.loadPromise]).then(() => {
       m.redraw.sync();
 
-      // After post data has been loaded in, we will attempt to scroll back
-      // to the top of the requested post (or to the top of the page if the
-      // first post was requested). In some cases, we may have scrolled to
-      // the end of the available post range, in which case, the next range
-      // of posts will be loaded in. However, in those cases, the post we
-      // requested won't exist, so scrolling to it would cause an error.
-      // Accordingly, we start by checking that it's offset is defined.
+      // Rendering post contents will probably throw off our position.
+      // To counter this, we'll scroll either:
+      //   - To the top of the page if we're on the first post
+      //   - To the reply placeholder (aligned with composer top)
+      //   - To the top of a post (if that post exists)
+      // If the post does not currently exist, it's probably
+      // outside of the range we loaded in, so we won't adjust anything,
+      // as it will soon be rendered by the "load more" system.
       const $item = $(`.PostStream-item[data-index=${index}]`);
       if (index === 0) {
         $(window).scrollTop(0);

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -137,8 +137,7 @@ export default class PostStream extends Component {
     if ('number' in newTarget) {
       this.scrollToNumber(newTarget.number, this.stream.animateScroll);
     } else if ('index' in newTarget) {
-      const backwards = newTarget.index === this.stream.count() - 1;
-      this.scrollToIndex(newTarget.index, this.stream.animateScroll, backwards);
+      this.scrollToIndex(newTarget.index, this.stream.animateScroll, newTarget.reply);
     }
   }
 
@@ -316,9 +315,11 @@ export default class PostStream extends Component {
   scrollToIndex(index, animate, bottom) {
     const $item = this.$(`.PostStream-item[data-index=${index}]`);
 
-    return this.scrollToItem($item, animate, true, bottom).then(() => {
-      if (index == this.stream.count() - 1) {
-        this.flashItem(this.$('.PostStream-item:last-child'));
+    return this.scrollToItem($item, animate, true).then(() => {
+      if (bottom) {
+        const $placeholder = this.$('.PostStream-item:last-child');
+        this.scrollToItem($placeholder, animate, true, true);
+        this.flashItem($placeholder);
       }
     });
   }
@@ -383,7 +384,7 @@ export default class PostStream extends Component {
       const offset = $(`.PostStream-item[data-index=${index}]`).offset();
       if (index === 0) {
         $(window).scrollTop(0);
-      } else if (offset) {
+      } else if (offset && !bottom) {
         $(window).scrollTop($(`.PostStream-item[data-index=${index}]`).offset().top - this.getMarginTop());
       }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -359,7 +359,7 @@ export default class PostStream extends Component {
       // We manually set the index because we want to display the index of the
       // exact post we've scrolled to, not just that of the first post within viewport.
       this.updateScrubber();
-     if (index !== undefined) this.stream.index = index + 1;
+      if (index !== undefined) this.stream.index = index + 1;
     };
 
     // If we don't update this before the scroll, the scrubber will start

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -372,19 +372,20 @@ export default class PostStream extends Component {
 
       // Rendering post contents will probably throw off our position.
       // To counter this, we'll scroll either:
-      //   - To the top of the page if we're on the first post
       //   - To the reply placeholder (aligned with composer top)
+      //   - To the top of the page if we're on the first post
       //   - To the top of a post (if that post exists)
       // If the post does not currently exist, it's probably
       // outside of the range we loaded in, so we won't adjust anything,
       // as it will soon be rendered by the "load more" system.
-      const $item = $(`.PostStream-item[data-index=${index}]`);
-      if (index === 0) {
+      let itemOffset;
+      if (reply) {
+        const $placeholder = $('.PostStream-item:last-child');
+        $(window).scrollTop($placeholder.offset().top + $placeholder.height() - $(window).height() + app.composer.computedHeight());
+      } else if (index === 0) {
         $(window).scrollTop(0);
-      } else if ($item.offset() && reply) {
-        $(window).scrollTop($item.offset().top + $item.height() - $(window).height() + app.composer.computedHeight());
-      } else if ($item.offset()) {
-        $(window).scrollTop($item.offset().top - this.getMarginTop());
+      } else if ((itemOffset = $(`.PostStream-item[data-index=${index}]`).offset())) {
+        $(window).scrollTop(itemOffset.top - this.getMarginTop());
       }
 
       // We want to adjust this again after posts have been loaded in

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -96,7 +96,9 @@ class PostStreamState {
     // If we want to go to the reply preview, then we will go to the end of the
     // discussion and then scroll to the very bottom of the page.
     if (number === 'reply') {
-      return this.goToLast();
+      const resultPromise = this.goToLast();
+      this.targetPost.reply = true;
+      return resultPromise;
     }
 
     this.paused = true;


### PR DESCRIPTION
Fixes #2334

Currently in master, scrolling to the reply placeholder is considered the same as scrolling to the last post. This relation doesn't actually hold in reality, and as a result, neither is done well. This PR decouples the two actions, and fixes both `PostStreamState`'s `goToLast` method, and actually scrolling to  reply via `goToNumber('reply')`. It also renames references to the "bottom" flag to "reply": we currently only scroll to the bottom of a post when replying; otherwise, it is not done well. This way, the purpose behind that flag is clearer, and more closely matches implementation.