### PR TITLE
Updater should show on any subpath, like installer

### DIFF
--- a/src/Update/UpdateServiceProvider.php
+++ b/src/Update/UpdateServiceProvider.php
@@ -44,13 +44,13 @@ class UpdateServiceProvider extends AbstractServiceProvider
         $route = $this->app->make(RouteHandlerFactory::class);
 
         $routes->get(
-            '/',
+            '/{path:.*}',
             'index',
             $route->toController(Controller\IndexController::class)
         );
 
         $routes->post(
-            '/',
+            '/{path:.*}',
             'update',
             $route->toController(Controller\UpdateController::class)
         );


### PR DESCRIPTION
If not yet installed and you go to any subpath, the installer will still be shown.

If an update is not installed and you go to a subpath, it'll crash because it can't find the route.

Now, the updater will work just like the installer.