### PR TITLE
Fix Select-based setting breaking admin pages

### DIFF
--- a/js/src/admin/components/AdminPage.js
+++ b/js/src/admin/components/AdminPage.js
@@ -98,39 +98,37 @@ export default class AdminPage extends Page {
       return entry.call(this);
     }
 
-    const { setting, help, ...componentAttrs } = entry;
+    const { setting, help, type, label, ...componentAttrs } = entry;
 
-    const value = this.setting([setting])();
-    if (['bool', 'checkbox', 'switch', 'boolean'].includes(componentAttrs.type)) {
+    const value = this.setting(setting)();
+
+    if (['bool', 'checkbox', 'switch', 'boolean'].includes(type)) {
       return (
         <div className="Form-group">
           <Switch state={!!value && value !== '0'} onchange={this.settings[setting]} {...componentAttrs}>
-            {componentAttrs.label}
+            {label}
           </Switch>
           <div className="helpText">{help}</div>
         </div>
       );
-    } else if (['select', 'dropdown', 'selectdropdown'].includes(componentAttrs.type)) {
+    } else if (['select', 'dropdown', 'selectdropdown'].includes(type)) {
+      const { default: defaultValue, options } = componentAttrs;
+
       return (
         <div className="Form-group">
-          <label>{componentAttrs.label}</label>
+          <label>{label}</label>
           <div className="helpText">{help}</div>
-          <Select
-            value={value || componentAttrs.default}
-            options={componentAttrs.options}
-            buttonClassName="Button"
-            onchange={this.settings[setting]}
-            {...componentAttrs}
-          />
+          <Select value={value || defaultValue} options={options} onchange={this.settings[setting]} {...componentAttrs} />
         </div>
       );
     } else {
       componentAttrs.className = classList(['FormControl', componentAttrs.className]);
+
       return (
         <div className="Form-group">
-          {componentAttrs.label ? <label>{componentAttrs.label}</label> : ''}
+          {label ? <label>{label}</label> : ''}
           <div className="helpText">{help}</div>
-          <input type={componentAttrs.type} bidi={this.setting(setting)} {...componentAttrs} />
+          <input type={type} bidi={this.setting(setting)} {...componentAttrs} />
         </div>
       );
     }

--- a/js/src/admin/components/MailPage.js
+++ b/js/src/admin/components/MailPage.js
@@ -62,7 +62,6 @@ export default class MailPage extends AdminPage {
           setting: 'mail_driver',
           options: Object.keys(this.driverFields).reduce((memo, val) => ({ ...memo, [val]: val }), {}),
           label: app.translator.trans('core.admin.email.driver_heading'),
-          className: 'MailPage-MailSettings',
         })}
         {this.status.sending ||
           Alert.component(

--- a/js/src/admin/components/MailPage.js
+++ b/js/src/admin/components/MailPage.js
@@ -55,7 +55,6 @@ export default class MailPage extends AdminPage {
           type: 'text',
           setting: 'mail_from',
           label: app.translator.trans('core.admin.email.addresses_heading'),
-          className: 'MailPage-MailSettings',
         })}
         {this.buildSettingComponent({
           type: 'select',

--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -22,18 +22,20 @@ export default class Select extends Component {
       onchange,
       value,
       disabled,
+      className,
+      class: _class,
 
       // Destructure the `wrapperAttrs` object to extract the `className` for passing to `classList()`
       // `= {}` prevents errors when `wrapperAttrs` is undefined
-      wrapperAttrs: { className: wrapperClassName, ...wrapperAttrs } = {},
+      wrapperAttrs: { className: wrapperClassName, class: wrapperClass, ...wrapperAttrs } = {},
 
       ...domAttrs
     } = this.attrs;
 
     return (
-      <span className={classList('Select', wrapperClassName)} {...wrapperAttrs}>
+      <span className={classList('Select', wrapperClassName, wrapperClass)} {...wrapperAttrs}>
         <select
-          className="Select-input FormControl"
+          className={classList("Select-input FormControl", className, _class)}
           onchange={onchange ? withAttr('value', onchange.bind(this)) : undefined}
           value={value}
           disabled={disabled}

--- a/js/src/common/components/Select.js
+++ b/js/src/common/components/Select.js
@@ -35,7 +35,7 @@ export default class Select extends Component {
     return (
       <span className={classList('Select', wrapperClassName, wrapperClass)} {...wrapperAttrs}>
         <select
-          className={classList("Select-input FormControl", className, _class)}
+          className={classList('Select-input FormControl', className, _class)}
           onchange={onchange ? withAttr('value', onchange.bind(this)) : undefined}
           value={value}
           disabled={disabled}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes bug caused by #2959**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Prevents some attrs being passed to the `<Select>` component when they should not be.

For example, `type: "select"` creates a Select component, but this `type` attr was also passed to the component, resulting in Mithril attempting to perform weird changes on elements which are then disallowed by the DOM engine, causing the page to error.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Are there other areas broken by the Select change? Extension setting pages seem to be fine when using these changes.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/126389146-18d3e9c8-39e0-473f-aff8-103774849b68.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] ~~Backend changes: tests are green (run `composer test`).~~
