### PR TITLE
DRY up image uploading code

### DIFF
--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -31,7 +31,8 @@ class UploadFaviconController extends UploadImageController
     /**
      * {@inheritdoc}
      */
-    protected function makeImage(UploadedFileInterface $file): Image {
+    protected function makeImage(UploadedFileInterface $file): Image
+    {
         $this->fileExtension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
 
         if ($this->fileExtension === 'ico') {

--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -9,24 +9,15 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
-use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 class UploadFaviconController extends UploadImageController
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
-    {
-        parent::__construct($settings, $uploadDir);
+    protected $filePathSettingKey = 'favicon_path';
 
-        $this->filenamePrefix = 'favicon';
-        $this->filePathSettingKey = 'favicon_path';
-    }
+    protected $filenamePrefix = 'favicon';
 
     /**
      * {@inheritdoc}

--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -10,68 +10,43 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
+use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use League\Flysystem\FilesystemInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Tobscure\JsonApi\Document;
+use Psr\Http\Message\UploadedFileInterface;
 
-class UploadFaviconController extends ShowForumController
+class UploadFaviconController extends UploadImageController
 {
     /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
-
-    /**
-     * @var FilesystemInterface
-     */
-    protected $uploadDir;
-
-    /**
-     * @param SettingsRepositoryInterface $settings
-     * @param FilesystemInterface $uploadDir
+     * {@inheritdoc}
      */
     public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
     {
-        $this->settings = $settings;
-        $this->uploadDir = $uploadDir;
+        parent::__construct($settings, $uploadDir);
+
+        $this->filenamePrefix = 'favicon';
+        $this->filePathSettingKey = 'favicon_path';
     }
 
     /**
      * {@inheritdoc}
      */
-    public function data(ServerRequestInterface $request, Document $document)
-    {
-        $request->getAttribute('actor')->assertAdmin();
+    protected function makeImage(UploadedFileInterface $file): Image {
+        $this->fileExtension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
 
-        $file = Arr::get($request->getUploadedFiles(), 'favicon');
-        $extension = pathinfo($file->getClientFilename(), PATHINFO_EXTENSION);
-
-        if ($extension === 'ico') {
-            $image = $file->getStream();
+        if ($this->fileExtension === 'ico') {
+            $encodedImage = $file->getStream();
         } else {
-            $manager = new ImageManager;
+            $manager = new ImageManager();
 
-            $image = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
+            $encodedImage = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
                 $constraint->aspectRatio();
                 $constraint->upsize();
             })->encode('png');
 
-            $extension = 'png';
+            $this->fileExtension = 'png';
         }
 
-        if (($path = $this->settings->get('favicon_path')) && $this->uploadDir->has($path)) {
-            $this->uploadDir->delete($path);
-        }
-
-        $uploadName = 'favicon-'.Str::lower(Str::random(8)).'.'.$extension;
-
-        $this->uploadDir->write($uploadName, $image);
-
-        $this->settings->set('favicon_path', $uploadName);
-
-        return parent::data($request, $document);
+        return $encodedImage;
     }
 }

--- a/src/Api/Controller/UploadImageController.php
+++ b/src/Api/Controller/UploadImageController.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Intervention\Image\Image;
+use League\Flysystem\FilesystemInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Tobscure\JsonApi\Document;
+
+abstract class UploadImageController extends ShowForumController
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @var FilesystemInterface
+     */
+    protected $uploadDir;
+
+    /**
+     * @var string
+     */
+    protected $fileExtension = 'png';
+
+    /**
+     * @var string
+     */
+    protected $filePathSettingKey;
+
+    /**
+     * @var string
+     */
+    protected $filenamePrefix;
+
+    /**
+     * @param SettingsRepositoryInterface $settings
+     * @param FilesystemInterface $uploadDir
+     */
+    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
+    {
+        $this->settings = $settings;
+        $this->uploadDir = $uploadDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function data(ServerRequestInterface $request, Document $document)
+    {
+        $request->getAttribute('actor')->assertAdmin();
+
+        $file = Arr::get($request->getUploadedFiles(), $this->filenamePrefix);
+
+        $encodedImage = $this->makeImage($file);
+
+        if (($path = $this->settings->get($this->filePathSettingKey)) && $this->uploadDir->has($path)) {
+            $this->uploadDir->delete($path);
+        }
+
+        $uploadName = $this->filenamePrefix.'-'.Str::lower(Str::random(8)).'.'.$this->fileExtension;
+
+        $this->uploadDir->write($uploadName, $encodedImage);
+
+        $this->settings->set($this->filePathSettingKey, $uploadName);
+
+        return parent::data($request, $document);
+    }
+
+    /**
+     * @param UploadedFileInterface $file
+     * @return Image
+     */
+    abstract protected function makeImage(UploadedFileInterface $file): Image;
+}

--- a/src/Api/Controller/UploadImageController.php
+++ b/src/Api/Controller/UploadImageController.php
@@ -38,12 +38,12 @@ abstract class UploadImageController extends ShowForumController
     /**
      * @var string
      */
-    protected $filePathSettingKey;
+    protected $filePathSettingKey = '';
 
     /**
      * @var string
      */
-    protected $filenamePrefix;
+    protected $filenamePrefix = '';
 
     /**
      * @param SettingsRepositoryInterface $settings

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -31,7 +31,8 @@ class UploadLogoController extends UploadImageController
     /**
      * {@inheritdoc}
      */
-    protected function makeImage(UploadedFileInterface $file): Image {
+    protected function makeImage(UploadedFileInterface $file): Image
+    {
         $manager = new ImageManager();
 
         $encodedImage = $manager->make($file->getStream())->heighten(60, function ($constraint) {

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -9,24 +9,15 @@
 
 namespace Flarum\Api\Controller;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
-use League\Flysystem\FilesystemInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 class UploadLogoController extends UploadImageController
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct(SettingsRepositoryInterface $settings, FilesystemInterface $uploadDir)
-    {
-        parent::__construct($settings, $uploadDir);
+    protected $filePathSettingKey = 'logo_path';
 
-        $this->filenamePrefix = 'logo';
-        $this->filePathSettingKey = 'logo_path';
-    }
+    protected $filenamePrefix = 'logo';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
**Refs #1306**

**Changes proposed in this pull request:**

Abstracted common functionality into a generic UploadImageController class. Did not tackle SVG support as it's not defined in the issue what this should be - simply leave them as is as for `.ico` files? Or something else? Happy to tackle this either in this PR or separately.

**Reviewers should focus on:**

The refactored code; new class property names in particular in UploadImageController.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
