### PR TITLE
Add Back Button to Post Scrubber

### DIFF
--- a/less/forum/Scrubber.less
+++ b/less/forum/Scrubber.less
@@ -22,6 +22,23 @@
 .Scrubber-before, .Scrubber-after {
   border-left: 1px solid @control-bg;
 }
+.Scrubber-back {
+  position: absolute;
+  z-index: 1;
+
+  .icon {
+    margin-left: -0.35em;
+    color: @muted-color;
+  }
+
+  .Button {
+    padding: 5px;
+    position: absolute;
+    left: 15px;
+    top: -5px;
+    width: initial;
+  }
+}
 .Scrubber-unread {
   position: absolute;
   border-left: 1px solid lighten(@muted-color, 10%);


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adding a Back button to the post stream scrubber when moving around. This makes it super convenient to jump back and forth when checking out different locations in the discussion - Discourse has something similar. 

**Screenshot**
<img width="239" alt="Screen Shot 2021-02-17 at 12 50 25 PM" src="https://user-images.githubusercontent.com/13856015/108301513-0383e100-7157-11eb-8b59-4e80908e5d9d.png">


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

**Required changes:**

- [ ] Related English PR: Will do this when/if merged.
