### PR TITLE
[A11Y] Add focus ring mixin to restore ring to elements which no longer have it

### DIFF
--- a/less/common/mixins.less
+++ b/less/common/mixins.less
@@ -1,3 +1,4 @@
+@import "mixins/accessibility.less";
 @import "mixins/border-radius.less";
 @import "mixins/clearfix.less";
 @import "mixins/light-contents.less";

--- a/less/common/mixins/accessibility.less
+++ b/less/common/mixins/accessibility.less
@@ -1,0 +1,96 @@
+// This mixin should **only** be used in this file.
+.__priv-focus-ring-styles() {
+  // This uses the browser's default outline styles, rather than
+  // using custom ones, which could introduce more issues
+  //
+  // Source: https://css-tricks.com/copy-the-browsers-native-focus-styles
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+/**
+ * Adds a focus ring to an element.
+ *
+ * This is only shown when focus is provided via keyboard, using the
+ * `:focus-visible` selector, and `:-moz-focusring` for older Firefox.
+ */
+.add-keyboard-focus-ring() {
+  // We need to declare these separately, otherwise
+  // browsers will ignore `:focus-visible` as they
+  // don't understand `:-moz-focusring`
+
+  // These are the keyboard-only versions of :focus
+  &:-moz-focusring {
+    .focusRingStyles();
+  }
+
+  &:focus-visible {
+    .focusRingStyles();
+  }
+}
+
+/** 
+ * This mixin allows support for a custom focus
+ * selector to be supplied.
+ *
+ * For example...
+ * 
+ *? button { .addKeyboardFocusRing(":focus-within") }
+ * becomes
+ *? button:focus-within { <styles>  }
+ *
+ * AND
+ *
+ *? button { .addKeyboardFocusRing(" :focus-within") }
+ * becomes
+ *? button :focus-within { <styles>  }
+ */
+.add-keyboard-focus-ring(@customFocusSelector) {
+  @realFocusSelector: ~"@{customFocusSelector}";
+
+  &@{realFocusSelector} {
+    .focusRingStyles();
+  }
+}
+
+/**
+ * Allows an offset to be supplied for an a11y
+ * outline.
+ *
+ * Useful for elements whose content is right up
+ * against their bounds.
+ *
+ * `.addKeyboardFocusRingOffset(2px)` will add an
+ *  offset of 2 pixels to the outline.
+ */
+.add-keyboard-focus-ring-offset(@offset) {
+  .offset() {
+    outline-offset: @offset;
+  }
+
+  &:-moz-focusring {
+    .offset();
+  }
+  &:focus-visible {
+    .offset();
+  }
+}
+
+/**
+ * Allows an offset to be supplied for an a11y
+ * outline.
+ *
+ * Useful for elements whose content is right up
+ * against their bounds.
+ */
+.add-keyboard-focus-ring-offset(@customSelector, @offset) {
+  .offset() {
+    outline-offset: @offset;
+  }
+
+  @realFocusSelector: ~"@{customFocusSelector}";
+
+  &@{realFocusSelector} {
+    .offset();
+  }
+}

--- a/less/common/mixins/accessibility.less
+++ b/less/common/mixins/accessibility.less
@@ -1,11 +1,15 @@
-// This mixin should **only** be used in this file.
-.__priv-focus-ring-styles() {
-  // This uses the browser's default outline styles, rather than
-  // using custom ones, which could introduce more issues
-  //
-  // Source: https://css-tricks.com/copy-the-browsers-native-focus-styles
-  outline: 5px auto Highlight;
-  outline: 5px auto -webkit-focus-ring-color;
+// This mixin should **only** be used in this file. If you want to define your own
+// custom outline style(s), override this mixin in your own theme extension, or in
+// the Custom Less section of the Admin dashboard.
+#private {
+  .__focus-ring-styles() {
+    // This uses the browser's default outline styles, rather than
+    // using custom ones, which could introduce more issues
+
+    // Source: https://css-tricks.com/copy-the-browsers-native-focus-styles
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
 }
 
 /**
@@ -21,11 +25,11 @@
 
   // These are the keyboard-only versions of :focus
   &:-moz-focusring {
-    .focusRingStyles();
+    #private.__focus-ring-styles();
   }
 
   &:focus-visible {
-    .focusRingStyles();
+    #private.__focus-ring-styles();
   }
 }
 
@@ -49,7 +53,7 @@
   @realFocusSelector: ~"@{customFocusSelector}";
 
   &@{realFocusSelector} {
-    .focusRingStyles();
+    #private.__focus-ring-styles();
   }
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- -->
These mixins allow us to restore default browser focus rings on elements which no longer have them.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
I chose to make the styles mixin "private" as it shouldn't be used manually elsewhere in core -- we should instead use the other available mixins in the file. Is this the right choice?

**Screenshot**
![image](https://user-images.githubusercontent.com/7406822/116595544-56c69c80-a91b-11eb-9ae4-4f101c0f7071.png)

This screenshot uses:

```less
.add-keyboard-focus-ring();
.add-keyboard-focus-ring-offset(4px);
```

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
