### PR TITLE
Page Scroll Cleanup

### DIFF
--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -30,6 +30,10 @@ export default class Page extends Component {
     if (this.bodyClass) {
       $('#app').addClass(this.bodyClass);
     }
+
+    if (!this.dontScrollTopOnCreate) {
+      window.scrollTo(0, 0);
+    }
   }
 
   onremove() {

--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -22,6 +22,13 @@ export default class Page extends Component {
      * @type {String}
      */
     this.bodyClass = '';
+
+    /**
+     * Whether we should scroll to the top of the page when its rendered.
+     *
+     * @type {Boolean}
+     */
+    this.scrollTopOnCreate = true;
   }
 
   oncreate(vnode) {
@@ -31,8 +38,8 @@ export default class Page extends Component {
       $('#app').addClass(this.bodyClass);
     }
 
-    if (!this.dontScrollTopOnCreate) {
-      window.scrollTo(0, 0);
+    if (this.scrollTopOnCreate) {
+      $(window).scrollTop(0);
     }
   }
 

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -89,7 +89,13 @@ export default class IndexPage extends Page {
     // Let browser handle scrolling on page reload.
     if (app.previous.type == null) return;
 
-    $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
+    // When on mobile, only retain scroll if we're coming from a discussion page.
+    // Otherwise, we've just changed the filter, so we should go to the top of the page.
+    if (app.screen() == 'desktop' || app.screen() == 'desktop-hd' || this.lastDiscussion) {
+      $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
+    } else {
+      $(window).scrollTop(0);
+    }
 
     // If we've just returned from a discussion page, then the constructor will
     // have set the `lastDiscussion` property. If this is the case, we want to

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -42,7 +42,7 @@ export default class IndexPage extends Page {
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
 
     this.bodyClass = 'App--index';
-    this.dontScrollTopOnCreate = true;
+    this.scrollTopOnCreate = false;
   }
 
   view() {

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -86,6 +86,7 @@ export default class IndexPage extends Page {
 
     $('#app').css('min-height', $(window).height() + heroHeight);
 
+    // Let browser handle scrolling on page reload.
     if (app.previous.type == null) return;
 
     $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
@@ -94,7 +95,7 @@ export default class IndexPage extends Page {
     // have set the `lastDiscussion` property. If this is the case, we want to
     // scroll down to that discussion so that it's in view.
     if (this.lastDiscussion) {
-      const $discussion = this.$(`.DiscussionListItem[data-id="${this.lastDiscussion.id()}"]`);
+      const $discussion = this.$(`li[data-id="${this.lastDiscussion.id()}"] .DiscussionListItem`);
 
       if ($discussion.length) {
         const indexTop = $('#header').outerHeight();

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -42,6 +42,7 @@ export default class IndexPage extends Page {
     app.history.push('index', app.translator.trans('core.forum.header.back_to_index_tooltip'));
 
     this.bodyClass = 'App--index';
+    this.dontScrollTopOnCreate = true;
   }
 
   view() {
@@ -84,6 +85,8 @@ export default class IndexPage extends Page {
     const scrollTop = app.cache.scrollTop;
 
     $('#app').css('min-height', $(window).height() + heroHeight);
+
+    if (app.previous.type == null) return;
 
     // Scroll to the remembered position. We do this after a short delay so that
     // it happens after the browser has done its own "back button" scrolling,

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -116,14 +116,16 @@ export default class IndexPage extends Page {
     }
   }
 
+  onbeforeremove() {
+    // Save the scroll position so we can restore it when we return to the
+    // discussion list.
+    app.cache.scrollTop = $(window).scrollTop();
+  }
+
   onremove() {
     super.onremove();
 
     $('#app').css('min-height', '');
-
-    // Save the scroll position so we can restore it when we return to the
-    // discussion list.
-    app.cache.scrollTop = $(window).scrollTop();
   }
 
   /**

--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -88,12 +88,7 @@ export default class IndexPage extends Page {
 
     if (app.previous.type == null) return;
 
-    // Scroll to the remembered position. We do this after a short delay so that
-    // it happens after the browser has done its own "back button" scrolling,
-    // which isn't right. https://github.com/flarum/core/issues/835
-    const scroll = () => $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
-    scroll();
-    setTimeout(scroll, 1);
+    $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
 
     // If we've just returned from a discussion page, then the constructor will
     // have set the `lastDiscussion` property. If this is the case, we want to


### PR DESCRIPTION
This PR makes several modifications to retain (or fix) beta 13 behavior:

- Whenever a new page is rendered, scroll to the top. This was previous behavior. This can also be cancelled in a page by setting `this.dontScrollTopOnCreate` in `oninit`.
- Remove some now-obsolete hacks for browsers, since browsers have gotten better. This also fixes a flash of the top of the page when refreshing.
- Fix broken selector for scrolling to discussion if its out of view
- On mobile, only retain scroll position if coming from a discussion (fixes https://github.com/flarum/core/issues/2284, https://github.com/flarum/core/issues/1951)