### PR TITLE
Simplify Extension Categories

### DIFF
--- a/js/src/admin/AdminApplication.js
+++ b/js/src/admin/AdminApplication.js
@@ -16,7 +16,7 @@ export default class AdminApplication extends Application {
   extensionCategories = {
     feature: 30,
     theme: 20,
-    language: 10
+    language: 10,
   };
 
   history = {

--- a/js/src/admin/AdminApplication.js
+++ b/js/src/admin/AdminApplication.js
@@ -14,14 +14,9 @@ export default class AdminApplication extends Application {
   extensionData = new ExtensionData();
 
   extensionCategories = {
-    discussion: 70,
-    moderation: 60,
-    feature: 50,
-    formatting: 40,
-    theme: 30,
-    authentication: 20,
-    language: 10,
-    other: 0,
+    feature: 30,
+    theme: 20,
+    language: 10
   };
 
   history = {

--- a/js/src/admin/utils/getCategorizedExtensions.js
+++ b/js/src/admin/utils/getCategorizedExtensions.js
@@ -15,9 +15,9 @@ export default function getCategorizedExtensions() {
 
       extensions[category].push(extension);
     } else {
-      extensions.other = extensions.other || [];
+      extensions.feature = extensions.feature || [];
 
-      extensions.other.push(extension);
+      extensions.feature.push(extension);
     }
   });
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Extension categories can be hard to pick for developers. This makes it really simple, features, languages, and themes. Nice and easy to pick from. It makes the admin panel look quite a bit better too, fewer dividers.

- [x] Frontend changes: tested on a local Flarum installation.

**Required changes:**

- [x] English: https://github.com/flarum/lang-english/pull/185
- [x] Markdown: https://github.com/flarum/markdown/pull/25 
- [x] Mentions: https://github.com/flarum/mentions/pull/62 
- [x] Emoji: https://github.com/flarum/emoji/pull/35
- [x] Tags: https://github.com/flarum/tags/pull/118
- [x] Suspend: https://github.com/flarum/suspend/pull/33
- [x] Sticky: https://github.com/flarum/sticky/pull/27
- [x] Flags: https://github.com/flarum/flags/pull/36
- [x] Subscriptions: https://github.com/flarum/subscriptions/pull/39
- [x] Akismet: https://github.com/flarum/akismet/pull/18
- [x] BBcode: https://github.com/flarum/bbcode/pull/11
- [x] Approval: https://github.com/flarum/approval/pull/24
- [x] Likes: https://github.com/flarum/likes/pull/26
- [x] Lock: https://github.com/flarum/lock/pull/27
