### PR TITLE
Add Notification Type Extender

### DIFF
--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -75,6 +75,12 @@ class ApiServiceProvider extends AbstractServiceProvider
 
             return $pipe;
         });
+
+        $this->app->singleton('flarum.api.notification_serializers', function () {
+            return [
+                'discussionRenamed' => BasicDiscussionSerializer::class
+            ];
+        });
     }
 
     /**
@@ -96,12 +102,6 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     protected function registerNotificationSerializers()
     {
-        $this->app->singleton('flarum.api.notification_serializers', function () {
-            return [
-                'discussionRenamed' => BasicDiscussionSerializer::class
-            ];
-        });
-
         $blueprints = [];
         $serializers = $this->app->make('flarum.api.notification_serializers');
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -88,7 +88,7 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $this->bootNotificationSerializers();
+        $this->setNotificationSerializers();
 
         AbstractSerializeController::setContainer($this->app);
         AbstractSerializeController::setEventDispatcher($events = $this->app->make('events'));
@@ -100,7 +100,7 @@ class ApiServiceProvider extends AbstractServiceProvider
     /**
      * Register notification serializers.
      */
-    protected function bootNotificationSerializers()
+    protected function setNotificationSerializers()
     {
         $blueprints = [];
         $serializers = $this->app->make('flarum.api.notification_serializers');

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -88,7 +88,7 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $this->registerNotificationSerializers();
+        $this->bootNotificationSerializers();
 
         AbstractSerializeController::setContainer($this->app);
         AbstractSerializeController::setEventDispatcher($events = $this->app->make('events'));
@@ -100,7 +100,7 @@ class ApiServiceProvider extends AbstractServiceProvider
     /**
      * Register notification serializers.
      */
-    protected function registerNotificationSerializers()
+    protected function bootNotificationSerializers()
     {
         $blueprints = [];
         $serializers = $this->app->make('flarum.api.notification_serializers');

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -101,6 +101,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             'discussionRenamed' => BasicDiscussionSerializer::class
         ];
 
+        // Deprecated in beta 15, remove in beta 16
         $this->app->make('events')->dispatch(
             new ConfigureNotificationTypes($blueprints, $serializers)
         );

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -96,10 +96,14 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     protected function registerNotificationSerializers()
     {
+        $this->app->singleton('flarum.api.notification_serializers', function () {
+            return [
+                'discussionRenamed' => BasicDiscussionSerializer::class
+            ];
+        });
+
         $blueprints = [];
-        $serializers = [
-            'discussionRenamed' => BasicDiscussionSerializer::class
-        ];
+        $serializers = $this->app->make('flarum.api.notification_serializers');
 
         // Deprecated in beta 15, remove in beta 16
         $this->app->make('events')->dispatch(

--- a/src/Event/ConfigureNotificationTypes.php
+++ b/src/Event/ConfigureNotificationTypes.php
@@ -13,6 +13,9 @@ use Flarum\Notification\Blueprint\BlueprintInterface;
 use InvalidArgumentException;
 use ReflectionClass;
 
+/**
+ * @deprecated in beta 15, removed in beta 16
+ */
 class ConfigureNotificationTypes
 {
     /**

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -9,13 +9,8 @@
 
 namespace Flarum\Extend;
 
-use Flarum\Api\Serializer\NotificationSerializer;
 use Flarum\Extension\Extension;
-use Flarum\Notification\MailableInterface;
-use Flarum\Notification\Notification as NotificationModel;
-use Flarum\User\User;
 use Illuminate\Contracts\Container\Container;
-use ReflectionClass;
 
 class Notification implements ExtenderInterface
 {

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Api\Serializer\NotificationSerializer;
+use Flarum\Extension\Extension;
+use Flarum\Notification\MailableInterface;
+use Flarum\Notification\Notification as NotificationModel;
+use Flarum\User\User;
+use Illuminate\Contracts\Container\Container;
+use ReflectionClass;
+
+class Notification implements ExtenderInterface
+{
+    public function type(string $blueprint, string $serializer, array $enabledByDefault = [])
+    {
+        $type = $blueprint::getType();
+
+        NotificationSerializer::setSubjectSerializer($type, $serializer);
+
+        NotificationModel::setSubjectModel($type, $blueprint::getSubjectModel());
+
+        User::addPreference(
+            User::getNotificationPreferenceKey($type, 'alert'),
+            'boolval',
+            in_array('alert', $enabledByDefault)
+        );
+
+        if ((new ReflectionClass($blueprint))->implementsInterface(MailableInterface::class)) {
+            User::addPreference(
+                User::getNotificationPreferenceKey($type, 'email'),
+                'boolval',
+                in_array('email', $enabledByDefault)
+            );
+        }
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        // ...
+    }
+}

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -40,7 +40,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
     /**
      * Register notification types.
      */
-    public function registerNotificationTypes()
+    protected function registerNotificationTypes()
     {
         $blueprints = $this->app->make('flarum.notification.blueprints');
 

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -48,7 +48,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
         }
     }
 
-    public function addType(string $blueprint, array $channelsEnabledByDefault)
+    protected function addType(string $blueprint, array $channelsEnabledByDefault)
     {
         Notification::setSubjectModel(
             $type = $blueprint::getType(),

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -34,13 +34,13 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $this->bootNotificationTypes();
+        $this->setNotificationTypes();
     }
 
     /**
      * Register notification types.
      */
-    protected function bootNotificationTypes()
+    protected function setNotificationTypes()
     {
         $blueprints = $this->app->make('flarum.notification.blueprints');
 

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -34,13 +34,13 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $this->registerNotificationTypes();
+        $this->bootNotificationTypes();
     }
 
     /**
      * Register notification types.
      */
-    protected function registerNotificationTypes()
+    protected function bootNotificationTypes()
     {
         $blueprints = $this->app->make('flarum.notification.blueprints');
 

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -20,6 +20,18 @@ class NotificationServiceProvider extends AbstractServiceProvider
     /**
      * {@inheritdoc}
      */
+    public function register()
+    {
+        $this->app->singleton('flarum.notification.blueprints', function () {
+            return [
+                DiscussionRenamedBlueprint::class => ['alert']
+            ];
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function boot()
     {
         $this->registerNotificationTypes();
@@ -30,12 +42,6 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     public function registerNotificationTypes()
     {
-        $this->app->singleton('flarum.notification.blueprints', function () {
-            return [
-                DiscussionRenamedBlueprint::class => ['alert']
-            ];
-        });
-
         $blueprints = $this->app->make('flarum.notification.blueprints');
 
         // Deprecated in beta 15, remove in beta 16

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -30,9 +30,13 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     public function registerNotificationTypes()
     {
-        $blueprints = [
-            DiscussionRenamedBlueprint::class => ['alert']
-        ];
+        $this->app->singleton('flarum.notification.blueprints', function () {
+            return [
+                DiscussionRenamedBlueprint::class => ['alert']
+            ];
+        });
+
+        $blueprints = $this->app->make('flarum.notification.blueprints');
 
         // Deprecated in beta 15, remove in beta 16
         $this->app->make('events')->dispatch(

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -34,6 +34,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
             DiscussionRenamedBlueprint::class => ['alert']
         ];
 
+        // Deprecated in beta 15, remove in beta 16
         $this->app->make('events')->dispatch(
             new ConfigureNotificationTypes($blueprints)
         );

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -48,7 +48,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
         }
     }
 
-    public function addType(Blueprint\BlueprintInterface $blueprint, array $channelsEnabledByDefault)
+    public function addType(string $blueprint, array $channelsEnabledByDefault)
     {
         Notification::setSubjectModel(
             $type = $blueprint::getType(),

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Notification;
+
+class NotificationTest extends \Flarum\Tests\integration\TestCase
+{
+    /**
+     * @test
+     */
+    public function notification_type_doesnt_exist_by_default()
+    {
+        $this->assertArrayNotHasKey('customNotificationType', Notification::getSubjectModels());
+    }
+
+    /**
+     * @test
+     */
+    public function notification_type_exists_if_added()
+    {
+        $this->extend((new Extend\Notification)->type(
+            CustomNotificationType::class,
+            'customNotificationTypeSerializer'
+        ));
+
+        $this->app();
+
+        $this->assertArrayHasKey('customNotificationType', Notification::getSubjectModels());
+    }
+}
+
+class CustomNotificationType implements BlueprintInterface
+{
+    public function getFromUser()
+    {
+        // ...
+    }
+
+    public function getSubject()
+    {
+        // ...
+    }
+
+    public function getData()
+    {
+        // ...
+    }
+
+    public static function getType()
+    {
+        return 'customNotificationType';
+    }
+
+    public static function getSubjectModel()
+    {
+        return 'customNotificationTypeSubjectModel';
+    }
+}


### PR DESCRIPTION
**Fixes #2422**
**Part of #1891**

**Reviewers should focus on:**
Would it be better to try avoiding duplicating this block of code (by defining a singleton and extending that instead in the extender)
https://github.com/flarum/core/blob/24b7a21507c4bdc5f44d1fed633129915ade0bd7/src/Notification/NotificationServiceProvider.php#L42-L59

**Confirmed**

- ~[ ] Frontend changes: tested on a local Flarum installation.~
- [x] Backend changes: tests are green (run `composer test`).