### PR TITLE
Lazy draw dropdowns to improve performance

### DIFF
--- a/js/src/admin/components/PermissionDropdown.js
+++ b/js/src/admin/components/PermissionDropdown.js
@@ -37,6 +37,7 @@ export default class PermissionDropdown extends Dropdown {
 
     attrs.className = 'PermissionDropdown';
     attrs.buttonClassName = 'Button Button--text';
+    attrs.lazyDraw = true;
   }
 
   view(vnode) {

--- a/js/src/admin/components/PermissionGrid.js
+++ b/js/src/admin/components/PermissionGrid.js
@@ -143,6 +143,7 @@ export default class PermissionGrid extends Component {
               { value: '1', label: app.translator.trans('core.admin.permissions_controls.signup_open_button') },
               { value: '0', label: app.translator.trans('core.admin.permissions_controls.signup_closed_button') },
             ],
+            lazyDraw: true,
           }),
       },
       90
@@ -190,6 +191,7 @@ export default class PermissionGrid extends Component {
               { value: '10', label: app.translator.trans('core.admin.permissions_controls.allow_ten_minutes_button') },
               { value: 'reply', label: app.translator.trans('core.admin.permissions_controls.allow_until_reply_button') },
             ],
+            lazyDraw: true,
           });
         },
       },

--- a/js/src/common/components/Dropdown.js
+++ b/js/src/common/components/Dropdown.js
@@ -37,11 +37,12 @@ export default class Dropdown extends Component {
 
   view(vnode) {
     const items = vnode.children ? listItems(vnode.children) : [];
+    const renderItems = this.attrs.lazyDraw ? this.showing : true;
 
     return (
       <div className={'ButtonGroup Dropdown dropdown ' + this.attrs.className + ' itemCount' + items.length + (this.showing ? ' open' : '')}>
         {this.getButton(vnode.children)}
-        {this.getMenu(items)}
+        {renderItems && this.getMenu(items)}
       </div>
     );
   }
@@ -53,13 +54,25 @@ export default class Dropdown extends Component {
     // bottom of the viewport. If it does, we will apply class to make it show
     // above the toggle button instead of below it.
     this.$().on('shown.bs.dropdown', () => {
+      const { lazyDraw, onshow } = this.attrs;
+
       this.showing = true;
 
-      if (this.attrs.onshow) {
-        this.attrs.onshow();
+      // If using lazy drawing, redraw before calling `onshow` function
+      // to make sure the menu DOM exists in case the callback tries to use it.
+      if (lazyDraw) {
+        m.redraw.sync();
       }
 
-      m.redraw();
+      if (onshow) {
+        onshow();
+      }
+
+      // If not using lazy drawing, keep previous functionality
+      // of redrawing after calling onshow()
+      if (!lazyDraw) {
+        m.redraw();
+      }
 
       const $menu = this.$('.Dropdown-menu');
       const isRight = $menu.hasClass('Dropdown-menu--right');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #876**

**Changes proposed in this pull request:**
- Add `lazyDraw` attribute to `Dropdown` component
- Make `PermissionGrid` dropdowns use lazy draw

**Reviewers should focus on:**
- Do we like this implementation? Did we have something else in mind?
- Could this potentially be breaking if an extension has logic that occurs on the `items()` call of a Dropdown?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
