### PR TITLE
Fix search box out of screen

### DIFF
--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -116,7 +116,8 @@ export default class Search extends Component {
 
     if (this.state.getValue() && this.hasFocus) {
       const resultsElementMargin = 14;
-      const maxHeight = window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
+      const maxHeight =
+        window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
       this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
     }
   }

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -113,6 +113,13 @@ export default class Search extends Component {
   onupdate() {
     // Highlight the item that is currently selected.
     this.setIndex(this.getCurrentNumericIndex());
+
+    // Since extensions might add elements above the search box on mobile,
+    // we need to calculate and set the max height dynamically.
+    const resultsElementMargin = 14;
+    const maxHeight =
+      window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
+    this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
   }
 
   oncreate(vnode) {
@@ -177,13 +184,6 @@ export default class Search extends Component {
           .one('mouseup', (e) => e.preventDefault())
           .select();
       });
-
-    // Since extensions might add elements above the search box on mobile,
-    // we need to calculate and set the max height dynamically.
-    const resultsElementMargin = 14;
-    const maxHeight =
-      window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
-    this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
   }
 
   /**

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -113,13 +113,6 @@ export default class Search extends Component {
   onupdate() {
     // Highlight the item that is currently selected.
     this.setIndex(this.getCurrentNumericIndex());
-
-    if (this.state.getValue() && this.hasFocus) {
-      const resultsElementMargin = 14;
-      const maxHeight =
-        window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
-      this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
-    }
   }
 
   oncreate(vnode) {
@@ -184,6 +177,13 @@ export default class Search extends Component {
           .one('mouseup', (e) => e.preventDefault())
           .select();
       });
+
+    // Since extensions might add elements above the search box on mobile,
+    // we need to calculate and set the max height dynamically.
+    const resultsElementMargin = 14;
+    const maxHeight =
+      window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
+    this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
   }
 
   /**

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -113,6 +113,12 @@ export default class Search extends Component {
   onupdate() {
     // Highlight the item that is currently selected.
     this.setIndex(this.getCurrentNumericIndex());
+
+    if (this.state.getValue() && this.hasFocus) {
+      const resultsElementMargin = 14;
+      const maxHeight = window.innerHeight - this.element.querySelector('.Search-input>.FormControl').getBoundingClientRect().bottom - resultsElementMargin;
+      this.element.querySelector('.Search-results').style['max-height'] = `${maxHeight}px`;
+    }
   }
 
   oncreate(vnode) {

--- a/less/common/Search.less
+++ b/less/common/Search.less
@@ -15,7 +15,6 @@
   }
 }
 .Search-results {
-  max-height: 70vh;
   overflow: auto;
   left: auto;
   right: 0;


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/2621**

**Changes proposed in this pull request:**
Set search results max height programatically instead of relying on 70vh, as elements like fof links might mess this up.