### PR TITLE
Fix deleting posts/discussions by deleted user

### DIFF
--- a/src/User/UserMetadataUpdater.php
+++ b/src/User/UserMetadataUpdater.php
@@ -65,7 +65,7 @@ class UserMetadataUpdater
     /**
      * @param \Flarum\User\User $user
      */
-    private function updateCommentsCount(User $user)
+    private function updateCommentsCount(?User $user)
     {
         if ($user && $user->exists) {
             $user->refreshCommentCount()->save();


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2506

Making the $user argument nullable prevents this unnecessary exception, and doesn't introduce any issues since we check that $user exists as part of the method.