### PR TITLE
Fix mobile PostStream top scroll adjustment & remove App:before

### DIFF
--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -275,7 +275,9 @@ export default class PostStream extends Component {
    * @return {Integer}
    */
   getMarginTop() {
-    return this.$() && $('#header').outerHeight() + parseInt(this.$().css('margin-top'), 10);
+    const headerId = app.screen() === 'phone' ? '#app-navigation' : '#header';
+
+    return this.$() && $(headerId).outerHeight() + parseInt(this.$().css('margin-top'), 10);
   }
 
   /**

--- a/less/common/App.less
+++ b/less/common/App.less
@@ -10,29 +10,23 @@
   }
 }
 
-// Fix a solid white box to the top of the viewport. This toolbar's contents
-// will differ depending on the device: on phones it will be content
-// controls, whereas on desktops it will be the header. We will overlay
-// these things on top of it later.
-.App:before {
-  content: " ";
-  .header-background();
-  border-bottom: 0;
-  position: absolute;
-
-  .affix& {
-    position: fixed;
-  }
-
-  .scrolled& {
-    .box-shadow(0 2px 6px @shadow-color);
-  }
-}
-
 // PHONES: Somewhere on the page there will be a .App-backControl, a
 // .App-primaryControl, and a .App-titleControl. We will position these on the
 // left, right, and center of the header respectively.
 @media @phone {
+  .App-navigation {
+    .header-background();
+    border-bottom: 0;
+    position: absolute;
+
+    .affix & {
+      position: fixed;
+    }
+
+    .scrolled & {
+      .box-shadow(0 2px 6px @shadow-color);
+    }
+  }
   .App-primaryControl, .App-titleControl, .App-backControl {
     position: absolute !important;
     z-index: @zindex-header + 1;
@@ -234,16 +228,16 @@
     display: none;
   }
   .App-header {
+    .header-background();
     padding: 8px;
-    height: @header-height;
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: @zindex-header;
-
+   
     .affix & {
       position: fixed;
+    }
+
+    .scrolled & {
+      .box-shadow(0 2px 6px @shadow-color);
     }
 
     & when (@config-colored-header = true) {


### PR DESCRIPTION
Removing App:before, the behavior I believe doesn't change and is a lot cleaner. This has several advantages:
- the mobile header has now height, which was needed for the PostStream fix to work.
- it's now possible to access the mobile header via element id, and f.e. change the color programmatically on mobile. (I've been using that on my site for quite a while)

- [x] Frontend changes: tested on a local Flarum installation.

