### PR TITLE
Speed up JS linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'js/src/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Install JS dependencies
-        run: npm ci
+      - name: Install Prettier
+        run: npm i -g prettier
         working-directory: ./js
 
       - name: Check JS code for formatting
-        run: node_modules/.bin/prettier --check src
+        run: prettier --check src
         working-directory: ./js

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   prettier:
-    name: Validate JS formatting
+    name: JS / Prettier
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,22 +11,18 @@ on:
 
 jobs:
   prettier:
+    name: Validate JS formatting
     runs-on: ubuntu-latest
 
-    name: JS / Prettier
-
     steps:
-      - uses: actions/checkout@master
+      - name: Check out code
+        uses: actions/checkout@master
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "14"
 
-      - name: Install Prettier
-        run: npm i -g prettier
-        working-directory: ./js
-
-      - name: Check JS code for formatting
-        run: prettier --check src
+      - name: Check JS formatting
+        run: npx prettier --check src
         working-directory: ./js


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently, the linting workflow installs all of core's deps before linting with Prettier.

We can save a bit of time by only installing Prettier, as no other deps are required to format our source code.
