### PR TITLE
Hide post footer when empty

### DIFF
--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -72,7 +72,7 @@ export default class Post extends Component {
               )}
             </ul>
           </aside>
-          <footer className="Post-footer">{(footerItems.length && <ul>{listItems(footerItems)}</ul>) || null}</footer>
+          <footer className="Post-footer">{(footerItems.length ? <ul>{listItems(footerItems)}</ul>) : null}</footer>
         </div>
       </article>
     );

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -44,6 +44,7 @@ export default class Post extends Component {
     attrs.className = this.classes(attrs.className).join(' ');
 
     const controls = PostControls.controls(this.attrs.post, this).toArray();
+    const footerItems = this.footerItems().toArray();
 
     return (
       <article {...attrs}>
@@ -71,8 +72,8 @@ export default class Post extends Component {
               )}
             </ul>
           </aside>
-          <footer className="Post-footer">
-            <ul>{listItems(this.footerItems().toArray())}</ul>
+          <footer className={classList('Post-footer', !footerItems.length && 'Post-footer--empty')}>
+            <ul>{listItems(footerItems)}</ul>
           </footer>
         </div>
       </article>

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -72,9 +72,7 @@ export default class Post extends Component {
               )}
             </ul>
           </aside>
-          <footer className={classList('Post-footer', !footerItems.length && 'Post-footer--empty')}>
-            <ul>{listItems(footerItems)}</ul>
-          </footer>
+          <footer className="Post-footer">{(footerItems.length && <ul>{listItems(footerItems)}</ul>) || null}</footer>
         </div>
       </article>
     );

--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -72,7 +72,7 @@ export default class Post extends Component {
               )}
             </ul>
           </aside>
-          <footer className="Post-footer">{(footerItems.length ? <ul>{listItems(footerItems)}</ul>) : null}</footer>
+          <footer className="Post-footer">{footerItems.length ? <ul>{listItems(footerItems)}</ul> : null}</footer>
         </div>
       </article>
     );

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -285,7 +285,7 @@
     margin-right: 5px;
   }
   
-  &--empty {
+  &:empty {
     display: none;
   }
 }

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -247,9 +247,6 @@
   a {
     font-weight: bold;
   }
-  .Post-footer {
-    margin-bottom: 0;
-  }
 }
 .EventPost-info {
   font-size: 14px;
@@ -286,6 +283,10 @@
   .icon {
     font-size: 14px;
     margin-right: 5px;
+  }
+  
+  &--empty {
+    display: none;
   }
 }
 .Post-actions {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR changes the post footer to hide itself when it contains no items.

Currently, even if the footer has no items, it still exists and has margin, resulting in unexpected and weird white space at the bottom of posts.

In the screenshots below, notice the non-even spacing on the EventPost and on the whitespace below the post actions on the CommentPost.

I believe we previously had a more "hacky" way of doing this, by setting the footer bottom margin to 0 for Event Posts, but this fix will affect all posts instead of just Event Posts.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
This **shouldn't** be breaking (unless extensions are adding content to footers in hacky ways which we should probably discourage anyway).

As long as extensions are using the ItemList to add items to the footer, this class shouldn't end up being added.

### Screenshot

**Before:**

![image](https://user-images.githubusercontent.com/7406822/122301701-f73b4500-cef8-11eb-91ab-a246e8d4da0c.png)

**After:**

![image](https://user-images.githubusercontent.com/7406822/122301785-1043f600-cef9-11eb-96e9-18979434693e.png)

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] ~~Backend changes: tests are green (run `composer test`).~~