### PR TITLE
huntr.dev as first point for security vuln

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,12 +2,10 @@
 
 ## Supported Versions
 
-We will only patch security vulnerabilities in the stable 1.x release.
+**We only patch security vulnerabilities in the latest major release (1.x).**
 
-## Reporting a Vulnerability
+We use [huntr.dev](https://huntr.dev/) for security issues that affect our project. If you believe you have found a vulnerability, please disclose it via [this form](https://huntr.dev/bounties/disclose/?target=https://github.com/flarum/core).
 
-If you discover a security vulnerability within Flarum, please send an email to security@flarum.org so we can address it promptly.
+This will enable us to **review** the vulnerability, **fix** it promptly, and **reward** you for your efforts.
 
-We will get back to you as time allows.
-Discussions may commence internally, so you may not hear back immediately.
-When reporting a vulnerability, please provide your GitHub username (if available), so that we can invite you to collaborate on a [security advisory on GitHub](https://help.github.com/en/articles/about-maintainer-security-advisories).
+If you have any questions about the process, feel free to reach out to security@huntr.dev or security@flarum.org.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/dt/flarum/core" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/github/v/release/flarum/core?sort=semver" alt="Latest Version"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/l/flarum/core" alt="License"></a>
+<a href="https://huntr.dev/bounties/disclose/?target=https://github.com/flarum/core"><img src="https://cdn.huntr.dev/huntr_security_badge_mono.svg" alt="huntr"></a>
 <a href="https://github.styleci.io/repos/28257573"><img src="https://github.styleci.io/repos/28257573/shield?style=flat" alt="StyleCI"></a>
 </p>
 


### PR DESCRIPTION
Merging this moves the responsibility for vulnerability disclosures to huntr.dev while offering bounties for reporters and fixers in one swoop.