### PR TITLE
Replace removed hasDiscussions method from DiscussionListPane

### DIFF
--- a/js/src/forum/components/DiscussionListPane.js
+++ b/js/src/forum/components/DiscussionListPane.js
@@ -17,7 +17,7 @@ const hotEdge = (e) => {
  */
 export default class DiscussionListPane extends Component {
   view() {
-    if (!this.attrs.state.hasDiscussions()) {
+    if (!this.attrs.state.hasItems()) {
       return;
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR replaces the remaining removed `hasDiscussions` method with `hasItems` from `DiscussionListPane`. I also checked for remaining instances of `empty` to be replaced with `isEmpty` as requested by @askvortsov1, but I did not find any left over.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
This is my first PR, please forgive me in advanced if I missed a step in the PR process ♥

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).