### PR TITLE
Revision compiler revised

### DIFF
--- a/src/Frontend/Compiler/CompilerInterface.php
+++ b/src/Frontend/Compiler/CompilerInterface.php
@@ -11,26 +11,14 @@ namespace Flarum\Frontend\Compiler;
 
 interface CompilerInterface
 {
-    /**
-     * @return string
-     */
     public function getFilename(): string;
 
-    /**
-     * @param string $filename
-     */
     public function setFilename(string $filename);
 
-    /**
-     * @param callable $callback
-     */
     public function addSources(callable $callback);
 
     public function commit();
 
-    /**
-     * @return string|null
-     */
     public function getUrl(): ?string;
 
     public function flush();

--- a/src/Frontend/Compiler/CompilerInterface.php
+++ b/src/Frontend/Compiler/CompilerInterface.php
@@ -17,7 +17,7 @@ interface CompilerInterface
 
     public function addSources(callable $callback);
 
-    public function commit();
+    public function commit(bool $force = false);
 
     public function getUrl(): ?string;
 

--- a/src/Frontend/Compiler/JsCompiler.php
+++ b/src/Frontend/Compiler/JsCompiler.php
@@ -14,9 +14,6 @@ use Flarum\Frontend\Compiler\Source\FileSource;
 
 class JsCompiler extends RevisionCompiler
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function save(string $file, array $sources): bool
     {
         if (empty($sources)) {
@@ -60,9 +57,6 @@ class JsCompiler extends RevisionCompiler
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function format(string $string): string
     {
         return preg_replace('~//# sourceMappingURL.*$~m', '', $string)."\n";

--- a/src/Frontend/Compiler/LessCompiler.php
+++ b/src/Frontend/Compiler/LessCompiler.php
@@ -72,8 +72,10 @@ class LessCompiler extends RevisionCompiler
         return $parser->getCss();
     }
 
-    protected function getCacheDifferentiator()
+    protected function getCacheDifferentiator(): ?array
     {
-        return time();
+        return [
+            'import_dirs' => $this->importDirs
+        ];
     }
 }

--- a/src/Frontend/Compiler/LessCompiler.php
+++ b/src/Frontend/Compiler/LessCompiler.php
@@ -24,33 +24,21 @@ class LessCompiler extends RevisionCompiler
      */
     protected $importDirs = [];
 
-    /**
-     * @return string
-     */
     public function getCacheDir(): string
     {
         return $this->cacheDir;
     }
 
-    /**
-     * @param string $cacheDir
-     */
     public function setCacheDir(string $cacheDir)
     {
         $this->cacheDir = $cacheDir;
     }
 
-    /**
-     * @return array
-     */
     public function getImportDirs(): array
     {
         return $this->importDirs;
     }
 
-    /**
-     * @param array $importDirs
-     */
     public function setImportDirs(array $importDirs)
     {
         $this->importDirs = $importDirs;
@@ -84,9 +72,6 @@ class LessCompiler extends RevisionCompiler
         return $parser->getCss();
     }
 
-    /**
-     * @return mixed
-     */
     protected function getCacheDifferentiator()
     {
         return time();

--- a/src/Frontend/Compiler/RevisionCompiler.php
+++ b/src/Frontend/Compiler/RevisionCompiler.php
@@ -161,19 +161,6 @@ class RevisionCompiler implements CompilerInterface
         return $string;
     }
 
-    /**
-     * Get the filename for the given revision.
-     *
-     * @param string $revision
-     * @return string
-     */
-    protected function getFilenameForRevision(string $revision): string
-    {
-        $ext = pathinfo($this->filename, PATHINFO_EXTENSION);
-
-        return substr_replace($this->filename, '-'.$revision, -strlen($ext) - 1, 0);
-    }
-
     protected function getRevision(): ?string
     {
         if ($this->assetsDir->has(static::REV_MANIFEST)) {
@@ -217,8 +204,9 @@ class RevisionCompiler implements CompilerInterface
         return hash('crc32b', serialize($cacheDifferentiator));
     }
 
-    protected function getCacheDifferentiator()
+    protected function getCacheDifferentiator(): ?array
     {
+        return null;
     }
 
     public function flush()

--- a/src/Frontend/Compiler/RevisionCompiler.php
+++ b/src/Frontend/Compiler/RevisionCompiler.php
@@ -45,25 +45,16 @@ class RevisionCompiler implements CompilerInterface
         $this->filename = $filename;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilename(): string
     {
         return $this->filename;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setFilename(string $filename)
     {
         $this->filename = $filename;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function commit()
     {
         $sources = $this->getSources();
@@ -72,12 +63,10 @@ class RevisionCompiler implements CompilerInterface
 
         $newRevision = $this->calculateRevision($sources);
 
-        $oldFile = $oldRevision ? $this->getFilenameForRevision($oldRevision) : null;
-
-        if ($oldRevision !== $newRevision || ($oldFile && ! $this->assetsDir->has($oldFile))) {
-            $newFile = $this->getFilenameForRevision($newRevision);
-
-            if (! $this->save($newFile, $sources)) {
+        // In case the previous and current revisions do not match
+        // Or no file was written yet, let's save the file to disk.
+        if ($oldRevision !== $newRevision || ! $this->assetsDir->has($this->filename)) {
+            if (! $this->save($this->filename, $sources)) {
                 // If no file was written (because the sources were empty), we
                 // will set the revision to a special value so that we can tell
                 // that this file does not have a URL.
@@ -85,16 +74,9 @@ class RevisionCompiler implements CompilerInterface
             }
 
             $this->putRevision($newRevision);
-
-            if ($oldFile && $oldFile !== $newFile) {
-                $this->delete($oldFile);
-            }
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addSources(callable $callback)
     {
         $this->sourcesCallbacks[] = $callback;
@@ -103,7 +85,7 @@ class RevisionCompiler implements CompilerInterface
     /**
      * @return SourceInterface[]
      */
-    protected function getSources()
+    protected function getSources(): array
     {
         $sources = new SourceCollector;
 
@@ -114,9 +96,6 @@ class RevisionCompiler implements CompilerInterface
         return $sources->getSources();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getUrl(): ?string
     {
         $revision = $this->getRevision();
@@ -135,9 +114,11 @@ class RevisionCompiler implements CompilerInterface
             return null;
         }
 
-        $file = $this->getFilenameForRevision($revision);
+        $url = $this->assetsDir->url($this->filename);
 
-        return $this->assetsDir->url($file);
+        // Append revision as GET param to signify that there's been
+        // a change to the file and it should be refreshed.
+        return "$url?v=$revision";
     }
 
     /**
@@ -193,9 +174,6 @@ class RevisionCompiler implements CompilerInterface
         return substr_replace($this->filename, '-'.$revision, -strlen($ext) - 1, 0);
     }
 
-    /**
-     * @return string|null
-     */
     protected function getRevision(): ?string
     {
         if ($this->assetsDir->has(static::REV_MANIFEST)) {
@@ -207,9 +185,6 @@ class RevisionCompiler implements CompilerInterface
         return null;
     }
 
-    /**
-     * @param string|null $revision
-     */
     protected function putRevision(?string $revision)
     {
         if ($this->assetsDir->has(static::REV_MANIFEST)) {
@@ -242,22 +217,14 @@ class RevisionCompiler implements CompilerInterface
         return hash('crc32b', serialize($cacheDifferentiator));
     }
 
-    /**
-     * @return mixed
-     */
     protected function getCacheDifferentiator()
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function flush()
     {
-        if ($revision = $this->getRevision()) {
-            $file = $this->getFilenameForRevision($revision);
-
-            $this->delete($file);
+        if ($this->getRevision() !== null) {
+            $this->delete($this->filename);
 
             $this->putRevision(null);
         }

--- a/src/Frontend/Compiler/RevisionCompiler.php
+++ b/src/Frontend/Compiler/RevisionCompiler.php
@@ -55,7 +55,7 @@ class RevisionCompiler implements CompilerInterface
         $this->filename = $filename;
     }
 
-    public function commit()
+    public function commit(bool $force = false)
     {
         $sources = $this->getSources();
 
@@ -65,7 +65,7 @@ class RevisionCompiler implements CompilerInterface
 
         // In case the previous and current revisions do not match
         // Or no file was written yet, let's save the file to disk.
-        if ($oldRevision !== $newRevision || ! $this->assetsDir->has($this->filename)) {
+        if ($force || $oldRevision !== $newRevision || ! $this->assetsDir->has($this->filename)) {
             if (! $this->save($this->filename, $sources)) {
                 // If no file was written (because the sources were empty), we
                 // will set the revision to a special value so that we can tell

--- a/src/Frontend/Content/Assets.php
+++ b/src/Frontend/Content/Assets.php
@@ -48,6 +48,7 @@ class Assets
             'css' => [$this->assets->makeCss(), $this->assets->makeLocaleCss($locale)]
         ];
 
+        // In debug we force a recompilation of assets.
         if ($this->config->inDebugMode()) {
             $this->commit(Arr::flatten($compilers));
         }
@@ -58,8 +59,9 @@ class Assets
 
     private function commit(array $compilers)
     {
+        /** @var CompilerInterface $compiler */
         foreach ($compilers as $compiler) {
-            $compiler->commit();
+            $compiler->commit(true);
         }
     }
 

--- a/src/Frontend/Content/Assets.php
+++ b/src/Frontend/Content/Assets.php
@@ -48,16 +48,20 @@ class Assets
             'css' => [$this->assets->makeCss(), $this->assets->makeLocaleCss($locale)]
         ];
 
-        // In debug we force a recompilation of assets.
         if ($this->config->inDebugMode()) {
-            $this->commit(Arr::flatten($compilers));
+            $this->forceCommit(Arr::flatten($compilers));
         }
 
         $document->js = array_merge($document->js, $this->getUrls($compilers['js']));
         $document->css = array_merge($document->css, $this->getUrls($compilers['css']));
     }
 
-    private function commit(array $compilers)
+    /**
+     * Force compilation of assets when in debug mode.
+     *
+     * @param array $compilers
+     */
+    private function forceCommit(array $compilers)
     {
         /** @var CompilerInterface $compiler */
         foreach ($compilers as $compiler) {


### PR DESCRIPTION
**Changes proposed in this pull request:**

Moving from `<asset>-<revision>.<js|css>` to `<asset>.<js|css>?v=<revision>`. As a consequence we no longer need to delete the old file, browsers will automatically pick up that a new file was generated. 

Additional changes

- clean up the revision classes, adding more type hinting (compatible with php 7.3), removing unneeded phpdoc
- changed the cache differentiator for Less; previously it would use `time()` causing a recompile every time assets are compiled; but as all sources (string, file) offer their own differentiator and the less compiler only adds import dirs, I've used that as another differentiator. Let me clarify the impact:

For production sites there won't be any change, except that css is compiled less often.
For development environments where import dirs see changes this might be problematic, however this PR also takes this into consideration by allowing the `commit()` method of the recompiler to get an argument `$force (false)`  to force recompilation when in debug mode.


**Reviewers should focus on:**

Whether we want to modify the differentator for Less like this.

**Screenshot**

![image](https://user-images.githubusercontent.com/504687/115707171-beef0e80-a36e-11eb-9ca0-80a746cd03b4.png)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
