### PR TITLE
Support global functions in ContainerUtil

### DIFF
--- a/src/Foundation/ContainerUtil.php
+++ b/src/Foundation/ContainerUtil.php
@@ -23,7 +23,7 @@ class ContainerUtil
      */
     public static function wrapCallback($callback, Container $container)
     {
-        if (is_string($callback)) {
+        if (is_string($callback) && !function_exists($callback)) {
             $callback = function (&...$args) use ($container, $callback) {
                 $callback = $container->make($callback);
 

--- a/src/Foundation/ContainerUtil.php
+++ b/src/Foundation/ContainerUtil.php
@@ -18,7 +18,7 @@ class ContainerUtil
      *
      * @internal Backwards compatability not guaranteed.
      *
-     * @param callable|string $callback: A callable, or a ::class attribute of an invokable class
+     * @param callable|string $callback: A callable, global function, or a ::class attribute of an invokable class
      * @param Container $container
      */
     public static function wrapCallback($callback, Container $container)

--- a/src/Foundation/ContainerUtil.php
+++ b/src/Foundation/ContainerUtil.php
@@ -23,7 +23,7 @@ class ContainerUtil
      */
     public static function wrapCallback($callback, Container $container)
     {
-        if (is_string($callback) && ! function_exists($callback)) {
+        if (is_string($callback) && ! is_callable($callback)) {
             $callback = function (&...$args) use ($container, $callback) {
                 $callback = $container->make($callback);
 

--- a/src/Foundation/ContainerUtil.php
+++ b/src/Foundation/ContainerUtil.php
@@ -23,7 +23,7 @@ class ContainerUtil
      */
     public static function wrapCallback($callback, Container $container)
     {
-        if (is_string($callback) && !function_exists($callback)) {
+        if (is_string($callback) && ! function_exists($callback)) {
             $callback = function (&...$args) use ($container, $callback) {
                 $callback = $container->make($callback);
 

--- a/tests/unit/Foundation/ContainerUtilTest.php
+++ b/tests/unit/Foundation/ContainerUtilTest.php
@@ -87,6 +87,14 @@ class ContainerUtilTest extends TestCase
     }
 
     /** @test */
+    public function it_works_with_static_class_method_arrays()
+    {
+        $callback = ContainerUtil::wrapCallback([ClassWithMethod::class, 'staticMethod'], $this->container);
+
+        $this->assertEquals('returnStatic', $callback());
+    }
+
+    /** @test */
     public function it_allows_passing_args_by_reference_on_closures()
     {
         $callback = ContainerUtil::wrapCallback(function (&$array) {
@@ -151,5 +159,12 @@ class SecondCustomInvokableClass
         $array['key'] = 'newValue4';
 
         return 'return4';
+    }
+}
+
+class ClassWithMethod
+{
+    public static function staticMethod() {
+        return "returnStatic";
     }
 }

--- a/tests/unit/Foundation/ContainerUtilTest.php
+++ b/tests/unit/Foundation/ContainerUtilTest.php
@@ -164,7 +164,8 @@ class SecondCustomInvokableClass
 
 class ClassWithMethod
 {
-    public static function staticMethod() {
-        return "returnStatic";
+    public static function staticMethod()
+    {
+        return 'returnStatic';
     }
 }

--- a/tests/unit/Foundation/ContainerUtilTest.php
+++ b/tests/unit/Foundation/ContainerUtilTest.php
@@ -75,6 +75,18 @@ class ContainerUtilTest extends TestCase
     }
 
     /** @test */
+    public function it_works_with_global_functions()
+    {
+        $callback = ContainerUtil::wrapCallback('boolval', $this->container);
+
+        $this->assertEquals(true, $callback(true));
+        $this->assertEquals(true, $callback(1));
+        $this->assertEquals(true, $callback('1'));
+        $this->assertEquals(false, $callback(0));
+        $this->assertEquals(false, $callback(false));
+    }
+
+    /** @test */
     public function it_allows_passing_args_by_reference_on_closures()
     {
         $callback = ContainerUtil::wrapCallback(function (&$array) {


### PR DESCRIPTION
It can be very annoying if we want to use something like `boolval`, but have to define an entire anonymous function to pass it in. This PR adds support for tpassing it in directly as a string, like is posible with User::registerPreference.