### PR TITLE
Refactor AccountActivationMailer and SendConfirmationEmailController

### DIFF
--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -10,9 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Http\UrlGenerator;
-use Flarum\Mail\Job\SendRawEmailJob;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\EmailToken;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\Arr;

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use \Flarum\User\AccountActivationMailerTrait;
+use Flarum\User\AccountActivationMailerTrait;
 
 class SendConfirmationEmailController implements RequestHandlerInterface
 {

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -23,6 +23,8 @@ use Flarum\User\AccountActivationMailerTrait;
 
 class SendConfirmationEmailController implements RequestHandlerInterface
 {
+    use AccountActivationMailerTrait;
+
     /**
      * @var SettingsRepositoryInterface
      */

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -19,11 +19,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use \Flarum\User\AccountActivationMailerTrait;
 
 class SendConfirmationEmailController implements RequestHandlerInterface
 {
-    use \Flarum\User\AccountActivationMailerTrait;
-
     /**
      * @var SettingsRepositoryInterface
      */
@@ -73,7 +72,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
         }
 
         $token = $this->generateToken($actor, $actor->email);
-        $data = $this->getEmailData($actor, $actor->email, $token);
+        $data = $this->getEmailData($actor, $token);
 
         $this->sendConfirmationEmail($actor, $data);
 

--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -11,6 +11,7 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\AccountActivationMailerTrait;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\Arr;
@@ -19,7 +20,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Flarum\User\AccountActivationMailerTrait;
 
 class SendConfirmationEmailController implements RequestHandlerInterface
 {

--- a/src/User/AccountActivationMailer.php
+++ b/src/User/AccountActivationMailer.php
@@ -10,7 +10,6 @@
 namespace Flarum\User;
 
 use Flarum\Http\UrlGenerator;
-use Flarum\Mail\Job\SendRawEmailJob;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Event\Registered;
 use Illuminate\Contracts\Queue\Queue;

--- a/src/User/AccountActivationMailer.php
+++ b/src/User/AccountActivationMailer.php
@@ -62,7 +62,7 @@ class AccountActivationMailer
         }
 
         $token = $this->generateToken($user, $user->email);
-        $data = $this->getEmailData($user, $user->email, $token);
+        $data = $this->getEmailData($user, $token);
 
         $this->sendConfirmationEmail($user, $data);
     }

--- a/src/User/AccountActivationMailerTrait.php
+++ b/src/User/AccountActivationMailerTrait.php
@@ -47,7 +47,8 @@ trait AccountActivationMailerTrait
      * @param User $user
      * @param array $data
      */
-    protected function sendConfirmationEmail(User $user, $data) {
+    protected function sendConfirmationEmail(User $user, $data)
+    {
         $body = $this->translator->trans('core.email.activate_account.body', $data);
         $subject = '['.$data['{forum}'].'] '.$this->translator->trans('core.email.activate_account.subject');
 

--- a/src/User/AccountActivationMailerTrait.php
+++ b/src/User/AccountActivationMailerTrait.php
@@ -30,11 +30,10 @@ trait AccountActivationMailerTrait
      * Get the data that should be made available to email templates.
      *
      * @param User $user
-     * @param string $email
      * @param EmailToken $token
      * @return array
      */
-    protected function getEmailData(User $user, $email, EmailToken $token)
+    protected function getEmailData(User $user, EmailToken $token)
     {
         return [
             '{username}' => $user->display_name,

--- a/src/User/AccountActivationMailerTrait.php
+++ b/src/User/AccountActivationMailerTrait.php
@@ -49,7 +49,7 @@ trait AccountActivationMailerTrait
     protected function sendConfirmationEmail(User $user, $data)
     {
         $body = $this->translator->trans('core.email.activate_account.body', $data);
-        $subject = '['.$data['{forum}'].'] '.$this->translator->trans('core.email.activate_account.subject');
+        $subject = $this->translator->trans('core.email.activate_account.subject');
 
         $this->queue->push(new SendRawEmailJob($user->email, $subject, $body));
     }

--- a/src/User/AccountActivationMailerTrait.php
+++ b/src/User/AccountActivationMailerTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User;
+
+use Flarum\Mail\Job\SendRawEmailJob;
+
+trait AccountActivationMailerTrait
+{
+    /**
+     * @param User $user
+     * @param string $email
+     * @return EmailToken
+     */
+    protected function generateToken(User $user, $email)
+    {
+        $token = EmailToken::generate($email, $user->id);
+        $token->save();
+
+        return $token;
+    }
+
+    /**
+     * Get the data that should be made available to email templates.
+     *
+     * @param User $user
+     * @param string $email
+     * @param EmailToken $token
+     * @return array
+     */
+    protected function getEmailData(User $user, $email, EmailToken $token)
+    {
+        return [
+            '{username}' => $user->display_name,
+            '{url}' => $this->url->to('forum')->route('confirmEmail', ['token' => $token->token]),
+            '{forum}' => $this->settings->get('forum_title')
+        ];
+    }
+
+    /**
+     * @param User $user
+     * @param array $data
+     */
+    protected function sendConfirmationEmail(User $user, $data) {
+        $body = $this->translator->trans('core.email.activate_account.body', $data);
+        $subject = '['.$data['{forum}'].'] '.$this->translator->trans('core.email.activate_account.subject');
+
+        $this->queue->push(new SendRawEmailJob($user->email, $subject, $body));
+    }
+}


### PR DESCRIPTION
**Fixes #2193**

**Changes proposed in this pull request:**

Moves the common code between [SendConfirmationEmailController](https://github.com/flarum/core/blob/master/src/Api/Controller/SendConfirmationEmailController.php) and [AccountActivationMailer](https://github.com/flarum/core/blob/master/src/User/AccountActivationMailer.php) into a trait.

**Reviewers should focus on:**

I wasn't sure what to name the trait or where to put it, but because most of the code for the trait was taken from the AccountActivationMailer class I decided to name it the AccountActivationMailerTrait and keep it in the same directory. Also, I decoupled the generateToken and getEmailData functions because I think it will make more modular and maintainable even through it may make using the trait more verbose.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
