### PR TITLE
Allow document title to be edited through extender

### DIFF
--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -123,6 +123,11 @@ class Document implements Renderable
     public $css = [];
 
     /**
+     * @var array
+     */
+    public $premadeData = [];
+
+    /**
      * @var Factory
      */
     protected $view;
@@ -159,6 +164,16 @@ class Document implements Renderable
     }
 
     /**
+     * Prepares the document to be populated.
+     *
+     * @return void
+     */
+    public function prepare()
+    {
+        $this->premadeData['title'] = $this->makeTitle();
+    }
+
+    /**
      * @return View
      */
     protected function makeView(): View
@@ -180,6 +195,10 @@ class Document implements Renderable
      */
     protected function makeTitle(): string
     {
+        if (isset($this->premadeData['title'])) {
+            return $this->premadeData['title'];
+        }
+
         $onHomePage = rtrim($this->request->getUri()->getPath(), '/') === '';
 
         return ($this->title && ! $onHomePage ? $this->title.' - ' : '').Arr::get($this->forumApiDocument, 'data.attributes.title');

--- a/src/Frontend/Frontend.php
+++ b/src/Frontend/Frontend.php
@@ -58,6 +58,8 @@ class Frontend
 
     protected function populate(Document $document, Request $request)
     {
+        $document->prepare();
+
         foreach ($this->content as $content) {
             $content($document, $request);
         }


### PR DESCRIPTION
**Related to #2947**

**Changes proposed in this pull request:**
Of all the document fields that can be manipulated through the Frontend\content extender, the title is the only one that can't be changed. This PR fixes that by premaking it and allowing content callbacks to then manipulate that value.

**Reviewers should focus on:**
Code, any better way to go about doing this ?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).