### PR TITLE
Add fix for broken type hinting on class components

### DIFF
--- a/js/@types/global/index.d.ts
+++ b/js/@types/global/index.d.ts
@@ -30,6 +30,19 @@ declare global {
   interface JQuery {
     tooltip: TooltipJQueryFunction;
   }
+
+  /**
+   * For more info, see: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking
+   *
+   * In a nutshell, we need to add `ElementAttributesProperty` to tell Typescript
+   * what property on component classes to look at for attribute typings. For our
+   * Component class, this would be `attrs` (e.g. `this.attrs...`)
+   */
+  namespace JSX {
+    interface ElementAttributesProperty {
+      attrs: Record<string, unknown>;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
This PR fixes some issues with custom attribute hinting and type validation.

For more info, see: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking

In a nutshell, we need to add `ElementAttributesProperty` to tell Typescript what property on component classes to look at for attribute typings. For our `Component` class, this would be `attrs` (e.g. `this.attrs...`)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![image](https://user-images.githubusercontent.com/7406822/125519476-9b3d7d3a-e714-455a-bcdf-ad4ffb958991.png)