### PR TITLE
Allow easier extensibility of page document

### DIFF
--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -49,7 +49,9 @@ class Frontend
     {
         $forumDocument = $this->getForumDocument($request);
 
-        $document = new Document($this->view, $forumDocument, $request);
+        $responseDocument = resolve('flarum.frontend.document');
+
+        $document = $responseDocument($forumDocument, $request);
 
         $this->populate($document, $request);
 

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -16,6 +16,8 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\View\Factory;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 class FrontendServiceProvider extends AbstractServiceProvider
 {
@@ -55,6 +57,16 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend->content($container->make(Content\Meta::class));
 
                 return $frontend;
+            };
+        });
+
+        $this->container->singleton('flarum.frontend.document', function (Container $container) {
+            return function (array $apiDocument, Request $request) use ($container){
+                return new Document(
+                    $container->make(Factory::class),
+                    $apiDocument,
+                    $request
+                );
             };
         });
     }

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -61,7 +61,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
         });
 
         $this->container->singleton('flarum.frontend.document', function (Container $container) {
-            return function (array $apiDocument, Request $request) use ($container){
+            return function (array $apiDocument, Request $request) use ($container) {
                 return new Document(
                     $container->make(Factory::class),
                     $apiDocument,


### PR DESCRIPTION
This allows extensions to:

- mutate the json api document sent with php documents
- override/interact with the Document

Right now extensions need to replace the complete Frontend class
in order to interact with the document. Let's abstract into ioc
so that advanced devs can interact with it.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
