### PR TITLE
[A11Y] Make checkboxes focusable

### DIFF
--- a/js/src/common/components/Checkbox.js
+++ b/js/src/common/components/Checkbox.js
@@ -33,7 +33,9 @@ export default class Checkbox extends Component {
     return (
       <label className={className}>
         <input type="checkbox" checked={this.attrs.state} disabled={this.attrs.disabled} onchange={withAttr('checked', this.onchange.bind(this))} />
-        <div className="Checkbox-display">{this.getDisplay()}</div>
+        <div className="Checkbox-display" aria-hidden="true">
+          {this.getDisplay()}
+        </div>
         {vnode.children}
       </label>
     );

--- a/less/common/Checkbox.less
+++ b/less/common/Checkbox.less
@@ -2,19 +2,42 @@
   display: block;
   cursor: pointer;
   margin: 0;
+  position: relative;
 
   input[type="checkbox"] {
-    .visually-hidden();
+    position: absolute;
+    z-index: 1;
+
+    opacity: 0;
+
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    width: 100%;
+    height: 100%;
+
+    cursor: pointer;
+
     .add-keyboard-focus-ring-nearby("+ .Checkbox-display");
   }
 }
 .Checkbox--switch {
-  padding-left: 65px;
+  @left-pad: 65px;
+
+  padding-left: @left-pad;
   margin: 5px 0;
+
+  input[type="checkbox"] {
+    top: -4px;
+    width: 50px;
+    height: 28px;
+  }
 
   .Checkbox-display {
     float: left;
-    margin-left: -65px;
+    margin-left: -@left-pad;
     margin-top: -4px;
   }
 }

--- a/less/common/Checkbox.less
+++ b/less/common/Checkbox.less
@@ -5,6 +5,7 @@
 
   input[type="checkbox"] {
     .visually-hidden();
+    .add-keyboard-focus-ring-nearby("+ .Checkbox-display");
   }
 }
 .Checkbox--switch {

--- a/less/common/Checkbox.less
+++ b/less/common/Checkbox.less
@@ -3,8 +3,8 @@
   cursor: pointer;
   margin: 0;
 
-  & input[type="checkbox"] {
-    display: none;
+  input[type="checkbox"] {
+    .visually-hidden();
   }
 }
 .Checkbox--switch {

--- a/less/common/mixins/accessibility.less
+++ b/less/common/mixins/accessibility.less
@@ -39,13 +39,13 @@
  *
  * For example...
  * 
- *? button { .addKeyboardFocusRing(":focus-within") }
+ *? button { .add-keyboard-focus-ring(":focus-within") }
  * becomes
  *? button:focus-within { <styles>  }
  *
  * AND
  *
- *? button { .addKeyboardFocusRing(" :focus-within") }
+ *? button { .add-keyboard-focus-ring(" :focus-within") }
  * becomes
  *? button :focus-within { <styles>  }
  */
@@ -54,6 +54,38 @@
 
   &@{realFocusSelector} {
     #private.__focus-ring-styles();
+  }
+}
+
+/** 
+ * This mixin allows support for a custom element nearby the focused one
+ * to have a focus style applied to it
+ *
+ * For example...
+ * 
+ *? button { .add-keyboard-focus-ring-nearby("+ .myOtherElement") }
+ * becomes
+ *? button:-moz-focusring + .myOtherElement { <styles> }
+ *? button:focus-within + .myOtherElement { <styles> }
+ */
+.add-keyboard-focus-ring-nearby(@nearbySelector) {
+  @realNearbySelector: ~"@{nearbySelector}";
+
+  // We need to declare these separately, otherwise
+  // browsers will ignore `:focus-visible` as they
+  // don't understand `:-moz-focusring`
+
+  // These are the keyboard-only versions of :focus
+  &:-moz-focusring {
+    @{realNearbySelector} {
+      #private.__focus-ring-styles();
+    }
+  }
+
+  &:focus-visible {
+    @{realNearbySelector} {
+      #private.__focus-ring-styles();
+    }
   }
 }
 

--- a/less/common/scaffolding.less
+++ b/less/common/scaffolding.less
@@ -159,3 +159,13 @@ blockquote ol:last-child {
   font-size: 18px;
   color: @muted-more-color;
 }
+
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2973**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Make checkbox inputs appear over their display elements so that they are accessible to mobile screen-readers
- Add `aria-hidden` to the purely visual checkbox elements
- Restore browser focus rings to the checkbox display elements

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Nothing, really.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

https://user-images.githubusercontent.com/7406822/129100197-7769a3b1-e8ed-4e18-83ea-51db2293ec56.mp4

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
