### PR TITLE
Fix keyboard on small mobile screens hiding composer

### DIFF
--- a/less/forum/Composer.less
+++ b/less/forum/Composer.less
@@ -117,6 +117,7 @@
       position: fixed;
       top: 0;
       height: 350px !important;
+      max-height: 100%;
       padding-top: @header-height-phone;
 
       &:before {


### PR DESCRIPTION
**Fixes #2628**

**Reviewers should focus on:**
You can test this by going to nightly and adding/removing this custom CSS
```CSS
@media (max-width: 767px) {
  .Composer:not(.minimized) {
    height: 550px !important; /* This makes the composer long enough to emulate your mobile keyboard hiding a part of it (in case your screen is large enough for that not to happen by default) */
    max-height: 100%; /* The actual fix, try with and without */
  }
}
```

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
