### PR TITLE
[A11Y] Add aria-label and landmark role to search input

### DIFF
--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -88,6 +88,7 @@ export default class Search extends Component {
             className="FormControl"
             type="search"
             placeholder={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
+            aria-label={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
             value={this.state.getValue()}
             oninput={(e) => this.state.setValue(e.target.value)}
             onfocus={() => (this.hasFocus = true)}

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -73,6 +73,7 @@ export default class Search extends Component {
 
     return (
       <div
+        role="search"
         className={
           'Search ' +
           classList({

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -71,6 +71,8 @@ export default class Search extends Component {
     // Hide the search view if no sources were loaded
     if (!this.sources.length) return <div></div>;
 
+    const searchCtaText = extractText(app.translator.trans('core.forum.header.search_placeholder'));
+
     return (
       <div
         role="search"
@@ -86,10 +88,10 @@ export default class Search extends Component {
       >
         <div className="Search-input">
           <input
+            aria-label={searchCtaText}
             className="FormControl"
             type="search"
-            placeholder={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
-            aria-label={extractText(app.translator.trans('core.forum.header.search_placeholder'))}
+            placeholder={searchCtaText}
             value={this.state.getValue()}
             oninput={(e) => this.state.setValue(e.target.value)}
             onfocus={() => (this.hasFocus = true)}

--- a/js/src/forum/components/Search.js
+++ b/js/src/forum/components/Search.js
@@ -71,7 +71,7 @@ export default class Search extends Component {
     // Hide the search view if no sources were loaded
     if (!this.sources.length) return <div></div>;
 
-    const searchCtaText = extractText(app.translator.trans('core.forum.header.search_placeholder'));
+    const searchLabel = extractText(app.translator.trans('core.forum.header.search_placeholder'));
 
     return (
       <div
@@ -88,10 +88,10 @@ export default class Search extends Component {
       >
         <div className="Search-input">
           <input
-            aria-label={searchCtaText}
+            aria-label={searchLabel}
             className="FormControl"
             type="search"
-            placeholder={searchCtaText}
+            placeholder={searchLabel}
             value={this.state.getValue()}
             oninput={(e) => this.state.setValue(e.target.value)}
             onfocus={() => (this.hasFocus = true)}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2667**

**Changes proposed in this pull request:**
Adds the `aria-label` attribute to the search input.

Also adds `role="search"` to the containing div. See [this page](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role) for more info.

For info about why this is required, see the related issue (#2667).

**Screenshot**
![jAoNe3](https://user-images.githubusercontent.com/7406822/110227198-b8572580-7eed-11eb-8d74-db6fe4ca03c2.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
