### PR TITLE
Revert "Fix intervention/image version to 2.5.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "illuminate/support": "^8.0",
         "illuminate/validation": "^8.0",
         "illuminate/view": "^8.0",
-        "intervention/image": "^2.6.1 || 2.5.*",
+        "intervention/image": "2.5.* || ^2.6.1",
         "laminas/laminas-diactoros": "^2.4.1",
         "laminas/laminas-httphandlerrunner": "^1.2.0",
         "laminas/laminas-stratigility": "^3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "illuminate/support": "^8.0",
         "illuminate/validation": "^8.0",
         "illuminate/view": "^8.0",
-        "intervention/image": ">=2.5.0 <2.6.0",
+        "intervention/image": "^2.5.0",
         "laminas/laminas-diactoros": "^2.4.1",
         "laminas/laminas-httphandlerrunner": "^1.2.0",
         "laminas/laminas-stratigility": "^3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "illuminate/support": "^8.0",
         "illuminate/validation": "^8.0",
         "illuminate/view": "^8.0",
-        "intervention/image": "^2.5.0",
+        "intervention/image": "^2.6.1 || 2.5.*",
         "laminas/laminas-diactoros": "^2.4.1",
         "laminas/laminas-httphandlerrunner": "^1.2.0",
         "laminas/laminas-stratigility": "^3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "illuminate/support": "^8.0",
         "illuminate/validation": "^8.0",
         "illuminate/view": "^8.0",
-        "intervention/image": "2.5.*",
+        "intervention/image": ">=2.5.0 <2.6.0",
         "laminas/laminas-diactoros": "^2.4.1",
         "laminas/laminas-httphandlerrunner": "^1.2.0",
         "laminas/laminas-stratigility": "^3.2.2",


### PR DESCRIPTION
intervention/image have pushed a fix and release 2.6.1, so this is no longer necessary.

https://github.com/Intervention/image/commit/e2b8aebe3e5baf1e3db61a0f5227502313d74b29