### PR TITLE
Deprecate event helper

### DIFF
--- a/src/Forum/Controller/LogInController.php
+++ b/src/Forum/Controller/LogInController.php
@@ -60,6 +60,7 @@ class LogInController implements RequestHandlerInterface
         $this->users = $users;
         $this->apiClient = $apiClient;
         $this->authenticator = $authenticator;
+        $this->events = $events;
         $this->rememberer = $rememberer;
     }
 

--- a/src/Forum/Controller/LogInController.php
+++ b/src/Forum/Controller/LogInController.php
@@ -16,6 +16,7 @@ use Flarum\Http\Rememberer;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\User\Event\LoggedIn;
 use Flarum\User\UserRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -39,6 +40,11 @@ class LogInController implements RequestHandlerInterface
     protected $authenticator;
 
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
      * @var Rememberer
      */
     protected $rememberer;
@@ -49,7 +55,7 @@ class LogInController implements RequestHandlerInterface
      * @param SessionAuthenticator $authenticator
      * @param Rememberer $rememberer
      */
-    public function __construct(UserRepository $users, Client $apiClient, SessionAuthenticator $authenticator, Rememberer $rememberer)
+    public function __construct(UserRepository $users, Client $apiClient, SessionAuthenticator $authenticator, Dispatcher $events, Rememberer $rememberer)
     {
         $this->users = $users;
         $this->apiClient = $apiClient;
@@ -76,7 +82,7 @@ class LogInController implements RequestHandlerInterface
 
             $token = AccessToken::find($data->token);
 
-            event(new LoggedIn($this->users->findOrFail($data->userId), $token));
+            $this->events->dispatch(new LoggedIn($this->users->findOrFail($data->userId), $token));
 
             if (Arr::get($body, 'remember')) {
                 $response = $this->rememberer->remember($response, $token);

--- a/src/Foundation/Console/CacheClearCommand.php
+++ b/src/Foundation/Console/CacheClearCommand.php
@@ -13,6 +13,7 @@ use Flarum\Console\AbstractCommand;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class CacheClearCommand extends AbstractCommand
 {
@@ -20,6 +21,11 @@ class CacheClearCommand extends AbstractCommand
      * @var Store
      */
     protected $cache;
+
+    /**
+     * @var Dispatcher
+     */
+    protected $events;
 
     /**
      * @var Paths
@@ -30,9 +36,10 @@ class CacheClearCommand extends AbstractCommand
      * @param Store $cache
      * @param Paths $paths
      */
-    public function __construct(Store $cache, Paths $paths)
+    public function __construct(Store $cache, Dispatcher $events, Paths $paths)
     {
         $this->cache = $cache;
+        $this->events = $events;
         $this->paths = $paths;
 
         parent::__construct();
@@ -61,6 +68,6 @@ class CacheClearCommand extends AbstractCommand
         array_map('unlink', glob($storagePath.'/formatter/*'));
         array_map('unlink', glob($storagePath.'/locale/*'));
 
-        event(new ClearingCache);
+        $this->events->dispatch(new ClearingCache);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,11 +27,9 @@ if (! function_exists('app')) {
     }
 }
 
-/**
- * @deprecated beta 16, removed in beta 17
- */
 if (! function_exists('event')) {
     /**
+     * @deprecated beta 16, removed in beta 17
      * Fire an event and call the listeners.
      *
      * @param  string|object  $event

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,6 +27,9 @@ if (! function_exists('app')) {
     }
 }
 
+/**
+ * @deprecated beta 16, removed in beta 17
+ */
 if (! function_exists('event')) {
     /**
      * Fire an event and call the listeners.


### PR DESCRIPTION
**Refs #1796**

**Changes proposed in this pull request:**
Deprecates `event` helper.

I left in the one used for ListPostsController since that will be removed in #2479 