### PR TITLE
clear cache files from storage/views

### DIFF
--- a/src/Extend/View.php
+++ b/src/Extend/View.php
@@ -10,10 +10,11 @@
 namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
+use Flarum\Foundation\Paths;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\View\Factory;
 
-class View implements ExtenderInterface
+class View implements ExtenderInterface, LifecycleInterface
 {
     private $namespaces = [];
 
@@ -47,5 +48,27 @@ class View implements ExtenderInterface
                 $view->addNamespace($namespace, $hints);
             }
         });
+    }
+
+    /**
+     * @param Container $container
+     * @param Extension $extension
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function onEnable(Container $container, Extension $extension)
+    {
+        $storagePath = $container->make(Paths::class)->storage;
+        array_map('unlink', glob($storagePath.'/views/*'));
+    }
+
+    /**
+     * @param Container $container
+     * @param Extension $extension
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function onDisable(Container $container, Extension $extension)
+    {
+        $storagePath = $container->make(Paths::class)->storage;
+        array_map('unlink', glob($storagePath.'/views/*'));
     }
 }

--- a/src/Foundation/Console/CacheClearCommand.php
+++ b/src/Foundation/Console/CacheClearCommand.php
@@ -60,6 +60,7 @@ class CacheClearCommand extends AbstractCommand
         $storagePath = $this->paths->storage;
         array_map('unlink', glob($storagePath.'/formatter/*'));
         array_map('unlink', glob($storagePath.'/locale/*'));
+        array_map('unlink', glob($storagePath.'/views/*'));
 
         event(new ClearingCache);
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
2630 - https://github.com/flarum/core/issues/2630

**Changes proposed in this pull request:**

**src/Extend/View.php**
added OnEnable and OnDisable methods - to clear cache files from storage/views folder when an extension is enabled or disabled from admin

**src/Foundation/Console/CacheClearCommand.php**
added a line of code to remove cache files from storage/views folder

**Reviewers should focus on:**
Testing if the cache files are removed from storage/views when cache clear command is executed and when an extension is enabled/disabled

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
