### PR TITLE
Use slugs for user pages

### DIFF
--- a/js/src/forum/components/UserPage.js
+++ b/js/src/forum/components/UserPage.js
@@ -135,7 +135,7 @@ export default class UserPage extends Page {
 
     items.add(
       'posts',
-      <LinkButton href={app.route('user.posts', { username: user.username() })} icon="far fa-comment">
+      <LinkButton href={app.route('user.posts', { username: user.slug() })} icon="far fa-comment">
         {app.translator.trans('core.forum.user.posts_link')} <span className="Button-badge">{user.commentCount()}</span>
       </LinkButton>,
       100
@@ -143,7 +143,7 @@ export default class UserPage extends Page {
 
     items.add(
       'discussions',
-      <LinkButton href={app.route('user.discussions', { username: user.username() })} icon="fas fa-bars">
+      <LinkButton href={app.route('user.discussions', { username: user.slug() })} icon="fas fa-bars">
         {app.translator.trans('core.forum.user.discussions_link')} <span className="Button-badge">{user.discussionCount()}</span>
       </LinkButton>,
       90


### PR DESCRIPTION
Caught by QA

Mentions was also fixed: https://github.com/flarum/mentions/commit/5811cf5bbf4d9d5fcd5a9716e8af2ddd41ded4e6

**Changes proposed in this pull request:**
Uses slugs instead if usernames for user page links.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
