### PR TITLE
Update DiscussionListItem.less to fix double tap on mobile

### DIFF
--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -110,6 +110,11 @@
   }
 }
 
+@media (any-hover: none) { 
+  .DiscussionListItem-controls > .Dropdown-toggle { 
+    display: none;
+  } 
+}
 
 @media @phone {
   .DiscussionListItem-controls {
@@ -265,10 +270,4 @@
       }
     }
   }
-}
-
-@media (any-hover: none) { 
-  .DiscussionListItem-controls > .Dropdown-toggle { 
-    display: none;
-  } 
 }

--- a/less/forum/DiscussionListItem.less
+++ b/less/forum/DiscussionListItem.less
@@ -266,3 +266,9 @@
     }
   }
 }
+
+@media (any-hover: none) { 
+  .DiscussionListItem-controls > .Dropdown-toggle { 
+    display: none;
+  } 
+}


### PR DESCRIPTION
Fix double tap to open discussion on mobile.

**Fixes #1913**

**Changes proposed in this pull request:**
Adds a rule to the discussion list less file which targets touch devices whose primary way of interacting does not include a mouse / ability to hover. For those devices the toggle button is hidden which fixes the double tap issue. 

**Reviewers should focus on:**
Test on small screens. You should no longer have to double tap to open a discussion.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).