### PR TITLE
Add missing a11y attributes to "Mark as read" button on DiscussionListItem

### DIFF
--- a/js/src/forum/components/DiscussionListItem.js
+++ b/js/src/forum/components/DiscussionListItem.js
@@ -121,6 +121,8 @@ export default class DiscussionListItem extends Component {
           </Link>
 
           <span
+            tabindex="0"
+            role="button"
             className="DiscussionListItem-count"
             onclick={this.markAsRead.bind(this)}
             title={showUnread ? app.translator.trans('core.forum.discussion_list.mark_as_read_tooltip') : ''}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

<!--**Fixes #0000**-->

**Changes proposed in this pull request:**
This PR adds missing accessibility attributes to the "Mark as read" button on `DiscussionListItem`.

`<span>`s are inherently inaccessible to keyboard users and unfocusable. Using an `onClick` on them without any other attributes indicating that this performs an action is bad practice as it means keyboard navigators and screen-readers cannot access the elements, so never know that the buttons exist.

Assigning unfocusable elements with a `tabindex="0"` allow them to be focuses, and `role="button"` lets screen-readers know that it is a button-like element.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Other locations where issues like this may be present: they may be able to be bundled into one whole PR.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`). **(N/A)**
