### PR TITLE
Update code block styling to match HLJS 11's new styles

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -131,7 +131,7 @@
   // Code blocks
   pre {
     border: 0;
-    padding: 15px;
+    padding: 0;
     background: @code-bg;
     color: #666;
     font-size: 90%;
@@ -139,12 +139,14 @@
     overflow-wrap: normal;
 
     code {
-      padding: 0;
+      padding: 1em;
       background: none;
       color: inherit;
       line-height: inherit;
       font-size: 100%;
       border-radius: 0;
+      display: block;
+      overflow-x: auto;
     }
   }
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

### Changes proposed in this pull request:
<!-- fill this out, mention the pages and/or components which have been impacted -->
HLJS (which we use for code syntax highlighting) has padding set on the `code` element inside `pre`, and our styles put padding onto `pre`, resulting in double padding.

This PR brings the two stylesheets closer together and syncs some options between them, such as `overflow-x` and `display` to prevent any weird styling differences between non-hljs code blocks and hljs code blocks.

### Reviewers should focus on:
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/7406822/121052027-e0d31200-c7b1-11eb-95dc-d273c795f409.png)
#### After
![image](https://user-images.githubusercontent.com/7406822/121051995-da449a80-c7b1-11eb-8813-7563ef077ba2.png)


### Confirmed

- [x] Frontend changes: tested on a local Flarum installation.
