### PR TITLE
Update required PHP Version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.3, 7.4]
         service: ['mysql:5.7', mariadb]
         prefix: ['', flarum_]
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "docs": "https://flarum.org/docs/"
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "axy/sourcemap": "^0.1.4",
         "components/font-awesome": "^5.14.0",
         "dflydev/fig-cookies": "^2.0.1",


### PR DESCRIPTION
**Changes proposed in this pull request:**
Updates the required PHP version to PHP 7.3 as 7.2 will stop receiving security updates on Nov 30th 2020, given that beta 15 will likely be after this date we should drop support for the older version. As we did when PHP 7.1 stopped receiving updates.
