### PR TITLE
Set this.changingState back to false in ExtensionPage if an error occurs

### DIFF
--- a/js/src/admin/components/ExtensionPage.js
+++ b/js/src/admin/components/ExtensionPage.js
@@ -346,6 +346,8 @@ export default class ExtensionPage extends Page {
       app.modal.close();
     }, 300); // Bootstrap's Modal.TRANSITION_DURATION is 300 ms.
 
+    this.changingState = false;
+
     if (e.status !== 409) {
       throw e;
     }

--- a/js/src/admin/components/ExtensionPage.js
+++ b/js/src/admin/components/ExtensionPage.js
@@ -59,6 +59,8 @@ export default class ExtensionPage extends Page {
   }
 
   header() {
+    const isEnabled = this.isEnabled();
+
     return [
       <div className="ExtensionPage-header">
         <div className="container">
@@ -75,10 +77,12 @@ export default class ExtensionPage extends Page {
           </div>
           <div className="helpText">{this.extension.description}</div>
           <div className="ExtensionPage-headerItems">
-            <Switch state={this.isEnabled()} onchange={this.toggle.bind(this, this.extension.id)}>
-              {this.isEnabled(this.extension.id)
-                ? app.translator.trans('core.admin.extension.enabled')
-                : app.translator.trans('core.admin.extension.disabled')}
+            <Switch
+              state={this.changingState ? !isEnabled : isEnabled}
+              loading={this.changingState}
+              onchange={this.toggle.bind(this, this.extension.id)}
+            >
+              {isEnabled ? app.translator.trans('core.admin.extension.enabled') : app.translator.trans('core.admin.extension.disabled')}
             </Switch>
             <aside className="ExtensionInfo">
               <ul>{listItems(this.infoItems().toArray())}</ul>
@@ -333,9 +337,7 @@ export default class ExtensionPage extends Page {
   }
 
   isEnabled() {
-    let isEnabled = isExtensionEnabled(this.extension.id);
-
-    return this.changingState ? !isEnabled : isEnabled;
+    return isExtensionEnabled(this.extension.id);
   }
 
   onerror(e) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2536**

**Changes proposed in this pull request:**
- Set `this.changingState = false` in `onerror` handler.
- Only use `this.changingState` for Switch status & its loading attribute
  - do not take it into account in whether to show the ext settings as that makes it look bad (see reviewer focus below)

<details>
<summary><b>Reviewers should focus on:</b></summary>


I feel like we should instead get rid of `changingState` completely. It causes the UI to glitch out and there's no reason for the text & info shown to update while the "Please wait" modal is active and then be wrong.


https://user-images.githubusercontent.com/6401250/105232641-acc6bf80-5b36-11eb-8235-cf97a436af02.mp4

</details>

**Video:**

https://user-images.githubusercontent.com/6401250/105638030-8a86b780-5e3e-11eb-922d-6ce8850eae7d.mp4


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
