### PR TITLE
Deprecate GetModelIsPrivate and its usages

### DIFF
--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -110,6 +110,10 @@ class Discussion extends AbstractModel
             Notification::whereSubject($discussion)->delete();
         });
 
+        /**
+         * @deprecated beta 15, remove beta 16
+         * When needed, the `Flarum\Discussion\Event\Saving` event should be listened to directly.
+         */
         static::saving(function (self $discussion) {
             $event = new GetModelIsPrivate($discussion);
 

--- a/src/Event/GetModelIsPrivate.php
+++ b/src/Event/GetModelIsPrivate.php
@@ -13,6 +13,9 @@ use Flarum\Database\AbstractModel;
 
 /**
  * Determine whether or not a model should be marked as `is_private`.
+ *
+ * @deprecated beta 15, remove beta 16
+ * When needed, the `Flarum\Discussion\Event\Saving` event should be listened to directly.
  */
 class GetModelIsPrivate
 {

--- a/src/Post/Post.php
+++ b/src/Post/Post.php
@@ -96,6 +96,10 @@ class Post extends AbstractModel
             $post->discussion->save();
         });
 
+        /**
+         * @deprecated beta 15, remove beta 16
+         * When needed, the `Flarum\Discussion\Event\Saving` event should be listened to directly.
+         */
         static::saving(function (self $post) {
             $event = new GetModelIsPrivate($post);
 


### PR DESCRIPTION
**Fixes part of #1891**
**Fixes #2420**

**Changes proposed in this pull request:**
This PR deprecates the `GetModelIsPrivate` event; instead, extensions that need to set this should listen to the discussion `Saving` event, and set `is_private` there. I see no reason to treat `is_private` differently than other attributes of models. It's also only present on 2 models (without plans to be included on others, as far as I can tell). A full extender doesn't really make sense.

This will affect the downstream approval and byobu extensions, possibly others (I think php import query on https://query.flarum.dev might be broken).

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
