### PR TITLE
Navigate to dashboard page if extension ID not found

### DIFF
--- a/js/src/admin/components/ExtensionPage.js
+++ b/js/src/admin/components/ExtensionPage.js
@@ -32,6 +32,10 @@ export default class ExtensionPage extends Page {
       source: 'fas fa-code',
     };
 
+    if (!this.extension) {
+      return m.route.set(app.route('dashboard'));
+    }
+
     // Backwards compatibility layer will be removed in
     // Beta 16
     if (app.extensionSettings[this.extension.id]) {
@@ -40,10 +44,14 @@ export default class ExtensionPage extends Page {
   }
 
   className() {
+    if (!this.extension) return '';
+
     return this.extension.id + '-Page';
   }
 
   view() {
+    if (!this.extension) return null;
+
     return (
       <div className={'ExtensionPage ' + this.className()}>
         {this.header()}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2583**

**Changes proposed in this pull request:**
- Navigate to dashboard route if `this.extension` is undefined
- Return `''` and `null` in `className` and `view` to prevent accessing `this.extension` before the route changes

**Reviewers should focus on:**
Do we want to add/change the returns or add checks when `this.extension` is used? The user doesn't see the rendered view as it instantly goes to the Dashboard page, but it will still error because Mithril calls the method (but doesn't render it)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.