### PR TITLE
Correct non-existent cursor value (disallowed -> not-allowed)

### DIFF
--- a/less/common/FormControl.less
+++ b/less/common/FormControl.less
@@ -32,7 +32,7 @@
 
   &[disabled],
   fieldset[disabled] & {
-    cursor: disallowed;
+    cursor: not-allowed;
   }
 
   textarea& {


### PR DESCRIPTION
**Changes proposed in this pull request:**
`disallowed` isn't a valid `cursor` value: I think this was meant to be `not-allowed`.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] ~~Backend changes: tests are green (run `composer test`).~~
