### PR TITLE
Remove unneeded `delete`

### DIFF
--- a/js/src/admin/components/AdminPage.js
+++ b/js/src/admin/components/AdminPage.js
@@ -100,8 +100,6 @@ export default class AdminPage extends Page {
 
     const { setting, help, ...componentAttrs } = entry;
 
-    delete componentAttrs.help;
-
     const value = this.setting([setting])();
     if (['bool', 'checkbox', 'switch', 'boolean'].includes(componentAttrs.type)) {
       return (


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Super simple change -- just removes this `delete`.

Since we destructure the object on the line before, `help` will not be in `componentAttrs` as `componentAttrs` only contains the remaining keys in `entry` after `setting` and `help` have been removed.
