### PR TITLE
Fix image avatar alignment in notifications

### DIFF
--- a/less/forum/NotificationList.less
+++ b/less/forum/NotificationList.less
@@ -136,6 +136,14 @@
     .Avatar--size(24px);
     grid-area: avatar;
   }
+  
+  // Since images don't have baselines, aligning against the baseline won't work.
+  // Instead we need to do some manual hackery to fix then, otherwise they won't
+  // be correctly vertically aligned.
+  img.Avatar {
+    align-self: flex-start;
+    margin-top: -2px;
+  }
 
   &-icon {
     font-size: 14px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2905**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Fixes issue introduced with #2822 where image-based avatars would display misaligned in the notifications list.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

Are there any other issues with Notification avatars? Can anyone think of a less hacky way to achieve this?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

### Before
![image](https://user-images.githubusercontent.com/7406822/121014415-dbfe6600-c791-11eb-89ff-8ea487a1bed2.png)

### After
![image](https://user-images.githubusercontent.com/7406822/121014390-d3a62b00-c791-11eb-8907-217f4e39b631.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
