### PR TITLE
Replace forum and admin global compat exports with a Proxy

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -10,8 +10,9 @@ export { app };
 // Export public API
 
 // Export compat API
-import compat from './compat';
+import compatObj from './compat';
+import proxifyCompat from '../common/utils/proxifyCompat';
 
-compat.app = app;
+compatObj.app = app;
 
-export { compat };
+export const compat = proxifyCompat(compatObj, 'admin');

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -21,6 +21,7 @@ import stringToColor from './utils/stringToColor';
 import subclassOf from './utils/subclassOf';
 import SuperTextarea from './utils/SuperTextarea';
 import patchMithril from './utils/patchMithril';
+import proxifyCompat from './utils/proxifyCompat';
 import classList from './utils/classList';
 import extractText from './utils/extractText';
 import formatNumber from './utils/formatNumber';
@@ -94,6 +95,7 @@ export default {
   'utils/SuperTextarea': SuperTextarea,
   'utils/setRouteWithForcedRefresh': setRouteWithForcedRefresh,
   'utils/patchMithril': patchMithril,
+  'utils/proxifyCompat': proxifyCompat,
   'utils/classList': classList,
   'utils/extractText': extractText,
   'utils/formatNumber': formatNumber,

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -1,0 +1,10 @@
+export default (compat: { [key: string]: any }, namespace: string) => {
+  // regex to replace common/ and NAMESPACE/ for core & core extensions
+  // e.g. admin/utils/extract --> utils/extract
+  // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
+  const regex = new RegExp(`(\\w+\\/)?(${namespace}|common)\\/`);
+
+  return new Proxy(compat, {
+    get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '$1')],
+  });
+};

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -15,8 +15,9 @@ export { app };
 // export { IndexPage, DicsussionList } from './components';
 
 // Export compat API
-import compat from './compat';
+import compatObj from './compat';
+import proxifyCompat from '../common/utils/proxifyCompat';
 
-compat.app = app;
+compatObj.app = app;
 
-export { compat };
+export const compat = proxifyCompat(compatObj, 'forum');


### PR DESCRIPTION
Refs #2085.

Replaces https://github.com/flarum/flarum-webpack-config/pull/7.

Adds ability for import statements of core & core extensions to include their namespaces (`forum`, `admin`, and `common`).

We'll eventually require extensions use the namespaces in their imports. This PR makes them optional for extensions and allows extensions to continue working once we require them.

Original compat objects are left intact & do not contain the namespaces.

- import `admin/utils/extract` --> returns import `utils/extract`
- import `tags/common/utils/sortTags` --> returns import `tags/utils/sortTags`

Technically extensions can also use the incorrect namespace (forum/admin and common) as this code doesn't check whether it's correct. This shouldn't be a problem that we focus on, however.