### PR TITLE
Fix relevance sort

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -12,6 +12,7 @@ namespace Flarum\Api\Controller;
 use Flarum\Api\JsonApiResponse;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -261,7 +262,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      */
     protected function sortIsDefault(ServerRequestInterface $request)
     {
-        return ! array_key_exists('sort', $request->getQueryParams());
+        return !Arr::get($request->getQueryParams(), 'sort');
     }
 
     /**

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -256,6 +256,15 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     }
 
     /**
+     * @param ServerRequestInterface $request
+     * @return bool
+     */
+    protected function sortIsDefault(ServerRequestInterface $request)
+    {
+        return !array_key_exists('sort', $request->getQueryParams());
+    }
+
+    /**
      * Set the serializer that will serialize data for the endpoint.
      *
      * @param string $serializer

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -256,11 +256,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
         return new Parameters($request->getQueryParams());
     }
 
-    /**
-     * @param ServerRequestInterface $request
-     * @return bool
-     */
-    protected function sortIsDefault(ServerRequestInterface $request)
+    protected function sortIsDefault(ServerRequestInterface $request): bool
     {
         return ! Arr::get($request->getQueryParams(), 'sort');
     }

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -261,7 +261,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      */
     protected function sortIsDefault(ServerRequestInterface $request)
     {
-        return !array_key_exists('sort', $request->getQueryParams());
+        return ! array_key_exists('sort', $request->getQueryParams());
     }
 
     /**

--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -262,7 +262,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      */
     protected function sortIsDefault(ServerRequestInterface $request)
     {
-        return !Arr::get($request->getQueryParams(), 'sort');
+        return ! Arr::get($request->getQueryParams(), 'sort');
     }
 
     /**

--- a/src/Api/Controller/ListDiscussionsController.php
+++ b/src/Api/Controller/ListDiscussionsController.php
@@ -15,6 +15,7 @@ use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Http\UrlGenerator;
 use Flarum\Query\QueryCriteria;
+use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -88,12 +89,13 @@ class ListDiscussionsController extends AbstractListController
         $actor = $request->getAttribute('actor');
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);
+        $sortIsDefault = $this->sortIsDefault($request);
 
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);
         $include = array_merge($this->extractInclude($request), ['state']);
 
-        $criteria = new QueryCriteria($actor, $filters, $sort);
+        $criteria = new QueryCriteria($actor, $filters, $sort, $sortIsDefault);
         if (array_key_exists('q', $filters)) {
             $results = $this->searcher->search($criteria, $limit, $offset);
         } else {

--- a/src/Api/Controller/ListDiscussionsController.php
+++ b/src/Api/Controller/ListDiscussionsController.php
@@ -15,7 +15,6 @@ use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Http\UrlGenerator;
 use Flarum\Query\QueryCriteria;
-use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -84,7 +84,7 @@ class ListPostsController extends AbstractListController
         $offset = $this->extractOffset($request);
         $include = $this->extractInclude($request);
 
-        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort, $sortIsDefault), $limit, $offset,);
+        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort, $sortIsDefault), $limit, $offset, );
 
         $document->addPaginationLinks(
             $this->url->to('api')->route('posts.index'),

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -78,12 +78,13 @@ class ListPostsController extends AbstractListController
 
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);
+        $sortIsDefault = $this->sortIsDefault($request);
 
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);
         $include = $this->extractInclude($request);
 
-        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort), $limit, $offset);
+        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort, $sortIsDefault), $limit, $offset,);
 
         $document->addPaginationLinks(
             $this->url->to('api')->route('posts.index'),

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -84,7 +84,7 @@ class ListPostsController extends AbstractListController
         $offset = $this->extractOffset($request);
         $include = $this->extractInclude($request);
 
-        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort, $sortIsDefault), $limit, $offset, );
+        $results = $this->filterer->filter(new QueryCriteria($actor, $filters, $sort, $sortIsDefault), $limit, $offset);
 
         $document->addPaginationLinks(
             $this->url->to('api')->route('posts.index'),

--- a/src/Api/Controller/ListUsersController.php
+++ b/src/Api/Controller/ListUsersController.php
@@ -85,12 +85,13 @@ class ListUsersController extends AbstractListController
 
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);
+        $sortIsDefault = $this->sortIsDefault($request);
 
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);
         $include = $this->extractInclude($request);
 
-        $criteria = new QueryCriteria($actor, $filters, $sort);
+        $criteria = new QueryCriteria($actor, $filters, $sort, $sortIsDefault);
         if (array_key_exists('q', $filters)) {
             $results = $this->searcher->search($criteria, $limit, $offset);
         } else {

--- a/src/Filter/AbstractFilterer.php
+++ b/src/Filter/AbstractFilterer.php
@@ -65,7 +65,7 @@ abstract class AbstractFilterer
             }
         }
 
-        $this->applySort($filterState, $criteria->sort);
+        $this->applySort($filterState, $criteria->sort, $criteria->sortIsDefault);
         $this->applyOffset($filterState, $offset);
         $this->applyLimit($filterState, $limit + 1);
 

--- a/src/Query/ApplyQueryParametersTrait.php
+++ b/src/Query/ApplyQueryParametersTrait.php
@@ -11,6 +11,9 @@ namespace Flarum\Query;
 
 use Illuminate\Support\Str;
 
+/**
+ * @internal
+ */
 trait ApplyQueryParametersTrait
 {
     /**
@@ -18,15 +21,18 @@ trait ApplyQueryParametersTrait
      *
      * @param AbstractQueryState $query
      * @param array $sort
+     * @param bool $sortIsDefault
      */
-    protected function applySort(AbstractQueryState $query, array $sort = null)
+    protected function applySort(AbstractQueryState $query, array $sort = null, bool $sortIsDefault = false)
     {
-        $sort = $sort ?: $query->getDefaultSort();
+        if ($sortIsDefault && !empty($query->getDefaultSort())) {
+            $sort = $query->getDefaultSort();
+        }
 
         if (is_callable($sort)) {
             $sort($query->getQuery());
         } else {
-            foreach ($sort as $field => $order) {
+            foreach ((array) $sort as $field => $order) {
                 if (is_array($order)) {
                     foreach ($order as $value) {
                         $query->getQuery()->orderByRaw(Str::snake($field).' != ?', [$value]);

--- a/src/Query/ApplyQueryParametersTrait.php
+++ b/src/Query/ApplyQueryParametersTrait.php
@@ -25,7 +25,7 @@ trait ApplyQueryParametersTrait
      */
     protected function applySort(AbstractQueryState $query, array $sort = null, bool $sortIsDefault = false)
     {
-        if ($sortIsDefault && !empty($query->getDefaultSort())) {
+        if ($sortIsDefault && ! empty($query->getDefaultSort())) {
             $sort = $query->getDefaultSort();
         }
 

--- a/src/Query/QueryCriteria.php
+++ b/src/Query/QueryCriteria.php
@@ -42,16 +42,25 @@ class QueryCriteria
     public $sort;
 
     /**
+     * Is the sort for this request the default sort from the controller?
+     * If false, the current request specifies a sort.
+     * 
+     * @var bool
+     */
+    public $sortIsDefault;
+
+    /**
      * @param User $actor The user performing the query.
      * @param array $query The query params.
      * @param array $sort An array of sort-order pairs, where the column is the
      *     key, and the order is the value. The order may be 'asc', 'desc', or
      *     an array of IDs to order by.
      */
-    public function __construct(User $actor, $query, array $sort = null)
+    public function __construct(User $actor, $query, array $sort = null, bool $sortIsDefault = false)
     {
         $this->actor = $actor;
         $this->query = $query;
         $this->sort = $sort;
+        $this->sortIsDefault = $sortIsDefault;
     }
 }

--- a/src/Query/QueryCriteria.php
+++ b/src/Query/QueryCriteria.php
@@ -44,7 +44,7 @@ class QueryCriteria
     /**
      * Is the sort for this request the default sort from the controller?
      * If false, the current request specifies a sort.
-     * 
+     *
      * @var bool
      */
     public $sortIsDefault;

--- a/src/Search/AbstractSearcher.php
+++ b/src/Search/AbstractSearcher.php
@@ -54,7 +54,7 @@ abstract class AbstractSearcher
         $search = new SearchState($query->getQuery(), $actor);
 
         $this->gambits->apply($search, $criteria->query['q']);
-        $this->applySort($search, $criteria->sort);
+        $this->applySort($search, $criteria->sort, $criteria->sortIsDefault);
         $this->applyOffset($search, $offset);
         $this->applyLimit($search, $limit + 1);
 


### PR DESCRIPTION
**Fixes #2772**

**Changes proposed in this pull request:**
- Adds a field to `QueryCriteria` that determines whether the sort provided is the controller's default sort
- Set this field to `true` iff `sort` not in query params. Default it to false
- Override $sort if a new default sort has been set on search state, and the param is true.
- Add tests!

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
