### PR TITLE
Allow extra attrs provided to `<Select>` to be passed through to the DOM element

### DIFF
--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -11,16 +11,30 @@ import classList from '../utils/classList';
  * - `onchange` A callback to run when the selected value is changed.
  * - `value` The value of the selected option.
  * - `disabled` Disabled state for the input.
- * - `outerClassName` class given to the containing Select element
+ * - `wrapperAttrs` A map of attrs to be passed to the DOM element wrapping the `<select>`
  *
  * Other attributes are passed directly to the `<select>` element rendered to the DOM.
  */
 export default class Select extends Component {
   view() {
-    const { options, onchange, value, disabled, outerClassName, ...domAttrs } = this.attrs;
+    const {
+      options,
+      onchange,
+      value,
+      disabled,
+
+      // Destructure the `wrapperAttrs` object to extract the `className` for passing to `classList()`
+      // `= {}` prevents errors when `wrapperAttrs` is undefined
+      wrapperAttrs: {
+        className: wrapperClassName,
+        ...wrapperAttrs
+      } = {},
+
+      ...domAttrs
+    } = this.attrs;
 
     return (
-      <span className={classList('Select', outerClassName)}>
+      <span className={classList('Select', wrapperClassName)} {...wrapperAttrs}>
         <select
           className="Select-input FormControl"
           onchange={onchange ? withAttr('value', onchange.bind(this)) : undefined}

--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -25,10 +25,7 @@ export default class Select extends Component {
 
       // Destructure the `wrapperAttrs` object to extract the `className` for passing to `classList()`
       // `= {}` prevents errors when `wrapperAttrs` is undefined
-      wrapperAttrs: {
-        className: wrapperClassName,
-        ...wrapperAttrs
-      } = {},
+      wrapperAttrs: { className: wrapperClassName, ...wrapperAttrs } = {},
 
       ...domAttrs
     } = this.attrs;

--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -1,6 +1,7 @@
 import Component from '../Component';
 import icon from '../helpers/icon';
 import withAttr from '../utils/withAttr';
+import classList from '../utils/classList';
 
 /**
  * The `Select` component displays a <select> input, surrounded with some extra
@@ -10,18 +11,22 @@ import withAttr from '../utils/withAttr';
  * - `onchange` A callback to run when the selected value is changed.
  * - `value` The value of the selected option.
  * - `disabled` Disabled state for the input.
+ * - `outerClassName` class given to the containing Select element
+ *
+ * Other attributes are passed directly to the `<select>` element rendered to the DOM.
  */
 export default class Select extends Component {
   view() {
-    const { options, onchange, value, disabled } = this.attrs;
+    const { options, onchange, value, disabled, outerClassName, ...domAttrs } = this.attrs;
 
     return (
-      <span className="Select">
+      <span className={classList('Select', outerClassName)}>
         <select
           className="Select-input FormControl"
           onchange={onchange ? withAttr('value', onchange.bind(this)) : undefined}
           value={value}
           disabled={disabled}
+          {...domAttrs}
         >
           {Object.keys(options).map((key) => (
             <option value={key}>{options[key]}</option>


### PR DESCRIPTION

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Extra attrspassed to the Select component are given straight to the DOM element
  - This is **critical** for accessibility. Currently, there is no way to provide a11y attrs (such as `for`, `id`, `aria-described-by`, etc.) to the DOM element.
- ~~Custom class names can be provided to the outer wrapping element for easier customisability~~
- Custom attrs can also be passed to the wrapper via the `wrapperAttrs` attr

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
~~Should we allow a way to pass any attrs wanted to the outer element, too? Something like  a `wrapperAttrs` attribute?~~ Done!

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
