### PR TITLE
Improved Permissions Error Messages for Initial Install

### DIFF
--- a/src/Install/Prerequisite/WritablePaths.php
+++ b/src/Install/Prerequisite/WritablePaths.php
@@ -53,7 +53,7 @@ class WritablePaths implements PrerequisiteInterface
             })->map(function ($path, $index) {
                 return [
                     'message' => 'The '.$this->getAbsolutePath($path).' directory is not writable.',
-                    'detail' => 'Please chmod this directory'.(in_array($index, $this->wildcards) ? ' and its contents' : '').' to 0775.'
+                    'detail' => 'Please make sure your web server/PHP user has write access to this directory'.(in_array($index, $this->wildcards) ? ' and its contents' : '').'. Please read the <a href="https://docs.flarum.org/install.html#folder-ownership">installation documentation</a> for a detailed explanation and steps to follow to resolve this error.'
                 ];
             });
     }

--- a/src/Install/Prerequisite/WritablePaths.php
+++ b/src/Install/Prerequisite/WritablePaths.php
@@ -53,7 +53,7 @@ class WritablePaths implements PrerequisiteInterface
             })->map(function ($path, $index) {
                 return [
                     'message' => 'The '.$this->getAbsolutePath($path).' directory is not writable.',
-                    'detail' => 'Please make sure your web server/PHP user has write access to this directory'.(in_array($index, $this->wildcards) ? ' and its contents' : '').'. Please read the <a href="https://docs.flarum.org/install.html#folder-ownership">installation documentation</a> for a detailed explanation and steps to follow to resolve this error.'
+                    'detail' => 'Please make sure your web server/PHP user has write access to this directory'.(in_array($index, $this->wildcards) ? ' and its contents' : '').'. Read the <a href="https://docs.flarum.org/install.html#folder-ownership">installation documentation</a> for a detailed explanation and steps to resolve this error.'
                 ];
             });
     }


### PR DESCRIPTION
- Made the wording of the error more generic
- Added link to the relevant section in the installation guide

**Fixes #2327**

**Changes proposed in this pull request:**

The "Hold up!" page during the installation process. 


**Reviewers should focus on:**

The wording of the message. 


**Screenshot**
![flarum-updated-permissions-error-message](https://user-images.githubusercontent.com/22447785/97951889-bf5f1180-1def-11eb-8cc9-107de762c553.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).


**Required changes:**

- [x] Related documentation PR: flarum/docs#147
