### PR TITLE
Removes duplication of cache clearing

### DIFF
--- a/src/Locale/LocaleManager.php
+++ b/src/Locale/LocaleManager.php
@@ -112,4 +112,11 @@ class LocaleManager
     {
         $this->translator = $translator;
     }
+
+    public function clearCache()
+    {
+        if ($this->cacheDir) {
+            array_map('unlink', glob($this->cacheDir.'/*'));
+        }
+    }
 }

--- a/src/Locale/LocaleManager.php
+++ b/src/Locale/LocaleManager.php
@@ -112,11 +112,4 @@ class LocaleManager
     {
         $this->translator = $translator;
     }
-
-    public function clearCache()
-    {
-        if ($this->cacheDir) {
-            array_map('unlink', glob($this->cacheDir.'/*'));
-        }
-    }
 }

--- a/src/Locale/LocaleServiceProvider.php
+++ b/src/Locale/LocaleServiceProvider.php
@@ -10,25 +10,13 @@
 namespace Flarum\Locale;
 
 use Flarum\Foundation\AbstractServiceProvider;
-use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LocaleServiceProvider extends AbstractServiceProvider
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function boot(Dispatcher $events)
-    {
-        $events->listen(ClearingCache::class, function () {
-            $this->container->make('flarum.locales')->clearCache();
-        });
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
**Changes proposed in this pull request:**

This PR removes the duplicated cache clearing of the locales. The locales are cleared using the cache:clear command which is centrally dispatched from the CacheClear command. Using an listener on the ClearingCache event causes extensions to fail to do stuff with locales.

Eg:

- extension listens on ClearingCache to run cache:assets to create locales ahead of next visit
- LocaleServiceProvider, executed last, removes those files immediately

Ref: https://github.com/flarum/core/blob/d642fb531c1335c33ff7515da367f6815ea93b12/src/Foundation/Console/CacheClearCommand.php#L69

**Confirmed**

- [ ] ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).

