### PR TITLE
Fixes validation failures of avatars that are jpg/jpeg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "symfony/config": "^4.3.4",
         "symfony/console": "^4.3.4",
         "symfony/event-dispatcher": "^4.3.4",
+        "symfony/mime": "^5.2.0",
         "symfony/translation": "^4.3.4",
         "symfony/yaml": "^4.3.4",
         "tobscure/json-api": "^0.3.0",

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -80,6 +80,6 @@ class AvatarValidator extends AbstractValidator
 
     protected function getAllowedTypes()
     {
-        return ['jpeg', 'png', 'bmp', 'gif'];
+        return ['jpg', 'png', 'bmp', 'gif'];
     }
 }


### PR DESCRIPTION
Summary: https://discuss.flarum.org/d/25536-avatar-upload-jpg/47

Due to a commit by @fabpot in october, the mimetypes symfony class
now re-orders the shortened mimetypes that are returned when looking
up based on header mimetype. Our validator uses the first key, pops
the prefix off and then matches against our hardcoded array.

I've added a constraint to symfony/mime ^5.2.0 which ships with this change.
This constraint is fully compatible with our current lineup. In addition
I changed the hardcoded array to use the first entry from symfony mime types
now `jpg` instead of `jpeg`.

This change has been locally tested and confirmed fixed.