### PR TITLE
Require unique route names

### DIFF
--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -62,7 +62,7 @@ class Frontend implements ExtenderInterface
 
     public function removeRoute(string $name)
     {
-        $this->removedRoutes[] = compact('name');
+        $this->removedRoutes[] = $name;
 
         return $this;
     }
@@ -159,8 +159,8 @@ class Frontend implements ExtenderInterface
                 /** @var RouteHandlerFactory $factory */
                 $factory = $container->make(RouteHandlerFactory::class);
 
-                foreach ($this->removedRoutes as $route) {
-                    $collection->removeRoute('GET', $route['name']);
+                foreach ($this->removedRoutes as $routeName) {
+                    $collection->removeRoute($routeName);
                 }
 
                 foreach ($this->routes as $route) {

--- a/src/Extend/Routes.php
+++ b/src/Extend/Routes.php
@@ -63,9 +63,9 @@ class Routes implements ExtenderInterface
         return $this;
     }
 
-    public function remove(string $method, string $name)
+    public function remove(string $name)
     {
-        $this->removedRoutes[] = compact('method', 'name');
+        $this->removedRoutes[] = $name;
 
         return $this;
     }
@@ -82,8 +82,8 @@ class Routes implements ExtenderInterface
                 /** @var RouteHandlerFactory $factory */
                 $factory = $container->make(RouteHandlerFactory::class);
 
-                foreach ($this->removedRoutes as $route) {
-                    $collection->removeRoute($route['method'], $route['name']);
+                foreach ($this->removedRoutes as $routeName) {
+                    $collection->removeRoute($routeName);
                 }
 
                 foreach ($this->routes as $route) {

--- a/src/Http/RouteCollection.php
+++ b/src/Http/RouteCollection.php
@@ -73,34 +73,32 @@ class RouteCollection
 
     public function addRoute($method, $path, $name, $handler)
     {
-        if (isset($this->routes[$method][$name])) {
-            throw new \RuntimeException("Route $name on method $method already exists");
+        if (isset($this->routes[$name])) {
+            throw new \RuntimeException("Route $name already exists");
         }
 
-        $this->routes[$method][$name] = $this->pendingRoutes[$method][$name] = compact('path', 'handler');
+        $this->routes[$name] = $this->pendingRoutes[$name] = compact('method', 'path', 'handler');
 
         return $this;
     }
 
-    public function removeRoute(string $method, string $name): self
+    public function removeRoute(string $name): self
     {
-        unset($this->routes[$method][$name], $this->pendingRoutes[$method][$name]);
+        unset($this->routes[$name], $this->pendingRoutes[$name]);
 
         return $this;
     }
 
     protected function applyRoutes(): void
     {
-        foreach ($this->pendingRoutes as $method => $routes) {
-            foreach ($routes as $name => $route) {
-                $routeDatas = $this->routeParser->parse($route['path']);
+        foreach ($this->pendingRoutes as $name => $route) {
+            $routeDatas = $this->routeParser->parse($route['path']);
 
-                foreach ($routeDatas as $routeData) {
-                    $this->dataGenerator->addRoute($method, $routeData, ['name' => $name, 'handler' => $route['handler']]);
-                }
-
-                $this->reverse[$name] = $routeDatas;
+            foreach ($routeDatas as $routeData) {
+                $this->dataGenerator->addRoute($route['method'], $routeData, ['name' => $name, 'handler' => $route['handler']]);
             }
+
+            $this->reverse[$name] = $routeDatas;
         }
 
         $this->pendingRoutes = [];

--- a/tests/integration/extenders/RoutesTest.php
+++ b/tests/integration/extenders/RoutesTest.php
@@ -55,7 +55,7 @@ class RoutesTest extends TestCase
     {
         $this->extend(
             (new Extend\Routes('api'))
-                ->remove('GET', 'forum.show')
+                ->remove('forum.show')
         );
 
         $response = $this->send(
@@ -72,7 +72,7 @@ class RoutesTest extends TestCase
     {
         $this->extend(
             (new Extend\Routes('api'))
-                ->remove('GET', 'forum.show')
+                ->remove('forum.show')
                 ->get('/', 'forum.show', CustomRoute::class)
         );
 


### PR DESCRIPTION
**Fixes #2707**

**Changes proposed in this pull request:**
Require route names to be unique instead of a unique couple [name, method].

**Reviewers should focus on:**
I don't think we remembered to warn extension devs about this change, but I didn't add a BC layer, I think it's fine to go through with this.

**Confirmed**

- [X] Backend changes: tests are green (run `composer test`).