### PR TITLE
Use absolute positioning for the Composer on Safari

### DIFF
--- a/js/src/forum/ForumApplication.js
+++ b/js/src/forum/ForumApplication.js
@@ -16,6 +16,7 @@ import NotificationListState from './states/NotificationListState';
 import GlobalSearchState from './states/GlobalSearchState';
 import DiscussionListState from './states/DiscussionListState';
 import ComposerState from './states/ComposerState';
+import isSafariMobile from './utils/isSafariMobile';
 
 export default class ForumApplication extends Application {
   /**
@@ -138,6 +139,12 @@ export default class ForumApplication extends Application {
         m.redraw();
       }
     });
+
+    if (isSafariMobile()) {
+      $(() => {
+        $('.App').addClass('mobile-safari');
+      });
+    }
   }
 
   /**

--- a/js/src/forum/components/Composer.js
+++ b/js/src/forum/components/Composer.js
@@ -265,7 +265,10 @@ export default class Composer extends Component {
     this.animateHeightChange().then(() => this.focus());
 
     if (app.screen() === 'phone') {
-      this.$().css('top', 0);
+      // On safari fixed position doesn't properly work on mobile,
+      // So we use absolute and set the top value.
+      // https://github.com/flarum/core/issues/2652
+      this.$().css('top', $('.App.mobile-safari').length ? $(window).scrollTop() : 0);
       this.showBackdrop();
     }
   }

--- a/js/src/forum/components/Composer.js
+++ b/js/src/forum/components/Composer.js
@@ -268,7 +268,7 @@ export default class Composer extends Component {
       // On safari fixed position doesn't properly work on mobile,
       // So we use absolute and set the top value.
       // https://github.com/flarum/core/issues/2652
-      this.$().css('top', $('.App.mobile-safari').length ? $(window).scrollTop() : 0);
+      this.$().css('top', $('.App').is('.mobile-safari') ? $(window).scrollTop() : 0);
       this.showBackdrop();
     }
   }

--- a/js/src/forum/utils/isSafariMobile.ts
+++ b/js/src/forum/utils/isSafariMobile.ts
@@ -5,9 +5,9 @@ export default function isSafariMobile(): boolean {
   return (
     'ontouchstart' in window &&
     navigator.vendor &&
-    navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.vendor.includes('Apple') &&
     navigator.userAgent &&
-    navigator.userAgent.indexOf('CriOS') == -1 &&
-    navigator.userAgent.indexOf('FxiOS') == -1
+    !navigator.userAgent.includes('CriOS') &&
+    !navigator.userAgent.includes('FxiOS')
   );
 }

--- a/js/src/forum/utils/isSafariMobile.ts
+++ b/js/src/forum/utils/isSafariMobile.ts
@@ -1,0 +1,13 @@
+/**
+ * @see https://stackoverflow.com/a/31732310
+ */
+export default function isSafariMobile(): boolean {
+  return (
+    'ontouchstart' in window &&
+    navigator.vendor &&
+    navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') == -1 &&
+    navigator.userAgent.indexOf('FxiOS') == -1
+  );
+}

--- a/less/forum/Composer.less
+++ b/less/forum/Composer.less
@@ -120,6 +120,12 @@
       max-height: 100%;
       padding-top: @header-height-phone;
 
+      // Fixes a bug where fixed position doesn't properly work in Safari mobile
+      // https://github.com/flarum/core/issues/2652
+      .mobile-safari & {
+        position: absolute;
+      }
+
       &:before {
         content: " ";
         .header-background();


### PR DESCRIPTION
**Fixes #2652**

**Changes proposed in this pull request:**
Use absolute positioning on Safari mobile, we can't use absolute positioning in all browsers because that causes other issues, however Safari mobile doesn't handle fixed positioning and inputs well either.

**Reviewers should focus on:**
I don't really like this tbh, there is no reliable way to tell what browser is used, the user agent string might change in the future, and feature inference (testing for specific features unique to the browser) is also not reliable as features might also be removed in the future.

I would have preferred trying to fix this on the JS side by maybe checking the composer position isn't off the viewport or perhaps trying somethings with a timeout before focusing on the text editor, but not being able to reproduce and test the issue doesn't help.

If anyone else has access to an iOS device and able to reproduce this wants to try and find a better fix please feel free.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
