### PR TITLE
Use extension names instead of IDs when erroring on enable/disable reqs

### DIFF
--- a/src/Extension/Exception/DependentExtensionsException.php
+++ b/src/Extension/Exception/DependentExtensionsException.php
@@ -11,6 +11,7 @@ namespace Flarum\Extension\Exception;
 
 use Exception;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 
 /**
  * This exception is thrown when someone attempts to disable an extension
@@ -30,18 +31,6 @@ class DependentExtensionsException extends Exception
         $this->extension = $extension;
         $this->dependent_extensions = $dependent_extensions;
 
-        parent::__construct($extension->getId().' could not be disabled, because it is a dependency of: '.implode(', ', $this->getDependentExtensionNames()));
-    }
-
-    /**
-     * Get array of IDs for extensions that depend on this extension.
-     *
-     * @return array
-     */
-    public function getDependentExtensionNames()
-    {
-        return array_map(function (Extension $extension) {
-            return $extension->getTitle();
-        }, $this->dependent_extensions);
+        parent::__construct($extension->getId().' could not be disabled, because it is a dependency of: '.implode(', ', ExtensionManager::pluckTitles($dependent_extensions)));
     }
 }

--- a/src/Extension/Exception/DependentExtensionsException.php
+++ b/src/Extension/Exception/DependentExtensionsException.php
@@ -41,7 +41,7 @@ class DependentExtensionsException extends Exception
     public function getDependentExtensionNames()
     {
         return array_map(function (Extension $extension) {
-            return $extension->composerJsonAttribute('extra.flarum-extension.title') ?: $extension->getId();
+            return $extension->getTitle();
         }, $this->dependent_extensions);
     }
 }

--- a/src/Extension/Exception/DependentExtensionsException.php
+++ b/src/Extension/Exception/DependentExtensionsException.php
@@ -31,6 +31,6 @@ class DependentExtensionsException extends Exception
         $this->extension = $extension;
         $this->dependent_extensions = $dependent_extensions;
 
-        parent::__construct($extension->getId().' could not be disabled, because it is a dependency of: '.implode(', ', ExtensionManager::pluckTitles($dependent_extensions)));
+        parent::__construct($extension->getTitle().' could not be disabled, because it is a dependency of: '.implode(', ', ExtensionManager::pluckTitles($dependent_extensions)));
     }
 }

--- a/src/Extension/Exception/DependentExtensionsException.php
+++ b/src/Extension/Exception/DependentExtensionsException.php
@@ -30,7 +30,7 @@ class DependentExtensionsException extends Exception
         $this->extension = $extension;
         $this->dependent_extensions = $dependent_extensions;
 
-        parent::__construct($extension->getId().' could not be disabled, because it is a dependency of: '.implode(', ', $this->getDependentExtensionIds()));
+        parent::__construct($extension->getId().' could not be disabled, because it is a dependency of: '.implode(', ', $this->getDependentExtensionNames()));
     }
 
     /**
@@ -38,10 +38,10 @@ class DependentExtensionsException extends Exception
      *
      * @return array
      */
-    public function getDependentExtensionIds()
+    public function getDependentExtensionNames()
     {
         return array_map(function (Extension $extension) {
-            return $extension->getId();
+            return $extension->composerJsonAttribute('extra.flarum-extension.title') ?: $extension->getId();
         }, $this->dependent_extensions);
     }
 }

--- a/src/Extension/Exception/DependentExtensionsExceptionHandler.php
+++ b/src/Extension/Exception/DependentExtensionsExceptionHandler.php
@@ -27,7 +27,7 @@ class DependentExtensionsExceptionHandler
         return [
             [
                 'extension' => $e->extension->getId(),
-                'extensions' => $e->getDependentExtensionIds(),
+                'extensions' => $e->getDependentExtensionNames(),
             ]
         ];
     }

--- a/src/Extension/Exception/DependentExtensionsExceptionHandler.php
+++ b/src/Extension/Exception/DependentExtensionsExceptionHandler.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Extension\Exception;
 
+use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\ErrorHandling\HandledError;
 
 class DependentExtensionsExceptionHandler
@@ -26,8 +27,8 @@ class DependentExtensionsExceptionHandler
     {
         return [
             [
-                'extension' => $e->extension->getId(),
-                'extensions' => $e->getDependentExtensionNames(),
+                'extension' => $e->extension->getTitle(),
+                'extensions' => ExtensionManager::pluckTitles($e->dependent_extensions),
             ]
         ];
     }

--- a/src/Extension/Exception/MissingDependenciesException.php
+++ b/src/Extension/Exception/MissingDependenciesException.php
@@ -11,6 +11,7 @@ namespace Flarum\Extension\Exception;
 
 use Exception;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 
 /**
  * This exception is thrown when someone attempts to enable an extension
@@ -30,18 +31,6 @@ class MissingDependenciesException extends Exception
         $this->extension = $extension;
         $this->missing_dependencies = $missing_dependencies;
 
-        parent::__construct($extension->getId().' could not be enabled, because it depends on: '.implode(', ', $this->getMissingDependencyNames()));
-    }
-
-    /**
-     * Get array of IDs for missing (disabled) extensions that this extension depends on.
-     *
-     * @return array
-     */
-    public function getMissingDependencyNames()
-    {
-        return array_map(function (Extension $extension) {
-            return $extension->getTitle();
-        }, $this->missing_dependencies);
+        parent::__construct($extension->getId().' could not be enabled, because it depends on: '.implode(', ', ExtensionManager::pluckTitles($missing_dependencies)));
     }
 }

--- a/src/Extension/Exception/MissingDependenciesException.php
+++ b/src/Extension/Exception/MissingDependenciesException.php
@@ -41,7 +41,7 @@ class MissingDependenciesException extends Exception
     public function getMissingDependencyNames()
     {
         return array_map(function (Extension $extension) {
-            return $extension->composerJsonAttribute('extra.flarum-extension.title') ?: $extension->getId();
+            return $extension->getTitle();
         }, $this->missing_dependencies);
     }
 }

--- a/src/Extension/Exception/MissingDependenciesException.php
+++ b/src/Extension/Exception/MissingDependenciesException.php
@@ -31,6 +31,6 @@ class MissingDependenciesException extends Exception
         $this->extension = $extension;
         $this->missing_dependencies = $missing_dependencies;
 
-        parent::__construct($extension->getId().' could not be enabled, because it depends on: '.implode(', ', ExtensionManager::pluckTitles($missing_dependencies)));
+        parent::__construct($extension->getTitle().' could not be enabled, because it depends on: '.implode(', ', ExtensionManager::pluckTitles($missing_dependencies)));
     }
 }

--- a/src/Extension/Exception/MissingDependenciesException.php
+++ b/src/Extension/Exception/MissingDependenciesException.php
@@ -30,7 +30,7 @@ class MissingDependenciesException extends Exception
         $this->extension = $extension;
         $this->missing_dependencies = $missing_dependencies;
 
-        parent::__construct($extension->getId().' could not be enabled, because it depends on: '.implode(', ', $this->getMissingDependencyIds()));
+        parent::__construct($extension->getId().' could not be enabled, because it depends on: '.implode(', ', $this->getMissingDependencyNames()));
     }
 
     /**
@@ -38,10 +38,10 @@ class MissingDependenciesException extends Exception
      *
      * @return array
      */
-    public function getMissingDependencyIds()
+    public function getMissingDependencyNames()
     {
         return array_map(function (Extension $extension) {
-            return $extension->getId();
+            return $extension->composerJsonAttribute('extra.flarum-extension.title') ?: $extension->getId();
         }, $this->missing_dependencies);
     }
 }

--- a/src/Extension/Exception/MissingDependenciesExceptionHandler.php
+++ b/src/Extension/Exception/MissingDependenciesExceptionHandler.php
@@ -27,7 +27,7 @@ class MissingDependenciesExceptionHandler
         return [
             [
                 'extension' => $e->extension->getId(),
-                'extensions' => $e->getMissingDependencyIds(),
+                'extensions' => $e->getMissingDependencyNames(),
             ]
         ];
     }

--- a/src/Extension/Exception/MissingDependenciesExceptionHandler.php
+++ b/src/Extension/Exception/MissingDependenciesExceptionHandler.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Extension\Exception;
 
+use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\ErrorHandling\HandledError;
 
 class MissingDependenciesExceptionHandler
@@ -26,8 +27,8 @@ class MissingDependenciesExceptionHandler
     {
         return [
             [
-                'extension' => $e->extension->getId(),
-                'extensions' => $e->getMissingDependencyNames(),
+                'extension' => $e->extension->getTitle(),
+                'extensions' => ExtensionManager::pluckTitles($e->missing_dependencies),
             ]
         ];
     }

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -281,6 +281,14 @@ class Extension implements Arrayable
     /**
      * @return string
      */
+    public function getTitle()
+    {
+        return $this->composerJsonAttribute('extra.flarum-extension.title');
+    }
+
+    /**
+     * @return string
+     */
     public function getPath()
     {
         return $this->path;

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -369,4 +369,16 @@ class ExtensionManager
 
         return isset($enabled[$extension]);
     }
+
+    /**
+     * Returns the titles of the extensions passed
+     *
+     * @param array $exts
+     * @return string[]
+     */
+    public static function pluckTitles(array $exts) {
+        return array_map(function (Extension $extension) {
+            return $extension->getTitle();
+        }, $exts);
+    }
 }

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -371,12 +371,13 @@ class ExtensionManager
     }
 
     /**
-     * Returns the titles of the extensions passed
+     * Returns the titles of the extensions passed.
      *
      * @param array $exts
      * @return string[]
      */
-    public static function pluckTitles(array $exts) {
+    public static function pluckTitles(array $exts)
+    {
         return array_map(function (Extension $extension) {
             return $extension->getTitle();
         }, $exts);

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -114,7 +114,7 @@ class ExtensionManager
             }
 
             $this->extensions = $extensions->sortBy(function ($extension, $name) {
-                return $extension->composerJsonAttribute('extra.flarum-extension.title');
+                return $extension->getTitle();
             });
         }
 

--- a/src/Install/Steps/EnableBundledExtensions.php
+++ b/src/Install/Steps/EnableBundledExtensions.php
@@ -111,7 +111,7 @@ class EnableBundledExtensions implements Step
             })->filter(function (Extension $extension) {
                 return in_array($extension->getId(), self::EXTENSION_WHITELIST);
             })->sortBy(function (Extension $extension) {
-                return $extension->composerJsonAttribute('extra.flarum-extension.title');
+                return $extension->getTitle();
             })->mapWithKeys(function (Extension $extension) {
                 return [$extension->getId() => $extension];
             });


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2341**

**Changes proposed in this pull request:**
- Use extension name where available
- Create `Extension@getTitle` method
- Create `ExtensionManager::pluckTitles` method

![image](https://user-images.githubusercontent.com/6401250/106051901-0b4fe880-60b7-11eb-8a2f-ff3b42fdabb9.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).

---

**_ORIGINAL DESCRIPTION_**

**Changes needed:**

Is there a better way to obtain the extension name? I assume we also want to change the extension to use its name (apart from dependencies/dependents) in error message, but this is a lot of duplicated code.
Not sure if we want to have a fallback to ID in case title doesn't exist.
I'm surprised the `Extension` class doesn't have a method to obtain the extension title.

**Reviewers should focus on:**
- Should the method name be renamed? Could technically be a breaking change
- Should these 2 methods be condensed into 1 in a separate class? The logic is the exact same.