### PR TITLE
Passive Scroll Event Listener 

### DIFF
--- a/js/src/common/utils/ScrollListener.js
+++ b/js/src/common/utils/ScrollListener.js
@@ -58,7 +58,7 @@ export default class ScrollListener {
    */
   start() {
     if (!this.active) {
-      window.addEventListener('scroll', (this.active = this.loop.bind(this)));
+      window.addEventListener('scroll', (this.active = this.loop.bind(this)), { passive: true });
     }
   }
 


### PR DESCRIPTION
see: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

> A Boolean that, if true, indicates that the function specified by listener will never call preventDefault(). If a passive listener does call preventDefault(), the user agent will do nothing other than generate a console warning. See Improving scrolling performance with passive listeners to learn more.

The `ScrollListener` util is used in PostStream and PostStreamScrubber.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
