### PR TITLE
Add accessibility attributes to loading spinner

### DIFF
--- a/js/src/common/components/LoadingIndicator.tsx
+++ b/js/src/common/components/LoadingIndicator.tsx
@@ -53,8 +53,14 @@ export default class LoadingIndicator extends Component<LoadingIndicatorAttrs> {
     attrs.containerClassName = classList({ 'LoadingIndicator-container': true, [attrs.containerClassName || '']: true });
 
     return (
-      <div {...attrs.containerAttrs} data-size={size} className={attrs.containerClassName}>
-        <div {...attrs}></div>
+      <div
+        aria-label={app.translator.trans('core.lib.loading_indicator.accessible_label')}
+        role="status"
+        {...attrs.containerAttrs}
+        data-size={size}
+        className={attrs.containerClassName}
+      >
+        <div aria-hidden {...attrs} />
       </div>
     );
   }

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -483,6 +483,10 @@ core:
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
 
+    # These translations are used in the loading indicator component.
+    loading_indicator:
+      accessible_label: => core.ref.loading
+
     # These translations are used as suffixes when abbreviating numbers.
     number_suffix:
       kilo_text: K
@@ -505,7 +509,7 @@ core:
     content:
       javascript_disabled_message: This site is best viewed in a modern browser with JavaScript enabled.
       load_error_message: Something went wrong while trying to load the full version of this site. Try hard-refreshing this page to fix the error.
-      loading_text: Loading...
+      loading_text: => core.ref.loading
 
     # Translations in this namespace are displayed in the basic HTML discussion view.
     discussion:
@@ -624,6 +628,7 @@ core:
     icon: Icon
     icon_text: "Enter the name of any <a>FontAwesome</a> icon class, <em>including</em> the <code>fas fa-</code> prefix."
     load_more: Load More
+    loading: Loading...
     log_in: Log In
     log_out: Log Out
     mark_all_as_read: Mark All as Read


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
After doing some research, it looks like we need a few a11y attributes on the loading spinner.

`role="status"` seems a little weird at first (at least it did to me), but it's important. W3 describe a status message as:
 > **[a] change in content** that is not a change of context, and **that provides information to the user** on the success or results of an action, **on the waiting state of an application**, on the progress of a process, or on the existence of errors

This role also sets an implicit `aria-live="polite"`, meaning screenreaders will know that the contents of this element may change in the future, and that they should notify the user of this element being added/removed/changed in real-time.

We also add an accessible label to ensure that screen readers understand what the element is.

**Screenshot**
![](https://user-images.githubusercontent.com/7406822/115423031-60eaeb80-a1f5-11eb-9d86-bc79a0b86507.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
