### PR TITLE
Don't show excerpt in PostPreview component if there are no plain content

### DIFF
--- a/js/src/forum/components/PostPreview.js
+++ b/js/src/forum/components/PostPreview.js
@@ -16,7 +16,8 @@ export default class PostPreview extends Component {
   view() {
     const post = this.attrs.post;
     const user = post.user();
-    const excerpt = highlight(post.contentPlain(), this.attrs.highlight, 300);
+    const content = post.contentType() === 'comment' && post.contentPlain();
+    const excerpt = content ? highlight(content, this.attrs.highlight, 300) : '';
 
     return (
       <Link className="PostPreview" href={app.route.post(post)} onclick={this.attrs.onclick}>


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/2942**

**Reviewers should focus on:**
`span.PostPreview-excerpt` is still necessary for proper view.

Quoting from @SychO9:
> Besides fixing the JS error, it would be a good idea to improve the preview for an event post mention, even though people aren't supposed to reply to event posts, they still can by manually writing the post mention, as long as they have the post's ID.

Since we don't store any information about event posts in db, I think this kind of enhancement will need some breaking changes.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
