### PR TITLE
Don't use browser scroll restore in DiscussionPage

### DIFF
--- a/js/src/common/components/Page.js
+++ b/js/src/common/components/Page.js
@@ -29,6 +29,13 @@ export default class Page extends Component {
      * @type {Boolean}
      */
     this.scrollTopOnCreate = true;
+
+    /**
+     * Whether the browser should restore scroll state on refreshes.
+     *
+     * @type {Boolean}
+     */
+    this.useBrowserScrollRestoration = true;
   }
 
   oncreate(vnode) {
@@ -40,6 +47,10 @@ export default class Page extends Component {
 
     if (this.scrollTopOnCreate) {
       $(window).scrollTop(0);
+    }
+
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = this.useBrowserScrollRestoration ? 'auto' : 'manual';
     }
   }
 

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -18,6 +18,8 @@ export default class DiscussionPage extends Page {
   oninit(vnode) {
     super.oninit(vnode);
 
+    this.useBrowserScrollRestoration = false;
+
     /**
      * The discussion that is being viewed.
      *


### PR DESCRIPTION
**Fixes #789**

Although native browser scroll restorations have become quite powerful, it interferes with Flarum's PostStream scrolling system, so if we're on a DiscussionPage, we use manual scroll restoration.