### PR TITLE
Fix a missed getRouteData()

### DIFF
--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -205,7 +205,7 @@ class ForumServiceProvider extends AbstractServiceProvider
         $defaultRoute = $this->container->make('flarum.settings')->get('default_route');
 
         if (isset($routes->getRouteData()[0]['GET'][$defaultRoute]['handler'])) {
-            $toDefaultController = $routes->getRoutes()['GET'][$defaultRoute]['handler'];
+            $toDefaultController = $routes->getRouteData()[0]['GET'][$defaultRoute]['handler'];
         } else {
             $toDefaultController = $factory->toForum(Content\Index::class);
         }


### PR DESCRIPTION
**Related to #2754**

Tests didn't run on that PR, for some reason the usual auto StyleCi fix commit didn't run the tests.

**Confirmed**

- [X] Backend changes: tests are green (run `composer test`).
