### PR TITLE
Use anonymous class for FakeApp

### DIFF
--- a/src/Console/Schedule.php
+++ b/src/Console/Schedule.php
@@ -17,24 +17,21 @@ class Schedule extends LaravelSchedule
 {
     public function dueEvents($container)
     {
-        return (new Collection($this->events))->filter->isDue(new FakeApp($container));
-    }
-}
+        return (new Collection($this->events))->filter->isDue(new class($container) {
+            public function __construct($container)
+            {
+                $this->config = $container->make(Config::class);
+            }
 
-class FakeApp
-{
-    public function __construct($container)
-    {
-        $this->config = $container->make(Config::class);
-    }
+            public function isDownForMaintenance()
+            {
+                return $this->config->inMaintenanceMode();
+            }
 
-    public function isDownForMaintenance()
-    {
-        return $this->config->inMaintenanceMode();
-    }
-
-    public function environment()
-    {
-        return '';
+            public function environment()
+            {
+                return '';
+            }
+        });
     }
 }


### PR DESCRIPTION
It's a better implementation than declaring a second class in the same file, which can confuse IDEs. Furthermore, FakeApp shouldn't be used outside this file.

See https://github.com/flarum/core/pull/2704/files#r598124032