### PR TITLE
Use ItemList for DiscussionPage content

### DIFF
--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -9,6 +9,7 @@ import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
 import PostStreamState from '../states/PostStreamState';
+import Mithril from 'mithril';
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -68,34 +69,86 @@ export default class DiscussionPage extends Page {
   }
 
   view() {
-    const discussion = this.discussion;
-
     return (
       <div className="DiscussionPage">
         <DiscussionListPane state={app.discussions} />
-        <div className="DiscussionPage-discussion">
-          {discussion ? (
-            [
-              DiscussionHero.component({ discussion }),
-              <div className="container">
-                <nav className="DiscussionPage-nav">
-                  <ul>{listItems(this.sidebarItems().toArray())}</ul>
-                </nav>
-                <div className="DiscussionPage-stream">
-                  {PostStream.component({
-                    discussion,
-                    stream: this.stream,
-                    onPositionChange: this.positionChanged.bind(this),
-                  })}
-                </div>
-              </div>,
-            ]
-          ) : (
-            <LoadingIndicator />
-          )}
-        </div>
+        <div className="DiscussionPage-discussion">{this.discussion ? this.pageContent().toArray() : this.loadingItems().toArray()}</div>
       </div>
     );
+  }
+
+  /**
+   * List of components shown while the discussion is loading.
+   *
+   * @returns {ItemList}
+   */
+  loadingItems() {
+    const items = new ItemList();
+
+    items.add('spinner', <LoadingIndicator />, 100);
+
+    return items;
+  }
+
+  /**
+   * Function that renders the `sidebarItems` ItemList.
+   *
+   * @returns {Mithril.Children}
+   */
+  sidebar() {
+    return (
+      <nav className="DiscussionPage-nav">
+        <ul>{listItems(this.sidebarItems().toArray())}</ul>
+      </nav>
+    );
+  }
+
+  /**
+   * Renders the discussion's hero.
+   *
+   * @returns {Mithril.Children}
+   */
+  hero() {
+    return <DiscussionHero discussion={this.discussion} />;
+  }
+
+  /**
+   * List of items rendered as the main page content.
+   *
+   * @returns {ItemList}
+   */
+  pageContent() {
+    const items = new ItemList();
+
+    items.add('hero', this.hero(), 100);
+    items.add('main', <div className="container">{this.mainContent().toArray()}</div>, 10);
+
+    return items;
+  }
+
+  /**
+   * List of items rendered inside the main page content container.
+   *
+   * @returns {ItemList}
+   */
+  mainContent() {
+    const items = new ItemList();
+
+    items.add('sidebar', this.sidebar(), 100);
+
+    items.add(
+      'poststream',
+      <div className="DiscussionPage-stream">
+        {PostStream.component({
+          discussion,
+          stream: this.stream,
+          onPositionChange: this.positionChanged.bind(this),
+        })}
+      </div>,
+      10
+    );
+
+    return items;
   }
 
   /**

--- a/js/src/forum/components/DiscussionPage.js
+++ b/js/src/forum/components/DiscussionPage.js
@@ -9,7 +9,6 @@ import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
 import PostStreamState from '../states/PostStreamState';
-import Mithril from 'mithril';
 
 /**
  * The `DiscussionPage` component displays a whole discussion page, including
@@ -93,7 +92,7 @@ export default class DiscussionPage extends Page {
   /**
    * Function that renders the `sidebarItems` ItemList.
    *
-   * @returns {Mithril.Children}
+   * @returns {import('mithril').Children}
    */
   sidebar() {
     return (
@@ -106,7 +105,7 @@ export default class DiscussionPage extends Page {
   /**
    * Renders the discussion's hero.
    *
-   * @returns {Mithril.Children}
+   * @returns {import('mithril').Children}
    */
   hero() {
     return <DiscussionHero discussion={this.discussion} />;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR uses `ItemList`s for the content of DiscussionPage content.

When writing my Ad Units extension, I found it [very difficult](https://github.com/davwheat/flarum-ext-ads/blob/main/js/src/forum/InsertDiscussionPageHeaderAd.tsx) to add ads around Flarum, especially in this area.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Nothing in particular.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
