### PR TITLE
Reduce modal hide timeout

### DIFF
--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -35,7 +35,7 @@ export default class Modal extends Component {
       this.attrs.animateHide();
       // Here, we ensure that the animation has time to complete.
       // See https://mithril.js.org/lifecycle-methods.html#onbeforeremove
-      return new Promise((resolve) => setTimeout(resolve, 250));
+      return new Promise((resolve) => setTimeout(resolve, 300));
     }
   }
 

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -35,7 +35,7 @@ export default class Modal extends Component {
       this.attrs.animateHide();
       // Here, we ensure that the animation has time to complete.
       // See https://mithril.js.org/lifecycle-methods.html#onbeforeremove
-      // Bootstrap's default animation duration is 300 ms.
+      // Bootstrap's Modal.TRANSITION_DURATION is 300 ms.
       return new Promise((resolve) => setTimeout(resolve, 300));
     }
   }

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -35,6 +35,7 @@ export default class Modal extends Component {
       this.attrs.animateHide();
       // Here, we ensure that the animation has time to complete.
       // See https://mithril.js.org/lifecycle-methods.html#onbeforeremove
+      // Bootstrap's default animation duration is 300 ms.
       return new Promise((resolve) => setTimeout(resolve, 300));
     }
   }

--- a/js/src/common/components/Modal.js
+++ b/js/src/common/components/Modal.js
@@ -35,7 +35,7 @@ export default class Modal extends Component {
       this.attrs.animateHide();
       // Here, we ensure that the animation has time to complete.
       // See https://mithril.js.org/lifecycle-methods.html#onbeforeremove
-      return new Promise((resolve) => setTimeout(resolve, 1000));
+      return new Promise((resolve) => setTimeout(resolve, 250));
     }
   }
 


### PR DESCRIPTION
**Fixes a minor bug:**
as a result of: https://github.com/flarum/core/pull/2332

When opening a modal quickly after closing one, it shows 2 modals for a moment.

**Screenshot**
![image](https://user-images.githubusercontent.com/36057469/95311077-59966d00-08b7-11eb-81d0-f6dd34f1a5c5.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.


