### PR TITLE
`LESS` should be capitalised as `Less`

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -17,7 +17,7 @@ core:
       custom_header_heading: Custom Header
       custom_header_text: => core.ref.custom_header_text
       custom_styles_heading: Custom Styles
-      custom_styles_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's default styles.
+      custom_styles_text: Customize your forum's appearance by adding your own Less/CSS code to be applied on top of Flarum's default styles.
       dark_mode_label: Dark Mode
       description: "Customize your forum's colors, logos, and other variables."
       edit_css_button: Edit Custom CSS
@@ -58,7 +58,7 @@ core:
 
     # These translations are used in the Edit Custom CSS modal dialog.
     edit_css:
-      customize_text: "Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>."
+      customize_text: "Customize your forum's appearance by adding your own Less/CSS code to be applied on top of Flarum's <a>default styles</a>."
       submit_button: => core.ref.save_changes
       title: Edit Custom CSS
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Simple change: LESS -> Less

This matches how Less themselves capitalise their technology. See https://lesscss.org/#overview

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
These should be the only places we use "LESS" on the forum, I believe.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
