### PR TITLE
Remove MyISAM Requirement

### DIFF
--- a/migrations/2015_02_24_000000_create_posts_table.php
+++ b/migrations/2015_02_24_000000_create_posts_table.php
@@ -30,8 +30,6 @@ return [
             $table->integer('hide_user_id')->unsigned()->nullable();
 
             $table->unique(['discussion_id', 'number']);
-
-
         });
 
         $connection = $schema->getConnection();

--- a/migrations/2015_02_24_000000_create_posts_table.php
+++ b/migrations/2015_02_24_000000_create_posts_table.php
@@ -31,7 +31,7 @@ return [
 
             $table->unique(['discussion_id', 'number']);
 
-            $table->engine = 'MyISAM';
+
         });
 
         $connection = $schema->getConnection();

--- a/src/Install/DatabaseConfig.php
+++ b/src/Install/DatabaseConfig.php
@@ -47,7 +47,7 @@ class DatabaseConfig implements Arrayable
             'collation' => 'utf8mb4_unicode_ci',
             'prefix'    => $this->prefix,
             'strict'    => false,
-            'engine'    => NULL,
+            'engine'    => null,
             'prefix_indexes' => true
         ];
     }

--- a/src/Install/DatabaseConfig.php
+++ b/src/Install/DatabaseConfig.php
@@ -47,7 +47,7 @@ class DatabaseConfig implements Arrayable
             'collation' => 'utf8mb4_unicode_ci',
             'prefix'    => $this->prefix,
             'strict'    => false,
-            'engine'    => 'InnoDB',
+            'engine'    => NULL,
             'prefix_indexes' => true
         ];
     }


### PR DESCRIPTION
**Fixes**
The requirement for Database to be MyISAM Compatible.

DigitalOcean Managed Databases do not have MyISAM enabled and there is no way of allowing it. The solution offered by the [forum ](https://discuss.flarum.org/d/23108-sql-general-error-3161-storage-engine-myisam-is-disabled/8) was to not elegant.

If this is not have breaking changes, it is an improvement to the installation process for those with Limited Database Engines.

**Changes proposed in this pull request:**
Installation Changes
Edits Create Post, Migration table to remove hardcoded MyISAM requirement.
Edits Installation DatabaseConfig.php to remove hardcoded MyISAM requirement, leaving it up to the database to decide.

**Reviewers should focus on:**
1) Can you just edit old Migration Files? It shouldn't affect existing installations and will allow easier to install new installations. That do not have MyISAM.

2) What effect does setting engine to NULL have in real terms. Was MyISAM selected by default for a reason? Would it be better to fallback if MyISAM is not available?

Issue #1661 and #677 and #1675 are loosely relevant

**Screenshot**

![MyISAM Disabled](https://i.ibb.co/k016Vvj/error.png)