### PR TITLE
Use laravel validator to replace avatar validation error params

### DIFF
--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -73,7 +73,10 @@ class AvatarValidator extends AbstractValidator
     protected function raise($error, array $parameters = [], $rule = null)
     {
         $message = $this->laravelValidator->makeReplacements(
-            $this->translator->trans("validation.$error"), 'avatar', $rule ?? $error, array_values($parameters)
+            $this->translator->trans("validation.$error"),
+            'avatar',
+            $rule ?? $error,
+            array_values($parameters)
         );
 
         throw new ValidationException(['avatar' => $message]);


### PR DESCRIPTION
**Fixes #2933**

**Changes proposed in this pull request:**
When we switched to intl icu message format, the translation parameters 
have become required to be in the format `{param}`, so we can no longer 
use the translator here.

This PR switches to consistently rely on the laravel validator to make 
the replacements, just like with all other validation errors in the rest 
of the application.

**Reviewers should focus on:**
Is this the best way to go about this ?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
