### PR TITLE
Mark JS `dist` folder as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,6 @@ phpunit.xml export-ignore
 tests export-ignore
 
 js/dist/* -diff
+js/dist/* linguist-generated
 
 * text=auto eol=lf


### PR DESCRIPTION
This excludes it from the repo's language stats and are suppressed in Linguist diffs.

See: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
