### PR TITLE
Fixes issue with the worker defaulting to the illuminate queue manager

### DIFF
--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -22,7 +22,6 @@ use Illuminate\Queue\Console as Commands;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\Listener as QueueListener;
-use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SyncQueue;
 use Illuminate\Queue\Worker;
 

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -66,7 +66,7 @@ class QueueServiceProvider extends AbstractServiceProvider
             $config = $app->make(Config::class);
 
             return new Worker(
-                new QueueManager($app),
+                $app[Factory::class],
                 $app['events'],
                 $app[ExceptionHandling::class],
                 function () use ($config) {


### PR DESCRIPTION
We are instantiating our own queue handling factory which returns the
flarum.queue.connection binding no matter what. The queue Worker and
other queue related code rely on this manager to get its thing going.
Therefor we need to re-use our own factory everywhere, including in
the worker.
