### PR TITLE
Add typings for class component state attribute

### DIFF
--- a/js/src/common/Component.ts
+++ b/js/src/common/Component.ts
@@ -29,7 +29,9 @@ export interface ComponentAttrs extends Mithril.Attributes {}
  *
  * @see https://mithril.js.org/components.html
  */
-export default abstract class Component<T extends ComponentAttrs = ComponentAttrs> implements Mithril.ClassComponent<T> {
+export default abstract class Component<Attrs extends ComponentAttrs = ComponentAttrs, State = undefined>
+  implements Mithril.ClassComponent<Attrs>
+{
   /**
    * The root DOM element for the component.
    */
@@ -40,48 +42,59 @@ export default abstract class Component<T extends ComponentAttrs = ComponentAttr
    *
    * @see https://mithril.js.org/components.html#passing-data-to-components
    */
-  protected attrs!: T;
+  protected attrs!: Attrs;
+
+  /**
+   * Class component state that is persisted between redraws.
+   *
+   * Updating this will **not** automatically trigger a redraw, unlike
+   * other frameworks.
+   *
+   * This is different to Vnode state, which is always an instance of your
+   * class component.
+   */
+  protected state!: State;
 
   /**
    * @inheritdoc
    */
-  abstract view(vnode: Mithril.Vnode<T, this>): Mithril.Children;
+  abstract view(vnode: Mithril.Vnode<Attrs, this>): Mithril.Children;
 
   /**
    * @inheritdoc
    */
-  oninit(vnode: Mithril.Vnode<T, this>) {
+  oninit(vnode: Mithril.Vnode<Attrs, this>) {
     this.setAttrs(vnode.attrs);
   }
 
   /**
    * @inheritdoc
    */
-  oncreate(vnode: Mithril.VnodeDOM<T, this>) {
+  oncreate(vnode: Mithril.VnodeDOM<Attrs, this>) {
     this.element = vnode.dom;
   }
 
   /**
    * @inheritdoc
    */
-  onbeforeupdate(vnode: Mithril.VnodeDOM<T, this>) {
+  onbeforeupdate(vnode: Mithril.VnodeDOM<Attrs, this>) {
     this.setAttrs(vnode.attrs);
   }
 
   /**
    * @inheritdoc
    */
-  onupdate(vnode: Mithril.VnodeDOM<T, this>) {}
+  onupdate(vnode: Mithril.VnodeDOM<Attrs, this>) {}
 
   /**
    * @inheritdoc
    */
-  onbeforeremove(vnode: Mithril.VnodeDOM<T, this>) {}
+  onbeforeremove(vnode: Mithril.VnodeDOM<Attrs, this>) {}
 
   /**
    * @inheritdoc
    */
-  onremove(vnode: Mithril.VnodeDOM<T, this>) {}
+  onremove(vnode: Mithril.VnodeDOM<Attrs, this>) {}
 
   /**
    * Returns a jQuery object for this component's element. If you pass in a
@@ -118,7 +131,7 @@ export default abstract class Component<T extends ComponentAttrs = ComponentAttr
    * Saves a reference to the vnode attrs after running them through initAttrs,
    * and checking for common issues.
    */
-  private setAttrs(attrs: T = {} as T): void {
+  private setAttrs(attrs: Attrs = {} as Attrs): void {
     (this.constructor as typeof Component).initAttrs(attrs);
 
     if (attrs) {

--- a/js/src/common/Component.ts
+++ b/js/src/common/Component.ts
@@ -29,9 +29,7 @@ export interface ComponentAttrs extends Mithril.Attributes {}
  *
  * @see https://mithril.js.org/components.html
  */
-export default abstract class Component<Attrs extends ComponentAttrs = ComponentAttrs, State = undefined>
-  implements Mithril.ClassComponent<Attrs>
-{
+export default abstract class Component<Attrs extends ComponentAttrs = ComponentAttrs, State = undefined> implements Mithril.ClassComponent<Attrs> {
   /**
    * The root DOM element for the component.
    */
@@ -52,6 +50,8 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
    *
    * This is different to Vnode state, which is always an instance of your
    * class component.
+   *
+   * This is `undefined` by default.
    */
   protected state!: State;
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
All of our class component instances have a `state` attribute which is, by default, `undefined`. This is managed by Mithril itself, but we currently have no way to apply types to it within Flarum.

This PR adds the ability to set typings for this attribute more easily, so that extensions can choose to store the data for their components within `this.state` more easily.

We generally store component data directly on the `this` object, but this often ends up polluting the class with lots of data. Storing it under `state` makes it easier to be typed, especially if data is set dynamically, and it is more friendly to developers coming from other frameworks, such as React.

We might want to consider defaulting `this.state` to an empty object within our class component. This shouldn't cause any backwards-compatibility issues, but might be better in another PR.

**Current method:**
```tsx
class MyComponent extends Component<Record<string, never>> {
  loading!: boolean;
  apiData?: Record<string, unknown>;
  formData!: {
    icon: string,
  };

  oninit() {
    super.oninit(arguments);
    this.loading = true;
    this.formData = {
      icon: "fas fa-blah",
    };
  }

  stopLoading() {
    this.loading = false;
  }

  async fetchApiData() {
    this.apiData = await m.request("https://example.com/endpoint");
  }
}
```

**`this.state` method:**
```tsx
interface IComponentState {
  loading: boolean;
  apiData?: Record<string, unknown>;
  formData: {
    icon: string;
  }
}

class MyComponent extends Component<Record<string, never>, IComponentState> {
  oninit() {
    super.oninit(arguments);

    this.state = {
      loading: true,
      formData: {
         icon: "fas fa-blah"
      },
    };
  }

  stopLoading() {
    this.state.loading = false;
  }

  async fetchApiData() {
    this.apiData = await m.request("https://example.com/endpoint");
  }
}
```
**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
