### PR TITLE
Refactor Route Resolving and Dispatch

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -54,9 +54,9 @@ class AdminServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\StartSession::class,
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
+                HttpMiddleware\SetLocale::class,
                 'flarum.admin.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
-                HttpMiddleware\SetLocale::class,
                 Middleware\RequireAdministrateAbility::class
             ];
         });

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -54,9 +54,11 @@ class AdminServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\StartSession::class,
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
+                'flarum.admin.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
                 HttpMiddleware\SetLocale::class,
                 Middleware\RequireAdministrateAbility::class,
+                HttpMiddleware\ExecuteRoute::class
             ];
         });
 
@@ -68,15 +70,16 @@ class AdminServiceProvider extends AbstractServiceProvider
             );
         });
 
+        $this->app->bind('flarum.admin.route_resolver', function () {
+            return new HttpMiddleware\ResolveRoute($this->app->make('flarum.admin.routes'));
+        });
+
         $this->app->singleton('flarum.admin.handler', function () {
             $pipe = new MiddlewarePipe;
 
             foreach ($this->app->make('flarum.admin.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
-
-            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.admin.routes')));
-            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -75,7 +75,8 @@ class AdminServiceProvider extends AbstractServiceProvider
                 $pipe->pipe($this->app->make($middleware));
             }
 
-            $pipe->pipe(new HttpMiddleware\DispatchRoute($this->app->make('flarum.admin.routes')));
+            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.admin.routes')));
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -57,8 +57,7 @@ class AdminServiceProvider extends AbstractServiceProvider
                 'flarum.admin.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
                 HttpMiddleware\SetLocale::class,
-                Middleware\RequireAdministrateAbility::class,
-                HttpMiddleware\ExecuteRoute::class
+                Middleware\RequireAdministrateAbility::class
             ];
         });
 
@@ -80,6 +79,8 @@ class AdminServiceProvider extends AbstractServiceProvider
             foreach ($this->app->make('flarum.admin.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
+
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -51,9 +51,9 @@ class ApiServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
                 HttpMiddleware\AuthenticateWithHeader::class,
+                HttpMiddleware\SetLocale::class,
                 'flarum.api.route_resolver',
-                HttpMiddleware\CheckCsrfToken::class,
-                HttpMiddleware\SetLocale::class
+                HttpMiddleware\CheckCsrfToken::class
             ];
         });
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -51,8 +51,10 @@ class ApiServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
                 HttpMiddleware\AuthenticateWithHeader::class,
+                'flarum.api.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
                 HttpMiddleware\SetLocale::class,
+                HttpMiddleware\ExecuteRoute::class
             ];
         });
 
@@ -64,15 +66,16 @@ class ApiServiceProvider extends AbstractServiceProvider
             );
         });
 
+        $this->app->bind('flarum.api.route_resolver', function() {
+            return new HttpMiddleware\ResolveRoute($this->app->make('flarum.api.routes'));
+        });
+
         $this->app->singleton('flarum.api.handler', function () {
             $pipe = new MiddlewarePipe;
 
             foreach ($this->app->make('flarum.api.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
-
-            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.api.routes')));
-            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -65,7 +65,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->bind('flarum.api.route_resolver', function() {
+        $this->app->bind('flarum.api.route_resolver', function () {
             return new HttpMiddleware\ResolveRoute($this->app->make('flarum.api.routes'));
         });
 

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -71,7 +71,8 @@ class ApiServiceProvider extends AbstractServiceProvider
                 $pipe->pipe($this->app->make($middleware));
             }
 
-            $pipe->pipe(new HttpMiddleware\DispatchRoute($this->app->make('flarum.api.routes')));
+            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.api.routes')));
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -53,8 +53,7 @@ class ApiServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\AuthenticateWithHeader::class,
                 'flarum.api.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
-                HttpMiddleware\SetLocale::class,
-                HttpMiddleware\ExecuteRoute::class
+                HttpMiddleware\SetLocale::class
             ];
         });
 
@@ -76,6 +75,8 @@ class ApiServiceProvider extends AbstractServiceProvider
             foreach ($this->app->make('flarum.api.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
+
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Extend/Csrf.php
+++ b/src/Extend/Csrf.php
@@ -28,7 +28,6 @@ class Csrf implements ExtenderInterface
         return $this;
     }
 
-
     /**
      * Exempt a path from csrf checks. Wildcards are supported.
      *

--- a/src/Extend/Csrf.php
+++ b/src/Extend/Csrf.php
@@ -14,11 +14,29 @@ use Illuminate\Contracts\Container\Container;
 
 class Csrf implements ExtenderInterface
 {
-    protected $csrfExemptPaths = [];
+    protected $csrfExemptRoutes = [];
 
+    /**
+     * Exempt a named route from CSRF checks.
+     *
+     * @param string $routeName
+     */
+    public function exemptRoute(string $routeName)
+    {
+        $this->csrfExemptRoutes[] = $routeName;
+
+        return $this;
+    }
+
+
+    /**
+     * Exempt a path from csrf checks. Wildcards are supported.
+     *
+     * @deprecated beta 15, remove beta 16. Exempt routes should be used instead.
+     */
     public function exemptPath(string $path)
     {
-        $this->csrfExemptPaths[] = $path;
+        $this->csrfExemptRoutes[] = $path;
 
         return $this;
     }
@@ -26,7 +44,7 @@ class Csrf implements ExtenderInterface
     public function extend(Container $container, Extension $extension = null)
     {
         $container->extend('flarum.http.csrfExemptPaths', function ($existingExemptPaths) {
-            return array_merge($existingExemptPaths, $this->csrfExemptPaths);
+            return array_merge($existingExemptPaths, $this->csrfExemptRoutes);
         });
     }
 }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -64,9 +64,9 @@ class ForumServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\StartSession::class,
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
+                HttpMiddleware\SetLocale::class,
                 'flarum.forum.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
-                HttpMiddleware\SetLocale::class,
                 HttpMiddleware\ShareErrorsFromSession::class
             ];
         });

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -64,9 +64,11 @@ class ForumServiceProvider extends AbstractServiceProvider
                 HttpMiddleware\StartSession::class,
                 HttpMiddleware\RememberFromCookie::class,
                 HttpMiddleware\AuthenticateWithSession::class,
+                'flarum.forum.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
                 HttpMiddleware\SetLocale::class,
-                HttpMiddleware\ShareErrorsFromSession::class
+                HttpMiddleware\ShareErrorsFromSession::class,
+                HttpMiddleware\ExecuteRoute::class
             ];
         });
 
@@ -78,16 +80,16 @@ class ForumServiceProvider extends AbstractServiceProvider
             );
         });
 
+        $this->app->bind('flarum.forum.route_resolver', function () {
+            return new HttpMiddleware\ResolveRoute($this->app->make('flarum.forum.routes'));
+        });
+
         $this->app->singleton('flarum.forum.handler', function () {
             $pipe = new MiddlewarePipe;
 
             foreach ($this->app->make('flarum.forum.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
-
-            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.forum.routes')));
-            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
-
 
             return $pipe;
         });
@@ -200,8 +202,8 @@ class ForumServiceProvider extends AbstractServiceProvider
         $factory = $this->app->make(RouteHandlerFactory::class);
         $defaultRoute = $this->app->make('flarum.settings')->get('default_route');
 
-        if (isset($routes->getRouteData()[0]['GET'][$defaultRoute])) {
-            $toDefaultController = $routes->getRouteData()[0]['GET'][$defaultRoute];
+        if (isset($routes->getRouteData()[0]['GET'][$defaultRoute]['handler'])) {
+            $toDefaultController = $routes->getRouteData()[0]['GET'][$defaultRoute]['handler'];
         } else {
             $toDefaultController = $factory->toForum(Content\Index::class);
         }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -67,8 +67,7 @@ class ForumServiceProvider extends AbstractServiceProvider
                 'flarum.forum.route_resolver',
                 HttpMiddleware\CheckCsrfToken::class,
                 HttpMiddleware\SetLocale::class,
-                HttpMiddleware\ShareErrorsFromSession::class,
-                HttpMiddleware\ExecuteRoute::class
+                HttpMiddleware\ShareErrorsFromSession::class
             ];
         });
 
@@ -90,6 +89,8 @@ class ForumServiceProvider extends AbstractServiceProvider
             foreach ($this->app->make('flarum.forum.middleware') as $middleware) {
                 $pipe->pipe($this->app->make($middleware));
             }
+
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
             return $pipe;
         });

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -85,7 +85,9 @@ class ForumServiceProvider extends AbstractServiceProvider
                 $pipe->pipe($this->app->make($middleware));
             }
 
-            $pipe->pipe(new HttpMiddleware\DispatchRoute($this->app->make('flarum.forum.routes')));
+            $pipe->pipe(new HttpMiddleware\ResolveRoute($this->app->make('flarum.forum.routes')));
+            $pipe->pipe(new HttpMiddleware\ExecuteRoute());
+
 
             return $pipe;
         });

--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -9,7 +9,7 @@
 
 namespace Flarum\Foundation;
 
-use Flarum\Http\Middleware\DispatchRoute;
+use Flarum\Http\Middleware as HttpMiddleware;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\Container;
@@ -85,8 +85,9 @@ class InstalledApp implements AppInterface
         $pipe = new MiddlewarePipe;
         $pipe->pipe(new BasePath($this->basePath()));
         $pipe->pipe(
-            new DispatchRoute($this->container->make('flarum.update.routes'))
+            new HttpMiddleware\ResolveRoute($this->container->make('flarum.update.routes'))
         );
+        $pipe->pipe(new HttpMiddleware\ExecuteRoute());
 
         return $pipe;
     }

--- a/src/Http/HttpServiceProvider.php
+++ b/src/Http/HttpServiceProvider.php
@@ -19,7 +19,7 @@ class HttpServiceProvider extends AbstractServiceProvider
     public function register()
     {
         $this->app->singleton('flarum.http.csrfExemptPaths', function () {
-            return ['/api/token'];
+            return ['token'];
         });
 
         $this->app->bind(Middleware\CheckCsrfToken::class, function ($app) {

--- a/src/Http/Middleware/CheckCsrfToken.php
+++ b/src/Http/Middleware/CheckCsrfToken.php
@@ -28,7 +28,10 @@ class CheckCsrfToken implements Middleware
     {
         $path = $request->getAttribute('originalUri')->getPath();
         foreach ($this->exemptRoutes as $exemptRoute) {
-            if (fnmatch($exemptRoute, $path)) {
+            /**
+             * @deprecated path match should be removed in beta 16, only route name match should be supported.
+             */
+            if ($exemptRoute === $request->getAttribute('routeName') || fnmatch($exemptRoute, $path)) {
                 return $handler->handle($request);
             }
         }

--- a/src/Http/Middleware/ExecuteRoute.php
+++ b/src/Http/Middleware/ExecuteRoute.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
+
+class ExecuteRoute implements Middleware
+{
+    /**
+     * Executes the route handler resolved in ResolveRoute.
+     */
+    public function process(Request $request, Handler $handler): Response
+    {
+        $handler = $request->getAttribute('routeHandler');
+        $parameters = $request->getAttribute('routeParameters');
+        return $handler($request, $parameters);
+    }
+}

--- a/src/Http/Middleware/ExecuteRoute.php
+++ b/src/Http/Middleware/ExecuteRoute.php
@@ -23,6 +23,7 @@ class ExecuteRoute implements Middleware
     {
         $handler = $request->getAttribute('routeHandler');
         $parameters = $request->getAttribute('routeParameters');
+
         return $handler($request, $parameters);
     }
 }

--- a/src/Http/Middleware/ResolveRoute.php
+++ b/src/Http/Middleware/ResolveRoute.php
@@ -59,9 +59,9 @@ class ResolveRoute implements Middleware
             case Dispatcher::METHOD_NOT_ALLOWED:
                 throw new MethodNotAllowedException($method);
             case Dispatcher::FOUND:
-                echo json_encode($routeInfo);
                 $request = $request
-                    ->withAttribute('routeHandler', $routeInfo[1])
+                    ->withAttribute('routeName', $routeInfo[1]['name'])
+                    ->withAttribute('routeHandler', $routeInfo[1]['handler'])
                     ->withAttribute('routeParameters', $routeInfo[2]);
 
                 return $handler->handle($request);

--- a/src/Http/Middleware/ResolveRoute.php
+++ b/src/Http/Middleware/ResolveRoute.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
 
-class DispatchRoute implements Middleware
+class ResolveRoute implements Middleware
 {
     /**
      * @var RouteCollection
@@ -41,7 +41,7 @@ class DispatchRoute implements Middleware
     }
 
     /**
-     * Dispatch the given request to our route collection.
+     * Resolve the given request from our route collection.
      *
      * @throws MethodNotAllowedException
      * @throws RouteNotFoundException
@@ -59,10 +59,12 @@ class DispatchRoute implements Middleware
             case Dispatcher::METHOD_NOT_ALLOWED:
                 throw new MethodNotAllowedException($method);
             case Dispatcher::FOUND:
-                $handler = $routeInfo[1];
-                $parameters = $routeInfo[2];
+                echo json_encode($routeInfo);
+                $request = $request
+                    ->withAttribute('routeHandler', $routeInfo[1])
+                    ->withAttribute('routeParameters', $routeInfo[2]);
 
-                return $handler($request, $parameters);
+                return $handler->handle($request);
         }
     }
 

--- a/src/Http/RouteCollection.php
+++ b/src/Http/RouteCollection.php
@@ -66,7 +66,7 @@ class RouteCollection
         $routeDatas = $this->routeParser->parse($path);
 
         foreach ($routeDatas as $routeData) {
-            $this->dataGenerator->addRoute($method, $routeData, $handler);
+            $this->dataGenerator->addRoute($method, $routeData, ['name' => $name, 'handler' => $handler]);
         }
 
         $this->reverse[$name] = $routeDatas;

--- a/tests/integration/extenders/CsrfTest.php
+++ b/tests/integration/extenders/CsrfTest.php
@@ -50,6 +50,7 @@ class CsrfTest extends TestCase
 
     /**
      * @test
+     * @deprecated
      */
     public function create_user_post_doesnt_need_csrf_token_if_whitelisted()
     {
@@ -86,7 +87,7 @@ class CsrfTest extends TestCase
     {
         $this->extend(
             (new Extend\Csrf)
-                ->exemptPath('users.create')
+                ->exemptRoute('users.create')
         );
 
         $this->prepDb();
@@ -112,6 +113,7 @@ class CsrfTest extends TestCase
 
     /**
      * @test
+     * @deprecated
      */
     public function csrf_matches_wildcards_properly()
     {

--- a/tests/integration/extenders/CsrfTest.php
+++ b/tests/integration/extenders/CsrfTest.php
@@ -82,15 +82,32 @@ class CsrfTest extends TestCase
     /**
      * @test
      */
-    public function post_to_unknown_route_will_cause_400_error_without_csrf_override()
+    public function create_user_post_doesnt_need_csrf_token_if_whitelisted_via_routename()
     {
+        $this->extend(
+            (new Extend\Csrf)
+                ->exemptPath('users.create')
+        );
+
         $this->prepDb();
 
         $response = $this->send(
-            $this->request('POST', '/api/fake/route/i/made/up')
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => $this->testUser
+                    ]
+                ],
+            ])
         );
 
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $user = User::where('username', $this->testUser['username'])->firstOrFail();
+
+        $this->assertEquals(0, $user->is_email_confirmed);
+        $this->assertEquals($this->testUser['username'], $user->username);
+        $this->assertEquals($this->testUser['email'], $user->email);
     }
 
     /**


### PR DESCRIPTION
**Prep for #2170**

**Changes proposed in this pull request:**
- Split DispatchRoute into middleware to figure out which route should be used, and another for actually executing it, so that we can use the route name in middleware in between
- Similarly, logic in `RouteCollection` has been changed to return the route name as well as the handler function
- CSRF extender has been changed to use the route name instead of path (path still works, but has been deprecated)

**Reviewers should focus on:**
- Currently, if a CSRF-invalid request is made to a path that doesn't exist, CSRF will be evaluated before the route, so it'll be returned as a CSRF error. Now, it'll return a 404 before getting to the CSRF middleware. When we get to floodgate, this will similarly be an issue: not found will run before floodgate is. I don't think this is particularly problematic, but still something to think about.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).