### PR TITLE
Make filter mutator API consistent with search mutator API.

### DIFF
--- a/src/Filter/AbstractFilterer.php
+++ b/src/Filter/AbstractFilterer.php
@@ -62,6 +62,7 @@ abstract class AbstractFilterer
                 $filterKey = substr($filterKey, 1);
             }
             foreach (Arr::get($this->filters, $filterKey, []) as $filter) {
+                $filterState->addActiveFilter($filter);
                 $filter->filter($filterState, $filterValue, $negate);
             }
         }

--- a/src/Filter/AbstractFilterer.php
+++ b/src/Filter/AbstractFilterer.php
@@ -77,7 +77,7 @@ abstract class AbstractFilterer
         // END DEPRECATED BC LAYER
 
         foreach ($this->filterMutators as $mutator) {
-            $mutator($query, $actor, $criteria->query, $criteria->sort);
+            $mutator($filterState, $criteria);
         }
 
         // Execute the filter query and retrieve the results. We get one more

--- a/src/Filter/FilterState.php
+++ b/src/Filter/FilterState.php
@@ -13,4 +13,29 @@ use Flarum\Query\AbstractQueryState;
 
 class FilterState extends AbstractQueryState
 {
+    /**
+     * @var FilterInterface[]
+     */
+    protected $activeFilters = [];
+
+    /**
+     * Get a list of the filters that are active.
+     *
+     * @return FilterInterface[]
+     */
+    public function getActiveFilters()
+    {
+        return $this->activeFilters;
+    }
+
+    /**
+     * Add a filter as being active.
+     *
+     * @param FilterInterface $filter
+     * @return void
+     */
+    public function addActiveFilter(FilterInterface $filter)
+    {
+        $this->activeFilters[] = $filter;
+    }
 }

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -75,9 +75,13 @@ class Index
 
         $params = [
             'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',
-            'filter' => compact('q'),
+            'filter' => [],
             'page' => ['offset' => ($page - 1) * 20, 'limit' => 20]
         ];
+
+        if ($q) {
+            $params['filter']['q'] = $q;
+        }
 
         $apiDocument = $this->getApiDocument($request->getAttribute('actor'), $params);
         $defaultRoute = $this->settings->get('default_route');

--- a/tests/integration/extenders/FilterTest.php
+++ b/tests/integration/extenders/FilterTest.php
@@ -84,8 +84,8 @@ class FilterTest extends TestCase
      */
     public function filter_mutator_has_effect_if_added()
     {
-        $this->extend((new Extend\Filter(DiscussionFilterer::class))->addFilterMutator(function ($query, $actor, $filters, $sort) {
-            $query->getQuery()->whereRaw('1=0');
+        $this->extend((new Extend\Filter(DiscussionFilterer::class))->addFilterMutator(function ($filterState, $criteria) {
+            $filterState->getQuery()->whereRaw('1=0');
         }));
 
         $this->prepDb();
@@ -127,8 +127,8 @@ class NoResultFilter implements FilterInterface
 
 class CustomFilterMutator
 {
-    public function __invoke($query, $actor, $filters, $sort)
+    public function __invoke($filterState, $criteria)
     {
-        $query->getQuery()->whereRaw('1=0');
+        $filterState->getQuery()->whereRaw('1=0');
     }
 }


### PR DESCRIPTION
This is inline with the docblock for the Filter extender, and is much more sensible.