### PR TITLE
Add default value to Settings extender

### DIFF
--- a/src/Extend/Settings.php
+++ b/src/Extend/Settings.php
@@ -26,11 +26,12 @@ class Settings implements ExtenderInterface
      * @param string $attributeName: The attribute name to be used in the ForumSerializer attributes array.
      * @param string $key: The key of the setting.
      * @param string|callable|null $callback: Optional callback to modify the value before serialization.
+     * @param mixed $default: Optional default serialized value.
      * @return $this
      */
-    public function serializeToForum(string $attributeName, string $key, $callback = null)
+    public function serializeToForum(string $attributeName, string $key, $callback = null, $default = null)
     {
-        $this->settings[$key] = compact('attributeName', 'callback');
+        $this->settings[$key] = compact('attributeName', 'callback', 'default');
 
         return $this;
     }
@@ -45,7 +46,7 @@ class Settings implements ExtenderInterface
                     $attributes = [];
 
                     foreach ($this->settings as $key => $setting) {
-                        $value = $settings->get($key, null);
+                        $value = $settings->get($key, $setting['default']);
 
                         if (isset($setting['callback'])) {
                             $callback = ContainerUtil::wrapCallback($setting['callback'], $container);

--- a/src/Extend/Settings.php
+++ b/src/Extend/Settings.php
@@ -26,7 +26,7 @@ class Settings implements ExtenderInterface
      * @param string $attributeName: The attribute name to be used in the ForumSerializer attributes array.
      * @param string $key: The key of the setting.
      * @param string|callable|null $callback: Optional callback to modify the value before serialization.
-     * @param mixed $default: Optional default serialized value. Is also passed to the optional callback.
+     * @param mixed $default: Optional default serialized value. Will be run through the optional callback.
      * @return $this
      */
     public function serializeToForum(string $attributeName, string $key, $callback = null, $default = null)

--- a/src/Extend/Settings.php
+++ b/src/Extend/Settings.php
@@ -26,7 +26,7 @@ class Settings implements ExtenderInterface
      * @param string $attributeName: The attribute name to be used in the ForumSerializer attributes array.
      * @param string $key: The key of the setting.
      * @param string|callable|null $callback: Optional callback to modify the value before serialization.
-     * @param mixed $default: Optional default serialized value.
+     * @param mixed $default: Optional default serialized value. Is also passed to the optional callback.
      * @return $this
      */
     public function serializeToForum(string $attributeName, string $key, $callback = null, $default = null)

--- a/tests/integration/extenders/SettingsTest.php
+++ b/tests/integration/extenders/SettingsTest.php
@@ -130,6 +130,30 @@ class SettingsTest extends TestCase
     {
         $this->extend(
             (new Extend\Settings())
+                ->serializeToForum('customPrefix.noCustomSetting', 'custom-prefix.no_custom_setting', null, 'customDefault')
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayHasKey('customPrefix.noCustomSetting', $payload['data']['attributes']);
+        $this->assertEquals('customDefault', $payload['data']['attributes']['customPrefix.noCustomSetting']);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_setting_default_passed_to_callback()
+    {
+        $this->extend(
+            (new Extend\Settings())
                 ->serializeToForum('customPrefix.noCustomSetting', 'custom-prefix.no_custom_setting', function ($value) {
                     return $value.'Modified2';
                 }, 'customDefault')

--- a/tests/integration/extenders/SettingsTest.php
+++ b/tests/integration/extenders/SettingsTest.php
@@ -122,6 +122,32 @@ class SettingsTest extends TestCase
         $this->assertArrayHasKey('customPrefix.customSetting2', $payload['data']['attributes']);
         $this->assertEquals('customValueModifiedByInvokable', $payload['data']['attributes']['customPrefix.customSetting2']);
     }
+
+    /**
+     * @test
+     */
+    public function custom_setting_falls_back_to_default()
+    {
+        $this->extend(
+            (new Extend\Settings())
+                ->serializeToForum('customPrefix.noCustomSetting', 'custom-prefix.no_custom_setting', function ($value) {
+                    return $value.'Modified2';
+                }, 'customDefault')
+        );
+
+        $this->prepDb();
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertArrayHasKey('customPrefix.noCustomSetting', $payload['data']['attributes']);
+        $this->assertEquals('customDefaultModified2', $payload['data']['attributes']['customPrefix.noCustomSetting']);
+    }
 }
 
 class CustomInvokableClass


### PR DESCRIPTION
**Related to #2452**

**Changes proposed in this pull request:**
So it seems as though adding default values through migrations isn't always the way to go, at least for serializing.

**Confirmed**
- [x] Backend changes: tests are green (run `composer test`).
