### PR TITLE
ApiController Extender

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -117,7 +117,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
         foreach (array_reverse(array_merge([static::class], class_parents($this))) as $class) {
             if (isset(static::$beforeSerializationCallbacks[$class])) {
                 foreach (static::$beforeSerializationCallbacks[$class] as $callback) {
-                    $data = array_merge($data, $callback($this, $data, $request, $document));
+                    $callback($this, $data, $request, $document);
                 }
             }
         }

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -14,6 +14,7 @@ use Flarum\Api\Event\WillSerializeData;
 use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -83,18 +84,46 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     protected static $events;
 
     /**
+     * @var array
+     */
+    protected static $beforeDataCallbacks = [];
+
+    /**
+     * @var array
+     */
+    protected static $beforeSerializationCallbacks = [];
+
+    /**
      * {@inheritdoc}
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $document = new Document;
 
+        foreach (array_merge([static::class], class_parents($this)) as $class) {
+            if (isset(static::$beforeDataCallbacks[$class])) {
+                foreach (static::$beforeDataCallbacks as $callback) {
+                    $callback($this);
+                }
+            }
+        }
+
+        // Deprected in beta 15, removed in beta 16
         static::$events->dispatch(
             new WillGetData($this)
         );
 
         $data = $this->data($request, $document);
 
+        foreach (array_merge([static::class], class_parents($this)) as $class) {
+            if (isset(static::$beforeSerializationCallbacks[$class])) {
+                foreach (static::$beforeSerializationCallbacks as $callback) {
+                    $data = array_merge($data, $callback($this, $data, $request, $document));
+                }
+            }
+        }
+
+        // Deprecated in beta 15, removed in beta 16
         static::$events->dispatch(
             new WillSerializeData($this, $data, $request, $document)
         );
@@ -198,6 +227,106 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     }
 
     /**
+     * Set the serializer that will serialize data for the endpoint.
+     *
+     * @param string $serializer
+     */
+    public function setSerializer($serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Include the given relationship by default.
+     *
+     * @param string|array $name
+     */
+    public function addInclude($name)
+    {
+        $this->include = array_merge($this->include, (array) $name);
+    }
+
+    /**
+     * Don't include the given relationship by default.
+     *
+     * @param string $name
+     */
+    public function removeInclude($name)
+    {
+        Arr::forget($this->include, $name);
+    }
+
+    /**
+     * Make the given relationship available for inclusion.
+     *
+     * @param string $name
+     */
+    public function addOptionalInclude($name)
+    {
+        $this->optionalInclude[] = $name;
+    }
+
+    /**
+     * Don't allow the given relationship to be included.
+     *
+     * @param string $name
+     */
+    public function removeOptionalInclude($name)
+    {
+        Arr::forget($this->optionalInclude, $name);
+    }
+
+    /**
+     * Set the default number of results.
+     *
+     * @param int $limit
+     */
+    public function setLimit($limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * Set the maximum number of results.
+     *
+     * @param int $max
+     */
+    public function setMaxLimit($max)
+    {
+        $this->maxLimit = $max;
+    }
+
+    /**
+     * Allow sorting results by the given field.
+     *
+     * @param string $field
+     */
+    public function addSortField($field)
+    {
+        $this->sortFields[] = $field;
+    }
+
+    /**
+     * Disallow sorting results by the given field.
+     *
+     * @param string $field
+     */
+    public function removeSortField($field)
+    {
+        Arr::forget($this->sortFields, $field);
+    }
+
+    /**
+     * Set the default sort order for the results.
+     *
+     * @param array $sort
+     */
+    public function setSort(array $sort)
+    {
+        $this->sort = $sort;
+    }
+
+    /**
      * @return Dispatcher
      */
     public static function getEventDispatcher()
@@ -227,5 +356,23 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     public static function setContainer(Container $container)
     {
         static::$container = $container;
+    }
+
+    /**
+     * @param string $controllerClass
+     * @param callable $callback
+     */
+    public static function addDataPreparationCallback(string $controllerClass, callable $callback)
+    {
+        static::$beforeDataCallbacks[$controllerClass][] = $callback;
+    }
+
+    /**
+     * @param string $controllerClass
+     * @param callable $callback
+     */
+    public static function addSerializationPreparationCallback(string $controllerClass, callable $callback)
+    {
+        static::$beforeSerializationCallbacks[$controllerClass][] = $callback;
     }
 }

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -100,7 +100,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     {
         $document = new Document;
 
-        foreach (array_merge([static::class], class_parents($this)) as $class) {
+        foreach (array_reverse(array_merge([static::class], class_parents($this))) as $class) {
             if (isset(static::$beforeDataCallbacks[$class])) {
                 foreach (static::$beforeDataCallbacks as $callback) {
                     $callback($this);
@@ -115,7 +115,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
 
         $data = $this->data($request, $document);
 
-        foreach (array_merge([static::class], class_parents($this)) as $class) {
+        foreach (array_reverse(array_merge([static::class], class_parents($this))) as $class) {
             if (isset(static::$beforeSerializationCallbacks[$class])) {
                 foreach (static::$beforeSerializationCallbacks as $callback) {
                     $data = array_merge($data, $callback($this, $data, $request, $document));

--- a/src/Api/Event/WillGetData.php
+++ b/src/Api/Event/WillGetData.php
@@ -12,6 +12,9 @@ namespace Flarum\Api\Event;
 use Flarum\Api\Controller\AbstractSerializeController;
 use Illuminate\Support\Arr;
 
+/**
+ * @deprecated in beta 15, removed in beta 16
+ */
 class WillGetData
 {
     /**

--- a/src/Api/Event/WillSerializeData.php
+++ b/src/Api/Event/WillSerializeData.php
@@ -13,6 +13,9 @@ use Flarum\Api\Controller\AbstractSerializeController;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
+/**
+ * @deprecated in beta 15, removed in beta 16
+ */
 class WillSerializeData
 {
     /**

--- a/src/Extend/ApiController.php
+++ b/src/Extend/ApiController.php
@@ -59,7 +59,7 @@ class ApiController implements ExtenderInterface
      *
      * The callback can be a closure or an invokable class, and should accept:
      * - $controller: An instance of this controller.
-     * - $data: An array of data.
+     * - $data: Mixed, can be an array of data or an object (like an instance of Collection or AbstractModel).
      * - $request: An instance of \Psr\Http\Message\ServerRequestInterface.
      * - $document: An instance of \Tobscure\JsonApi\Document.
      *

--- a/src/Extend/ApiController.php
+++ b/src/Extend/ApiController.php
@@ -11,6 +11,7 @@ namespace Flarum\Extend;
 
 use Flarum\Api\Controller\AbstractSerializeController;
 use Flarum\Extension\Extension;
+use Flarum\Foundation\ContainerUtil;
 use Illuminate\Contracts\Container\Container;
 
 class ApiController implements ExtenderInterface
@@ -18,6 +19,16 @@ class ApiController implements ExtenderInterface
     private $controllerClass;
     private $beforeDataCallbacks = [];
     private $beforeSerializationCallbacks = [];
+    private $serializer;
+    private $addIncludes = [];
+    private $removeIncludes = [];
+    private $addOptionalIncludes = [];
+    private $removeOptionalIncludes = [];
+    private $limit;
+    private $maxLimit;
+    private $addSortFields = [];
+    private $removeSortFields = [];
+    private $sort;
 
     /**
      * @param string $controllerClass The ::class attribute of the controller you are modifying.
@@ -44,7 +55,7 @@ class ApiController implements ExtenderInterface
     }
 
     /**
-     * @param $callback
+     * @param callable|string $callback
      *
      * The callback can be a closure or an invokable class, and should accept:
      * - $controller: An instance of this controller.
@@ -65,8 +76,202 @@ class ApiController implements ExtenderInterface
         return $this;
     }
 
+    /**
+     * Set the serializer that will serialize data for the endpoint.
+     *
+     * @param string $serializerClass
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function setSerializer(string $serializerClass, $callback = null)
+    {
+        $this->serializer = [$serializerClass, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Include the given relationship by default.
+     *
+     * @param string|array $name
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function addInclude($name, $callback = null)
+    {
+        $this->addIncludes[] = [$name, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Don't include the given relationship by default.
+     *
+     * @param string|array $name
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function removeInclude($name, $callback = null)
+    {
+        $this->removeIncludes[] = [$name, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Make the given relationship available for inclusion.
+     *
+     * @param string|array $name
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function addOptionalInclude($name, $callback = null)
+    {
+        $this->addOptionalIncludes[] = [$name, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Don't allow the given relationship to be included.
+     *
+     * @param string|array $name
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function removeOptionalInclude($name, $callback = null)
+    {
+        $this->removeOptionalIncludes = [$name, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Set the default number of results.
+     *
+     * @param int $limit
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function setLimit(int $limit, $callback = null)
+    {
+        $this->limit = [$limit, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum number of results.
+     *
+     * @param int $max
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function setMaxLimit(int $max, $callback = null)
+    {
+        $this->maxLimit = [$max, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Allow sorting results by the given field.
+     *
+     * @param string|array $field
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function addSortField($field, $callback = null)
+    {
+        $this->addSortFields[] = [$field, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Disallow sorting results by the given field.
+     *
+     * @param string|array $field
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function removeSortField($field, $callback = null)
+    {
+        $this->removeSortFields[] = [$field, $callback];
+
+        return $this;
+    }
+
+    /**
+     * Set the default sort order for the results.
+     *
+     * @param array $sort
+     * @param callable|string|null $callback
+     * @return self
+     */
+    public function setSort(array $sort, $callback = null)
+    {
+        $this->sort = [$sort, $callback];
+
+        return $this;
+    }
+
     public function extend(Container $container, Extension $extension = null)
     {
+        $this->beforeDataCallbacks[] = function (AbstractSerializeController $controller) use ($container) {
+            if (isset($this->serializer) && $this->isApplicable($this->serializer[1], $controller, $container)) {
+                $controller->setSerializer($this->serializer[0]);
+            }
+
+            foreach ($this->addIncludes as $addingInclude) {
+                if ($this->isApplicable($addingInclude[1], $controller, $container)) {
+                    $controller->addInclude($addingInclude[0]);
+                }
+            }
+
+            foreach ($this->removeIncludes as $removingInclude) {
+                if ($this->isApplicable($removingInclude[1], $controller, $container)) {
+                    $controller->removeInclude($removingInclude[0]);
+                }
+            }
+
+            foreach ($this->addOptionalIncludes as $addingOptionalInclude) {
+                if ($this->isApplicable($addingOptionalInclude[1], $controller, $container)) {
+                    $controller->addOptionalInclude($addingOptionalInclude[0]);
+                }
+            }
+
+            foreach ($this->removeOptionalIncludes as $removingOptionalInclude) {
+                if ($this->isApplicable($removingOptionalInclude[1], $controller, $container)) {
+                    $controller->removeOptionalInclude($removingOptionalInclude[0]);
+                }
+            }
+
+            foreach ($this->addSortFields as $addingSortField) {
+                if ($this->isApplicable($addingSortField[1], $controller, $container)) {
+                    $controller->addSortField($addingSortField[0]);
+                }
+            }
+
+            foreach ($this->removeSortFields as $removingSortField) {
+                if ($this->isApplicable($removingSortField[1], $controller, $container)) {
+                    $controller->removeSortField($removingSortField[0]);
+                }
+            }
+
+            if (isset($this->limit) && $this->isApplicable($this->limit[1], $controller, $container)) {
+                $controller->setLimit($this->limit[0]);
+            }
+
+            if (isset($this->maxLimit) && $this->isApplicable($this->maxLimit[1], $controller, $container)) {
+                $controller->setMaxLimit($this->maxLimit[0]);
+            }
+
+            if (isset($this->sort) && $this->isApplicable($this->sort[1], $controller, $container)) {
+                $controller->setSort($this->sort[0]);
+            }
+        };
+
         foreach ($this->beforeDataCallbacks as $beforeDataCallback) {
             AbstractSerializeController::addDataPreparationCallback($this->controllerClass, $beforeDataCallback);
         }
@@ -74,5 +279,22 @@ class ApiController implements ExtenderInterface
         foreach ($this->beforeSerializationCallbacks as $beforeSerializationCallback) {
             AbstractSerializeController::addSerializationPreparationCallback($this->controllerClass, $beforeSerializationCallback);
         }
+    }
+
+    /**
+     * @param callable|string|null $callback
+     * @param AbstractSerializeController $controller
+     * @param Container $container
+     * @return bool
+     */
+    private function isApplicable($callback, AbstractSerializeController $controller, Container $container)
+    {
+        if (! isset($callback)) {
+            return true;
+        }
+
+        $callback = ContainerUtil::wrapCallback($callback, $container);
+
+        return (bool) $callback($controller);
     }
 }

--- a/src/Extend/ApiController.php
+++ b/src/Extend/ApiController.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extend;
+
+use Flarum\Api\Controller\AbstractSerializeController;
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+
+class ApiController implements ExtenderInterface
+{
+    private $controllerClass;
+    private $beforeDataCallbacks = [];
+    private $beforeSerializationCallbacks = [];
+
+    /**
+     * @param string $controllerClass The ::class attribute of the controller you are modifying.
+     *                                This controller should extend from \Flarum\Api\Controller\AbstractSerializeController.
+     */
+    public function __construct(string $controllerClass)
+    {
+        $this->controllerClass = $controllerClass;
+    }
+
+    /**
+     * @param callable|string $callback
+     *
+     * The callback can be a closure or an invokable class, and should accept:
+     * - $controller: An instance of this controller.
+     *
+     * @return self
+     */
+    public function prepareDataQuery($callback)
+    {
+        $this->beforeDataCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @param $callback
+     *
+     * The callback can be a closure or an invokable class, and should accept:
+     * - $controller: An instance of this controller.
+     * - $data: An array of data.
+     * - $request: An instance of \Psr\Http\Message\ServerRequestInterface.
+     * - $document: An instance of \Tobscure\JsonApi\Document.
+     *
+     * The callable should return:
+     * - An array of additional data to merge with the existing array.
+     *   Or a modified $data array.
+     *
+     * @return self
+     */
+    public function prepareDataForSerialization($callback)
+    {
+        $this->beforeSerializationCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        foreach ($this->beforeDataCallbacks as $beforeDataCallback) {
+            AbstractSerializeController::addDataPreparationCallback($this->controllerClass, $beforeDataCallback);
+        }
+
+        foreach ($this->beforeSerializationCallbacks as $beforeSerializationCallback) {
+            AbstractSerializeController::addSerializationPreparationCallback($this->controllerClass, $beforeSerializationCallback);
+        }
+    }
+}

--- a/src/Extend/ApiController.php
+++ b/src/Extend/ApiController.php
@@ -141,7 +141,7 @@ class ApiController implements ExtenderInterface
      */
     public function removeOptionalInclude($name, $callback = null)
     {
-        $this->removeOptionalIncludes = [$name, $callback];
+        $this->removeOptionalIncludes[] = [$name, $callback];
 
         return $this;
     }

--- a/src/Extend/ApiController.php
+++ b/src/Extend/ApiController.php
@@ -273,10 +273,12 @@ class ApiController implements ExtenderInterface
         };
 
         foreach ($this->beforeDataCallbacks as $beforeDataCallback) {
+            $beforeDataCallback = ContainerUtil::wrapCallback($beforeDataCallback, $container);
             AbstractSerializeController::addDataPreparationCallback($this->controllerClass, $beforeDataCallback);
         }
 
         foreach ($this->beforeSerializationCallbacks as $beforeSerializationCallback) {
+            $beforeSerializationCallback = ContainerUtil::wrapCallback($beforeSerializationCallback, $container);
             AbstractSerializeController::addSerializationPreparationCallback($this->controllerClass, $beforeSerializationCallback);
         }
     }

--- a/tests/integration/extenders/ApiControllerTest.php
+++ b/tests/integration/extenders/ApiControllerTest.php
@@ -316,7 +316,7 @@ class ApiControllerTest extends TestCase
     {
         $this->extend(
             (new Extend\ApiController(ShowPostController::class))
-                ->setSerializer(CustomPostSerializer::class, CustomInvokableClass::class)
+                ->setSerializer(CustomPostSerializer::class, CustomApiControllerInvokableClass::class)
         );
 
         $this->prepDb();
@@ -748,7 +748,7 @@ class CustomPostSerializer extends PostSerializer
     }
 }
 
-class CustomInvokableClass
+class CustomApiControllerInvokableClass
 {
     public function __invoke()
     {

--- a/tests/integration/extenders/ApiControllerTest.php
+++ b/tests/integration/extenders/ApiControllerTest.php
@@ -465,7 +465,7 @@ class ApiControllerTest extends TestCase
         $payload = json_decode($response->getBody(), true);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(3, $payload['data'][0]['id']);
+        $this->assertEquals([3, 1, 2], Arr::pluck($payload['data'], 'id'));
     }
 
     /**
@@ -531,7 +531,7 @@ class ApiControllerTest extends TestCase
         $payload = json_decode($response->getBody(), true);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(2, $payload['data'][0]['id']);
+        $this->assertEquals([2, 1, 3], Arr::pluck($payload['data'], 'id'));
     }
 }
 

--- a/tests/integration/extenders/ApiControllerTest.php
+++ b/tests/integration/extenders/ApiControllerTest.php
@@ -390,8 +390,8 @@ class CustomDiscussionSerializer extends DiscussionSerializer
     protected function getDefaultAttributes($discussion)
     {
         return parent::getDefaultAttributes($discussion) + [
-                'customSerializer' => true
-            ];
+            'customSerializer' => true
+        ];
     }
 }
 
@@ -400,8 +400,8 @@ class CustomUserSerializer extends UserSerializer
     protected function getDefaultAttributes($user)
     {
         return parent::getDefaultAttributes($user) + [
-                'customSerializer' => true
-            ];
+            'customSerializer' => true
+        ];
     }
 }
 
@@ -410,8 +410,8 @@ class CustomPostSerializer extends PostSerializer
     protected function getDefaultAttributes($post)
     {
         return parent::getDefaultAttributes($post) + [
-                'customSerializer' => true
-            ];
+            'customSerializer' => true
+        ];
     }
 }
 

--- a/tests/integration/extenders/ApiControllerTest.php
+++ b/tests/integration/extenders/ApiControllerTest.php
@@ -657,8 +657,8 @@ class CustomDiscussionSerializer extends DiscussionSerializer
     protected function getDefaultAttributes($discussion)
     {
         return parent::getDefaultAttributes($discussion) + [
-                'customSerializer' => true
-            ];
+            'customSerializer' => true
+        ];
     }
 }
 
@@ -667,8 +667,8 @@ class CustomDiscussionSerializer2 extends DiscussionSerializer
     protected function getDefaultAttributes($discussion)
     {
         return parent::getDefaultAttributes($discussion) + [
-                'customSerializer2' => true
-            ];
+            'customSerializer2' => true
+        ];
     }
 }
 

--- a/tests/integration/extenders/ApiControllerTest.php
+++ b/tests/integration/extenders/ApiControllerTest.php
@@ -1,0 +1,432 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Carbon\Carbon;
+use Flarum\Api\Controller\ListDiscussionsController;
+use Flarum\Api\Controller\ShowDiscussionController;
+use Flarum\Api\Controller\ShowPostController;
+use Flarum\Api\Controller\ShowUserController;
+use Flarum\Api\Serializer\DiscussionSerializer;
+use Flarum\Api\Serializer\PostSerializer;
+use Flarum\Api\Serializer\UserSerializer;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Tests\integration\RetrievesAuthorizedUsers;
+use Flarum\Tests\integration\TestCase;
+
+class ApiControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function prepDb()
+    {
+        $this->prepareDatabase([
+            'users' => [
+                $this->adminUser(),
+                $this->normalUser()
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 2, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 3, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
+                ['id' => 3, 'title' => 'Custom Discussion Title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function prepare_data_serialization_callback_works_if_added()
+    {
+        $this->extend(
+            (new Extend\ApiController(ShowDiscussionController::class))
+                ->prepareDataForSerialization(function ($controller, Discussion $discussion) {
+                    $discussion->title = 'dataSerializationPrepCustomTitle';
+                })
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertEquals('dataSerializationPrepCustomTitle', $payload['data']['attributes']['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function prepare_data_serialization_callback_works_with_invokable_classes()
+    {
+        $this->extend(
+            (new Extend\ApiController(ShowDiscussionController::class))
+                ->prepareDataForSerialization(CustomPrepareDataSerializationInvokableClass::class)
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertEquals(CustomPrepareDataSerializationInvokableClass::class, $payload['data']['attributes']['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_serializer_doesnt_work_by_default()
+    {
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayNotHasKey('customSerializer', $payload['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_serializer_works_if_set()
+    {
+        $this->extend(
+            (new Extend\ApiController(ShowDiscussionController::class))
+                ->setSerializer(CustomDiscussionSerializer::class)
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayHasKey('customSerializer', $payload['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_serializer_works_if_set_with_invokable_class()
+    {
+        $this->extend(
+            (new Extend\ApiController(ShowPostController::class))
+                ->setSerializer(CustomPostSerializer::class, CustomInvokableClass::class)
+        );
+
+        $this->prepDb();
+        $this->prepareDatabase([
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>foo bar</p></t>'],
+            ],
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayHasKey('customSerializer', $payload['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_serializer_doesnt_work_with_false_callback_return()
+    {
+        $this->extend(
+            (new Extend\ApiController(ShowUserController::class))
+                ->setSerializer(CustomUserSerializer::class, function () {
+                    return false;
+                })
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayNotHasKey('customSerializer', $payload['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_limit_doesnt_work_by_default()
+    {
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertCount(3, $payload['data']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_limit_works_if_set()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->setLimit(1)
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertCount(1, $payload['data']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_max_limit_works_if_set()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->setMaxLimit(1)
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'page' => ['limit' => '5'],
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertCount(1, $payload['data']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_doesnt_exist_by_default()
+    {
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'sort' => 'userId',
+            ])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_doesnt_work_with_false_callback_return()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->addSortField('userId', function () {
+                    return false;
+                })
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'sort' => 'userId',
+            ])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_exists_if_added()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->addSortField('userId')
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'sort' => 'userId',
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(3, $payload['data'][0]['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_exists_by_default()
+    {
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'sort' => 'createdAt',
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_doesnt_exist_if_removed()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->removeSortField('createdAt')
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams([
+                'sort' => 'createdAt',
+            ])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function custom_sort_field_works_if_set()
+    {
+        $this->extend(
+            (new Extend\ApiController(ListDiscussionsController::class))
+                ->addSortField('userId')
+                ->setSort(['userId' => 'desc'])
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(2, $payload['data'][0]['id']);
+    }
+}
+
+class CustomDiscussionSerializer extends DiscussionSerializer
+{
+    protected function getDefaultAttributes($discussion)
+    {
+        return parent::getDefaultAttributes($discussion) + [
+                'customSerializer' => true
+            ];
+    }
+}
+
+class CustomUserSerializer extends UserSerializer
+{
+    protected function getDefaultAttributes($user)
+    {
+        return parent::getDefaultAttributes($user) + [
+                'customSerializer' => true
+            ];
+    }
+}
+
+class CustomPostSerializer extends PostSerializer
+{
+    protected function getDefaultAttributes($post)
+    {
+        return parent::getDefaultAttributes($post) + [
+                'customSerializer' => true
+            ];
+    }
+}
+
+class CustomInvokableClass
+{
+    public function __invoke()
+    {
+        return true;
+    }
+}
+
+class CustomPrepareDataSerializationInvokableClass
+{
+    public function __invoke(ShowDiscussionController $controller, Discussion $discussion)
+    {
+        $discussion->title = __CLASS__;
+    }
+}

--- a/tests/integration/extenders/ThrottleApiTest.php
+++ b/tests/integration/extenders/ThrottleApiTest.php
@@ -85,6 +85,8 @@ class ThrottleApiTest extends TestCase
 
         $this->prepDb();
 
+        $this->prepDb();
+
         $response = $this->send($this->request('GET', '/api/discussions', ['authenticatedAs' => 2]));
 
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
**Part B of #1624**
**Part of #1891**

**Changes proposed in this pull request:**
* Deprecate `WillGetData` Event.
* Deprecate `WillSerializeData` Event.
* Add extenders to replace both events above.

**Reviewers should focus on:**
* I had to move all the methods in `WillGetData` to the `AbstractSerializeController`, the signature for those methods are somewhat incomplete, some could use proper type hinting while other could explicitly support mixed parameter types of `string|array` do we want to do that ?
* Do we want to add to the extender convenience methods, similar to the ones present in the `WillGetData` event for adding/removing includes ...etc ?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
