### PR TITLE
Add `subscribe` method to event extender

### DIFF
--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -22,8 +22,10 @@ class Event implements ExtenderInterface
      * Add a listener to a domain event dispatched by flarum or a flarum extension.
      *
      * The listener can either be:
-     *  - a callback function or
+     *  - a callback function
      *  - the class attribute of a class with a public `handle` method, which accepts an instance of the event as a parameter
+     *  - an array, where the first argument is an object or class name, and the second argument is the method on the
+     *    first argument that should be executed as the listener
      *
      * @param string $event
      * @param callable|string $listener
@@ -37,8 +39,12 @@ class Event implements ExtenderInterface
 
     /**
      * Add a subscriber for a set of domain events dispatched by flarum or a flarum extension.
+     * Event subscribers are classes that may subscribe to multiple events from within the subscriber class itself,
+     * allowing you to define several event handlers within a single class.
      *
-     * @param string $subscriber
+     * @see https://laravel.com/docs/6.x/events#writing-event-subscribers
+     *
+     * @param string $subscriber: The class attribute of the subscriber class
      */
     public function subscribe(string $subscriber)
     {

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
+use Flarum\Foundation\Application;
 use Flarum\Group\Command\CreateGroup;
 use Flarum\Group\Event\Created;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
@@ -130,9 +131,9 @@ class CustomSubscriber
     protected $bootedAtConstruct;
     protected $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(Application $app, TranslatorInterface $translator)
     {
-        $this->bootedAtConstruct = app('flarum')->isBooted();
+        $this->bootedAtConstruct = $app->isBooted();
         $this->translator = $translator;
     }
 

--- a/tests/integration/extenders/EventTest.php
+++ b/tests/integration/extenders/EventTest.php
@@ -15,7 +15,8 @@ use Flarum\Group\Event\Created;
 use Flarum\Tests\integration\RetrievesAuthorizedUsers;
 use Flarum\Tests\integration\TestCase;
 use Flarum\User\User;
-use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class EventTest extends TestCase
@@ -33,7 +34,7 @@ class EventTest extends TestCase
             ],
         ]);
 
-        $bus = $this->app()->getContainer()->make(Dispatcher::class);
+        $bus = $this->app()->getContainer()->make(BusDispatcher::class);
 
         return $bus->dispatch(
             new CreateGroup(User::find(1), ['attributes' => [
@@ -81,6 +82,32 @@ class EventTest extends TestCase
 
         $this->assertEquals('core.group.admin', $group->name_singular);
     }
+
+    /**
+     * @test
+     */
+    public function custom_subscriber_works()
+    {
+        // Because it injects a translator, this also tests that stuff can be injected into this callback.
+        $this->extend((new Extend\Event)->subscribe(CustomSubscriber::class));
+
+        $group = $this->buildGroup();
+
+        $this->assertEquals('core.group.admin', $group->name_singular);
+    }
+
+    /**
+     * @test
+     */
+    public function custom_subscriber_applied_after_app_booted()
+    {
+        // Because it injects a translator, this also tests that stuff can be injected into this callback.
+        $this->extend((new Extend\Event)->subscribe(CustomSubscriber::class));
+
+        $group = $this->buildGroup();
+
+        $this->assertEquals('booted', $group->name_plural);
+    }
 }
 
 class CustomListener
@@ -95,5 +122,28 @@ class CustomListener
     public function handle(Created $event)
     {
         $event->group->name_singular = $this->translator->trans('core.group.admin');
+    }
+}
+
+class CustomSubscriber
+{
+    protected $bootedAtConstruct;
+    protected $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->bootedAtConstruct = app('flarum')->isBooted();
+        $this->translator = $translator;
+    }
+
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Created::class, [$this, 'whenGroupCreated']);
+    }
+
+    public function whenGroupCreated(Created $event)
+    {
+        $event->group->name_singular = $this->translator->trans('core.group.admin');
+        $event->group->name_plural = $this->bootedAtConstruct ? 'booted' : 'not booted';
     }
 }


### PR DESCRIPTION
Historically, extensions using subscribers has caused problems because subscribers were constructed/applied at extension boot. This caused some classes (e.g. UrlGenerator) to be resolved early, breaking parts of Flarum. For this reason, subscriber support wasn't included in the initial version of the Event extender.

However, updating extensions has shown that there is a legitimate use case for subscribers in organizing clean code; for instance, core's own `DiscussionMetadataUpdater`.

This commit introduces support for subscribers, but only applies them after the app has booted, which avoids the early resolution issues. Since event listeners/subscribers are only intended to be used with domain events, which would never be dispatched during app boot, the late activation of subscribers should not cause issue.