### PR TITLE
Initial user permission split

### DIFF
--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -326,12 +326,28 @@ export default class PermissionGrid extends Component {
       60
     );
 
+    items.add('userEditCredentials', {
+      icon: 'fas fa-user-cog',
+      label: app.translator.trans('core.admin.permissions.edit_users_credentials_label'),
+      permission: 'user.editCredentials',
+    });
+
     items.add(
-      'userEdit',
+      'userEditGroups',
       {
-        icon: 'fas fa-user-cog',
-        label: app.translator.trans('core.admin.permissions.edit_users_label'),
-        permission: 'user.edit',
+        icon: 'fas fa-users-cog',
+        label: app.translator.trans('core.admin.permissions.edit_users_groups_label'),
+        permission: 'user.editGroups',
+      },
+      60
+    );
+
+    items.add(
+      'userEditUsername',
+      {
+        icon: 'fas fa-address-card',
+        label: app.translator.trans('core.admin.permissions.edit_users_username_label'),
+        permission: 'user.editUsername',
       },
       60
     );

--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -29,8 +29,14 @@ Object.assign(User.prototype, {
   discussionCount: Model.attribute('discussionCount'),
   commentCount: Model.attribute('commentCount'),
 
-  canEdit: Model.attribute('canEdit'),
+  canEditCredentials: Model.attribute('canEditCredentials'),
+  canEditUsername: Model.attribute('canEditUsername'),
+  canEditGroups: Model.attribute('canEditGroups'),
   canDelete: Model.attribute('canDelete'),
+
+  canEdit: computed('canEditCredentials', 'canEditGroups', 'canEditUsername', function (canEditCredentials, canEditGroups, canEditUsername) {
+    return canEditCredentials || canEditGroups || canEditUsername;
+  }),
 
   avatarColor: null,
   color: computed('username', 'avatarUrl', 'avatarColor', function (username, avatarUrl, avatarColor) {

--- a/js/src/forum/components/EditUserModal.js
+++ b/js/src/forum/components/EditUserModal.js
@@ -47,96 +47,106 @@ export default class EditUserModal extends Modal {
   fields() {
     const items = new ItemList();
 
-    items.add(
-      'username',
-      <div className="Form-group">
-        <label>{app.translator.trans('core.forum.edit_user.username_heading')}</label>
-        <input className="FormControl" placeholder={extractText(app.translator.trans('core.forum.edit_user.username_label'))} bidi={this.username} />
-      </div>,
-      40
-    );
-
-    if (app.session.user !== this.attrs.user) {
+    if (app.session.user.canEditUsername()) {
       items.add(
-        'email',
+        'username',
         <div className="Form-group">
-          <label>{app.translator.trans('core.forum.edit_user.email_heading')}</label>
-          <div>
-            <input className="FormControl" placeholder={extractText(app.translator.trans('core.forum.edit_user.email_label'))} bidi={this.email} />
-          </div>
-          {!this.isEmailConfirmed() ? (
-            <div>
-              {Button.component(
-                {
-                  className: 'Button Button--block',
-                  loading: this.loading,
-                  onclick: this.activate.bind(this),
-                },
-                app.translator.trans('core.forum.edit_user.activate_button')
-              )}
-            </div>
-          ) : (
-            ''
-          )}
+          <label>{app.translator.trans('core.forum.edit_user.username_heading')}</label>
+          <input
+            className="FormControl"
+            placeholder={extractText(app.translator.trans('core.forum.edit_user.username_label'))}
+            bidi={this.username}
+          />
         </div>,
-        30
-      );
-
-      items.add(
-        'password',
-        <div className="Form-group">
-          <label>{app.translator.trans('core.forum.edit_user.password_heading')}</label>
-          <div>
-            <label className="checkbox">
-              <input
-                type="checkbox"
-                onchange={(e) => {
-                  this.setPassword(e.target.checked);
-                  m.redraw.sync();
-                  if (e.target.checked) this.$('[name=password]').select();
-                  e.redraw = false;
-                }}
-              />
-              {app.translator.trans('core.forum.edit_user.set_password_label')}
-            </label>
-            {this.setPassword() ? (
-              <input
-                className="FormControl"
-                type="password"
-                name="password"
-                placeholder={extractText(app.translator.trans('core.forum.edit_user.password_label'))}
-                bidi={this.password}
-              />
-            ) : (
-              ''
-            )}
-          </div>
-        </div>,
-        20
+        40
       );
     }
 
-    items.add(
-      'groups',
-      <div className="Form-group EditUserModal-groups">
-        <label>{app.translator.trans('core.forum.edit_user.groups_heading')}</label>
-        <div>
-          {Object.keys(this.groups)
-            .map((id) => app.store.getById('groups', id))
-            .map((group) => (
+    if (app.session.user.canEditCredentials()) {
+      if (app.session.user !== this.attrs.user) {
+        items.add(
+          'email',
+          <div className="Form-group">
+            <label>{app.translator.trans('core.forum.edit_user.email_heading')}</label>
+            <div>
+              <input className="FormControl" placeholder={extractText(app.translator.trans('core.forum.edit_user.email_label'))} bidi={this.email} />
+            </div>
+            {!this.isEmailConfirmed() ? (
+              <div>
+                {Button.component(
+                  {
+                    className: 'Button Button--block',
+                    loading: this.loading,
+                    onclick: this.activate.bind(this),
+                  },
+                  app.translator.trans('core.forum.edit_user.activate_button')
+                )}
+              </div>
+            ) : (
+              ''
+            )}
+          </div>,
+          30
+        );
+
+        items.add(
+          'password',
+          <div className="Form-group">
+            <label>{app.translator.trans('core.forum.edit_user.password_heading')}</label>
+            <div>
               <label className="checkbox">
                 <input
                   type="checkbox"
-                  bidi={this.groups[group.id()]}
-                  disabled={this.attrs.user.id() === '1' && group.id() === Group.ADMINISTRATOR_ID}
+                  onchange={(e) => {
+                    this.setPassword(e.target.checked);
+                    m.redraw.sync();
+                    if (e.target.checked) this.$('[name=password]').select();
+                    e.redraw = false;
+                  }}
                 />
-                {GroupBadge.component({ group, label: '' })} {group.nameSingular()}
+                {app.translator.trans('core.forum.edit_user.set_password_label')}
               </label>
-            ))}
-        </div>
-      </div>,
-      10
-    );
+              {this.setPassword() ? (
+                <input
+                  className="FormControl"
+                  type="password"
+                  name="password"
+                  placeholder={extractText(app.translator.trans('core.forum.edit_user.password_label'))}
+                  bidi={this.password}
+                />
+              ) : (
+                ''
+              )}
+            </div>
+          </div>,
+          20
+        );
+      }
+    }
+
+    if (app.session.user.canEditGroups()) {
+      items.add(
+        'groups',
+        <div className="Form-group EditUserModal-groups">
+          <label>{app.translator.trans('core.forum.edit_user.groups_heading')}</label>
+          <div>
+            {Object.keys(this.groups)
+              .map((id) => app.store.getById('groups', id))
+              .map((group) => (
+                <label className="checkbox">
+                  <input
+                    type="checkbox"
+                    bidi={this.groups[group.id()]}
+                    disabled={this.attrs.user.id() === '1' && group.id() === Group.ADMINISTRATOR_ID}
+                  />
+                  {GroupBadge.component({ group, label: '' })} {group.nameSingular()}
+                </label>
+              ))}
+          </div>
+        </div>,
+        10
+      );
+    }
 
     items.add(
       'submit',

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -176,7 +176,9 @@ core:
       delete_posts_label: Delete posts
       description: Configure who can see and do what.
       edit_posts_label: Edit posts
-      edit_users_label: Edit users
+      edit_users_credentials_label: Edit users credentials
+      edit_users_groups_label: Edit users groups
+      edit_users_username_label: Edit users username
       global_heading: Global
       moderate_heading: Moderate
       new_group_button: New Group

--- a/src/Api/Serializer/UserSerializer.php
+++ b/src/Api/Serializer/UserSerializer.php
@@ -19,14 +19,14 @@ class UserSerializer extends BasicUserSerializer
     {
         $attributes = parent::getDefaultAttributes($user);
 
-        $canEdit = $this->actor->can('edit', $user);
-
         $attributes += [
-            'joinTime'         => $this->formatDate($user->joined_at),
-            'discussionCount'  => (int) $user->discussion_count,
-            'commentCount'     => (int) $user->comment_count,
-            'canEdit'          => $canEdit,
-            'canDelete'        => $this->actor->can('delete', $user),
+            'joinTime'           => $this->formatDate($user->joined_at),
+            'discussionCount'    => (int) $user->discussion_count,
+            'commentCount'       => (int) $user->comment_count,
+            'canEditCredentials' => $this->actor->can('user.editCredentials'),
+            'canEditGroups'      => $this->actor->can('user.editGroups'),
+            'canEditUsername'    => $this->actor->can('user.editUsername'),
+            'canDelete'          => $this->actor->can('delete', $user),
         ];
 
         if ($user->getPreference('discloseOnline') || $this->actor->can('viewLastSeenAt', $user)) {
@@ -35,7 +35,7 @@ class UserSerializer extends BasicUserSerializer
             ];
         }
 
-        if ($canEdit || $this->actor->id === $user->id) {
+        if ($attributes['canEditCredentials'] || $this->actor->id === $user->id) {
             $attributes += [
                 'isEmailConfirmed' => (bool) $user->is_email_confirmed,
                 'email'            => $user->email

--- a/src/User/Command/EditUserHandler.php
+++ b/src/User/Command/EditUserHandler.php
@@ -58,7 +58,6 @@ class EditUserHandler
 
         $user = $this->users->findOrFail($command->userId, $actor);
 
-        $canEdit = $actor->can('edit', $user);
         $isSelf = $actor->id === $user->id;
 
         $attributes = Arr::get($data, 'attributes', []);
@@ -66,7 +65,7 @@ class EditUserHandler
         $validate = [];
 
         if (isset($attributes['username'])) {
-            $actor->assertPermission($canEdit);
+            $actor->assertPermission($actor->can('editUsername'));
             $user->rename($attributes['username']);
         }
 
@@ -78,7 +77,7 @@ class EditUserHandler
                     $validate['email'] = $attributes['email'];
                 }
             } else {
-                $actor->assertPermission($canEdit);
+                $actor->assertPermission($actor->can('editCredentials'));
                 $user->changeEmail($attributes['email']);
             }
         }
@@ -88,7 +87,7 @@ class EditUserHandler
         }
 
         if (isset($attributes['password'])) {
-            $actor->assertPermission($canEdit);
+            $actor->assertPermission($actor->can('editCredentials'));
             $user->changePassword($attributes['password']);
 
             $validate['password'] = $attributes['password'];
@@ -108,7 +107,7 @@ class EditUserHandler
         }
 
         if (isset($relationships['groups']['data']) && is_array($relationships['groups']['data'])) {
-            $actor->assertPermission($canEdit);
+            $actor->assertPermission($actor->can('editGroups'));
 
             $newGroupIds = [];
             foreach ($relationships['groups']['data'] as $group) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #1965 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Currently only prevents non-admins from editing admin
- Splits the edit.user permission into three permissions (username, credentials, groups)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
- Is this the best way of doing this?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/3457368/78311495-049c2780-751f-11ea-984f-fdda1e7fab0c.png)

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
