### PR TITLE
Move Day.js plugin types import to global typings

### DIFF
--- a/js/@types/global/index.d.ts
+++ b/js/@types/global/index.d.ts
@@ -3,6 +3,7 @@ import Mithril from 'mithril';
 
 // Other third-party libs
 import * as _dayjs from 'dayjs';
+import 'dayjs/plugin/relativeTime';
 import * as _$ from 'jquery';
 
 // Globals from flarum/core

--- a/js/src/common/utils/humanTime.ts
+++ b/js/src/common/utils/humanTime.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import 'dayjs/plugin/relativeTime';
 
 /**
  * The `humanTime` utility converts a date to a localized, human-readable time-


### PR DESCRIPTION
**Fixes #2417**

**Changes proposed in this pull request:**
Remove Day.js relativeTime plugin types import from humanTime util and add it to the global typings file.
See @davwheat's [proposal](https://github.com/flarum/core/issues/2417#issuecomment-866151040) on #2417.

**Reviewers should focus on:**
Ensuring that no error occurs when compiling the humanTime util.
```
$ ./node_modules/.bin/tsc --esModuleInterop ./@types/global/index.d.ts ./src/common/utils/humanTime.ts
```
Note that you'll need to pass the `--esModuleInterop` to avoid the following error (unrelated to this PR):
```
node_modules/dayjs/index.d.ts:3:1
    3 export = dayjs;
      ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```
This flag is [highly recommended](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) by the TypeScript team for both new and existing projects. I didn't add it to `tsconfig.json` because I don't understand ts enough right now to guarantee that it won't break anything :)