### PR TITLE
Eager load ListPostsController needed relations

### DIFF
--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -93,6 +93,14 @@ class ListPostsController extends AbstractListController
             $results->areMoreResults() ? null : 0
         );
 
+        if (! in_array('discussion', $include)) {
+            $include[] = 'discussion';
+        }
+
+        if (in_array('user', $include)) {
+            $include[] = 'user.groups';
+        }
+
         return $results->getResults()->load($include);
     }
 

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -93,6 +93,9 @@ class ListPostsController extends AbstractListController
             $results->areMoreResults() ? null : 0
         );
 
+        // Eager load discussion for use in the policies,
+        // eager loading does not affect the JSON response,
+        // the response only includes relations included in the request.
         if (! in_array('discussion', $include)) {
             $include[] = 'discussion';
         }


### PR DESCRIPTION
**Part of #2637**

**Changes proposed in this pull request:**
Eager loads the `discussion` and `user.groups` relations, leaving `discussion.tags` and `mentionedBy` relations until there is a mechanism for extensions to specify needed relations to be eager loaded (which I'll push after this).

**Reviewers should focus on:**
You can test this by hitting the `/api/posts?page[offset]=0&page[limit]=50&include=user` endpoint.

**Screenshot**
![flarum lan___clockwork_app (1)](https://user-images.githubusercontent.com/20267363/111874294-d9f7e880-8994-11eb-8c30-3ccc9157f204.png)
![flarum lan___clockwork_app (2)](https://user-images.githubusercontent.com/20267363/111874297-de240600-8994-11eb-8642-d6bced2dcd33.png)

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
