### PR TITLE
Pin GitHub Actions at specific tags and commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,14 @@ on:
 
 jobs:
   build:
+    name: JS / Build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
-      - uses: flarum/action-build@master
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build production JS
+        uses: flarum/action-build@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v2

--- a/.github/workflows/pr_size_change.yml
+++ b/.github/workflows/pr_size_change.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Install JS dependencies
         run: npm ci

--- a/.github/workflows/pr_size_change.yml
+++ b/.github/workflows/pr_size_change.yml
@@ -17,10 +17,11 @@ jobs:
     name: Bundlewatch
 
     steps:
-      - uses: actions/checkout@master
+      - name: Check out code
+        uses: actions/checkout@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@0b9d33cd0782337377999751fc10ea079fdd7104 # pin@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
     name: 'PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}'
 
     steps:
-      - uses: actions/checkout@master
+      - name: Check out code
+        uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@0b9d33cd0782337377999751fc10ea079fdd7104 # pin@v2


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2747**

**Changes proposed in this pull request:**
Replaces branch and tag action pins to remove the chance of future security issues as a result of compromised or malicious modifications to actions.

- GitHub maintained actions (`actions/*`) have been pinned to the latest tag. This also prevents breaking changes from affecting our workflows, too.
- Third-party actions (well, just one) have been tagged to a specific SHA1 commit hash, as per GitHub's security recommendations. 