### PR TITLE
Add Notification extender beforeSending method

### DIFF
--- a/src/Extend/Notification.php
+++ b/src/Extend/Notification.php
@@ -56,6 +56,7 @@ class Notification implements ExtenderInterface
 
     /**
      * @param callable|string $callback
+     * @return self
      */
     public function beforeSending($callback)
     {

--- a/src/Notification/NotificationSyncer.php
+++ b/src/Notification/NotificationSyncer.php
@@ -44,6 +44,11 @@ class NotificationSyncer
     protected static $notificationDrivers = [];
 
     /**
+     * @var array
+     */
+     protected static $beforeSendingCallbacks = [];
+
+    /**
      * Sync a notification so that it is visible to the specified users, and not
      * visible to anyone else. If it is being made visible for the first time,
      * attempt to send the user an email.
@@ -92,6 +97,10 @@ class NotificationSyncer
 
         if (count($toUndelete)) {
             $this->setDeleted($toUndelete, false);
+        }
+
+        foreach (static::$beforeSendingCallbacks as $callback) {
+            $callback($blueprint, $newRecipients);
         }
 
         // Create a notification record, and send an email, for all users
@@ -175,5 +184,13 @@ class NotificationSyncer
     public static function getNotificationDrivers(): array
     {
         return static::$notificationDrivers;
+    }
+
+    /**
+     * @param callable|string $callback
+     */
+    public static function beforeSending($callback): void
+    {
+        static::$beforeSendingCallbacks[] = $callback;
     }
 }

--- a/src/Notification/NotificationSyncer.php
+++ b/src/Notification/NotificationSyncer.php
@@ -46,7 +46,7 @@ class NotificationSyncer
     /**
      * @var array
      */
-     protected static $beforeSendingCallbacks = [];
+    protected static $beforeSendingCallbacks = [];
 
     /**
      * Sync a notification so that it is visible to the specified users, and not

--- a/src/Notification/NotificationSyncer.php
+++ b/src/Notification/NotificationSyncer.php
@@ -100,7 +100,7 @@ class NotificationSyncer
         }
 
         foreach (static::$beforeSendingCallbacks as $callback) {
-            $callback($blueprint, $newRecipients);
+            $newRecipients = $callback($blueprint, $newRecipients);
         }
 
         // Create a notification record, and send an email, for all users

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -145,13 +145,10 @@ class NotificationTest extends TestCase
         );
 
         $this->prepareDatabase([
-            'discussions' => [
-                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 3, 'first_post_id' => 1, 'comment_count' => 1],
-            ],
             'users' => [
                 $this->adminUser(),
                 $this->normalUser(),
-                ['id' => 3, 'username' => 'hani', 'password' => '$2y$10$HMOAe.XaQjOimA778VmFue1OCt7tj5j0wk5vfoL/CMSJq2BQlfBV2', 'email' => 'hani@machine.local', 'is_email_confirmed' => 1]
+                ['id' => 3, 'username' => 'hani']
             ],
         ]);
 
@@ -172,12 +169,12 @@ class CustomNotificationType implements BlueprintInterface
 {
     public function getFromUser()
     {
-        return User::find(3);
+        return null;
     }
 
     public function getSubject()
     {
-        return Discussion::find(1);
+        return null;
     }
 
     public function getData()
@@ -192,7 +189,7 @@ class CustomNotificationType implements BlueprintInterface
 
     public static function getSubjectModel()
     {
-        return Discussion::class;
+        return 'customNotificationSubjectModel';
     }
 }
 

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -9,8 +9,6 @@
 
 namespace Flarum\Tests\integration\extenders;
 
-use Carbon\Carbon;
-use Flarum\Discussion\Discussion;
 use Flarum\Extend;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Driver\NotificationDriverInterface;

--- a/tests/integration/extenders/NotificationTest.php
+++ b/tests/integration/extenders/NotificationTest.php
@@ -187,7 +187,7 @@ class CustomNotificationType implements BlueprintInterface
 
     public static function getSubjectModel()
     {
-        return 'customNotificationSubjectModel';
+        return 'customNotificationTypeSubjectModel';
     }
 }
 


### PR DESCRIPTION
**Part of #1891**

**Changes proposed in this pull request:**
This is needed for extensions to be able to prevent certain notifications from being sent.

Just need to figure out what to do for integration tests for this.

**Confirmed**
- [ ] Backend changes: tests are green (run `composer test`).
