### PR TITLE
Limit height of code blocks

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -149,7 +149,7 @@
       overflow-x: auto;
       // Backwards compatibility for browsers that don't support `max()`
       max-height: 50vh;
-      max-height: max(50vh, 250px);
+      max-height: ~"max(50vh, 250px)";
     }
   }
   h1, h2, h3, h4, h5, h6 {

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -147,6 +147,8 @@
       border-radius: 0;
       display: block;
       overflow-x: auto;
+      // Backwards compatibility for browsers that don't support `max()`
+      max-height: 50vh;
       max-height: max(50vh, 250px);
     }
   }

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -147,6 +147,7 @@
       border-radius: 0;
       display: block;
       overflow-x: auto;
+      max-height: 50vh;
     }
   }
   h1, h2, h3, h4, h5, h6 {

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -147,7 +147,7 @@
       border-radius: 0;
       display: block;
       overflow-x: auto;
-      max-height: 50vh;
+      max-height: max(50vh, 250px);
     }
   }
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Users often post lengthy code or configuration listings which makes following the actual discussion difficult. Therefore we limit a code block by half a screen while still being able to scroll through the code listing itself.

