### PR TITLE
Make disabled extension dot a red border instead of red background

### DIFF
--- a/less/admin/AdminNav.less
+++ b/less/admin/AdminNav.less
@@ -218,5 +218,6 @@
   background-color: #2ECC40;
 }
 .ExtensionListItem-Dot.disabled {
-  background-color: #FF4136;
+  border: 2px solid #FF4136;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2520**

**Changes proposed in this pull request:**
- Change `background-color` to 2px solid border
- Explicitly set `box-sizing` to `border-box` in case some other styles override it

**Screenshot**

Current (2px)
![image](https://user-images.githubusercontent.com/6401250/105608108-fb12d300-5d6f-11eb-9178-4c194cb1af7b.png)

<details>
<summary>Alternative (1px)</summary>

![image](https://user-images.githubusercontent.com/6401250/105608132-30b7bc00-5d70-11eb-977d-5c0a5e20c18f.png)

</details>

<details>
<summary>Alternative (3px)</summary>

![image](https://user-images.githubusercontent.com/6401250/105608119-1251c080-5d70-11eb-8277-bb2c796581fb.png)
</details>


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
