### PR TITLE
Don't push bidi function to DOM

### DIFF
--- a/js/src/common/utils/bidi.js
+++ b/js/src/common/utils/bidi.js
@@ -37,7 +37,7 @@ function bidi(node, prop) {
   } else {
     node.attrs.value = prop();
   }
-  
+
   node.attrs.bidi = null;
 
   return node;

--- a/js/src/common/utils/bidi.js
+++ b/js/src/common/utils/bidi.js
@@ -37,6 +37,8 @@ function bidi(node, prop) {
   } else {
     node.attrs.value = prop();
   }
+  
+  node.attrs.bidi = null;
 
   return node;
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
As of now, the bidi function is viewable in the DOM via inspect element. Although this doesn't cause any issues it doesn't look super clean and isn't necessary. This removes the attr before it is pushed into the view and after it sets the `onchange` and `value` attrs.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
