### PR TITLE
Add forum prefix in re-sent confirmation email

### DIFF
--- a/src/Api/Controller/SendConfirmationEmailController.php
+++ b/src/Api/Controller/SendConfirmationEmailController.php
@@ -82,7 +82,7 @@ class SendConfirmationEmailController implements RequestHandlerInterface
         ];
 
         $body = $this->translator->trans('core.email.activate_account.body', $data);
-        $subject = $this->translator->trans('core.email.activate_account.subject');
+        $subject = '['.$data['{forum}'].'] '.$this->translator->trans('core.email.activate_account.subject');
 
         $this->queue->push(new SendRawEmailJob($actor->email, $subject, $body));
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2515**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
In SendConfirmationEmailController::handle(), append forum title to the email subject. The title is provided by the $data array some few lines above.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
When a confirmation email is resent, the subject line should be similar to the subject line of activation email. That's should have "[Forum Name]" prefix, followed by the remaining subject text

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
