### PR TITLE
Fix required `selector` argument to `Component.$()`

### DIFF
--- a/js/src/common/Component.ts
+++ b/js/src/common/Component.ts
@@ -81,7 +81,7 @@ export default abstract class Component<T extends ComponentAttrs = ComponentAttr
    * @returns the jQuery object for the DOM node
    * @final
    */
-  protected $(selector: string): JQuery {
+  protected $(selector?: string): JQuery {
     const $element = $(this.element) as JQuery<HTMLElement>;
 
     return selector ? $element.find(selector) : $element;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
`this.$()` required an argument in the typings, but doesn't in real usage.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Nothing in particular.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
