### PR TITLE
Centralize permission caching

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -379,11 +379,7 @@ class User extends AbstractModel
             return true;
         }
 
-        if (is_null($this->permissions)) {
-            $this->permissions = $this->getPermissions();
-        }
-
-        return in_array($permission, $this->permissions);
+        return in_array($permission, $this->getPermissions());
     }
 
     /**
@@ -399,11 +395,7 @@ class User extends AbstractModel
             return true;
         }
 
-        if (is_null($this->permissions)) {
-            $this->permissions = $this->getPermissions();
-        }
-
-        foreach ($this->permissions as $permission) {
+        foreach ($this->getPermissions() as $permission) {
             if (substr($permission, -strlen($match)) === $match) {
                 return true;
             }
@@ -739,7 +731,11 @@ class User extends AbstractModel
      */
     public function getPermissions()
     {
-        return $this->permissions()->pluck('permission')->all();
+        if (is_null($this->permissions)) {
+            $this->permissions = $this->permissions()->pluck('permission')->all();
+        }
+    
+        return $this->permissions;
     }
 
     /**

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -734,7 +734,7 @@ class User extends AbstractModel
         if (is_null($this->permissions)) {
             $this->permissions = $this->permissions()->pluck('permission')->all();
         }
-    
+
         return $this->permissions;
     }
 


### PR DESCRIPTION
Currently, we cache the user's list of permissions through `hasPermission` and `hasPermissionLike`. This is unnecessary duplication when we could just cache it in `getPermissions` directly. Furthermore, caching through `getPermissions` speeds up `getPermission`, for obvious reasons.

This came up in https://github.com/flarum/tags/pull/126#discussion_r625767563