### PR TITLE
Minor fix for class naming

### DIFF
--- a/js/src/admin/components/UserListPage.tsx
+++ b/js/src/admin/components/UserListPage.tsx
@@ -123,7 +123,7 @@ export default class UserListPage extends AdminPage {
 
             return (
               <div
-                class={classList(['UserListPage-grid--rowItem', rowIndex % 2 > 0 && 'UserListPage-grid--shadedRow'])}
+                class={classList(['UserListPage-grid-rowItem', rowIndex % 2 > 0 && 'UserListPage-grid-rowItem--shaded'])}
                 data-user-id={user.id()}
                 data-column-name={col.itemName}
                 aria-colindex={colIndex + 1}

--- a/less/admin/UsersListPage.less
+++ b/less/admin/UsersListPage.less
@@ -48,7 +48,7 @@
       background: @control-bg;
     }
 
-    &--rowItem {
+    &-rowItem {
       padding: 4px 16px;
       display: flex;
       align-items: center;
@@ -57,13 +57,13 @@
         padding: 0;
         position: relative;
       }
-    }
 
-    &--shadedRow {
-      background: darken(@body-bg, 3%);
+      &--shaded {
+        background: darken(@body-bg, 3%);
 
-      & when (@config-dark-mode = true) {
-        background: lighten(@body-bg, 5%);
+        & when (@config-dark-mode = true) {
+          background: lighten(@body-bg, 5%);
+        }
       }
     }
   }


### PR DESCRIPTION
**Changes proposed in this pull request:**
This is a minor fix for the naming of the row item class, `rowItem` is not a modifier, it's a sub-element.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
