### PR TITLE
Make checkbox switch component background stand out in modals

### DIFF
--- a/less/common/Checkbox.less
+++ b/less/common/Checkbox.less
@@ -31,6 +31,10 @@
   background: @control-bg;
   .transition(background-color 0.2s);
 
+  .Modal-content & {
+    background: @body-bg;
+  }
+
   .on& {
     background: #58a400;
   }

--- a/less/common/Checkbox.less
+++ b/less/common/Checkbox.less
@@ -31,10 +31,6 @@
   background: @control-bg;
   .transition(background-color 0.2s);
 
-  .Modal-content & {
-    background: @body-bg;
-  }
-
   .on& {
     background: #58a400;
   }

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -106,12 +106,8 @@
     }
   }
 
-  .Checkbox--switch .Checkbox-display {
+  .off.Checkbox--switch .Checkbox-display {
     background: @body-bg;
-  }
-
-  .on.Checkbox--switch .Checkbox-display {
-    background: #58a400;
   }
 }
 .Modal-footer {

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -105,6 +105,14 @@
       text-align: left;
     }
   }
+
+  .Checkbox--switch .Checkbox-display {
+    background: @body-bg;
+  }
+
+  .on.Checkbox--switch .Checkbox-display {
+    background: #58a400;
+  }
 }
 .Modal-footer {
   border: 0;

--- a/less/common/Modal.less
+++ b/less/common/Modal.less
@@ -107,7 +107,7 @@
   }
 
   .off.Checkbox--switch .Checkbox-display {
-    background: @body-bg;
+    background: @muted-more-color;
   }
 }
 .Modal-footer {


### PR DESCRIPTION
**Fixes #2119**

**Changes proposed in this pull request:**

As discussed in the linked issue, make checkbox switch background white in modals as otherwise the component is barely discernible. Once I looked at the actual styles used, I decided that a better option would be to use the `body-bg` variable instead of hardcoding white. 

**Reviewers should focus on:**

UI changes.

**Screenshot**

- Disabled checkbox switch now has body background (white by default) within modals

![switch-off-on-modal](https://user-images.githubusercontent.com/22447785/98437248-e3df2480-2134-11eb-8dfc-14a029743e2c.png)

- Still turns green when on

![switch-on-on-modal](https://user-images.githubusercontent.com/22447785/98437259-f0fc1380-2134-11eb-8cc7-cc0ddfcb3057.png)

- Still has control background outside of modals when off

![switch-elsewhere](https://user-images.githubusercontent.com/22447785/98437270-007b5c80-2135-11eb-929e-8ae90f9528c0.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
