### PR TITLE
Rename `app` to container

### DIFF
--- a/src/Admin/AdminServiceProvider.php
+++ b/src/Admin/AdminServiceProvider.php
@@ -36,18 +36,18 @@ class AdminServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->extend(UrlGenerator::class, function (UrlGenerator $url) {
-            return $url->addCollection('admin', $this->app->make('flarum.admin.routes'), 'admin');
+        $this->container->extend(UrlGenerator::class, function (UrlGenerator $url) {
+            return $url->addCollection('admin', $this->container->make('flarum.admin.routes'), 'admin');
         });
 
-        $this->app->singleton('flarum.admin.routes', function () {
+        $this->container->singleton('flarum.admin.routes', function () {
             $routes = new RouteCollection;
             $this->populateRoutes($routes);
 
             return $routes;
         });
 
-        $this->app->singleton('flarum.admin.middleware', function () {
+        $this->container->singleton('flarum.admin.middleware', function () {
             return [
                 'flarum.admin.error_handler',
                 HttpMiddleware\ParseJsonBody::class,
@@ -61,23 +61,23 @@ class AdminServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->bind('flarum.admin.error_handler', function () {
+        $this->container->bind('flarum.admin.error_handler', function () {
             return new HttpMiddleware\HandleErrors(
-                $this->app->make(Registry::class),
-                $this->app['flarum.config']->inDebugMode() ? $this->app->make(WhoopsFormatter::class) : $this->app->make(ViewFormatter::class),
-                $this->app->tagged(Reporter::class)
+                $this->container->make(Registry::class),
+                $this->container['flarum.config']->inDebugMode() ? $this->container->make(WhoopsFormatter::class) : $this->container->make(ViewFormatter::class),
+                $this->container->tagged(Reporter::class)
             );
         });
 
-        $this->app->bind('flarum.admin.route_resolver', function () {
-            return new HttpMiddleware\ResolveRoute($this->app->make('flarum.admin.routes'));
+        $this->container->bind('flarum.admin.route_resolver', function () {
+            return new HttpMiddleware\ResolveRoute($this->container->make('flarum.admin.routes'));
         });
 
-        $this->app->singleton('flarum.admin.handler', function () {
+        $this->container->singleton('flarum.admin.handler', function () {
             $pipe = new MiddlewarePipe;
 
-            foreach ($this->app->make('flarum.admin.middleware') as $middleware) {
-                $pipe->pipe($this->app->make($middleware));
+            foreach ($this->container->make('flarum.admin.middleware') as $middleware) {
+                $pipe->pipe($this->container->make($middleware));
             }
 
             $pipe->pipe(new HttpMiddleware\ExecuteRoute());
@@ -85,9 +85,9 @@ class AdminServiceProvider extends AbstractServiceProvider
             return $pipe;
         });
 
-        $this->app->bind('flarum.assets.admin', function () {
+        $this->container->bind('flarum.assets.admin', function () {
             /** @var \Flarum\Frontend\Assets $assets */
-            $assets = $this->app->make('flarum.assets.factory')('admin');
+            $assets = $this->container->make('flarum.assets.factory')('admin');
 
             $assets->js(function (SourceCollector $sources) {
                 $sources->addFile(__DIR__.'/../../js/dist/admin.js');
@@ -97,17 +97,17 @@ class AdminServiceProvider extends AbstractServiceProvider
                 $sources->addFile(__DIR__.'/../../less/admin.less');
             });
 
-            $this->app->make(AddTranslations::class)->forFrontend('admin')->to($assets);
-            $this->app->make(AddLocaleAssets::class)->to($assets);
+            $this->container->make(AddTranslations::class)->forFrontend('admin')->to($assets);
+            $this->container->make(AddLocaleAssets::class)->to($assets);
 
             return $assets;
         });
 
-        $this->app->bind('flarum.frontend.admin', function () {
+        $this->container->bind('flarum.frontend.admin', function () {
             /** @var \Flarum\Frontend\Frontend $frontend */
-            $frontend = $this->app->make('flarum.frontend.factory')('admin');
+            $frontend = $this->container->make('flarum.frontend.factory')('admin');
 
-            $frontend->content($this->app->make(Content\AdminPayload::class));
+            $frontend->content($this->container->make(Content\AdminPayload::class));
 
             return $frontend;
         });
@@ -120,14 +120,14 @@ class AdminServiceProvider extends AbstractServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../../views', 'flarum.admin');
 
-        $events = $this->app->make('events');
+        $events = $this->container->make('events');
 
         $events->listen(
             [Enabled::class, Disabled::class, ClearingCache::class],
             function () {
                 $recompile = new RecompileFrontendAssets(
-                    $this->app->make('flarum.assets.admin'),
-                    $this->app->make(LocaleManager::class)
+                    $this->container->make('flarum.assets.admin'),
+                    $this->container->make(LocaleManager::class)
                 );
                 $recompile->flush();
             }
@@ -137,8 +137,8 @@ class AdminServiceProvider extends AbstractServiceProvider
             Saved::class,
             function (Saved $event) {
                 $recompile = new RecompileFrontendAssets(
-                    $this->app->make('flarum.assets.admin'),
-                    $this->app->make(LocaleManager::class)
+                    $this->container->make('flarum.assets.admin'),
+                    $this->container->make(LocaleManager::class)
                 );
                 $recompile->whenSettingsSaved($event);
             }
@@ -150,7 +150,7 @@ class AdminServiceProvider extends AbstractServiceProvider
      */
     protected function populateRoutes(RouteCollection $routes)
     {
-        $factory = $this->app->make(RouteHandlerFactory::class);
+        $factory = $this->container->make(RouteHandlerFactory::class);
 
         $callback = include __DIR__.'/routes.php';
         $callback($routes, $factory);

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -51,8 +51,8 @@ class ApiServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->container->bind(Middleware\ThrottleApi::class, function ($app) {
-            return new Middleware\ThrottleApi($app->make('flarum.api.throttlers'));
+        $this->container->bind(Middleware\ThrottleApi::class, function ($container) {
+            return new Middleware\ThrottleApi($container->make('flarum.api.throttlers'));
         });
 
         $this->container->singleton('flarum.api.middleware', function () {

--- a/src/Api/ApiServiceProvider.php
+++ b/src/Api/ApiServiceProvider.php
@@ -30,18 +30,18 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->extend(UrlGenerator::class, function (UrlGenerator $url) {
-            return $url->addCollection('api', $this->app->make('flarum.api.routes'), 'api');
+        $this->container->extend(UrlGenerator::class, function (UrlGenerator $url) {
+            return $url->addCollection('api', $this->container->make('flarum.api.routes'), 'api');
         });
 
-        $this->app->singleton('flarum.api.routes', function () {
+        $this->container->singleton('flarum.api.routes', function () {
             $routes = new RouteCollection;
             $this->populateRoutes($routes);
 
             return $routes;
         });
 
-        $this->app->singleton('flarum.api.throttlers', function () {
+        $this->container->singleton('flarum.api.throttlers', function () {
             return [
                 'bypassThrottlingAttribute' => function ($request) {
                     if ($request->getAttribute('bypassThrottling')) {
@@ -51,11 +51,11 @@ class ApiServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->bind(Middleware\ThrottleApi::class, function ($app) {
+        $this->container->bind(Middleware\ThrottleApi::class, function ($app) {
             return new Middleware\ThrottleApi($app->make('flarum.api.throttlers'));
         });
 
-        $this->app->singleton('flarum.api.middleware', function () {
+        $this->container->singleton('flarum.api.middleware', function () {
             return [
                 'flarum.api.error_handler',
                 HttpMiddleware\ParseJsonBody::class,
@@ -71,23 +71,23 @@ class ApiServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->bind('flarum.api.error_handler', function () {
+        $this->container->bind('flarum.api.error_handler', function () {
             return new HttpMiddleware\HandleErrors(
-                $this->app->make(Registry::class),
-                new JsonApiFormatter($this->app['flarum.config']->inDebugMode()),
-                $this->app->tagged(Reporter::class)
+                $this->container->make(Registry::class),
+                new JsonApiFormatter($this->container['flarum.config']->inDebugMode()),
+                $this->container->tagged(Reporter::class)
             );
         });
 
-        $this->app->bind('flarum.api.route_resolver', function () {
-            return new HttpMiddleware\ResolveRoute($this->app->make('flarum.api.routes'));
+        $this->container->bind('flarum.api.route_resolver', function () {
+            return new HttpMiddleware\ResolveRoute($this->container->make('flarum.api.routes'));
         });
 
-        $this->app->singleton('flarum.api.handler', function () {
+        $this->container->singleton('flarum.api.handler', function () {
             $pipe = new MiddlewarePipe;
 
-            foreach ($this->app->make('flarum.api.middleware') as $middleware) {
-                $pipe->pipe($this->app->make($middleware));
+            foreach ($this->container->make('flarum.api.middleware') as $middleware) {
+                $pipe->pipe($this->container->make($middleware));
             }
 
             $pipe->pipe(new HttpMiddleware\ExecuteRoute());
@@ -95,7 +95,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             return $pipe;
         });
 
-        $this->app->singleton('flarum.api.notification_serializers', function () {
+        $this->container->singleton('flarum.api.notification_serializers', function () {
             return [
                 'discussionRenamed' => BasicDiscussionSerializer::class
             ];
@@ -109,9 +109,9 @@ class ApiServiceProvider extends AbstractServiceProvider
     {
         $this->setNotificationSerializers();
 
-        AbstractSerializeController::setContainer($this->app);
+        AbstractSerializeController::setContainer($this->container);
 
-        AbstractSerializer::setContainer($this->app);
+        AbstractSerializer::setContainer($this->container);
     }
 
     /**
@@ -119,7 +119,7 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     protected function setNotificationSerializers()
     {
-        $serializers = $this->app->make('flarum.api.notification_serializers');
+        $serializers = $this->container->make('flarum.api.notification_serializers');
 
         foreach ($serializers as $type => $serializer) {
             NotificationSerializer::setSubjectSerializer($type, $serializer);
@@ -133,7 +133,7 @@ class ApiServiceProvider extends AbstractServiceProvider
      */
     protected function populateRoutes(RouteCollection $routes)
     {
-        $factory = $this->app->make(RouteHandlerFactory::class);
+        $factory = $this->container->make(RouteHandlerFactory::class);
 
         $callback = include __DIR__.'/routes.php';
         $callback($routes, $factory);

--- a/src/Bus/BusServiceProvider.php
+++ b/src/Bus/BusServiceProvider.php
@@ -19,18 +19,18 @@ class BusServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->bind(BaseDispatcher::class, function ($app) {
+        $this->container->bind(BaseDispatcher::class, function ($app) {
             return new Dispatcher($app, function ($connection = null) use ($app) {
                 return $app[QueueFactoryContract::class]->connection($connection);
             });
         });
 
-        $this->app->alias(
+        $this->container->alias(
             BaseDispatcher::class,
             DispatcherContract::class
         );
 
-        $this->app->alias(
+        $this->container->alias(
             BaseDispatcher::class,
             QueueingDispatcherContract::class
         );

--- a/src/Bus/BusServiceProvider.php
+++ b/src/Bus/BusServiceProvider.php
@@ -19,9 +19,9 @@ class BusServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->container->bind(BaseDispatcher::class, function ($app) {
-            return new Dispatcher($app, function ($connection = null) use ($app) {
-                return $app[QueueFactoryContract::class]->connection($connection);
+        $this->container->bind(BaseDispatcher::class, function ($container) {
+            return new Dispatcher($container, function ($connection = null) use ($container) {
+                return $container[QueueFactoryContract::class]->connection($connection);
             });
         });
 

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -23,7 +23,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.console.commands', function () {
+        $this->container->singleton('flarum.console.commands', function () {
             return [
                 CacheClearCommand::class,
                 GenerateMigrationCommand::class,

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -24,10 +24,10 @@ class DatabaseServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Manager::class, function ($app) {
+        $this->container->singleton(Manager::class, function ($app) {
             $manager = new Manager($app);
 
-            $config = $this->app['flarum']->config('database');
+            $config = $this->container['flarum']->config('database');
             $config['engine'] = 'InnoDB';
             $config['prefix_indexes'] = true;
 
@@ -36,7 +36,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
             return $manager;
         });
 
-        $this->app->singleton(ConnectionResolverInterface::class, function ($app) {
+        $this->container->singleton(ConnectionResolverInterface::class, function ($app) {
             $manager = $app->make(Manager::class);
             $manager->setAsGlobal();
             $manager->bootEloquent();
@@ -47,22 +47,22 @@ class DatabaseServiceProvider extends AbstractServiceProvider
             return $dbManager;
         });
 
-        $this->app->alias(ConnectionResolverInterface::class, 'db');
+        $this->container->alias(ConnectionResolverInterface::class, 'db');
 
-        $this->app->singleton(ConnectionInterface::class, function ($app) {
+        $this->container->singleton(ConnectionInterface::class, function ($app) {
             $resolver = $app->make(ConnectionResolverInterface::class);
 
             return $resolver->connection();
         });
 
-        $this->app->alias(ConnectionInterface::class, 'db.connection');
-        $this->app->alias(ConnectionInterface::class, 'flarum.db');
+        $this->container->alias(ConnectionInterface::class, 'db.connection');
+        $this->container->alias(ConnectionInterface::class, 'flarum.db');
 
-        $this->app->singleton(MigrationRepositoryInterface::class, function ($app) {
+        $this->container->singleton(MigrationRepositoryInterface::class, function ($app) {
             return new DatabaseMigrationRepository($app['flarum.db'], 'migrations');
         });
 
-        $this->app->singleton('flarum.database.model_private_checkers', function () {
+        $this->container->singleton('flarum.database.model_private_checkers', function () {
             // Discussion and Post are explicitly listed here to trigger the deprecated
             // event-based model privacy system. They should be removed in beta 17.
             return [
@@ -77,10 +77,10 @@ class DatabaseServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        AbstractModel::setConnectionResolver($this->app->make(ConnectionResolverInterface::class));
-        AbstractModel::setEventDispatcher($this->app->make('events'));
+        AbstractModel::setConnectionResolver($this->container->make(ConnectionResolverInterface::class));
+        AbstractModel::setEventDispatcher($this->container->make('events'));
 
-        foreach ($this->app->make('flarum.database.model_private_checkers') as $modelClass => $checkers) {
+        foreach ($this->container->make('flarum.database.model_private_checkers') as $modelClass => $checkers) {
             $modelClass::saving(function ($instance) use ($checkers) {
                 foreach ($checkers as $checker) {
                     if ($checker($instance) === true) {
@@ -95,7 +95,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
                 // @deprecated BC layer, remove beta 17
                 $event = new GetModelIsPrivate($instance);
 
-                $instance->is_private = $this->app->make('events')->until($event) === true;
+                $instance->is_private = $this->container->make('events')->until($event) === true;
             });
         }
     }

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -24,8 +24,8 @@ class DatabaseServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->container->singleton(Manager::class, function ($app) {
-            $manager = new Manager($app);
+        $this->container->singleton(Manager::class, function ($container) {
+            $manager = new Manager($container);
 
             $config = $this->container['flarum']->config('database');
             $config['engine'] = 'InnoDB';
@@ -36,8 +36,8 @@ class DatabaseServiceProvider extends AbstractServiceProvider
             return $manager;
         });
 
-        $this->container->singleton(ConnectionResolverInterface::class, function ($app) {
-            $manager = $app->make(Manager::class);
+        $this->container->singleton(ConnectionResolverInterface::class, function ($container) {
+            $manager = $container->make(Manager::class);
             $manager->setAsGlobal();
             $manager->bootEloquent();
 
@@ -49,8 +49,8 @@ class DatabaseServiceProvider extends AbstractServiceProvider
 
         $this->container->alias(ConnectionResolverInterface::class, 'db');
 
-        $this->container->singleton(ConnectionInterface::class, function ($app) {
-            $resolver = $app->make(ConnectionResolverInterface::class);
+        $this->container->singleton(ConnectionInterface::class, function ($container) {
+            $resolver = $container->make(ConnectionResolverInterface::class);
 
             return $resolver->connection();
         });
@@ -58,8 +58,8 @@ class DatabaseServiceProvider extends AbstractServiceProvider
         $this->container->alias(ConnectionInterface::class, 'db.connection');
         $this->container->alias(ConnectionInterface::class, 'flarum.db');
 
-        $this->container->singleton(MigrationRepositoryInterface::class, function ($app) {
-            return new DatabaseMigrationRepository($app['flarum.db'], 'migrations');
+        $this->container->singleton(MigrationRepositoryInterface::class, function ($container) {
+            return new DatabaseMigrationRepository($container['flarum.db'], 'migrations');
         });
 
         $this->container->singleton('flarum.database.model_private_checkers', function () {

--- a/src/Discussion/DiscussionServiceProvider.php
+++ b/src/Discussion/DiscussionServiceProvider.php
@@ -20,7 +20,7 @@ class DiscussionServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $events = $this->app->make('events');
+        $events = $this->container->make('events');
 
         $events->subscribe(DiscussionMetadataUpdater::class);
 

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -132,7 +132,7 @@ class Extension implements Arrayable
         $this->id = static::nameToId($this->name);
     }
 
-    public function extend(Container $app)
+    public function extend(Container $container)
     {
         foreach ($this->getExtenders() as $extender) {
             // If an extension has not yet switched to the new extend.php
@@ -142,7 +142,7 @@ class Extension implements Arrayable
                 $extender = new Compat($extender);
             }
 
-            $extender->extend($app, $this);
+            $extender->extend($container, $this);
         }
     }
 

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -341,12 +341,12 @@ class ExtensionManager
     /**
      * Call on all enabled extensions to extend the Flarum application.
      *
-     * @param Container $app
+     * @param Container $container
      */
-    public function extend(Container $app)
+    public function extend(Container $container)
     {
         foreach ($this->getEnabledExtensions() as $extension) {
-            $extension->extend($app);
+            $extension->extend($container);
         }
     }
 

--- a/src/Extension/ExtensionServiceProvider.php
+++ b/src/Extension/ExtensionServiceProvider.php
@@ -19,15 +19,15 @@ class ExtensionServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ExtensionManager::class);
-        $this->app->alias(ExtensionManager::class, 'flarum.extensions');
+        $this->container->singleton(ExtensionManager::class);
+        $this->container->alias(ExtensionManager::class, 'flarum.extensions');
 
         // Boot extensions when the app is booting. This must be done as a boot
         // listener on the app rather than in the service provider's boot method
         // below, so that extensions have a chance to register things on the
         // container before the core boots up (and starts resolving services).
-        $this->app['flarum']->booting(function () {
-            $this->app->make('flarum.extensions')->extend($this->app);
+        $this->container['flarum']->booting(function () {
+            $this->container->make('flarum.extensions')->extend($this->container);
         });
     }
 
@@ -36,7 +36,7 @@ class ExtensionServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        $this->app->make('events')->listen(
+        $this->container->make('events')->listen(
             Disabling::class,
             DefaultLanguagePackGuard::class
         );

--- a/src/Formatter/FormatterServiceProvider.php
+++ b/src/Formatter/FormatterServiceProvider.php
@@ -21,13 +21,13 @@ class FormatterServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.formatter', function (Container $container) {
+        $this->container->singleton('flarum.formatter', function (Container $container) {
             return new Formatter(
                 new Repository($container->make('cache.filestore')),
-                $this->app[Paths::class]->storage.'/formatter'
+                $this->container[Paths::class]->storage.'/formatter'
             );
         });
 
-        $this->app->alias('flarum.formatter', Formatter::class);
+        $this->container->alias('flarum.formatter', Formatter::class);
     }
 }

--- a/src/Foundation/AbstractServiceProvider.php
+++ b/src/Foundation/AbstractServiceProvider.php
@@ -15,9 +15,15 @@ use Illuminate\Support\ServiceProvider;
 abstract class AbstractServiceProvider extends ServiceProvider
 {
     /**
+     * @deprecated beta 16, remove beta 17
      * @var Container
      */
     protected $app;
+
+    /**
+     * @var Container
+     */
+    protected $container;
 
     /**
      * @param Container $container
@@ -25,6 +31,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     public function __construct(Container $container)
     {
         $this->app = $container;
+        $this->container = $container;
     }
 
     /**

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -135,8 +135,14 @@ class Application
     {
         \Illuminate\Container\Container::setInstance($this->container);
 
+        /**
+         * @deprecated beta 16, remove beta 17
+         */
         $this->container->instance('app', $this->container);
         $this->container->alias('app', \Illluminate\Container\Container::class);
+
+        $this->container->instance('container', $this->container);
+        $this->container->alias('container', \Illluminate\Container\Container::class);
 
         $this->container->instance('flarum', $this);
         $this->container->alias('flarum', self::class);

--- a/src/Foundation/ErrorServiceProvider.php
+++ b/src/Foundation/ErrorServiceProvider.php
@@ -25,7 +25,7 @@ class ErrorServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('flarum.error.statuses', function () {
+        $this->container->singleton('flarum.error.statuses', function () {
             return [
                 // 400 Bad Request
                 'csrf_token_mismatch' => 400,
@@ -50,14 +50,14 @@ class ErrorServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->singleton('flarum.error.classes', function () {
+        $this->container->singleton('flarum.error.classes', function () {
             return [
                 InvalidParameterException::class => 'invalid_parameter',
                 ModelNotFoundException::class => 'not_found',
             ];
         });
 
-        $this->app->singleton('flarum.error.handlers', function () {
+        $this->container->singleton('flarum.error.handlers', function () {
             return [
                 IlluminateValidationException::class => ExceptionHandler\IlluminateValidationExceptionHandler::class,
                 ValidationException::class => ExceptionHandler\ValidationExceptionHandler::class,
@@ -66,14 +66,14 @@ class ErrorServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->singleton(Registry::class, function () {
+        $this->container->singleton(Registry::class, function () {
             return new Registry(
-                $this->app->make('flarum.error.statuses'),
-                $this->app->make('flarum.error.classes'),
-                $this->app->make('flarum.error.handlers')
+                $this->container->make('flarum.error.statuses'),
+                $this->container->make('flarum.error.classes'),
+                $this->container->make('flarum.error.handlers')
             );
         });
 
-        $this->app->tag(LogReporter::class, Reporter::class);
+        $this->container->tag(LogReporter::class, Reporter::class);
     }
 }

--- a/src/Foundation/UninstalledSite.php
+++ b/src/Foundation/UninstalledSite.php
@@ -84,13 +84,13 @@ class UninstalledSite implements SiteInterface
             UninstalledSettingsRepository::class
         );
 
-        $container->singleton('view', function ($app) {
+        $container->singleton('view', function ($container) {
             $engines = new EngineResolver();
             $engines->register('php', function () {
                 return new PhpEngine();
             });
-            $finder = new FileViewFinder($app->make('files'), []);
-            $dispatcher = $app->make(Dispatcher::class);
+            $finder = new FileViewFinder($container->make('files'), []);
+            $dispatcher = $container->make(Dispatcher::class);
 
             return new \Illuminate\View\Factory(
                 $engines,

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -20,13 +20,13 @@ class FrontendServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('flarum.assets.factory', function () {
+        $this->container->singleton('flarum.assets.factory', function () {
             return function (string $name) {
-                $paths = $this->app[Paths::class];
+                $paths = $this->container[Paths::class];
 
                 $assets = new Assets(
                     $name,
-                    $this->app->make('filesystem')->disk('flarum-assets'),
+                    $this->container->make('filesystem')->disk('flarum-assets'),
                     $paths->storage
                 );
 
@@ -41,17 +41,17 @@ class FrontendServiceProvider extends AbstractServiceProvider
             };
         });
 
-        $this->app->singleton('flarum.frontend.factory', function () {
+        $this->container->singleton('flarum.frontend.factory', function () {
             return function (string $name) {
-                $frontend = $this->app->make(Frontend::class);
+                $frontend = $this->container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
                     $document->layoutView = 'flarum::frontend.'.$name;
                 });
 
-                $frontend->content($this->app->make(Content\Assets::class)->forFrontend($name));
-                $frontend->content($this->app->make(Content\CorePayload::class));
-                $frontend->content($this->app->make(Content\Meta::class));
+                $frontend->content($this->container->make(Content\Assets::class)->forFrontend($name));
+                $frontend->content($this->container->make(Content\CorePayload::class));
+                $frontend->content($this->container->make(Content\Meta::class));
 
                 return $frontend;
             };
@@ -65,9 +65,9 @@ class FrontendServiceProvider extends AbstractServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../../views', 'flarum');
 
-        $this->app->make(ViewFactory::class)->share([
-            'translator' => $this->app->make('translator'),
-            'url' => $this->app->make(UrlGenerator::class)
+        $this->container->make(ViewFactory::class)->share([
+            'translator' => $this->container->make('translator'),
+            'url' => $this->container->make(UrlGenerator::class)
         ]);
     }
 
@@ -82,7 +82,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
     private function addLessVariables(SourceCollector $sources)
     {
         $sources->addString(function () {
-            $settings = $this->app->make(SettingsRepositoryInterface::class);
+            $settings = $this->container->make(SettingsRepositoryInterface::class);
 
             $vars = [
                 'config-primary-color'   => $settings->get('theme_primary_color', '#000'),

--- a/src/Http/HttpServiceProvider.php
+++ b/src/Http/HttpServiceProvider.php
@@ -24,15 +24,15 @@ class HttpServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.http.csrfExemptPaths', function () {
+        $this->container->singleton('flarum.http.csrfExemptPaths', function () {
             return ['token'];
         });
 
-        $this->app->bind(Middleware\CheckCsrfToken::class, function ($app) {
+        $this->container->bind(Middleware\CheckCsrfToken::class, function ($app) {
             return new Middleware\CheckCsrfToken($app->make('flarum.http.csrfExemptPaths'));
         });
 
-        $this->app->singleton('flarum.http.slugDrivers', function () {
+        $this->container->singleton('flarum.http.slugDrivers', function () {
             return [
                 Discussion::class => [
                     'default' => IdWithTransliteratedSlugDriver::class
@@ -43,23 +43,23 @@ class HttpServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->singleton('flarum.http.selectedSlugDrivers', function () {
-            $settings = $this->app->make(SettingsRepositoryInterface::class);
+        $this->container->singleton('flarum.http.selectedSlugDrivers', function () {
+            $settings = $this->container->make(SettingsRepositoryInterface::class);
 
             $compiledDrivers = [];
 
-            foreach ($this->app->make('flarum.http.slugDrivers') as $resourceClass => $resourceDrivers) {
+            foreach ($this->container->make('flarum.http.slugDrivers') as $resourceClass => $resourceDrivers) {
                 $driverKey = $settings->get("slug_driver_$resourceClass", 'default');
 
                 $driverClass = Arr::get($resourceDrivers, $driverKey, $resourceDrivers['default']);
 
-                $compiledDrivers[$resourceClass] = $this->app->make($driverClass);
+                $compiledDrivers[$resourceClass] = $this->container->make($driverClass);
             }
 
             return $compiledDrivers;
         });
-        $this->app->bind(SlugManager::class, function () {
-            return new SlugManager($this->app->make('flarum.http.selectedSlugDrivers'));
+        $this->container->bind(SlugManager::class, function () {
+            return new SlugManager($this->container->make('flarum.http.selectedSlugDrivers'));
         });
     }
 }

--- a/src/Http/HttpServiceProvider.php
+++ b/src/Http/HttpServiceProvider.php
@@ -28,8 +28,8 @@ class HttpServiceProvider extends AbstractServiceProvider
             return ['token'];
         });
 
-        $this->container->bind(Middleware\CheckCsrfToken::class, function ($app) {
-            return new Middleware\CheckCsrfToken($app->make('flarum.http.csrfExemptPaths'));
+        $this->container->bind(Middleware\CheckCsrfToken::class, function ($container) {
+            return new Middleware\CheckCsrfToken($container->make('flarum.http.csrfExemptPaths'));
         });
 
         $this->container->singleton('flarum.http.slugDrivers', function () {

--- a/src/Install/InstallServiceProvider.php
+++ b/src/Install/InstallServiceProvider.php
@@ -20,7 +20,7 @@ class InstallServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.install.routes', function () {
+        $this->container->singleton('flarum.install.routes', function () {
             return new RouteCollection;
         });
     }
@@ -32,7 +32,7 @@ class InstallServiceProvider extends AbstractServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../../views/install', 'flarum.install');
 
-        $this->populateRoutes($this->app->make('flarum.install.routes'));
+        $this->populateRoutes($this->container->make('flarum.install.routes'));
     }
 
     /**
@@ -40,7 +40,7 @@ class InstallServiceProvider extends AbstractServiceProvider
      */
     protected function populateRoutes(RouteCollection $routes)
     {
-        $route = $this->app->make(RouteHandlerFactory::class);
+        $route = $this->container->make(RouteHandlerFactory::class);
 
         $routes->get(
             '/{path:.*}',

--- a/src/Locale/LocaleServiceProvider.php
+++ b/src/Locale/LocaleServiceProvider.php
@@ -25,7 +25,7 @@ class LocaleServiceProvider extends AbstractServiceProvider
     public function boot(Dispatcher $events)
     {
         $events->listen(ClearingCache::class, function () {
-            $this->app->make('flarum.locales')->clearCache();
+            $this->container->make('flarum.locales')->clearCache();
         });
     }
 
@@ -34,9 +34,9 @@ class LocaleServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(LocaleManager::class, function () {
+        $this->container->singleton(LocaleManager::class, function () {
             $locales = new LocaleManager(
-                $this->app->make('translator'),
+                $this->container->make('translator'),
                 $this->getCacheDir()
             );
 
@@ -45,14 +45,14 @@ class LocaleServiceProvider extends AbstractServiceProvider
             return $locales;
         });
 
-        $this->app->alias(LocaleManager::class, 'flarum.locales');
+        $this->container->alias(LocaleManager::class, 'flarum.locales');
 
-        $this->app->singleton('translator', function () {
+        $this->container->singleton('translator', function () {
             $translator = new Translator(
                 $this->getDefaultLocale(),
                 null,
                 $this->getCacheDir(),
-                $this->app['flarum.debug']
+                $this->container['flarum.debug']
             );
 
             $translator->setFallbackLocales(['en']);
@@ -62,20 +62,20 @@ class LocaleServiceProvider extends AbstractServiceProvider
 
             return $translator;
         });
-        $this->app->alias('translator', Translator::class);
-        $this->app->alias('translator', TranslatorContract::class);
-        $this->app->alias('translator', TranslatorInterface::class);
+        $this->container->alias('translator', Translator::class);
+        $this->container->alias('translator', TranslatorContract::class);
+        $this->container->alias('translator', TranslatorInterface::class);
     }
 
     private function getDefaultLocale(): string
     {
-        $repo = $this->app->make(SettingsRepositoryInterface::class);
+        $repo = $this->container->make(SettingsRepositoryInterface::class);
 
         return $repo->get('default_locale', 'en');
     }
 
     private function getCacheDir(): string
     {
-        return $this->app[Paths::class]->storage.'/locale';
+        return $this->container[Paths::class]->storage.'/locale';
     }
 }

--- a/src/Mail/MailServiceProvider.php
+++ b/src/Mail/MailServiceProvider.php
@@ -20,7 +20,7 @@ class MailServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('mail.supported_drivers', function () {
+        $this->container->singleton('mail.supported_drivers', function () {
             return [
                 'mail' => SendmailDriver::class,
                 'mailgun' => MailgunDriver::class,
@@ -29,31 +29,31 @@ class MailServiceProvider extends AbstractServiceProvider
             ];
         });
 
-        $this->app->singleton('mail.driver', function () {
-            $configured = $this->app->make('flarum.mail.configured_driver');
-            $settings = $this->app->make(SettingsRepositoryInterface::class);
-            $validator = $this->app->make(Factory::class);
+        $this->container->singleton('mail.driver', function () {
+            $configured = $this->container->make('flarum.mail.configured_driver');
+            $settings = $this->container->make(SettingsRepositoryInterface::class);
+            $validator = $this->container->make(Factory::class);
 
             return $configured->validate($settings, $validator)->any()
-                ? $this->app->make(NullDriver::class)
+                ? $this->container->make(NullDriver::class)
                 : $configured;
         });
 
-        $this->app->alias('mail.driver', DriverInterface::class);
+        $this->container->alias('mail.driver', DriverInterface::class);
 
-        $this->app->singleton('flarum.mail.configured_driver', function () {
-            $drivers = $this->app->make('mail.supported_drivers');
-            $settings = $this->app->make(SettingsRepositoryInterface::class);
+        $this->container->singleton('flarum.mail.configured_driver', function () {
+            $drivers = $this->container->make('mail.supported_drivers');
+            $settings = $this->container->make(SettingsRepositoryInterface::class);
             $driverName = $settings->get('mail_driver');
 
             $driverClass = Arr::get($drivers, $driverName);
 
             return $driverClass
-                ? $this->app->make($driverClass)
-                : $this->app->make(NullDriver::class);
+                ? $this->container->make($driverClass)
+                : $this->container->make(NullDriver::class);
         });
 
-        $this->app->singleton('swift.mailer', function ($app) {
+        $this->container->singleton('swift.mailer', function ($app) {
             return new Swift_Mailer(
                 $app->make('mail.driver')->buildTransport(
                     $app->make(SettingsRepositoryInterface::class)
@@ -61,7 +61,7 @@ class MailServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->singleton('mailer', function ($app) {
+        $this->container->singleton('mailer', function ($app) {
             $mailer = new Mailer(
                 $app['view'],
                 $app['swift.mailer'],

--- a/src/Mail/MailServiceProvider.php
+++ b/src/Mail/MailServiceProvider.php
@@ -53,26 +53,26 @@ class MailServiceProvider extends AbstractServiceProvider
                 : $this->container->make(NullDriver::class);
         });
 
-        $this->container->singleton('swift.mailer', function ($app) {
+        $this->container->singleton('swift.mailer', function ($container) {
             return new Swift_Mailer(
-                $app->make('mail.driver')->buildTransport(
-                    $app->make(SettingsRepositoryInterface::class)
+                $container->make('mail.driver')->buildTransport(
+                    $container->make(SettingsRepositoryInterface::class)
                 )
             );
         });
 
-        $this->container->singleton('mailer', function ($app) {
+        $this->container->singleton('mailer', function ($container) {
             $mailer = new Mailer(
-                $app['view'],
-                $app['swift.mailer'],
-                $app['events']
+                $container['view'],
+                $container['swift.mailer'],
+                $container['events']
             );
 
-            if ($app->bound('queue')) {
-                $mailer->setQueue($app->make('queue'));
+            if ($container->bound('queue')) {
+                $mailer->setQueue($container->make('queue'));
             }
 
-            $settings = $app->make(SettingsRepositoryInterface::class);
+            $settings = $container->make(SettingsRepositoryInterface::class);
             $mailer->alwaysFrom($settings->get('mail_from'), $settings->get('forum_title'));
 
             return $mailer;

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -19,14 +19,14 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.notification.drivers', function () {
+        $this->container->singleton('flarum.notification.drivers', function () {
             return [
                 'alert' => Driver\AlertNotificationDriver::class,
                 'email' => Driver\EmailNotificationDriver::class,
             ];
         });
 
-        $this->app->singleton('flarum.notification.blueprints', function () {
+        $this->container->singleton('flarum.notification.blueprints', function () {
             return [
                 DiscussionRenamedBlueprint::class => ['alert']
             ];
@@ -47,8 +47,8 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     protected function setNotificationDrivers()
     {
-        foreach ($this->app->make('flarum.notification.drivers') as $driverName => $driver) {
-            NotificationSyncer::addNotificationDriver($driverName, $this->app->make($driver));
+        foreach ($this->container->make('flarum.notification.drivers') as $driverName => $driver) {
+            NotificationSyncer::addNotificationDriver($driverName, $this->container->make($driver));
         }
     }
 
@@ -57,7 +57,7 @@ class NotificationServiceProvider extends AbstractServiceProvider
      */
     protected function setNotificationTypes()
     {
-        $blueprints = $this->app->make('flarum.notification.blueprints');
+        $blueprints = $this->container->make('flarum.notification.blueprints');
 
         foreach ($blueprints as $blueprint => $driversEnabledByDefault) {
             $this->addType($blueprint, $driversEnabledByDefault);

--- a/src/Post/PostServiceProvider.php
+++ b/src/Post/PostServiceProvider.php
@@ -20,7 +20,7 @@ class PostServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->extend('flarum.api.throttlers', function ($throttlers) {
+        $this->container->extend('flarum.api.throttlers', function ($throttlers) {
             $throttlers['postTimeout'] = function ($request) {
                 if (! in_array($request->getAttribute('routeName'), ['discussions.create', 'posts.create'])) {
                     return;
@@ -46,7 +46,7 @@ class PostServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        CommentPost::setFormatter($this->app->make('flarum.formatter'));
+        CommentPost::setFormatter($this->container->make('flarum.formatter'));
 
         $this->setPostTypes();
 

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -41,26 +41,26 @@ class QueueServiceProvider extends AbstractServiceProvider
     {
         // Register a simple connection factory that always returns the same
         // connection, as that is enough for our purposes.
-        $this->app->singleton(Factory::class, function () {
+        $this->container->singleton(Factory::class, function () {
             return new QueueFactory(function () {
-                return $this->app->make('flarum.queue.connection');
+                return $this->container->make('flarum.queue.connection');
             });
         });
 
         // Extensions can override this binding if they want to make Flarum use
         // a different queuing backend.
-        $this->app->singleton('flarum.queue.connection', function ($app) {
+        $this->container->singleton('flarum.queue.connection', function ($app) {
             $queue = new SyncQueue;
             $queue->setContainer($app);
 
             return $queue;
         });
 
-        $this->app->singleton(ExceptionHandling::class, function ($app) {
+        $this->container->singleton(ExceptionHandling::class, function ($app) {
             return new ExceptionHandler($app['log']);
         });
 
-        $this->app->singleton(Worker::class, function ($app) {
+        $this->container->singleton(Worker::class, function ($app) {
             /** @var Config $config */
             $config = $app->make(Config::class);
 
@@ -76,21 +76,21 @@ class QueueServiceProvider extends AbstractServiceProvider
 
         // Override the Laravel native Listener, so that we can ignore the environment
         // option and force the binary to flarum.
-        $this->app->singleton(QueueListener::class, function ($app) {
+        $this->container->singleton(QueueListener::class, function ($app) {
             return new Listener($app[Paths::class]->base);
         });
 
         // Bind a simple cache manager that returns the cache store.
-        $this->app->singleton('cache', function ($app) {
+        $this->container->singleton('cache', function ($app) {
             return new class($app) {
                 public function __construct($app)
                 {
-                    $this->app = $app;
+                    $this->container = $app;
                 }
 
                 public function driver()
                 {
-                    return $this->app['cache.store'];
+                    return $this->container['cache.store'];
                 }
 
                 public function __call($name, $arguments)
@@ -100,24 +100,24 @@ class QueueServiceProvider extends AbstractServiceProvider
             };
         });
 
-        $this->app->singleton('queue.failer', function () {
+        $this->container->singleton('queue.failer', function () {
             return new NullFailedJobProvider();
         });
 
-        $this->app->alias('flarum.queue.connection', Queue::class);
+        $this->container->alias('flarum.queue.connection', Queue::class);
 
-        $this->app->alias(ConnectorInterface::class, 'queue.connection');
-        $this->app->alias(Factory::class, 'queue');
-        $this->app->alias(Worker::class, 'queue.worker');
-        $this->app->alias(Listener::class, 'queue.listener');
+        $this->container->alias(ConnectorInterface::class, 'queue.connection');
+        $this->container->alias(Factory::class, 'queue');
+        $this->container->alias(Worker::class, 'queue.worker');
+        $this->container->alias(Listener::class, 'queue.listener');
 
         $this->registerCommands();
     }
 
     protected function registerCommands()
     {
-        $this->app->extend('flarum.console.commands', function ($commands) {
-            $queue = $this->app->make(Queue::class);
+        $this->container->extend('flarum.console.commands', function ($commands) {
+            $queue = $this->container->make(Queue::class);
 
             // There is no need to have the queue commands when using the sync driver.
             if ($queue instanceof SyncQueue) {
@@ -132,14 +132,14 @@ class QueueServiceProvider extends AbstractServiceProvider
 
     public function boot()
     {
-        $this->app['events']->listen(JobFailed::class, function (JobFailed $event) {
+        $this->container['events']->listen(JobFailed::class, function (JobFailed $event) {
             /** @var Registry $registry */
-            $registry = $this->app->make(Registry::class);
+            $registry = $this->container->make(Registry::class);
 
             $error = $registry->handle($event->exception);
 
             /** @var Reporter[] $reporters */
-            $reporters = $this->app->tagged(Reporter::class);
+            $reporters = $this->container->tagged(Reporter::class);
 
             if ($error->shouldBeReported()) {
                 foreach ($reporters as $reporter) {

--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -49,25 +49,25 @@ class QueueServiceProvider extends AbstractServiceProvider
 
         // Extensions can override this binding if they want to make Flarum use
         // a different queuing backend.
-        $this->container->singleton('flarum.queue.connection', function ($app) {
+        $this->container->singleton('flarum.queue.connection', function ($container) {
             $queue = new SyncQueue;
-            $queue->setContainer($app);
+            $queue->setContainer($container);
 
             return $queue;
         });
 
-        $this->container->singleton(ExceptionHandling::class, function ($app) {
-            return new ExceptionHandler($app['log']);
+        $this->container->singleton(ExceptionHandling::class, function ($container) {
+            return new ExceptionHandler($container['log']);
         });
 
-        $this->container->singleton(Worker::class, function ($app) {
+        $this->container->singleton(Worker::class, function ($container) {
             /** @var Config $config */
-            $config = $app->make(Config::class);
+            $config = $container->make(Config::class);
 
             return new Worker(
-                $app[Factory::class],
-                $app['events'],
-                $app[ExceptionHandling::class],
+                $container[Factory::class],
+                $container['events'],
+                $container[ExceptionHandling::class],
                 function () use ($config) {
                     return $config->inMaintenanceMode();
                 }
@@ -76,16 +76,16 @@ class QueueServiceProvider extends AbstractServiceProvider
 
         // Override the Laravel native Listener, so that we can ignore the environment
         // option and force the binary to flarum.
-        $this->container->singleton(QueueListener::class, function ($app) {
-            return new Listener($app[Paths::class]->base);
+        $this->container->singleton(QueueListener::class, function ($container) {
+            return new Listener($container[Paths::class]->base);
         });
 
         // Bind a simple cache manager that returns the cache store.
-        $this->container->singleton('cache', function ($app) {
-            return new class($app) {
-                public function __construct($app)
+        $this->container->singleton('cache', function ($container) {
+            return new class($container) {
+                public function __construct($container)
                 {
-                    $this->container = $app;
+                    $this->container = $container;
                 }
 
                 public function driver()

--- a/src/Settings/SettingsServiceProvider.php
+++ b/src/Settings/SettingsServiceProvider.php
@@ -26,21 +26,21 @@ class SettingsServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(SettingsRepositoryInterface::class, function () {
+        $this->container->singleton(SettingsRepositoryInterface::class, function () {
             return new MemoryCacheSettingsRepository(
                 new DatabaseSettingsRepository(
-                    $this->app->make(ConnectionInterface::class)
+                    $this->container->make(ConnectionInterface::class)
                 )
             );
         });
 
-        $this->app->alias(SettingsRepositoryInterface::class, 'flarum.settings');
+        $this->container->alias(SettingsRepositoryInterface::class, 'flarum.settings');
 
-        $assets = function (Container $app) {
-            return $app->make(Factory::class)->disk('flarum-assets')->getDriver();
+        $assets = function (Container $container) {
+            return $container->make(Factory::class)->disk('flarum-assets')->getDriver();
         };
 
-        $this->app->when([
+        $this->container->when([
             DeleteFaviconController::class,
             DeleteLogoController::class,
             UploadFaviconController::class,

--- a/src/Update/UpdateServiceProvider.php
+++ b/src/Update/UpdateServiceProvider.php
@@ -20,7 +20,7 @@ class UpdateServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flarum.update.routes', function () {
+        $this->container->singleton('flarum.update.routes', function () {
             $routes = new RouteCollection;
             $this->populateRoutes($routes);
 
@@ -41,7 +41,7 @@ class UpdateServiceProvider extends AbstractServiceProvider
      */
     protected function populateRoutes(RouteCollection $routes)
     {
-        $route = $this->app->make(RouteHandlerFactory::class);
+        $route = $this->container->make(RouteHandlerFactory::class);
 
         $routes->get(
             '/{path:.*}',

--- a/src/User/SessionServiceProvider.php
+++ b/src/User/SessionServiceProvider.php
@@ -20,7 +20,7 @@ class SessionServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('session.handler', function ($app) {
+        $this->container->singleton('session.handler', function ($app) {
             return new FileSessionHandler(
                 $app['files'],
                 $app['config']['session.files'],
@@ -28,6 +28,6 @@ class SessionServiceProvider extends AbstractServiceProvider
             );
         });
 
-        $this->app->alias('session.handler', SessionHandlerInterface::class);
+        $this->container->alias('session.handler', SessionHandlerInterface::class);
     }
 }

--- a/src/User/SessionServiceProvider.php
+++ b/src/User/SessionServiceProvider.php
@@ -20,11 +20,11 @@ class SessionServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->container->singleton('session.handler', function ($app) {
+        $this->container->singleton('session.handler', function ($container) {
             return new FileSessionHandler(
-                $app['files'],
-                $app['config']['session.files'],
-                $app['config']['session.lifetime']
+                $container['files'],
+                $container['config']['session.files'],
+                $container['config']['session.lifetime']
             );
         });
 

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -91,10 +91,10 @@ class UserServiceProvider extends AbstractServiceProvider
 
     protected function registerPasswordCheckers()
     {
-        $this->app->singleton('flarum.user.password_checkers', function () {
+        $this->container->singleton('flarum.user.password_checkers', function () {
             return [
                 'standard' => function (User $user, $password) {
-                    if ($this->app->make('hash')->check($password, $user->password)) {
+                    if ($this->container->make('hash')->check($password, $user->password)) {
                         return true;
                     }
                 }
@@ -112,6 +112,7 @@ class UserServiceProvider extends AbstractServiceProvider
         }
 
         User::setHasher($this->container->make('hash'));
+        User::setPasswordCheckers($this->container->make('flarum.user.password_checkers'));
         User::setGate($this->container->makeWith(Access\Gate::class, ['policyClasses' => $this->container->make('flarum.policies')]));
         User::setDisplayNameDriver($this->container->make('flarum.user.display_name.driver'));
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,11 +27,9 @@ if (! function_exists('container')) {
     }
 }
 
-/**
- * @deprecated beta 16, remove beta 17. Use container() instead.
- */
 if (! function_exists('app')) {
     /**
+     * @deprecated beta 16, remove beta 17. Use container() instead.
      * Get the available container instance.
      *
      * @param  string  $make

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,15 +9,15 @@
 
 use Illuminate\Container\Container;
 
-if (! function_exists('app')) {
+if (!function_exists('container')) {
     /**
      * Get the available container instance.
      *
      * @param  string  $make
      * @param  array   $parameters
-     * @return mixed|\Illuminate\Foundation\Application
+     * @return mixed|\Illuminate\Container\Container
      */
-    function app($make = null, $parameters = [])
+    function container($make = null, $parameters = [])
     {
         if (is_null($make)) {
             return Container::getInstance();
@@ -26,6 +26,24 @@ if (! function_exists('app')) {
         return Container::getInstance()->make($make, $parameters);
     }
 }
+
+/**
+ * @deprecated beta 16, remove beta 17. Use container() instead.
+ */
+if (!function_exists('app')) {
+    /**
+     * Get the available container instance.
+     *
+     * @param  string  $make
+     * @param  array   $parameters
+     * @return mixed|\Illuminate\Container\Container
+     */
+    function app($make = null, $parameters = [])
+    {
+        return container($make, $parameters);
+    }
+}
+
 
 if (! function_exists('event')) {
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,7 +9,7 @@
 
 use Illuminate\Container\Container;
 
-if (!function_exists('container')) {
+if (! function_exists('container')) {
     /**
      * Get the available container instance.
      *
@@ -30,7 +30,7 @@ if (!function_exists('container')) {
 /**
  * @deprecated beta 16, remove beta 17. Use container() instead.
  */
-if (!function_exists('app')) {
+if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
@@ -43,7 +43,6 @@ if (!function_exists('app')) {
         return container($make, $parameters);
     }
 }
-
 
 if (! function_exists('event')) {
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,21 +9,17 @@
 
 use Illuminate\Container\Container;
 
-if (! function_exists('container')) {
+if (! function_exists('resolve')) {
     /**
-     * Get the available container instance.
+     * Resolve a service from the container.
      *
-     * @param  string  $make
-     * @param  array   $parameters
-     * @return mixed|\Illuminate\Container\Container
+     * @param  string  $name
+     * @param  array  $parameters
+     * @return mixed
      */
-    function container($make = null, $parameters = [])
+    function resolve($name, $parameters = [])
     {
-        if (is_null($make)) {
-            return Container::getInstance();
-        }
-
-        return Container::getInstance()->make($make, $parameters);
+        return Container::getInstance()->make($name, $parameters);
     }
 }
 
@@ -38,7 +34,11 @@ if (! function_exists('app')) {
      */
     function app($make = null, $parameters = [])
     {
-        return container($make, $parameters);
+        if (is_null($make)) {
+            return Container::getInstance();
+        }
+
+        return resolve($make, $parameters);
     }
 }
 


### PR DESCRIPTION
**Refs #1796 **

**Changes proposed in this pull request:**
In #2142, the container was detached from the application in preparation for the upcoming Laravel upgrade. However, the terminology of `app` is still used everywhere which is fairly misleading. This PR renamed containers called $app to $container in core, and deprecates `AbstractServiceProvider::container` and the `app` helper in favor of `container`.