### PR TITLE
Allow configuring default enabled extensions as part of installation

### DIFF
--- a/src/Install/Installation.php
+++ b/src/Install/Installation.php
@@ -22,6 +22,7 @@ class Installation
     private $debug = false;
     private $baseUrl;
     private $customSettings = [];
+    private $enabledExtensions = null;
 
     /** @var DatabaseConfig */
     private $dbConfig;
@@ -74,6 +75,13 @@ class Installation
     public function settings($settings)
     {
         $this->customSettings = $settings;
+
+        return $this;
+    }
+
+    public function extensions($enabledExtensions)
+    {
+        $this->enabledExtensions = $enabledExtensions;
 
         return $this;
     }
@@ -152,7 +160,7 @@ class Installation
         });
 
         $pipeline->pipe(function () {
-            return new Steps\EnableBundledExtensions($this->db, $this->paths->vendor, $this->getAssetPath());
+            return new Steps\EnableBundledExtensions($this->db, $this->paths->vendor, $this->getAssetPath(), $this->enabledExtensions);
         });
 
         return $pipeline;

--- a/src/Install/Steps/EnableBundledExtensions.php
+++ b/src/Install/Steps/EnableBundledExtensions.php
@@ -22,6 +22,23 @@ use League\Flysystem\Filesystem;
 
 class EnableBundledExtensions implements Step
 {
+    const EXTENSION_WHITELIST = [
+        'flarum-approval',
+        'flarum-bbcode',
+        'flarum-emoji',
+        'flarum-lang-english',
+        'flarum-flags',
+        'flarum-likes',
+        'flarum-lock',
+        'flarum-markdown',
+        'flarum-mentions',
+        'flarum-statistics',
+        'flarum-sticky',
+        'flarum-subscriptions',
+        'flarum-suspend',
+        'flarum-tags',
+    ];
+
     /**
      * @var ConnectionInterface
      */
@@ -38,7 +55,7 @@ class EnableBundledExtensions implements Step
     private $assetPath;
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
     private $enabledExtensions;
 
@@ -71,23 +88,6 @@ class EnableBundledExtensions implements Step
             $extensions->keys()->toJson()
         );
     }
-
-    const EXTENSION_WHITELIST = [
-        'flarum-approval',
-        'flarum-bbcode',
-        'flarum-emoji',
-        'flarum-lang-english',
-        'flarum-flags',
-        'flarum-likes',
-        'flarum-lock',
-        'flarum-markdown',
-        'flarum-mentions',
-        'flarum-statistics',
-        'flarum-sticky',
-        'flarum-subscriptions',
-        'flarum-suspend',
-        'flarum-tags',
-    ];
 
     /**
      * @return \Illuminate\Support\Collection

--- a/src/Install/Steps/EnableBundledExtensions.php
+++ b/src/Install/Steps/EnableBundledExtensions.php
@@ -37,11 +37,17 @@ class EnableBundledExtensions implements Step
      */
     private $assetPath;
 
-    public function __construct(ConnectionInterface $database, $vendorPath, $assetPath)
+    /**
+     * @var string[]
+     */
+    private $enabledExtensions;
+
+    public function __construct(ConnectionInterface $database, $vendorPath, $assetPath, $enabledExtensions = null)
     {
         $this->database = $database;
         $this->vendorPath = $vendorPath;
         $this->assetPath = $assetPath;
+        $this->enabledExtensions = $enabledExtensions ?? self::EXTENSION_WHITELIST;
     }
 
     public function getMessage()
@@ -109,7 +115,7 @@ class EnableBundledExtensions implements Step
 
                 return $extension;
             })->filter(function (Extension $extension) {
-                return in_array($extension->getId(), self::EXTENSION_WHITELIST);
+                return in_array($extension->getId(), $this->enabledExtensions);
             })->sortBy(function (Extension $extension) {
                 return $extension->getTitle();
             })->mapWithKeys(function (Extension $extension) {


### PR DESCRIPTION
This is needed for the testing library

**Part of #2719**

**Changes proposed in this pull request:**
Allow configuring default enabled extensions as part of installation. Tested locally.