### PR TITLE
Fix searching titles in discussions

### DIFF
--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Discussion\Search\Gambit;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
 use Flarum\Search\GambitInterface;
 use Flarum\Search\SearchState;
@@ -29,6 +30,12 @@ class FulltextGambit implements GambitInterface
         $query = $search->getQuery();
         $grammar = $query->getGrammar();
 
+
+        $discussionSubquery = Discussion::select('id')
+            ->selectRaw('NULL as score')
+            ->selectRaw('first_post_id as most_relevant_post_id')
+            ->whereRaw('MATCH('.$grammar->wrap('discussions.title').') AGAINST (? IN BOOLEAN MODE)', [$bit]);
+
         // Construct a subquery to fetch discussions which contain relevant
         // posts. Retrieve the collective relevance of each discussion's posts,
         // which we will use later in the order by clause, and also retrieve
@@ -39,7 +46,8 @@ class FulltextGambit implements GambitInterface
             ->selectRaw('SUBSTRING_INDEX(GROUP_CONCAT('.$grammar->wrap('posts.id').' ORDER BY MATCH('.$grammar->wrap('posts.content').') AGAINST (?) DESC, '.$grammar->wrap('posts.number').'), \',\', 1) as most_relevant_post_id', [$bit])
             ->where('posts.type', 'comment')
             ->whereRaw('MATCH('.$grammar->wrap('posts.content').') AGAINST (? IN BOOLEAN MODE)', [$bit])
-            ->groupBy('posts.discussion_id');
+            ->groupBy('posts.discussion_id')
+            ->union($discussionSubquery);
 
         // Join the subquery into the main search query and scope results to
         // discussions that have a relevant title or that contain relevant posts.
@@ -51,11 +59,7 @@ class FulltextGambit implements GambitInterface
                 '=',
                 'discussions.id'
             )
-            ->addBinding($subquery->getBindings(), 'join')
-            ->where(function ($query) use ($grammar, $bit) {
-                $query->whereRaw('MATCH('.$grammar->wrap('discussions.title').') AGAINST (? IN BOOLEAN MODE)', [$bit])
-                      ->orWhereNotNull('posts_ft.score');
-            });
+            ->addBinding($subquery->getBindings(), 'join');
 
         $search->setDefaultSort(function ($query) use ($grammar, $bit) {
             $query->orderByRaw('MATCH('.$grammar->wrap('discussions.title').') AGAINST (?) desc', [$bit]);

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -58,6 +58,7 @@ class FulltextGambit implements GambitInterface
                 '=',
                 'discussions.id'
             )
+            ->distinct('posts_ft.discussion_id')
             ->addBinding($subquery->getBindings(), 'join');
 
         $search->setDefaultSort(function ($query) use ($grammar, $bit) {

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -58,7 +58,7 @@ class FulltextGambit implements GambitInterface
                 '=',
                 'discussions.id'
             )
-            ->distinct('posts_ft.discussion_id')
+            ->groupBy('discussions.id')
             ->addBinding($subquery->getBindings(), 'join');
 
         $search->setDefaultSort(function ($query) use ($grammar, $bit) {

--- a/src/Discussion/Search/Gambit/FulltextGambit.php
+++ b/src/Discussion/Search/Gambit/FulltextGambit.php
@@ -30,7 +30,6 @@ class FulltextGambit implements GambitInterface
         $query = $search->getQuery();
         $grammar = $query->getGrammar();
 
-
         $discussionSubquery = Discussion::select('id')
             ->selectRaw('NULL as score')
             ->selectRaw('first_post_id as most_relevant_post_id')


### PR DESCRIPTION
**Changes proposed in this pull request:**
This was originally attempted in https://github.com/flarum/core/pull/1741, but reverted in https://github.com/flarum/core/commit/9f6ec804324d0d7dfa5f378482f855a7bbdc3151 due to performance issues. From pure speculation, this should not cause such issues. From local dev environment testing (on a small dataset), that claim holds.

**Implementation:**
Instead of using a left join to include discussions, we add an additional subquery where we search discussions by title, union that into the posts subquery, and only then join. 

**Reviewers should focus on:**
- This MUST be tested for performance on a large site before we consider merging it.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
