### PR TITLE
Fix registering custom searchers, allow searchers without fulltext 

### DIFF
--- a/src/Extend/SimpleFlarumSearch.php
+++ b/src/Extend/SimpleFlarumSearch.php
@@ -73,7 +73,7 @@ class SimpleFlarumSearch implements ExtenderInterface
     public function extend(Container $container, Extension $extension = null)
     {
         if (! is_null($this->fullTextGambit)) {
-            $container->resolving('flarum.simple_search.fulltext_gambits', function ($oldFulltextGambits) {
+            $container->extend('flarum.simple_search.fulltext_gambits', function ($oldFulltextGambits) {
                 $oldFulltextGambits[$this->searcher] = $this->fullTextGambit;
 
                 return $oldFulltextGambits;

--- a/src/Search/GambitManager.php
+++ b/src/Search/GambitManager.php
@@ -12,7 +12,7 @@ namespace Flarum\Search;
 use LogicException;
 
 /**
- * @todo This whole gambits thing needs way better documentation.
+ * @internal
  */
 class GambitManager
 {
@@ -27,11 +27,19 @@ class GambitManager
     protected $fulltextGambit;
 
     /**
+     * @param GambitInterface $gambit
+     */
+    public function __construct(GambitInterface $fulltextGambit)
+    {
+        $this->fulltextGambit = $fulltextGambit;
+    }
+
+    /**
      * Add a gambit.
      *
      * @param GambitInterface $gambit
      */
-    public function add($gambit)
+    public function add(GambitInterface $gambit)
     {
         $this->gambits[] = $gambit;
     }
@@ -49,16 +57,6 @@ class GambitManager
         if ($query) {
             $this->applyFulltext($search, $query);
         }
-    }
-
-    /**
-     * Set the gambit to handle fulltext searching.
-     *
-     * @param GambitInterface $gambit
-     */
-    public function setFulltextGambit($gambit)
-    {
-        $this->fulltextGambit = $gambit;
     }
 
     /**
@@ -110,10 +108,6 @@ class GambitManager
      */
     protected function applyFulltext(SearchState $search, $query)
     {
-        if (! $this->fulltextGambit) {
-            return;
-        }
-
         $search->addActiveGambit($this->fulltextGambit);
         $this->fulltextGambit->apply($search, $query);
     }

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -74,7 +74,9 @@ class SearchServiceProvider extends AbstractServiceProvider
                 }
             }
 
-            throw new \RuntimeException('You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: '.implode(', ', $affectedGambits));
+            if (count($affectedGambits)) {
+                throw new \RuntimeException('You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: '.implode(', ', $affectedGambits));
+            }
         }
 
         foreach ($fullTextGambits as $searcher => $fullTextGambitClass) {

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -68,8 +68,7 @@ class SearchServiceProvider extends AbstractServiceProvider
                 ->when($searcher)
                 ->needs(GambitManager::class)
                 ->give(function () use ($searcher, $fullTextGambitClass) {
-                    $gambitManager = new GambitManager();
-                    $gambitManager->setFulltextGambit($this->container->make($fullTextGambitClass));
+                    $gambitManager = new GambitManager($this->container->make($fullTextGambitClass));
                     foreach (Arr::get($this->container->make('flarum.simple_search.gambits'), $searcher, []) as $gambit) {
                         $gambitManager->add($this->container->make($gambit));
                     }

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -66,7 +66,12 @@ class SearchServiceProvider extends AbstractServiceProvider
         if (count($searchersWithGambitsWithoutFulltext)) {
             $affectedGambits = [];
             foreach ($searchersWithGambitsWithoutFulltext as $searcher) {
-                $affectedGambits += $gambits[$searcher];
+                // This check is in place to support adding gambits to searchers
+                // registered in extensions that are optional dependencies of the
+                // current extension.
+                if (class_exists($searcher)) {
+                    $affectedGambits += $gambits[$searcher];
+                }
             }
 
             throw new \RuntimeException('You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: '.implode(', ', $affectedGambits));

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -59,33 +59,14 @@ class SearchServiceProvider extends AbstractServiceProvider
     public function boot()
     {
         $fullTextGambits = $this->container->make('flarum.simple_search.fulltext_gambits');
-        $gambits = $this->container->make('flarum.simple_search.gambits');
-
-        $searchersWithGambitsWithoutFulltext = array_diff(array_keys($gambits), array_keys($fullTextGambits));
-
-        if (count($searchersWithGambitsWithoutFulltext)) {
-            $affectedGambits = [];
-            foreach ($searchersWithGambitsWithoutFulltext as $searcher) {
-                // This check is in place to support adding gambits to searchers
-                // registered in extensions that are optional dependencies of the
-                // current extension.
-                if (class_exists($searcher)) {
-                    $affectedGambits += $gambits[$searcher];
-                }
-            }
-
-            if (count($affectedGambits)) {
-                throw new \RuntimeException('You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: '.implode(', ', $affectedGambits));
-            }
-        }
 
         foreach ($fullTextGambits as $searcher => $fullTextGambitClass) {
             $this->container
                 ->when($searcher)
                 ->needs(GambitManager::class)
-                ->give(function () use ($searcher, $fullTextGambitClass, $gambits) {
+                ->give(function () use ($searcher, $fullTextGambitClass) {
                     $gambitManager = new GambitManager($this->container->make($fullTextGambitClass));
-                    foreach (Arr::get($gambits, $searcher, []) as $gambit) {
+                    foreach (Arr::get($this->container->make('flarum.simple_search.gambits'), $searcher, []) as $gambit) {
                         $gambitManager->add($this->container->make($gambit));
                     }
 

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -58,19 +58,24 @@ class SearchServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
-        // The rest of these we can resolve in the when->needs->give callback,
-        // but we need to resolve at least one regardless so we know which
-        // searchers we need to register gambits for.
         $fullTextGambits = $this->container->make('flarum.simple_search.fulltext_gambits');
+        $gambits = $this->container->make('flarum.simple_search.gambits');
 
-        foreach ($fullTextGambits as $searcher => $fullTextGambitClass) {
+        $searchers = array_merge([], array_keys($fullTextGambits), array_keys($gambits));
+
+        foreach ($searchers as $searcher) {
             $this->container
                 ->when($searcher)
                 ->needs(GambitManager::class)
-                ->give(function () use ($searcher, $fullTextGambitClass) {
+                ->give(function () use ($searcher, $fullTextGambits, $gambits) {
                     $gambitManager = new GambitManager();
-                    $gambitManager->setFulltextGambit($this->container->make($fullTextGambitClass));
-                    foreach (Arr::get($this->container->make('flarum.simple_search.gambits'), $searcher, []) as $gambit) {
+
+                    $fullTextGambitClass = Arr::get($fullTextGambits, $searcher);
+                    if (isset($fullTextGambitClass)) {
+                        $gambitManager->setFulltextGambit($this->container->make($fullTextGambitClass));
+                    }
+
+                    foreach (Arr::get($gambits, $searcher, []) as $gambit) {
                         $gambitManager->add($this->container->make($gambit));
                     }
 

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -69,7 +69,7 @@ class SearchServiceProvider extends AbstractServiceProvider
                 $affectedGambits += $gambits[$searcher];
             }
 
-            throw new \RuntimeException("You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: ".implode(', ', $affectedGambits));
+            throw new \RuntimeException('You cannot add gambits to searchers that do not have fulltext gambits. The following searchers have this issue: '.implode(', ', $affectedGambits));
         }
 
         foreach ($fullTextGambits as $searcher => $fullTextGambitClass) {

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -10,7 +10,6 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Carbon\Carbon;
-use Carbon\Exceptions\RuntimeException;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use Flarum\Group\Group;

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -156,7 +156,27 @@ class SimpleFlarumSearchTest extends TestCase
     public function can_resolve_custom_searcher_with_fulltext_gambit()
     {
         $this->extend(
-            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->setFullTextGambit(CustomFullTextGambit::class)
+            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->setFullTextGambit(CustomGambit::class)
+        );
+
+        $anExceptionWasThrown = false;
+
+        try {
+            $this->app()->getContainer()->make(CustomSearcher::class);
+        } catch (BindingResolutionException $e) {
+            $anExceptionWasThrown = true;
+        }
+
+        $this->assertFalse($anExceptionWasThrown);
+    }
+
+    /**
+     * @test
+     */
+    public function can_resolve_custom_searcher_with_regular_gambit()
+    {
+        $this->extend(
+            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->addGambit(CustomGambit::class)
         );
 
         $anExceptionWasThrown = false;
@@ -222,9 +242,7 @@ class CustomSearcher extends AbstractSearcher
     }
 }
 
-class CustomFullTextGambit implements GambitInterface
+class CustomGambit implements GambitInterface
 {
-    public function apply(SearchState $search, $bit) {
-
-    }
+    public function apply(SearchState $search, $bit) {}
 }

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -237,12 +237,15 @@ class CustomSearchMutator
 class CustomSearcher extends AbstractSearcher
 {
     // This isn't actually used, we just need it to implement the abstract method.
-    protected function getQuery(User $actor): Builder {
+    protected function getQuery(User $actor): Builder
+    {
         return Group::query();
     }
 }
 
 class CustomGambit implements GambitInterface
 {
-    public function apply(SearchState $search, $bit) {}
+    public function apply(SearchState $search, $bit)
+    {
+    }
 }

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -169,6 +169,17 @@ class SimpleFlarumSearchTest extends TestCase
 
         $this->assertFalse($anExceptionWasThrown);
     }
+
+    /**
+     * @test
+     */
+    public function cant_add_gambit_to_searcher_without_fulltext()
+    {
+        $this->extend((new Extend\SimpleFlarumSearch(NonexistentClass::class))->addGambit(NoResultFilterGambit::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->app();
+    }
 }
 
 class NoResultFullTextGambit implements GambitInterface

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Carbon\Carbon;
+use Carbon\Exceptions\RuntimeException;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use Flarum\Group\Group;
@@ -170,12 +171,31 @@ class SimpleFlarumSearchTest extends TestCase
         $this->assertFalse($anExceptionWasThrown);
     }
 
+
     /**
      * @test
      */
-    public function cant_add_gambit_to_searcher_without_fulltext()
+    public function can_add_gambit_to_nonexistent_searcher_class_without_fulltext()
     {
         $this->extend((new Extend\SimpleFlarumSearch(NonexistentClass::class))->addGambit(NoResultFilterGambit::class));
+
+        $anExceptionWasThrown = false;
+
+        try {
+            $this->app();
+        } catch (RuntimeException $e) {
+            $anExceptionWasThrown = true;
+        }
+
+        $this->assertFalse($anExceptionWasThrown);
+    }
+
+    /**
+     * @test
+     */
+    public function cant_add_gambit_to_existent_searcher_class_without_fulltext()
+    {
+        $this->extend((new Extend\SimpleFlarumSearch(AbstractSearcher::class))->addGambit(NoResultFilterGambit::class));
 
         $this->expectException(\RuntimeException::class);
         $this->app();

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -183,7 +183,7 @@ class SimpleFlarumSearchTest extends TestCase
 
         try {
             $this->app();
-        } catch (RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $anExceptionWasThrown = true;
         }
 
@@ -195,9 +195,9 @@ class SimpleFlarumSearchTest extends TestCase
      */
     public function cant_add_gambit_to_existent_searcher_class_without_fulltext()
     {
-        $this->extend((new Extend\SimpleFlarumSearch(AbstractSearcher::class))->addGambit(NoResultFilterGambit::class));
-
         $this->expectException(\RuntimeException::class);
+        
+        $this->extend((new Extend\SimpleFlarumSearch(AbstractSearcher::class))->addGambit(NoResultFilterGambit::class));
         $this->app();
     }
 }

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -170,36 +170,6 @@ class SimpleFlarumSearchTest extends TestCase
 
         $this->assertFalse($anExceptionWasThrown);
     }
-
-
-    /**
-     * @test
-     */
-    public function can_add_gambit_to_nonexistent_searcher_class_without_fulltext()
-    {
-        $this->extend((new Extend\SimpleFlarumSearch(NonexistentClass::class))->addGambit(NoResultFilterGambit::class));
-
-        $anExceptionWasThrown = false;
-
-        try {
-            $this->app();
-        } catch (\RuntimeException $e) {
-            $anExceptionWasThrown = true;
-        }
-
-        $this->assertFalse($anExceptionWasThrown);
-    }
-
-    /**
-     * @test
-     */
-    public function cant_add_gambit_to_existent_searcher_class_without_fulltext()
-    {
-        $this->expectException(\RuntimeException::class);
-        
-        $this->extend((new Extend\SimpleFlarumSearch(AbstractSearcher::class))->addGambit(NoResultFilterGambit::class));
-        $this->app();
-    }
 }
 
 class NoResultFullTextGambit implements GambitInterface

--- a/tests/integration/extenders/SimpleFlarumSearchTest.php
+++ b/tests/integration/extenders/SimpleFlarumSearchTest.php
@@ -156,27 +156,7 @@ class SimpleFlarumSearchTest extends TestCase
     public function can_resolve_custom_searcher_with_fulltext_gambit()
     {
         $this->extend(
-            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->setFullTextGambit(CustomGambit::class)
-        );
-
-        $anExceptionWasThrown = false;
-
-        try {
-            $this->app()->getContainer()->make(CustomSearcher::class);
-        } catch (BindingResolutionException $e) {
-            $anExceptionWasThrown = true;
-        }
-
-        $this->assertFalse($anExceptionWasThrown);
-    }
-
-    /**
-     * @test
-     */
-    public function can_resolve_custom_searcher_with_regular_gambit()
-    {
-        $this->extend(
-            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->addGambit(CustomGambit::class)
+            (new Extend\SimpleFlarumSearch(CustomSearcher::class))->setFullTextGambit(CustomFullTextGambit::class)
         );
 
         $anExceptionWasThrown = false;
@@ -243,7 +223,7 @@ class CustomSearcher extends AbstractSearcher
     }
 }
 
-class CustomGambit implements GambitInterface
+class CustomFullTextGambit implements GambitInterface
 {
     public function apply(SearchState $search, $bit)
     {


### PR DESCRIPTION
**Fixes #2712**

**Changes proposed in this pull request:**
- Fix registering custom searchers
- Add integration tests
- Require FulltextGambit as constructor arg for GambitManager


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).