### PR TITLE
fix the ui modal problem in the change email

### DIFF
--- a/js/src/forum/components/ChangeEmailModal.js
+++ b/js/src/forum/components/ChangeEmailModal.js
@@ -118,10 +118,7 @@ export default class ChangeEmailModal extends Modal {
           meta: { password: this.password() },
         }
       )
-      .then(() => (
-        this.success = true,
-        this.alert = null
-      ))
+      .then(() => ((this.success = true), (this.alert = null)))
       .catch(() => {})
       .then(this.loaded.bind(this));
   }

--- a/js/src/forum/components/ChangeEmailModal.js
+++ b/js/src/forum/components/ChangeEmailModal.js
@@ -118,7 +118,10 @@ export default class ChangeEmailModal extends Modal {
           meta: { password: this.password() },
         }
       )
-      .then(() => (this.success = true))
+      .then(() => (
+        this.success = true,
+        this.alert = null
+      ))
       .catch(() => {})
       .then(this.loaded.bind(this));
   }

--- a/js/src/forum/components/ChangeEmailModal.js
+++ b/js/src/forum/components/ChangeEmailModal.js
@@ -120,7 +120,7 @@ export default class ChangeEmailModal extends Modal {
       )
       .then(() => {
         this.success = true;
-        this.alert = null;
+        this.alertAttrs = null;
       })
       .catch(() => {})
       .then(this.loaded.bind(this));

--- a/js/src/forum/components/ChangeEmailModal.js
+++ b/js/src/forum/components/ChangeEmailModal.js
@@ -118,7 +118,10 @@ export default class ChangeEmailModal extends Modal {
           meta: { password: this.password() },
         }
       )
-      .then(() => ((this.success = true), (this.alert = null)))
+      .then(() => {
+        this.success = true;
+        this.alert = null;
+      })
       .catch(() => {})
       .then(this.loaded.bind(this));
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1892**

**Changes proposed in this pull request:**

I just add the "this.alert = null" when i get the success response in the "ChangeEmailModal" component, and now if you write your password correctly, you do not see the last error alert.

