### PR TITLE
update a user's comment count after deleting a discussion

### DIFF
--- a/src/User/UserMetadataUpdater.php
+++ b/src/User/UserMetadataUpdater.php
@@ -15,6 +15,7 @@ use Flarum\Discussion\Event\Started;
 use Flarum\Post\Event\Deleted as PostDeleted;
 use Flarum\Post\Event\Posted;
 use Illuminate\Contracts\Events\Dispatcher;
+use Flarum\User\User;
 
 class UserMetadataUpdater
 {
@@ -34,7 +35,7 @@ class UserMetadataUpdater
      */
     public function whenPostWasPosted(Posted $event)
     {
-        $this->updateCommentsCount($event->post);
+        $this->updateCommentsCount($event->post->user);
     }
 
     /**
@@ -42,7 +43,7 @@ class UserMetadataUpdater
      */
     public function whenPostWasDeleted(PostDeleted $event)
     {
-        $this->updateCommentsCount($event->post);
+        $this->updateCommentsCount($event->post->user);
     }
 
     /**
@@ -59,16 +60,14 @@ class UserMetadataUpdater
     public function whenDiscussionWasDeleted(DiscussionDeleted $event)
     {
         $this->updateDiscussionsCount($event->discussion);
-        $this->updateCommentsCount($event->discussion);
+        $this->updateCommentsCount($event->discussion->user);
     }
 
     /**
-     * @param \Flarum\Discussion\Discussion|\Flarum\Post\Post $post
+     * @param \Flarum\User\User $user
      */
-    private function updateCommentsCount($post)
+    private function updateCommentsCount(User $user)
     {
-        $user = $post->user;
-
         if ($user && $user->exists) {
             $user->refreshCommentCount()->save();
         }

--- a/src/User/UserMetadataUpdater.php
+++ b/src/User/UserMetadataUpdater.php
@@ -15,7 +15,6 @@ use Flarum\Discussion\Event\Started;
 use Flarum\Post\Event\Deleted as PostDeleted;
 use Flarum\Post\Event\Posted;
 use Illuminate\Contracts\Events\Dispatcher;
-use Flarum\User\User;
 
 class UserMetadataUpdater
 {

--- a/src/User/UserMetadataUpdater.php
+++ b/src/User/UserMetadataUpdater.php
@@ -14,7 +14,6 @@ use Flarum\Discussion\Event\Deleted as DiscussionDeleted;
 use Flarum\Discussion\Event\Started;
 use Flarum\Post\Event\Deleted as PostDeleted;
 use Flarum\Post\Event\Posted;
-use Flarum\Post\Post;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class UserMetadataUpdater

--- a/src/User/UserMetadataUpdater.php
+++ b/src/User/UserMetadataUpdater.php
@@ -60,9 +60,13 @@ class UserMetadataUpdater
     public function whenDiscussionWasDeleted(DiscussionDeleted $event)
     {
         $this->updateDiscussionsCount($event->discussion);
+        $this->updateCommentsCount($event->discussion);
     }
 
-    private function updateCommentsCount(Post $post)
+    /**
+     * @param \Flarum\Discussion\Discussion|\Flarum\Post\Post $post
+     */
+    private function updateCommentsCount($post)
     {
         $user = $post->user;
 


### PR DESCRIPTION
**Fixes #2227**

**Changes proposed in this pull request:**
Remove type hinting from the `updateCommentsCount()` function in order to allow it to accept a Post or a Discussion as an argument. This allows you to call `updateCommentsCount()` from the `whenDiscussionWasDeleted()` listener.

The Post class is no longer used in this file, so I removed the use directive at the top of this file.

**Reviewers should focus on:**
Without union types, there aren't many options for allowing a function to accept two different types of arguments. However, the only other option I could think of other than the one I proposed here is having two arguments with two different types that both default to null. Let me know if there is a better option!

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).

Also, I noticed that if you delete the last post in the discussion, it deletes the discussion, but it does not update the user's discussion count. Should I create a separate issue for that?