### PR TITLE
Ensure scripts provided by textformatter are run

### DIFF
--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -65,10 +65,9 @@ export default class CommentPost extends Post {
     if (this.contentHtml !== contentHtml) {
       this.$('.Post-body script').each(function () {
         const script = document.createElement('script');
-        script.innerText = this.innerText;
+        script.textContent = this.textContent;
         Array.from(this.attributes).forEach((attr) => script.setAttribute(attr.name, attr.value));
-        this.parentNode.appendChild(script);
-        this.remove();
+        this.parentNode.replaceChild(script, this);
       });
     }
 

--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -56,9 +56,7 @@ export default class CommentPost extends Post {
     ]);
   }
 
-  onupdate(vnode) {
-    super.onupdate();
-
+  refreshContent() {
     const contentHtml = this.isEditing() ? '' : this.attrs.post.contentHtml();
 
     // If the post content has changed since the last render, we'll run through
@@ -71,6 +69,18 @@ export default class CommentPost extends Post {
     }
 
     this.contentHtml = contentHtml;
+  }
+
+  oncreate(vnode) {
+    super.oncreate(vnode);
+
+    this.refreshContent();
+  }
+
+  onupdate(vnode) {
+    super.onupdate(vnode);
+
+    this.refreshContent();
   }
 
   isEditing() {

--- a/js/src/forum/components/CommentPost.js
+++ b/js/src/forum/components/CommentPost.js
@@ -64,7 +64,11 @@ export default class CommentPost extends Post {
     // necessary because TextFormatter outputs them for e.g. syntax highlighting.
     if (this.contentHtml !== contentHtml) {
       this.$('.Post-body script').each(function () {
-        eval.call(window, $(this).text());
+        const script = document.createElement('script');
+        script.innerText = this.innerText;
+        Array.from(this.attributes).forEach((attr) => script.setAttribute(attr.name, attr.value));
+        this.parentNode.appendChild(script);
+        this.remove();
       });
     }
 


### PR DESCRIPTION
Fixes #2412 

It seems that between Mithril 0.2 and Mithril 2.0, scripts contained within m.trust are no longer automatically evaluated. So, now we have to make them run ourselves. To do this, we "clone" the script node (using `node.cloneNode()` didn't work unfortunately), and replace the text formatter provided script node with our cloned one. This works for both external and inline scripts, and also allows us to get rid of eval.

**comments for reviewers**

If I'm understanding this correctly (pun intended), `this` in the `<script>` tag previously pointed to the script tag, now it acts as the default `this` in the global scope. The script tag is still available via `document.currentScript`. However, `this` was never available by the default use of the textformatter extension, so I believe we should be fine. Is this something we are concerned about?