### PR TITLE
Don't fail silently on cache clear

### DIFF
--- a/src/Foundation/Console/CacheClearCommand.php
+++ b/src/Foundation/Console/CacheClearCommand.php
@@ -62,7 +62,12 @@ class CacheClearCommand extends AbstractCommand
     {
         $this->info('Clearing the cache...');
 
-        $this->cache->flush();
+        $succeeded = $this->cache->flush();
+
+        if (!$succeeded) {
+            $this->error('Could not clear contents of `storage/cache`. Please adjust file permissions and try again. This can frequently be fixed by clearing cache via the `Tools` dropdown on the Administration Dashboard page.');
+            return 1;
+        }
 
         $storagePath = $this->paths->storage;
         array_map('unlink', glob($storagePath.'/formatter/*'));

--- a/src/Foundation/Console/CacheClearCommand.php
+++ b/src/Foundation/Console/CacheClearCommand.php
@@ -64,8 +64,9 @@ class CacheClearCommand extends AbstractCommand
 
         $succeeded = $this->cache->flush();
 
-        if (!$succeeded) {
+        if (! $succeeded) {
             $this->error('Could not clear contents of `storage/cache`. Please adjust file permissions and try again. This can frequently be fixed by clearing cache via the `Tools` dropdown on the Administration Dashboard page.');
+
             return 1;
         }
 


### PR DESCRIPTION
**Fixes #2723**

**Changes proposed in this pull request:**
Don't fail silently when clearing cache doesn't work due to permissions issues.

Similar to https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cache/Console/ClearCommand.php#L71