### PR TITLE
flarum info command additions

### DIFF
--- a/src/Foundation/Console/InfoCommand.php
+++ b/src/Foundation/Console/InfoCommand.php
@@ -158,6 +158,7 @@ class InfoCommand extends AbstractCommand
     {
         /** @var MySqlConnection $connection */
         $connection = resolve(ConnectionInterface::class);
+
         return $connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
     }
 }

--- a/src/Foundation/Console/InfoCommand.php
+++ b/src/Foundation/Console/InfoCommand.php
@@ -53,8 +53,7 @@ class InfoCommand extends AbstractCommand
         SettingsRepositoryInterface $settings,
         ConnectionInterface $db,
         Queue $queue
-    )
-    {
+    ) {
         $this->extensions = $extensions;
         $this->config = $config;
         $this->settings = $settings;


### PR DESCRIPTION
This PR adds a couple of new details to the info command:

- MySQL version, so that we can spot mysql issues faster
- Queue driver, so that we can understand issues where email isn't sent when the queue worker isn't running
- Mail driver, so that we can understand issues where email isn't sent when set to log, null or something else

I've also added a newline above the debug warning and I've made debug string "ON" red.


![image](https://user-images.githubusercontent.com/504687/127631159-23da4437-2bf7-4afd-9bcf-4e00edac1ba5.png)
