### PR TITLE
Update DiscussionListItem.less to fix touch double tap

### DIFF
--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -110,7 +110,7 @@
   }
 }
 
-@media (hover: none) { 
+@media (hover-any: none) { 
   .DiscussionListItem .Dropdown-toggle.Button { 
     display: none; } 
 }

--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -110,6 +110,10 @@
   }
 }
 
+@media (hover: none) { 
+  .DiscussionListItem .Dropdown-toggle.Button { 
+    display: none; } 
+}
 
 @media @phone {
   .DiscussionListItem-controls {

--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -110,7 +110,7 @@
   }
 }
 
-@media (hover-any: none) { 
+@media (any-hover: none) { 
   .DiscussionListItem .Dropdown-toggle.Button { 
     display: none; } 
 }

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -103,13 +103,6 @@
     font-weight: bold;
     text-transform: uppercase;
   }
-
-  @media (any-hover: none) { 
-  .Notification-action.Button { 
-    display: none; } 
-    }
-  }
-
   .Notification-action {
     float: right;
     display: none;

--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -104,6 +104,12 @@
     text-transform: uppercase;
   }
 
+  @media (any-hover: none) { 
+  .Notification-action.Button { 
+    display: none; } 
+    }
+  }
+
   .Notification-action {
     float: right;
     display: none;


### PR DESCRIPTION
Adds rule for devices without hover capabilities which hides discussion item toggle button. This prevents having to tap twice to open the discussion. Also, the toggle button is not used on mobile devices and so it should be completely hidden. Additional nested rules could be added here in the future if needed. 

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://github.com/flarum/core/issues/1913**

**Changes proposed in this pull request:**
Adds rule for devices without hover capabilities which hides discussion item toggle button. This prevents having to tap twice to open the discussion. Also, the toggle button is not used on mobile devices and so it should be completely hidden. Additional nested rules could be added here in the future if needed. See issue: https://github.com/flarum/core/issues/1913

Fix uses a relatively new hover CSS media feature which can be used to test whether the user’s primary input mechanism can hover over elements. It is compatible will all major/modern browsers. No Internet Explorer support but on August 17th, 2021, Internet Explorer 11 will no longer be supported by Microsoft. All IE versions are on their way out. Also, if someone visits a forum with this one browser, the worst that would happen is they would have to double tap like before because the browser wouldn’t recognize the rule. 

**Reviewers should focus on:**
If reviewer does not have an iPhone or iPad, reviewer could at least confirm that this fix does not affect other devices. Toggle button should still work on desktop. If reviewer has an iPhone or iPad they will be able to open a discussion with one tap. 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).