### PR TITLE
Convert extend util to TypeScript

### DIFF
--- a/js/src/@types/global.d.ts
+++ b/js/src/@types/global.d.ts
@@ -6,7 +6,9 @@
  * Type that returns an array of all keys of a provided object that are of
  * of the provided type, or a subtype of the type.
  */
-declare type KeysOfType<Type extends object, Match> = { [Key in keyof Type]-?: Type[Key] extends Match ? Key : never };
+declare type KeysOfType<Type extends object, Match> = {
+  [Key in keyof Type]-?: Type[Key] extends Match ? Key : never
+};
 
 /**
  * Type that matches one of the keys of an object that is of the provided

--- a/js/src/@types/global.d.ts
+++ b/js/src/@types/global.d.ts
@@ -7,7 +7,7 @@
  * of the provided type, or a subtype of the type.
  */
 declare type KeysOfType<Type extends object, Match> = {
-  [Key in keyof Type]-?: Type[Key] extends Match ? Key : never
+  [Key in keyof Type]-?: Type[Key] extends Match ? Key : never;
 };
 
 /**
@@ -15,7 +15,6 @@ declare type KeysOfType<Type extends object, Match> = {
  * type, or a subtype of it.
  */
 declare type KeyOfType<Type extends object, Match> = KeysOfType<Type, Match>[keyof Type];
-
 
 /**
  * @deprecated Please import `app` from a namespace instead of using it as a global variable.

--- a/js/src/@types/global.d.ts
+++ b/js/src/@types/global.d.ts
@@ -1,4 +1,21 @@
 /**
+ * UTILITY TYPES
+ */
+
+/**
+ * Type that returns an array of all keys of a provided object that are of
+ * of the provided type, or a subtype of the type.
+ */
+declare type KeysOfType<Type extends object, Match> = { [Key in keyof Type]-?: Type[Key] extends Match ? Key : never };
+
+/**
+ * Type that matches one of the keys of an object that is of the provided
+ * type, or a subtype of it.
+ */
+declare type KeyOfType<Type extends object, Match> = KeysOfType<Type, Match>[keyof Type];
+
+
+/**
  * @deprecated Please import `app` from a namespace instead of using it as a global variable.
  *
  * @example App in forum JS

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -14,7 +14,7 @@ import mapRoutes from './utils/mapRoutes';
 import RequestError from './utils/RequestError';
 import ScrollListener from './utils/ScrollListener';
 import liveHumanTimes from './utils/liveHumanTimes';
-import { extend } from './extend';
+import { extend } from './extend.ts';
 
 import Forum from './models/Forum';
 import User from './models/User';

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -1,4 +1,4 @@
-import * as extend from './extend';
+import * as extend from './extend.ts';
 import Session from './Session';
 import Store from './Store';
 import BasicEditorDriver from './utils/BasicEditorDriver';

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -1,10 +1,3 @@
-export type KeyOfType<T extends object, Type> = Exclude<
-  {
-    [K in keyof T]: T[K] extends Type ? K : never;
-  }[keyof T],
-  undefined
->;
-
 /**
  * Extend an object's method by running its output through a mutating callback
  * every time it is called.

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -40,13 +40,13 @@ export function extend<T extends object, K extends KeyOfType<T, Function>>(
   allMethods.forEach((method: K) => {
     const original: Function | undefined = object[method];
 
-    object[method] = <T[K]>function (this: T, ...args: any[]) {
+    object[method] = function (this: T, ...args: Parameters<T[K]>) {
       const value = original ? original.apply(this, args) : undefined;
 
       callback.apply(this, [value, ...args]);
 
       return value;
-    };
+    } as T[K];
 
     Object.assign(object[method], original);
   });
@@ -89,9 +89,9 @@ export function override<T extends object, K extends KeyOfType<T, Function>>(
   allMethods.forEach((method) => {
     const original: Function = object[method];
 
-    object[method] = <T[K]>function (this: T, ...args: any[]) {
+    object[method] = function (this: T, ...args: Parameters<T[K]>) {
       return newMethod.apply(this, [original.bind(this), ...args]);
-    };
+    } as T[K];
 
     Object.assign(object[method], original);
   });

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -36,9 +36,9 @@ export function extend<T extends object, K extends KeyOfType<T, Function>>(objec
   const allMethods = Array.isArray(methods) ? methods : [methods];
 
   allMethods.forEach((method: K) => {
-    const original: Function|undefined = object[method];
+    const original: Function | undefined = object[method];
 
-    object[method] = <T[K]> function (this: T, ...args: any[]) {
+    object[method] = <T[K]>function (this: T, ...args: any[]) {
       const value = original ? original.apply(this, args) : undefined;
 
       callback.apply(this, [value, ...args]);
@@ -77,13 +77,17 @@ export function extend<T extends object, K extends KeyOfType<T, Function>>(objec
  * @param methods The name or names of the method(s) to override
  * @param newMethod The method to replace it with
  */
-export function override<T extends object, K extends KeyOfType<T, Function>> (object: T, methods: K|K[], newMethod: (orig: T[K], ...args: any) => void) {
+export function override<T extends object, K extends KeyOfType<T, Function>>(
+  object: T,
+  methods: K | K[],
+  newMethod: (orig: T[K], ...args: any) => void
+) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 
   allMethods.forEach((method) => {
     const original: Function = object[method];
 
-    object[method] = <T[K]> function (this: T, ...args: any[]) {
+    object[method] = <T[K]>function (this: T, ...args: any[]) {
       return newMethod.apply(this, [original.bind(this), ...args]);
     };
 

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -5,8 +5,6 @@ export type KeyOfType<T extends object, Type> = Exclude<
   undefined
 >;
 
-export type ExtendCallback<T extends (...args: any) => any> = (val: ReturnType<T>, ...args: any[]) => void;
-
 /**
  * Extend an object's method by running its output through a mutating callback
  * every time it is called.
@@ -32,7 +30,11 @@ export type ExtendCallback<T extends (...args: any) => any> = (val: ReturnType<T
  * @param methods The name or names of the method(s) to extend
  * @param callback A callback which mutates the method's output
  */
-export function extend<T extends object, K extends KeyOfType<T, Function>>(object: T, methods: K | K[], callback: ExtendCallback<T[K]>) {
+export function extend<T extends object, K extends KeyOfType<T, Function>>(
+  object: T,
+  methods: K | K[],
+  callback: (val: ReturnType<T[K]>, ...args: any[]) => void
+) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 
   allMethods.forEach((method: K) => {

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -33,7 +33,7 @@ export type KeyOfType<T extends object, Type> = Exclude<
 export function extend<T extends object, K extends KeyOfType<T, Function>>(
   object: T,
   methods: K | K[],
-  callback: (val: ReturnType<T[K]>, ...args: Parameters<T[K]>) => void
+  callback: (this: T, val: ReturnType<T[K]>, ...args: Parameters<T[K]>) => void
 ) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 
@@ -82,7 +82,7 @@ export function extend<T extends object, K extends KeyOfType<T, Function>>(
 export function override<T extends object, K extends KeyOfType<T, Function>>(
   object: T,
   methods: K | K[],
-  newMethod: (orig: T[K], ...args: Parameters<T[K]>) => void
+  newMethod: (this: T, orig: T[K], ...args: Parameters<T[K]>) => void
 ) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -33,7 +33,7 @@ export type KeyOfType<T extends object, Type> = Exclude<
 export function extend<T extends object, K extends KeyOfType<T, Function>>(
   object: T,
   methods: K | K[],
-  callback: (val: ReturnType<T[K]>, ...args: any[]) => void
+  callback: (val: ReturnType<T[K]>, ...args: Parameters<T[K]>) => void
 ) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 
@@ -82,7 +82,7 @@ export function extend<T extends object, K extends KeyOfType<T, Function>>(
 export function override<T extends object, K extends KeyOfType<T, Function>>(
   object: T,
   methods: K | K[],
-  newMethod: (orig: T[K], ...args: any) => void
+  newMethod: (orig: T[K], ...args: Parameters<T[K]>) => void
 ) {
   const allMethods = Array.isArray(methods) ? methods : [methods];
 

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -9,4 +9,4 @@ export default function proxifyCompat(compat: Record<string, unknown>, namespace
   return new Proxy(compat, {
     get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '$1').replace(fileExt, '')],
   });
-};
+}

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -3,7 +3,7 @@ export default (compat: { [key: string]: any }, namespace: string) => {
   // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract
   // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
-  const regex = new RegExp(`^(?:\w+\/)?(?:${namespace}|common)\/(.+?)(?:\.(?:js|tsx?))?$`);
+  const regex = new RegExp(`^(?:\\w+\/)?(?:${namespace}|common)\/(.+?)(?:\\.(?:js|tsx?))?$`);
 
   return new Proxy(compat, {
     get: (obj, prop: string) => {

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -3,15 +3,10 @@ export default (compat: { [key: string]: any }, namespace: string) => {
   // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract
   // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
-  const regex = new RegExp(`^(?:\\w+\/)?(?:${namespace}|common)\/(.+?)(?:\\.(?:js|tsx?))?$`);
+  const regex = new RegExp(`(^|(?<=\/))(${namespace}|common)\/`);
+  const fileExt = /\.(\.js|\.tsx?)$/;
 
   return new Proxy(compat, {
-    get: (obj, prop: string) => {
-      if (obj[prop]) return obj[prop];
-
-      const out = regex.exec(prop);
-
-      return out && obj[out[1]];
-    },
+    get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '').replace(fileExt, '')],
   });
 };

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -3,10 +3,10 @@ export default (compat: { [key: string]: any }, namespace: string) => {
   // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract
   // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
-  const regex = new RegExp(`(^|(?<=\/))(${namespace}|common)\/`);
+  const regex = new RegExp(`^(.+\/)?(${namespace}|common)\/`);
   const fileExt = /\.(\.js|\.tsx?)$/;
 
   return new Proxy(compat, {
-    get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '').replace(fileExt, '')],
+    get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '$1').replace(fileExt, '')],
   });
 };

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -1,10 +1,17 @@
 export default (compat: { [key: string]: any }, namespace: string) => {
   // regex to replace common/ and NAMESPACE/ for core & core extensions
+  // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract
   // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
-  const regex = new RegExp(`(\\w+\\/)?(${namespace}|common)\\/`);
+  const regex = new RegExp(`^(?:\w+\/)?(?:${namespace}|common)\/(.+?)(?:\.(?:js|tsx?))?$`);
 
   return new Proxy(compat, {
-    get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '$1')],
+    get: (obj, prop: string) => {
+      if (obj[prop]) return obj[prop];
+
+      const out = regex.exec(prop);
+
+      return out && obj[out[1]];
+    },
   });
 };

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -1,4 +1,4 @@
-export default (compat: { [key: string]: any }, namespace: string) => {
+export default function proxifyCompat(compat: Record<string, unknown>, namespace: string) {
   // regex to replace common/ and NAMESPACE/ for core & core extensions
   // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract

--- a/js/src/common/utils/proxifyCompat.ts
+++ b/js/src/common/utils/proxifyCompat.ts
@@ -3,8 +3,8 @@ export default function proxifyCompat(compat: Record<string, unknown>, namespace
   // and remove .js, .ts and .tsx extensions
   // e.g. admin/utils/extract --> utils/extract
   // e.g. tags/common/utils/sortTags --> tags/utils/sortTags
-  const regex = new RegExp(`^(.+\/)?(${namespace}|common)\/`);
-  const fileExt = /\.(\.js|\.tsx?)$/;
+  const regex = new RegExp(String.raw`(\w+\/)?(${namespace}|common)\/`);
+  const fileExt = /(\.js|\.tsx?)$/;
 
   return new Proxy(compat, {
     get: (obj, prop: string) => obj[prop] || obj[prop.replace(regex, '$1').replace(fileExt, '')],


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Use `.ts` extension when referring to `extend` util in core code
- Allow extensions to use `.ts` in import path through compat for typings to work properly
- Convert `extend` util to TypeScript

**Reviewers should focus on:**
- Do we want to create a bunch more exported types/interfaces to make reading the code easier
- I don't know how to make it so the typings accept a nonexistent key for `extend`
- Are we fine with the new RegExp for the `compat` proxy to accept `.js`, `.ts` and `.tsx`

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/122677057-950b6a00-d1ae-11eb-9e49-033f085830b7.png)

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
