### PR TITLE
Header UI fixes

### DIFF
--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -204,6 +204,9 @@ export default class Application {
       const offset = $app.offset().top;
 
       $app.toggleClass('affix', top >= offset).toggleClass('scrolled', top > offset);
+      // If we're scrolled down, add the navbar-fixed-top css class, so that Bootstrap's
+      // JS will compensate for shifts when the modal is opened/closed.
+      $('.App-header').toggleClass('navbar-fixed-top', top >= offset);
     }).start();
 
     $(() => {

--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -199,7 +199,7 @@ export default class Application {
 
     // Add a class to the body which indicates that the page has been scrolled
     // down.
-    new ScrollListener((top) => {
+    const scrollListener = new ScrollListener((top) => {
       const $app = $('#app');
       const offset = $app.offset().top;
 
@@ -207,7 +207,10 @@ export default class Application {
       // If we're scrolled down, add the navbar-fixed-top css class, so that Bootstrap's
       // JS will compensate for shifts when the modal is opened/closed.
       $('.App-header').toggleClass('navbar-fixed-top', top >= offset);
-    }).start();
+    });
+
+    scrollListener.start();
+    scrollListener.update();
 
     $(() => {
       $('body').addClass('ontouchstart' in window ? 'touch' : 'no-touch');

--- a/js/src/common/Application.js
+++ b/js/src/common/Application.js
@@ -198,14 +198,14 @@ export default class Application {
     m.route(document.getElementById('content'), basePath + '/', mapRoutes(this.routes, basePath));
 
     // Add a class to the body which indicates that the page has been scrolled
-    // down.
+    // down. When this happens, we'll add classes to the header and app body
+    // which will set the navbar's position to fixed. We don't want to always
+    // have it fixed, as that could overlap with custom headers.
     const scrollListener = new ScrollListener((top) => {
       const $app = $('#app');
       const offset = $app.offset().top;
 
       $app.toggleClass('affix', top >= offset).toggleClass('scrolled', top > offset);
-      // If we're scrolled down, add the navbar-fixed-top css class, so that Bootstrap's
-      // JS will compensate for shifts when the modal is opened/closed.
       $('.App-header').toggleClass('navbar-fixed-top', top >= offset);
     });
 

--- a/less/common/App.less
+++ b/less/common/App.less
@@ -236,11 +236,15 @@
   .App-header {
     padding: 8px;
     height: @header-height;
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     right: 0;
     z-index: @zindex-header;
+
+    .affix & {
+      position: fixed;
+    }
 
     & when (@config-colored-header = true) {
       .light-contents(@header-color, @header-control-bg, @header-control-color);

--- a/views/frontend/admin.blade.php
+++ b/views/frontend/admin.blade.php
@@ -4,7 +4,7 @@
 
     <div id="drawer" class="App-drawer">
 
-        <header id="header" class="App-header navbar-fixed-top">
+        <header id="header" class="App-header">
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <h1 class="Header-title">

--- a/views/frontend/forum.blade.php
+++ b/views/frontend/forum.blade.php
@@ -6,7 +6,7 @@
 
     <div id="drawer" class="App-drawer">
 
-        <header id="header" class="App-header navbar-fixed-top">
+        <header id="header" class="App-header">
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <h1 class="Header-title">


### PR DESCRIPTION
## Issue 1: Missing Header on Refresh

Due to some magic in Mithril 0.1's context:retain flag, some DOM elements were cached across page reloads. Since that has been eliminated, if we refresh the page and we are scrolled down, the "affix" class which makes the header fixed (and as a result, visible) isn't applied until the first scroll. We fix this by running ScrollListener.update() immediately to set initial navbar state.

## Issue 2: Header Overlap with Custom Header

![Example](https://user-images.githubusercontent.com/2059356/95367012-38775180-08a2-11eb-9b14-6f5d5b61288d.png)

This was accidentially introduced in #2131. In this PR, we revert that, and instead conditionally apply the navbar-fixed-top class only when needed, so that we can take advantage of it without always having the navbar in position:fixed, as was done in the previous solution.