### PR TITLE
Add Notification Channel Extender

### DIFF
--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -16,11 +16,19 @@ class Notification implements ExtenderInterface
 {
     private $blueprints = [];
     private $serializers = [];
+    private $drivers = [];
 
     public function type(string $blueprint, string $serializer, array $channelsEnabledByDefault = [])
     {
         $this->blueprints[$blueprint] = $channelsEnabledByDefault;
         $this->serializers[$blueprint::getType()] = $serializer;
+
+        return $this;
+    }
+
+    public function driver(string $driverName, string $driver)
+    {
+        $this->drivers[$driverName] = $driver;
 
         return $this;
     }
@@ -33,6 +41,10 @@ class Notification implements ExtenderInterface
 
         $container->extend('flarum.api.notification_serializers', function ($existingSerializers) {
             return array_merge($existingSerializers, $this->serializers);
+        });
+
+        $container->extend('flarum.notification.drivers', function ($existingDrivers) {
+            return array_merge($existingDrivers, $this->drivers);
         });
     }
 }

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -18,6 +18,14 @@ class Notification implements ExtenderInterface
     private $serializers = [];
     private $drivers = [];
 
+    /**
+     * @param string $blueprint The ::class attribute of the blueprint class.
+     *                          This blueprint should implement \Flarum\Notification\Blueprint\BlueprintInterface.
+     * @param string $serializer The ::class attribute of the serializer class.
+     *                           This serializer should extend from \Flarum\Api\Serializer\AbstractSerializer.
+     * @param array $channelsEnabledByDefault The channels enabled by default for this notification type
+     * @return self
+     */
     public function type(string $blueprint, string $serializer, array $channelsEnabledByDefault = [])
     {
         $this->blueprints[$blueprint] = $channelsEnabledByDefault;
@@ -26,6 +34,12 @@ class Notification implements ExtenderInterface
         return $this;
     }
 
+    /**
+     * @param string $driverName The name of the notification driver.
+     * @param string $driver The ::class attribute of the driver class.
+     *                       This driver should implement \Flarum\Notification\Driver\NotificationDriverInterface.
+     * @return self
+     */
     public function driver(string $driverName, string $driver)
     {
         $this->drivers[$driverName] = $driver;

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -23,12 +23,12 @@ class Notification implements ExtenderInterface
      *                          This blueprint should implement \Flarum\Notification\Blueprint\BlueprintInterface.
      * @param string $serializer The ::class attribute of the serializer class.
      *                           This serializer should extend from \Flarum\Api\Serializer\AbstractSerializer.
-     * @param array $channelsEnabledByDefault The channels enabled by default for this notification type
+     * @param array $driversEnabledByDefault The names of the drivers enabled by default for this notification type.
      * @return self
      */
-    public function type(string $blueprint, string $serializer, array $channelsEnabledByDefault = [])
+    public function type(string $blueprint, string $serializer, array $driversEnabledByDefault = [])
     {
-        $this->blueprints[$blueprint] = $channelsEnabledByDefault;
+        $this->blueprints[$blueprint] = $driversEnabledByDefault;
         $this->serializers[$blueprint::getType()] = $serializer;
 
         return $this;

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -70,7 +70,13 @@ class Notification implements ExtenderInterface
         });
 
         $container->extend('flarum.notification.drivers', function ($existingDrivers) {
-            return array_merge($existingDrivers, $this->drivers[0]);
+            $drivers = [];
+
+            array_walk($this->drivers, function ($driverData, $driverName) use (&$drivers) {
+                $drivers[$driverName] = $driverData[0];
+            });
+
+            return array_merge($existingDrivers, $drivers);
         });
     }
 }

--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -17,6 +17,7 @@ class Notification implements ExtenderInterface
     private $blueprints = [];
     private $serializers = [];
     private $drivers = [];
+    private $typesEnabledByDefault = [];
 
     /**
      * @param string $blueprint The ::class attribute of the blueprint class.
@@ -44,7 +45,8 @@ class Notification implements ExtenderInterface
      */
     public function driver(string $driverName, string $driver, array $typesEnabledByDefault = [])
     {
-        $this->drivers[$driverName] = [$driver, $typesEnabledByDefault];
+        $this->drivers[$driverName] = $driver;
+        $this->typesEnabledByDefault[$driverName] = $typesEnabledByDefault;
 
         return $this;
     }
@@ -54,7 +56,7 @@ class Notification implements ExtenderInterface
         $container->extend('flarum.notification.blueprints', function ($existingBlueprints) {
             $existingBlueprints = array_merge($existingBlueprints, $this->blueprints);
 
-            foreach ($this->drivers as $driverName => [$driver, $typesEnabledByDefault]) {
+            foreach ($this->typesEnabledByDefault as $driverName => $typesEnabledByDefault) {
                 foreach ($typesEnabledByDefault as $blueprintClass) {
                     if (isset($existingBlueprints[$blueprintClass]) && (! in_array($driverName, $existingBlueprints[$blueprintClass]))) {
                         $existingBlueprints[$blueprintClass][] = $driverName;
@@ -70,13 +72,7 @@ class Notification implements ExtenderInterface
         });
 
         $container->extend('flarum.notification.drivers', function ($existingDrivers) {
-            $drivers = [];
-
-            array_walk($this->drivers, function ($driverData, $driverName) use (&$drivers) {
-                $drivers[$driverName] = $driverData[0];
-            });
-
-            return array_merge($existingDrivers, $drivers);
+            return array_merge($existingDrivers, $this->drivers);
         });
     }
 }

--- a/src/Notification/Driver/AlertNotificationDriver.php
+++ b/src/Notification/Driver/AlertNotificationDriver.php
@@ -39,7 +39,7 @@ class AlertNotificationDriver implements NotificationDriverInterface
     /**
      * {@inheritdoc}
      */
-    public function addUserPreference(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, bool $default): void
     {
         User::addPreference(
             User::getNotificationPreferenceKey($blueprintClass::getType(), 'alert'),

--- a/src/Notification/Driver/AlertNotificationDriver.php
+++ b/src/Notification/Driver/AlertNotificationDriver.php
@@ -39,12 +39,12 @@ class AlertNotificationDriver implements NotificationDriverInterface
     /**
      * {@inheritdoc}
      */
-    public function registerType(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, array $driversEnabledByDefault): void
     {
         User::addPreference(
             User::getNotificationPreferenceKey($blueprintClass::getType(), 'alert'),
             'boolval',
-            $default
+            in_array('alert', $driversEnabledByDefault)
         );
     }
 }

--- a/src/Notification/Driver/AlertNotificationDriver.php
+++ b/src/Notification/Driver/AlertNotificationDriver.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Driver;
+
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Job\SendNotificationsJob;
+use Flarum\User\User;
+use Illuminate\Contracts\Queue\Queue;
+
+class AlertNotificationDriver implements NotificationDriverInterface
+{
+    /**
+     * @var Queue
+     */
+    private $queue;
+
+    public function __construct(Queue $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send(BlueprintInterface $blueprint, array $users): void
+    {
+        if (count($users)) {
+            $this->queue->push(new SendNotificationsJob($blueprint, $users));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addUserPreference(string $blueprintClass, bool $default): void
+    {
+        User::addPreference(
+            User::getNotificationPreferenceKey($blueprintClass::getType(), 'alert'),
+            'boolval',
+            $default
+        );
+    }
+}

--- a/src/Notification/Driver/EmailNotificationDriver.php
+++ b/src/Notification/Driver/EmailNotificationDriver.php
@@ -56,7 +56,7 @@ class EmailNotificationDriver implements NotificationDriverInterface
     /**
      * {@inheritdoc}
      */
-    public function addUserPreference(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, bool $default): void
     {
         if ((new ReflectionClass($blueprintClass))->implementsInterface(MailableInterface::class)) {
             User::addPreference(

--- a/src/Notification/Driver/EmailNotificationDriver.php
+++ b/src/Notification/Driver/EmailNotificationDriver.php
@@ -56,13 +56,13 @@ class EmailNotificationDriver implements NotificationDriverInterface
     /**
      * {@inheritdoc}
      */
-    public function registerType(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, array $driversEnabledByDefault): void
     {
         if ((new ReflectionClass($blueprintClass))->implementsInterface(MailableInterface::class)) {
             User::addPreference(
                 User::getNotificationPreferenceKey($blueprintClass::getType(), 'email'),
                 'boolval',
-                $default
+                in_array('email', $driversEnabledByDefault)
             );
         }
     }

--- a/src/Notification/Driver/EmailNotificationDriver.php
+++ b/src/Notification/Driver/EmailNotificationDriver.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Driver;
+
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Job\SendEmailNotificationJob;
+use Flarum\Notification\MailableInterface;
+use Flarum\User\User;
+use Illuminate\Contracts\Queue\Queue;
+use ReflectionClass;
+
+class EmailNotificationDriver implements NotificationDriverInterface
+{
+    /**
+     * @var Queue
+     */
+    private $queue;
+
+    public function __construct(Queue $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send(BlueprintInterface $blueprint, array $users): void
+    {
+        if ($blueprint instanceof MailableInterface) {
+            $this->mailNotifications($blueprint, $users);
+        }
+    }
+
+    /**
+     * Mail a notification to a list of users.
+     *
+     * @param MailableInterface $blueprint
+     * @param User[] $recipients
+     */
+    protected function mailNotifications(MailableInterface $blueprint, array $recipients)
+    {
+        foreach ($recipients as $user) {
+            if ($user->shouldEmail($blueprint::getType())) {
+                $this->queue->push(new SendEmailNotificationJob($blueprint, $user));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addUserPreference(string $blueprintClass, bool $default): void
+    {
+        if ((new ReflectionClass($blueprintClass))->implementsInterface(MailableInterface::class)) {
+            User::addPreference(
+                User::getNotificationPreferenceKey($blueprintClass::getType(), 'email'),
+                'boolval',
+                $default
+            );
+        }
+    }
+}

--- a/src/Notification/Driver/NotificationDriverInterface.php
+++ b/src/Notification/Driver/NotificationDriverInterface.php
@@ -15,7 +15,7 @@ use Flarum\User\User;
 interface NotificationDriverInterface
 {
     /**
-     * Enqueues the job for this notification
+     * Enqueues the job for this notification.
      *
      * @param BlueprintInterface $blueprint
      * @param User[] $users
@@ -24,7 +24,7 @@ interface NotificationDriverInterface
     public function send(BlueprintInterface $blueprint, array $users): void;
 
     /**
-     * Logic for adding a user preference
+     * Logic for adding a user preference.
      *
      * @param string $blueprintClass
      * @param bool $default

--- a/src/Notification/Driver/NotificationDriverInterface.php
+++ b/src/Notification/Driver/NotificationDriverInterface.php
@@ -15,7 +15,7 @@ use Flarum\User\User;
 interface NotificationDriverInterface
 {
     /**
-     * Enqueues the job for this notification.
+     * Conditionally sends a notification to users, generally using a queue.
      *
      * @param BlueprintInterface $blueprint
      * @param User[] $users
@@ -24,11 +24,11 @@ interface NotificationDriverInterface
     public function send(BlueprintInterface $blueprint, array $users): void;
 
     /**
-     * Logic for adding a user preference.
+     * Logic for registering a notification type, generally used for adding a user preference.
      *
      * @param string $blueprintClass
      * @param bool $default
      * @return void
      */
-    public function addUserPreference(string $blueprintClass, bool $default): void;
+    public function registerType(string $blueprintClass, bool $default): void;
 }

--- a/src/Notification/Driver/NotificationDriverInterface.php
+++ b/src/Notification/Driver/NotificationDriverInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Driver;
+
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\User\User;
+
+interface NotificationDriverInterface
+{
+    /**
+     * Enqueues the job for this notification
+     *
+     * @param BlueprintInterface $blueprint
+     * @param User[] $users
+     * @return void
+     */
+    public function send(BlueprintInterface $blueprint, array $users): void;
+
+    /**
+     * Logic for adding a user preference
+     *
+     * @param string $blueprintClass
+     * @param bool $default
+     * @return void
+     */
+    public function addUserPreference(string $blueprintClass, bool $default): void;
+}

--- a/src/Notification/Driver/NotificationDriverInterface.php
+++ b/src/Notification/Driver/NotificationDriverInterface.php
@@ -27,8 +27,8 @@ interface NotificationDriverInterface
      * Logic for registering a notification type, generally used for adding a user preference.
      *
      * @param string $blueprintClass
-     * @param bool $default
+     * @param array $driversEnabledByDefault
      * @return void
      */
-    public function registerType(string $blueprintClass, bool $default): void;
+    public function registerType(string $blueprintClass, array $driversEnabledByDefault): void;
 }

--- a/src/Notification/Event/Sending.php
+++ b/src/Notification/Event/Sending.php
@@ -11,6 +11,9 @@ namespace Flarum\Notification\Event;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
 
+/**
+ * @deprecated in beta 15, removed in beta 16
+ */
 class Sending
 {
     /**

--- a/src/Notification/Job/SendNotificationsJob.php
+++ b/src/Notification/Job/SendNotificationsJob.php
@@ -10,7 +10,6 @@
 namespace Flarum\Notification\Job;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
-use Flarum\Notification\Event\Sending;
 use Flarum\Notification\Notification;
 use Flarum\Queue\AbstractJob;
 use Flarum\User\User;
@@ -35,8 +34,6 @@ class SendNotificationsJob extends AbstractJob
 
     public function handle()
     {
-        event(new Sending($this->blueprint, $this->recipients));
-
         Notification::notify($this->recipients, $this->blueprint);
     }
 }

--- a/src/Notification/Notification.php
+++ b/src/Notification/Notification.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
 use Flarum\Event\ScopeModelVisibility;
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Driver\NotificationDriverInterface;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -62,6 +63,13 @@ class Notification extends AbstractModel
      * @var array
      */
     protected static $subjectModels = [];
+
+    /**
+     * A map of notification drivers
+     *
+     * @var NotificationDriverInterface[]
+     */
+    protected static $notificationDrivers = [];
 
     /**
      * Mark a notification as read.
@@ -265,5 +273,24 @@ class Notification extends AbstractModel
             'subject_id' => ($subject = $blueprint->getSubject()) ? $subject->id : null,
             'data' => ($data = $blueprint->getData()) ? json_encode($data) : null
         ];
+    }
+
+    /**
+     * Adds a notification driver to the list
+     *
+     * @param string $driverName
+     * @param NotificationDriverInterface $driver
+     */
+    public static function addNotificationDriver(string $driverName, NotificationDriverInterface $driver)
+    {
+        static::$notificationDrivers[$driverName] = $driver;
+    }
+
+    /**
+     * @return NotificationDriverInterface[]
+     */
+    public static function getNotificationDrivers(): array
+    {
+        return static::$notificationDrivers;
     }
 }

--- a/src/Notification/Notification.php
+++ b/src/Notification/Notification.php
@@ -65,7 +65,7 @@ class Notification extends AbstractModel
     protected static $subjectModels = [];
 
     /**
-     * A map of notification drivers
+     * A map of notification drivers.
      *
      * @var NotificationDriverInterface[]
      */
@@ -276,7 +276,7 @@ class Notification extends AbstractModel
     }
 
     /**
-     * Adds a notification driver to the list
+     * Adds a notification driver to the list.
      *
      * @param string $driverName
      * @param NotificationDriverInterface $driver

--- a/src/Notification/Notification.php
+++ b/src/Notification/Notification.php
@@ -13,7 +13,6 @@ use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
 use Flarum\Event\ScopeModelVisibility;
 use Flarum\Notification\Blueprint\BlueprintInterface;
-use Flarum\Notification\Driver\NotificationDriverInterface;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -63,13 +62,6 @@ class Notification extends AbstractModel
      * @var array
      */
     protected static $subjectModels = [];
-
-    /**
-     * A map of notification drivers.
-     *
-     * @var NotificationDriverInterface[]
-     */
-    protected static $notificationDrivers = [];
 
     /**
      * Mark a notification as read.
@@ -273,24 +265,5 @@ class Notification extends AbstractModel
             'subject_id' => ($subject = $blueprint->getSubject()) ? $subject->id : null,
             'data' => ($data = $blueprint->getData()) ? json_encode($data) : null
         ];
-    }
-
-    /**
-     * Adds a notification driver to the list.
-     *
-     * @param string $driverName
-     * @param NotificationDriverInterface $driver
-     */
-    public static function addNotificationDriver(string $driverName, NotificationDriverInterface $driver)
-    {
-        static::$notificationDrivers[$driverName] = $driver;
-    }
-
-    /**
-     * @return NotificationDriverInterface[]
-     */
-    public static function getNotificationDrivers(): array
-    {
-        return static::$notificationDrivers;
     }
 }

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -75,7 +75,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
         );
 
         foreach (Notification::getNotificationDrivers() as $driverName => $driver) {
-            $driver->addUserPreference(
+            $driver->registerType(
                 $blueprint,
                 in_array($driverName, $driversEnabledByDefault)
             );

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -80,7 +80,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
         foreach (NotificationSyncer::getNotificationDrivers() as $driverName => $driver) {
             $driver->registerType(
                 $blueprint,
-                in_array($driverName, $driversEnabledByDefault)
+                $driversEnabledByDefault
             );
         }
     }

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -43,10 +43,13 @@ class NotificationServiceProvider extends AbstractServiceProvider
         $this->setNotificationTypes();
     }
 
-    public function setNotificationDrivers()
+    /**
+     * Register notification drivers.
+     */
+    protected function setNotificationDrivers()
     {
         foreach ($this->app->make('flarum.notification.drivers') as $driverName => $driver) {
-            Notification::addNotificationDriver($driverName, $this->app->make($driver));
+            NotificationSyncer::addNotificationDriver($driverName, $this->app->make($driver));
         }
     }
 
@@ -74,7 +77,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
             $blueprint::getSubjectModel()
         );
 
-        foreach (Notification::getNotificationDrivers() as $driverName => $driver) {
+        foreach (NotificationSyncer::getNotificationDrivers() as $driverName => $driver) {
             $driver->registerType(
                 $blueprint,
                 in_array($driverName, $driversEnabledByDefault)

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -62,12 +62,12 @@ class NotificationServiceProvider extends AbstractServiceProvider
             new ConfigureNotificationTypes($blueprints)
         );
 
-        foreach ($blueprints as $blueprint => $channelsEnabledByDefault) {
-            $this->addType($blueprint, $channelsEnabledByDefault);
+        foreach ($blueprints as $blueprint => $driversEnabledByDefault) {
+            $this->addType($blueprint, $driversEnabledByDefault);
         }
     }
 
-    protected function addType(string $blueprint, array $channelsEnabledByDefault)
+    protected function addType(string $blueprint, array $driversEnabledByDefault)
     {
         Notification::setSubjectModel(
             $type = $blueprint::getType(),
@@ -77,7 +77,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
         foreach (Notification::getNotificationDrivers() as $driverName => $driver) {
             $driver->addUserPreference(
                 $blueprint,
-                in_array($driverName, $channelsEnabledByDefault)
+                in_array($driverName, $driversEnabledByDefault)
             );
         }
     }

--- a/src/Notification/NotificationSyncer.php
+++ b/src/Notification/NotificationSyncer.php
@@ -10,10 +10,8 @@
 namespace Flarum\Notification;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
-use Flarum\Notification\Job\SendEmailNotificationJob;
-use Flarum\Notification\Job\SendNotificationsJob;
+use Flarum\Notification\Event\Sending;
 use Flarum\User\User;
-use Illuminate\Contracts\Queue\Queue;
 
 /**
  * The Notification Syncer commits notification blueprints to the database, and
@@ -36,16 +34,6 @@ class NotificationSyncer
      * @var int[]
      */
     protected static $sentTo = [];
-
-    /**
-     * @var Queue
-     */
-    protected $queue;
-
-    public function __construct(Queue $queue)
-    {
-        $this->queue = $queue;
-    }
 
     /**
      * Sync a notification so that it is visible to the specified users, and not
@@ -102,12 +90,13 @@ class NotificationSyncer
         // receiving this notification for the first time (we know because they
         // didn't have a record in the database). As both operations can be
         // intensive on resources (database and mail server), we queue them.
-        if (count($newRecipients)) {
-            $this->queue->push(new SendNotificationsJob($blueprint, $newRecipients));
+        foreach (Notification::getNotificationDrivers() as $driverName => $driver) {
+            $driver->send($blueprint, $newRecipients);
         }
 
-        if ($blueprint instanceof MailableInterface) {
-            $this->mailNotifications($blueprint, $newRecipients);
+        if (count($newRecipients)) {
+            // Deprecated in beta 15, removed in beta 16
+            event(new Sending($blueprint, $newRecipients));
         }
     }
 
@@ -148,21 +137,6 @@ class NotificationSyncer
         $callback();
 
         static::$onePerUser = false;
-    }
-
-    /**
-     * Mail a notification to a list of users.
-     *
-     * @param MailableInterface $blueprint
-     * @param User[] $recipients
-     */
-    protected function mailNotifications(MailableInterface $blueprint, array $recipients)
-    {
-        foreach ($recipients as $user) {
-            if ($user->shouldEmail($blueprint::getType())) {
-                $this->queue->push(new SendEmailNotificationJob($blueprint, $user));
-            }
-        }
     }
 
     /**

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -95,11 +95,11 @@ class CustomNotificationDriver implements NotificationDriverInterface
 {
     public function send(BlueprintInterface $blueprint, array $users): void
     {
-        return;
+        // ...
     }
 
     public function addUserPreference(string $blueprintClass, bool $default): void
     {
-        return;
+        // ...
     }
 }

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -172,7 +172,7 @@ class CustomNotificationDriver implements NotificationDriverInterface
         // ...
     }
 
-    public function registerType(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, array $driversEnabledByDefault): void
     {
         // ...
     }

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -63,6 +63,22 @@ class NotificationTest extends TestCase
 
         $this->assertArrayHasKey('customNotificationDriver', NotificationSyncer::getNotificationDrivers());
     }
+
+    /**
+     * @test
+     */
+    public function notification_driver_default_types_exists_if_added()
+    {
+        $this->extend(
+            (new Extend\Notification())
+                ->type(CustomNotificationType::class, 'customSerializer')
+                ->driver('customDriver', CustomNotificationDriver::class, [CustomNotificationType::class])
+        );
+
+        $this->app();
+
+
+    }
 }
 
 class CustomNotificationType implements BlueprintInterface

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -29,6 +29,19 @@ class NotificationTest extends TestCase
     /**
      * @test
      */
+    public function notification_serializer_doesnt_exist_by_default()
+    {
+        $this->app();
+
+        $this->assertNotContains(
+            'customNotificationTypeSerializer',
+            $this->app->getContainer()->make('flarum.api.notification_serializers')
+        );
+    }
+
+    /**
+     * @test
+     */
     public function notification_driver_doesnt_exist_by_default()
     {
         $this->assertArrayNotHasKey('customNotificationDriver', NotificationSyncer::getNotificationDrivers());
@@ -47,6 +60,24 @@ class NotificationTest extends TestCase
         $this->app();
 
         $this->assertArrayHasKey('customNotificationType', Notification::getSubjectModels());
+    }
+
+    /**
+     * @test
+     */
+    public function notification_serializer_exists_if_added()
+    {
+        $this->extend((new Extend\Notification)->type(
+            CustomNotificationType::class,
+            'customNotificationTypeSerializer'
+        ));
+
+        $this->app();
+
+        $this->assertContains(
+            'customNotificationTypeSerializer',
+            $this->app->getContainer()->make('flarum.api.notification_serializers')
+        );
     }
 
     /**

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -31,7 +31,7 @@ class NotificationTest extends TestCase
      */
     public function notification_driver_doesnt_exist_by_default()
     {
-        $this->assertArrayNotHasKey('customNotificationDriver', Notification::getNotificationDrivers());
+        $this->assertArrayNotHasKey('customNotificationDriver', NotificationSyncer::getNotificationDrivers());
     }
 
     /**
@@ -61,7 +61,7 @@ class NotificationTest extends TestCase
 
         $this->app();
 
-        $this->assertArrayHasKey('customNotificationDriver', Notification::getNotificationDrivers());
+        $this->assertArrayHasKey('customNotificationDriver', NotificationSyncer::getNotificationDrivers());
     }
 }
 

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Driver\NotificationDriverInterface;
 use Flarum\Notification\Notification;
 
 class NotificationTest extends \Flarum\Tests\integration\TestCase
@@ -26,6 +27,14 @@ class NotificationTest extends \Flarum\Tests\integration\TestCase
     /**
      * @test
      */
+    public function notification_driver_doesnt_exist_by_default()
+    {
+        $this->assertArrayNotHasKey('customNotificationDriver', Notification::getNotificationDrivers());
+    }
+
+    /**
+     * @test
+     */
     public function notification_type_exists_if_added()
     {
         $this->extend((new Extend\Notification)->type(
@@ -36,6 +45,21 @@ class NotificationTest extends \Flarum\Tests\integration\TestCase
         $this->app();
 
         $this->assertArrayHasKey('customNotificationType', Notification::getSubjectModels());
+    }
+
+    /**
+     * @test
+     */
+    public function notification_driver_exists_if_added()
+    {
+        $this->extend((new Extend\Notification())->driver(
+            'customNotificationDriver',
+            CustomNotificationDriver::class
+        ));
+
+        $this->app();
+
+        $this->assertArrayHasKey('customNotificationDriver', Notification::getNotificationDrivers());
     }
 }
 
@@ -64,5 +88,18 @@ class CustomNotificationType implements BlueprintInterface
     public static function getSubjectModel()
     {
         return 'customNotificationTypeSubjectModel';
+    }
+}
+
+class CustomNotificationDriver implements NotificationDriverInterface
+{
+    public function send(BlueprintInterface $blueprint, array $users): void
+    {
+        return;
+    }
+
+    public function addUserPreference(string $blueprintClass, bool $default): void
+    {
+        return;
     }
 }

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -13,8 +13,10 @@ use Flarum\Extend;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Driver\NotificationDriverInterface;
 use Flarum\Notification\Notification;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\Tests\integration\TestCase;
 
-class NotificationTest extends \Flarum\Tests\integration\TestCase
+class NotificationTest extends TestCase
 {
     /**
      * @test
@@ -98,7 +100,7 @@ class CustomNotificationDriver implements NotificationDriverInterface
         // ...
     }
 
-    public function addUserPreference(string $blueprintClass, bool $default): void
+    public function registerType(string $blueprintClass, bool $default): void
     {
         // ...
     }

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -63,22 +63,6 @@ class NotificationTest extends TestCase
 
         $this->assertArrayHasKey('customNotificationDriver', NotificationSyncer::getNotificationDrivers());
     }
-
-    /**
-     * @test
-     */
-    public function notification_driver_default_types_exists_if_added()
-    {
-        $this->extend(
-            (new Extend\Notification())
-                ->type(CustomNotificationType::class, 'customSerializer')
-                ->driver('customDriver', CustomNotificationDriver::class, [CustomNotificationType::class])
-        );
-
-        $this->app();
-
-
-    }
 }
 
 class CustomNotificationType implements BlueprintInterface


### PR DESCRIPTION
**Fixes #2419**

**Changes proposed in this pull request:**
* Use drivers for the different channels, each driver takes care of enqueing the notification job and adding the user preference.
* Add an extender for adding new drivers.
* Deprecate `Flarum\Notification\Event\Sending` Event.
* Add some dockblocks for the notification extender.

**Reviewers should focus on:**
* Are the drivers being properly registered.
* Class/Interface/Method naming.

**Confirmed**
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**
- [x] Related core extension PRs: **flarum/pusher#28**
