### PR TITLE
PostStream: Fix minor load more issue

### DIFF
--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -399,6 +399,8 @@ export default class PostStream extends Component {
 
       this.calculatePosition();
       this.stream.paused = false;
+      // Run the onscroll handler to check if we need to load more posts after scrolling.
+      this.onscroll();
     });
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -142,8 +142,6 @@ export default class PostStream extends Component {
   }
 
   /**
-   * When the window is scrolled, check if either extreme of the post stream is
-   * in the viewport, and if so, trigger loading the next/previous page.
    *
    * @param {Integer} top
    */
@@ -154,6 +152,21 @@ export default class PostStream extends Component {
 
     if (this.stream.pagesLoading) return;
 
+    this.loadPostsWhenNeeded(top);
+
+    // Throttle calculation of our position (start/end numbers of posts in the
+    // viewport) to 100ms.
+    clearTimeout(this.calculatePositionTimeout);
+    this.calculatePositionTimeout = setTimeout(this.calculatePosition.bind(this, top), 100);
+  }
+
+  /**
+   * Check if either extreme of the post stream is in the viewport,
+   * and if so, trigger loading the next/previous page.
+   *
+   * @param {Integer} top
+   */
+  loadPostsWhenNeeded(top = window.pageYOffset) {
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
     const viewportTop = top + marginTop;
@@ -174,11 +187,6 @@ export default class PostStream extends Component {
         this.stream.loadNext();
       }
     }
-
-    // Throttle calculation of our position (start/end numbers of posts in the
-    // viewport) to 100ms.
-    clearTimeout(this.calculatePositionTimeout);
-    this.calculatePositionTimeout = setTimeout(this.calculatePosition.bind(this, top), 100);
   }
 
   updateScrubber(top = window.pageYOffset) {
@@ -399,8 +407,8 @@ export default class PostStream extends Component {
 
       this.calculatePosition();
       this.stream.paused = false;
-      // Run the onscroll handler to check if we need to load more posts after scrolling.
-      this.onscroll();
+      // Check if we need to load more posts after scrolling.
+      this.loadPostsWhenNeeded();
     });
   }
 

--- a/js/src/forum/components/PostStream.js
+++ b/js/src/forum/components/PostStream.js
@@ -152,7 +152,7 @@ export default class PostStream extends Component {
 
     if (this.stream.pagesLoading) return;
 
-    this.loadPostsWhenNeeded(top);
+    this.loadPostsIfNeeded(top);
 
     // Throttle calculation of our position (start/end numbers of posts in the
     // viewport) to 100ms.
@@ -166,7 +166,7 @@ export default class PostStream extends Component {
    *
    * @param {Integer} top
    */
-  loadPostsWhenNeeded(top = window.pageYOffset) {
+  loadPostsIfNeeded(top = window.pageYOffset) {
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
     const viewportTop = top + marginTop;
@@ -408,7 +408,7 @@ export default class PostStream extends Component {
       this.calculatePosition();
       this.stream.paused = false;
       // Check if we need to load more posts after scrolling.
-      this.loadPostsWhenNeeded();
+      this.loadPostsIfNeeded();
     });
   }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -172,7 +172,7 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearIndex(index) {
-    if (index >= this.visibleStart && index < this.visibleEnd) {
+    if (index >= this.visibleStart && index <= this.visibleEnd) {
       return Promise.resolve();
     }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -172,7 +172,7 @@ class PostStreamState {
    * @return {Promise}
    */
   loadNearIndex(index) {
-    if (index >= this.visibleStart && index <= this.visibleEnd) {
+    if (index >= this.visibleStart && index < this.visibleEnd) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
When we scroll to a post that is already loaded, the load more button might show and not trigger. 
To replicate (in beta.14) go to the start of a long enough discussion and run `app.current.get('stream').goToIndex(19)`.

**Screenshot**
before the fix:
![Screenshot_316](https://user-images.githubusercontent.com/36057469/95879297-67109300-0da0-11eb-9bc8-bc7eab717868.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

