### PR TITLE
Allow adding `page` parameters to PaginatedListState

### DIFF
--- a/js/src/common/states/PaginatedListState.ts
+++ b/js/src/common/states/PaginatedListState.ts
@@ -91,7 +91,10 @@ export default abstract class PaginatedListState<T extends Model> {
    */
   protected loadPage(page = 1): Promise<T[]> {
     const params = this.requestParams();
-    params.page = { offset: this.pageSize * (page - 1) };
+    params.page = {
+      offset: this.pageSize * (page - 1),
+      ...params.page,
+    };
 
     if (Array.isArray(params.include)) {
       params.include = params.include.join(',');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
I have made a small non-impacting change to `PaginatedListState`. This allows extensions to edit the `page` parameters and add something like `limit` or override the `offset`.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.