### PR TITLE
Update laravel docs references to 8.x

### DIFF
--- a/src/Extend/Event.php
+++ b/src/Extend/Event.php
@@ -42,7 +42,7 @@ class Event implements ExtenderInterface
      * Event subscribers are classes that may subscribe to multiple events from within the subscriber class itself,
      * allowing you to define several event handlers within a single class.
      *
-     * @see https://laravel.com/docs/6.x/events#writing-event-subscribers
+     * @see https://laravel.com/docs/8.x/events#writing-event-subscribers
      *
      * @param string $subscriber: The class attribute of the subscriber class
      */

--- a/src/Extend/View.php
+++ b/src/Extend/View.php
@@ -27,7 +27,7 @@ class View implements ExtenderInterface, LifecycleInterface
      *
      * Views can then be used in your extension by injecting an instance of `Illuminate\Contracts\View\Factory`,
      * and calling its `make` method. The `make` method takes the view parameter in the format NAMESPACE::VIEW_NAME.
-     * You can also pass variables into a view: for more information, see https://laravel.com/api/6.x/Illuminate/View/Factory.html#method_make
+     * You can also pass variables into a view: for more information, see https://laravel.com/api/8.x/Illuminate/View/Factory.html#method_make
      *
      * @param  string  $namespace: The name of the namespace.
      * @param  string|array  $hints: This is a path (or an array of paths) to the folder(s)

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -157,7 +157,7 @@ class Extension implements Arrayable
     /**
      * Dot notation getter for composer.json attributes.
      *
-     * @see https://laravel.com/docs/5.1/helpers#arrays
+     * @see https://laravel.com/docs/8.x/helpers#arrays
      *
      * @param $name
      * @return mixed


### PR DESCRIPTION
Noticed the links are outdated so this updates existing laravel docs references to 8.x since that's what the codebase is using right now.