### PR TITLE
Remove unnecessary laravel config

### DIFF
--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -153,18 +153,14 @@ class InstalledSite implements SiteInterface
     }
 
     /**
-     * @param Application $app
      * @return ConfigRepository
      */
-    protected function getIlluminateConfig(Application $app)
+    protected function getIlluminateConfig()
     {
         return new ConfigRepository([
             'view' => [
                 'paths' => [],
                 'compiled' => $this->paths->storage.'/views',
-            ],
-            'mail' => [
-                'driver' => 'mail',
             ],
             'session' => [
                 'lifetime' => 120,


### PR DESCRIPTION
These are probably left over from when we relied more on Laravel's mail config; we configure this entirely ourselves in https://github.com/flarum/core/blob/c9d4a492d664f745c7b288d083c26f4d283f1d83/src/Mail/MailServiceProvider.php#L19-L19