### PR TITLE
Fix PostStream loadRange doesn't return all posts

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -155,7 +155,7 @@ export default class DiscussionPage extends Page {
             record.relationships.discussion.data.id === discussionId
         )
         .map((record) => app.store.getById('posts', record.id))
-        .sort((a, b) => a.id() - b.id())
+        .sort((a, b) => a.createdAt() - b.createdAt())
         .slice(0, 20);
     }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -282,7 +282,13 @@ class PostStreamState {
         }
       });
 
-    return loadIds.length ? app.store.find('posts', loadIds) : Promise.resolve(loaded);
+    if (loadIds.length) {
+      return app.store.find('posts', loadIds).then((newPosts) => {
+        return loaded.concat(newPosts).sort((a, b) => a.id() - b.id());
+      });
+    }
+
+    return Promise.resolve(loaded);
   }
 
   /**

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -284,7 +284,7 @@ class PostStreamState {
 
     if (loadIds.length) {
       return app.store.find('posts', loadIds).then((newPosts) => {
-        return loaded.concat(newPosts).sort((a, b) => a.id() - b.id());
+        return loaded.concat(newPosts).sort((a, b) => a.createdAt() - b.createdAt());
       });
     }
 


### PR DESCRIPTION
**Fixes the following issues:**

PostStream `loadRange` is called like this from `loadNearIndex`:
```js
this.loadRange(start, end).then(this.show.bind(this));
```
The `show` function expects to always receive the whole range. 
Whenever posts are partially loaded, it just returned the new posts, which caused bugs when using the scrubber to go to a post index.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
