### PR TITLE
Make PostStreamScrubber work for Posts that have top margin

### DIFF
--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -225,7 +225,7 @@ export default class PostStream extends Component {
       if (time) period = time;
     });
 
-    let index = indexFromViewPort !== null ? indexFromViewPort : $items.first().data('index') || 0;
+    let index = indexFromViewPort !== null ? indexFromViewPort : 0;
     this.stream.index = index + 1;
     this.stream.visible = visible;
     if (period) this.stream.description = dayjs(period).format('MMMM YYYY');

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -181,10 +181,9 @@ export default class PostStream extends Component {
     // seen if the browser were scrolled right up to the top of the page,
     // and the viewport had a height of 0.
     const $items = this.$('.PostStream-item[data-index]');
-    let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';
-    let indexWasUpdated = false;
+    let indexFromViewPort = null;
 
     // Now loop through each of the items in the discussion. An 'item' is
     // either a single post or a 'gap' of one or more posts that haven't
@@ -212,9 +211,8 @@ export default class PostStream extends Component {
 
       // We take the index of the first item that passed the previous checks.
       // It is the item that is first visible in the viewport.
-      if (!indexWasUpdated) {
-        index = parseFloat($this.data('index')) + visibleTop / height;
-        indexWasUpdated = true;
+      if (indexFromViewPort === null) {
+        indexFromViewPort = parseFloat($this.data('index')) + visibleTop / height;
       }
 
       if (visiblePost > 0) {
@@ -227,6 +225,7 @@ export default class PostStream extends Component {
       if (time) period = time;
     });
 
+    let index = indexFromViewPort !== null ? indexFromViewPort : $items.first().data('index') || 0;
     this.stream.index = index + 1;
     this.stream.visible = visible;
     if (period) this.stream.description = dayjs(period).format('MMMM YYYY');

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -225,8 +225,7 @@ export default class PostStream extends Component {
       if (time) period = time;
     });
 
-    let index = indexFromViewPort !== null ? indexFromViewPort : 0;
-    this.stream.index = index + 1;
+    this.stream.index = indexFromViewPort !== null ? indexFromViewPort + 1 : 1;
     this.stream.visible = visible;
     if (period) this.stream.description = dayjs(period).format('MMMM YYYY');
   }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -225,7 +225,10 @@ export default class PostStream extends Component {
       if (time) period = time;
     });
 
-    this.stream.index = indexFromViewPort !== null ? indexFromViewPort + 1 : 1;
+    // If indexFromViewPort is null, it means no posts are visible in the
+    // viewport. This can happen, when drafting a long reply post. In that case
+    // set the index to the last post.
+    this.stream.index = indexFromViewPort !== null ? indexFromViewPort + 1 : this.stream.count();
     this.stream.visible = visible;
     if (period) this.stream.description = dayjs(period).format('MMMM YYYY');
   }

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -184,6 +184,7 @@ export default class PostStream extends Component {
     let index = $items.first().data('index') || 0;
     let visible = 0;
     let period = '';
+    let indexWasUpdated = false;
 
     // Now loop through each of the items in the discussion. An 'item' is
     // either a single post or a 'gap' of one or more posts that haven't
@@ -209,8 +210,11 @@ export default class PostStream extends Component {
       const visibleBottom = Math.min(height, viewportTop + viewportHeight - top);
       const visiblePost = visibleBottom - visibleTop;
 
-      if (top <= viewportTop) {
+      // We take the index of the first item that passed the previous checks.
+      // It is the item that is first visible in the viewport.
+      if (!indexWasUpdated) {
         index = parseFloat($this.data('index')) + visibleTop / height;
+        indexWasUpdated = true;
       }
 
       if (visiblePost > 0) {


### PR DESCRIPTION
Basically the same as https://github.com/flarum/core/pull/1944. I now know what that PR was fixing. When Posts have a top margin the scrubber will bounce around. 

To replicate go to https://nightly.flarum.site, set `margin-top: 50px` for `.Post` in the dev console. See scrubber bouncing back and forth when scrolling.

Not a priority, but should still be fixed I think.

Edit: New commit fixes #1897

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.



