### PR TITLE
Fix Stream function code being shown when renaming discussion

### DIFF
--- a/js/src/forum/components/RenameDiscussionModal.js
+++ b/js/src/forum/components/RenameDiscussionModal.js
@@ -49,7 +49,7 @@ export default class RenameDiscussionModal extends Modal {
 
     this.loading = true;
 
-    const title = this.newTitle;
+    const title = this.newTitle();
     const currentTitle = this.currentTitle;
 
     // If the title is different to what it was before, then save it. After the


### PR DESCRIPTION
**Fixes #2619**

**Changes proposed in this pull request:**
- Call Stream function to obtain `this.newTitle` value

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.