### PR TITLE
Hide boot error

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -85,7 +85,8 @@ class Server
             $line = $error->getLine();
             $type = get_class($error);
 
-            $this->printMessageAndExit(<<<ERROR
+            $this->printMessageAndExit(
+                <<<ERROR
             Flarum encountered a boot error ($type)<br />
             <b>$message</b><br />
             thrown in <b>$file</b> on line <b>$line</b>

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -61,7 +61,7 @@ class Server
                 // If the application booted far enough for the config to be available, we will check for debug mode
                 // Since the config is loaded very early, it is very likely to be available from the container
                 echo $this->formatBootException($e);
-            } else if (app()->has(LoggerInterface::class)) {
+            } elseif (app()->has(LoggerInterface::class)) {
                 // If the application booted far enough for the logger to be available, we will log the error there
                 // Considering most boot errors are related to database or extensions, the logger will be available
                 // We check for LoggerInterface binding because it's a constructor dependency of LogReporter,

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -57,49 +57,77 @@ class Server
         try {
             return $this->site->bootApp()->getRequestHandler();
         } catch (Throwable $e) {
-            http_response_code(500);
-
-            if (app()->has('flarum.config') && app('flarum.config')->inDebugMode()) {
-                // If the application booted far enough for the config to be available, we will check for debug mode
-                // Since the config is loaded very early, it is very likely to be available from the container
-                echo $this->formatBootException($e);
-            } elseif (app()->has(LoggerInterface::class)) {
-                // If the application booted far enough for the logger to be available, we will log the error there
-                // Considering most boot errors are related to database or extensions, the logger will be available
-                // We check for LoggerInterface binding because it's a constructor dependency of LogReporter,
-                // then instantiate LogReporter through the container for automatic dependency injection
-                app(LogReporter::class)->report($e);
-
-                echo 'Flarum encountered a boot error. Details have been logged to the Flarum log file.';
-            } else {
-                echo 'Flarum encountered a boot error. Details have been logged to the system PHP log file.<br />';
-
-                // Throwing the exception ensures it will be visible with PHP display_errors=On
-                // but invisible if that feature is turned off
-                // PHP will also automatically choose a valid place to log it based on the system settings
-                throw $e;
+            try {
+                $this->cleanBootExceptionLog($e);
+            } catch (Throwable $e) {
+                // Ignore errors in logger. The important goal is to log the original error
             }
 
-            exit(1);
+            $this->fallbackBootExceptionLog($e);
         }
     }
 
     /**
-     * Display the most relevant information about an early exception.
+     * Attempt to log the boot exception in a clean way and stop the script execution.
+     * This means looking for debug mode and/or our normal error logger.
+     * There is always a risk for this to fail,
+     * for example if the container bindings aren't present
+     * or if there is a filesystem error.
+     * @param Throwable $error
      */
-    private function formatBootException(Throwable $error): string
+    private function cleanBootExceptionLog(Throwable $error)
     {
-        $message = $error->getMessage();
-        $file = $error->getFile();
-        $line = $error->getLine();
-        $type = get_class($error);
+        if (app()->has('flarum.config') && app('flarum.config')->inDebugMode()) {
+            // If the application booted far enough for the config to be available, we will check for debug mode
+            // Since the config is loaded very early, it is very likely to be available from the container
+            $message = $error->getMessage();
+            $file = $error->getFile();
+            $line = $error->getLine();
+            $type = get_class($error);
 
-        return <<<ERROR
+            $this->printMessageAndExit(<<<ERROR
             Flarum encountered a boot error ($type)<br />
             <b>$message</b><br />
             thrown in <b>$file</b> on line <b>$line</b>
 
 <pre>$error</pre>
-ERROR;
+ERROR
+            );
+        } elseif (app()->has(LoggerInterface::class)) {
+            // If the application booted far enough for the logger to be available, we will log the error there
+            // Considering most boot errors are related to database or extensions, the logger should already be loaded
+            // We check for LoggerInterface binding because it's a constructor dependency of LogReporter,
+            // then instantiate LogReporter through the container for automatic dependency injection
+            app(LogReporter::class)->report($error);
+
+            $this->printMessageAndExit('Flarum encountered a boot error. Details have been logged to the Flarum log file.');
+        }
+    }
+
+    /**
+     * A simple and reliable way to stop the script and make sure the headers are set.
+     * @param string $message
+     */
+    private function printMessageAndExit(string $message)
+    {
+        http_response_code(500);
+        echo $message;
+        exit(1);
+    }
+
+    /**
+     * If the clean logging doesn't work, then we have a last opportunity.
+     * Here we need to be extra careful not to include anything that might be sensitive on the page.
+     * @param Throwable $error
+     * @throws Throwable
+     */
+    private function fallbackBootExceptionLog(Throwable $error)
+    {
+        echo 'Flarum encountered a boot error. Details have been logged to the system PHP log file.<br />';
+
+        // Throwing the exception ensures it will be visible with PHP display_errors=On
+        // but invisible if that feature is turned off
+        // PHP will also automatically choose a valid place to log it based on the system settings
+        throw $error;
     }
 }

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -57,6 +57,8 @@ class Server
         try {
             return $this->site->bootApp()->getRequestHandler();
         } catch (Throwable $e) {
+            http_response_code(500);
+
             if (app()->has('flarum.config') && app('flarum.config')->inDebugMode()) {
                 // If the application booted far enough for the config to be available, we will check for debug mode
                 // Since the config is loaded very early, it is very likely to be available from the container

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Http;
 
+use Flarum\Foundation\ErrorHandling\LogReporter;
 use Flarum\Foundation\SiteInterface;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
@@ -16,6 +17,7 @@ use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\Stratigility\Middleware\ErrorResponseGenerator;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class Server
@@ -55,7 +57,28 @@ class Server
         try {
             return $this->site->bootApp()->getRequestHandler();
         } catch (Throwable $e) {
-            exit($this->formatBootException($e));
+            if (app()->has('flarum.config') && app('flarum.config')->inDebugMode()) {
+                // If the application booted far enough for the config to be available, we will check for debug mode
+                // Since the config is loaded very early, it is very likely to be available from the container
+                echo $this->formatBootException($e);
+            } else if (app()->has(LoggerInterface::class)) {
+                // If the application booted far enough for the logger to be available, we will log the error there
+                // Considering most boot errors are related to database or extensions, the logger will be available
+                // We check for LoggerInterface binding because it's a constructor dependency of LogReporter,
+                // then instantiate LogReporter through the container for automatic dependency injection
+                app(LogReporter::class)->report($e);
+
+                echo 'Flarum encountered a boot error. Details have been logged to the Flarum log file.';
+            } else {
+                echo 'Flarum encountered a boot error. Details have been logged to the system PHP log file.<br />';
+
+                // Throwing the exception ensures it will be visible with PHP display_errors=On
+                // but invisible if that feature is turned off
+                // PHP will also automatically choose a valid place to log it based on the system settings
+                throw $e;
+            }
+
+            exit(1);
         }
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2290**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
 Completely redact boot error unless debug mode or display_errors is enabled. Attempt to use Flarum log file when possible.

Use HTTP error code 500 whenever a boot error occurs, whatever the handling method is.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

If debug mode is enabled, most errors will look exactly as before:
![image](https://user-images.githubusercontent.com/5264300/108923511-43f0cc80-7639-11eb-8360-121c1eb2eac9.png)

If debug mode is disabled, most errors including database and extension related will end up showing this:
![image](https://user-images.githubusercontent.com/5264300/108923562-59fe8d00-7639-11eb-9708-e31e95e5b87b.png)

If an error happened even earlier, which is unlikely, the error will appear in one of two ways (example: the file `vendor/flarum/core/src/Foundation/Application.php` is missing).

If `display_errors` is `Off`:
![image](https://user-images.githubusercontent.com/5264300/108924057-40117a00-763a-11eb-9247-df982d14a704.png)

If `display_errors` is `On`:
![image](https://user-images.githubusercontent.com/5264300/108924150-6e8f5500-763a-11eb-9d89-6fc93dc8666f.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
