### PR TITLE
Include updating of scoped tag permissions

### DIFF
--- a/migrations/2021_05_10_000000_rename_permissions.php
+++ b/migrations/2021_05_10_000000_rename_permissions.php
@@ -18,8 +18,8 @@ return [
             ->update(['permission' => $db->raw("REPLACE(permission,  'viewDiscussions', 'viewForum')")]);
 
         $db->table('group_permission')
-            ->where('permission', 'LIKE', 'viewUserList')
-            ->update(['permission' => $db->raw("REPLACE(permission,  'viewUserList', 'searchUsers')")]);
+            ->where('permission', 'viewUserList')
+            ->update(['permission' => 'searchUsers']);
     },
 
     'down' => function (Builder $schema) {
@@ -30,7 +30,7 @@ return [
             ->update(['permission' => $db->raw("REPLACE(permission,  'viewForum', 'viewDiscussions')")]);
 
         $db->table('group_permission')
-            ->where('permission', 'LIKE', 'searchUsers')
-            ->update(['permission' => $db->raw("REPLACE(permission,  'searchUsers', 'viewUserList')")]);
+            ->where('permission', 'searchUsers')
+            ->update(['permission' => 'viewUserList']);
     }
 ];

--- a/migrations/2021_05_10_000000_rename_permissions.php
+++ b/migrations/2021_05_10_000000_rename_permissions.php
@@ -14,7 +14,7 @@ return [
         $db = $schema->getConnection();
 
         $db->table('group_permission')
-            ->where('permission', 'LIKE', 'viewDiscussions')
+            ->where('permission', 'LIKE', '%viewDiscussions')
             ->update(['permission' => $db->raw("REPLACE(permission,  'viewDiscussions', 'viewForum')")]);
 
         $db->table('group_permission')
@@ -26,7 +26,7 @@ return [
         $db = $schema->getConnection();
 
         $db->table('group_permission')
-            ->where('permission', 'LIKE', 'viewForum')
+            ->where('permission', 'LIKE', '%viewForum')
             ->update(['permission' => $db->raw("REPLACE(permission,  'viewForum', 'viewDiscussions')")]);
 
         $db->table('group_permission')


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2924 **

**Changes proposed in this pull request:**
The rename `viewDiscussions` migration introduced for Flarum 1.0 does not take tag scoped permissions into account
https://github.com/flarum/core/blob/e92c267cdec46266b633f71c2f41040731cdaf39/migrations/2021_05_10_000000_rename_permissions.php#L17

This fixes the migration to additionally rename `tagX.viewDiscussions` to `tagX.viewForum`

As @clarkwinkelmann suggestion, fixing the current migration rather than introducing a new one so that this will only run for those forums which are yet to update to 1.0

Tested locally on an upgrade from core `beta.16` to `1.0.3`

**Reviewers should focus on:**
Scoped tag permissions are included in the rename of permission

**Confirmed**

- [X] Backend changes: tests are green (run `composer test`).


