### PR TITLE
allows replacing maintenance mode handler using ioc

### DIFF
--- a/src/Foundation/InstalledApp.php
+++ b/src/Foundation/InstalledApp.php
@@ -48,7 +48,7 @@ class InstalledApp implements AppInterface
     public function getRequestHandler()
     {
         if ($this->config->inMaintenanceMode()) {
-            return new MaintenanceModeHandler();
+            return $this->container->make('flarum.maintenance.handler');
         } elseif ($this->needsUpdate()) {
             return $this->getUpdaterHandler();
         }

--- a/src/Foundation/InstalledSite.php
+++ b/src/Foundation/InstalledSite.php
@@ -105,6 +105,7 @@ class InstalledSite implements SiteInterface
         $container->alias('flarum.config', Config::class);
         $container->instance('flarum.debug', $this->config->inDebugMode());
         $container->instance('config', $config = $this->getIlluminateConfig($laravel));
+        $container->instance('flarum.maintenance.handler', new MaintenanceModeHandler);
 
         $this->registerLogger($container);
         $this->registerCache($container);


### PR DESCRIPTION
**Changes proposed in this pull request:**
This change allows extensions to replace the maintenance mode handler. This is helpful to replace the native bare text version.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
