### PR TITLE
Drop session from user class

### DIFF
--- a/src/Http/Middleware/AuthenticateWithSession.php
+++ b/src/Http/Middleware/AuthenticateWithSession.php
@@ -26,8 +26,6 @@ class AuthenticateWithSession implements Middleware
 
         $actor = $this->getActor($session, $request);
 
-        $actor->setSession($session);
-
         $request = RequestUtil::withActor($request, $actor);
 
         return $handler->handle($request);

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -33,7 +33,6 @@ use Flarum\User\Event\Renamed;
 use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Hashing\Hasher;
-use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
 
 /**
@@ -75,11 +74,6 @@ class User extends AbstractModel
      * @var string[]|null
      */
     protected $permissions = null;
-
-    /**
-     * @var Session
-     */
-    protected $session;
 
     /**
      * An array of callables, through each of which the user's list of groups is passed
@@ -784,22 +778,6 @@ class User extends AbstractModel
     public function cannot($ability, $arguments = null)
     {
         return ! $this->can($ability, $arguments);
-    }
-
-    /**
-     * @return Session
-     */
-    public function getSession()
-    {
-        return $this->session;
-    }
-
-    /**
-     * @param Session $session
-     */
-    public function setSession(Session $session)
-    {
-        $this->session = $session;
     }
 
     /**


### PR DESCRIPTION
This was originally introduced inhttps://github.com/flarum/core/commit/3612ca7aca90b5d45310da1602256e247451cec3, but has not seen usage, since usually when the session needs to be modified, the request is available.

It causes issues with certain queue drivers, as it can't be serialized.

It's also not entirely accurate, as a user can have multiple sessions at once. Therefore, a given session is a property of the request, not of the user.