### PR TITLE
[A11Y] Add focus traps to modals and nav drawer

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -9,6 +9,7 @@
     "clsx": "^1.1.1",
     "color-thief-browser": "^2.0.2",
     "dayjs": "^1.10.7",
+    "focus-trap": "^6.7.1",
     "jquery": "^3.6.0",
     "jquery.hotkeys": "^0.1.0",
     "mithril": "^2.0.4",

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -31,6 +31,7 @@ import extractText from './utils/extractText';
 import formatNumber from './utils/formatNumber';
 import mapRoutes from './utils/mapRoutes';
 import withAttr from './utils/withAttr';
+import * as FocusTrap from './utils/focusTrap';
 import Notification from './models/Notification';
 import User from './models/User';
 import Post from './models/Post';
@@ -116,6 +117,7 @@ export default {
   'utils/withAttr': withAttr,
   'utils/throttleDebounce': ThrottleDebounce,
   'utils/isObject': isObject,
+  'utils/focusTrap': FocusTrap,
   'models/Notification': Notification,
   'models/User': User,
   'models/Post': Post,

--- a/js/src/common/components/ModalManager.tsx
+++ b/js/src/common/components/ModalManager.tsx
@@ -1,12 +1,9 @@
 import Component from '../Component';
 
 import { createFocusTrap, FocusTrap } from '../utils/focusTrap';
-import { tabbable } from 'tabbable';
 
 import type ModalManagerState from '../states/ModalManagerState';
 import type Mithril from 'mithril';
-
-window.tabbable = tabbable;
 
 interface IModalManagerAttrs {
   state: ModalManagerState;

--- a/js/src/common/components/ModalManager.tsx
+++ b/js/src/common/components/ModalManager.tsx
@@ -69,13 +69,13 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
       })
       .modal('show');
 
-    if (this.focusTrap) this.focusTrap.activate();
+    this.focusTrap.activate?.();
   }
 
   animateHide(): void {
     // @ts-expect-error: No typings available for Bootstrap modals.
     this.$().modal('hide');
 
-    if (this.focusTrap) this.focusTrap.deactivate();
+    this.focusTrap.deactivate?.();
   }
 }

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -26,11 +26,9 @@ export default class Drawer {
   }
 
   resizeHandler(e) {
-    if (this.isOpen()) {
-      if (document.documentElement.style.getPropertyValue('--flarum-screen') !== 'phone') {
-        // Drawer is open but we've made window bigger, so hide it.
-        this.hide();
-      }
+    if (this.isOpen() && app.screen() !== 'phone') {
+      // Drawer is open but we've made window bigger, so hide it.
+      this.hide();
     }
   }
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -28,7 +28,7 @@ export default class Drawer {
 
     this.appElement = document.getElementById('app');
     this.focusTrap = createFocusTrap('#drawer', { allowOutsideClick: true });
-    this.drawerAailableMediaQuery = window.matchMedia(
+    this.drawerAvailableMediaQuery = window.matchMedia(
       `(max-width: ${getComputedStyle(document.documentElement).getPropertyValue('--screen-phone-max')})`
     );
   }
@@ -57,7 +57,7 @@ export default class Drawer {
    * @internal
    * @type {MediaQueryList}
    */
-  drawerAailableMediaQuery;
+  drawerAvailableMediaQuery;
 
   /**
    * Check whether or not the drawer is currently open.
@@ -84,7 +84,7 @@ export default class Drawer {
      */
 
     this.focusTrap.deactivate();
-    this.drawerAailableMediaQuery.removeListener(this.resizeHandler);
+    this.drawerAvailableMediaQuery.removeListener(this.resizeHandler);
 
     if (!this.isOpen()) return;
 
@@ -106,7 +106,7 @@ export default class Drawer {
   show() {
     this.appElement.classList.add('drawerOpen');
 
-    this.drawerAailableMediaQuery.addListener(this.resizeHandler);
+    this.drawerAvailableMediaQuery.addListener(this.resizeHandler);
 
     this.$backdrop = $('<div/>').addClass('drawer-backdrop fade').appendTo('body').on('click', this.hide.bind(this));
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -41,7 +41,7 @@ export default class Drawer {
 
     const $app = $('#app');
 
-    if (!$app.hasClass('drawerOpen')) return;
+    if (!this.isOpen()) return;
 
     const $drawer = $('#drawer');
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -12,15 +12,22 @@ export default class Drawer {
    */
   focusTrap;
 
+  /**
+   * @type {HTMLElement}
+   */
+  appElement;
+
   constructor() {
     // Set up an event handler so that whenever the content area is tapped,
     // the drawer will close.
-    $('#content').on('click', (e) => {
+    document.getElementById('content').addEventListener('click', (e) => {
       if (this.isOpen()) {
         e.preventDefault();
         this.hide();
       }
     });
+
+    this.appElement = document.getElementById('app');
 
     this.focusTrap = createFocusTrap('#drawer', { allowOutsideClick: true });
   }
@@ -68,8 +75,6 @@ export default class Drawer {
      * More info: https://github.com/flarum/core/pull/2666#discussion_r595381014
      */
 
-    const $app = $('#app');
-
     this.focusTrap.deactivate();
     window.removeEventListener('resize', this.throttledResizeHandler);
 
@@ -80,7 +85,7 @@ export default class Drawer {
     // Used to prevent `visibility: hidden` from breaking the exit animation
     $drawer.css('visibility', 'visible').one('transitionend', () => $drawer.css('visibility', ''));
 
-    $app.removeClass('drawerOpen');
+    this.appElement.classList.remove('drawerOpen');
 
     this.$backdrop.remove?.();
   }
@@ -91,7 +96,7 @@ export default class Drawer {
    * @public
    */
   show() {
-    $('#app').addClass('drawerOpen');
+    this.appElement.classList.add('drawerOpen');
 
     window.addEventListener('resize', this.throttledResizeHandler, { passive: true });
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -7,7 +7,7 @@ export default class Drawer {
   constructor() {
     // Set up an event handler so that whenever the content area is tapped,
     // the drawer will close.
-    $('#content').click((e) => {
+    $('#content').on('click', (e) => {
       if (this.isOpen()) {
         e.preventDefault();
         this.hide();
@@ -61,10 +61,7 @@ export default class Drawer {
   show() {
     $('#app').addClass('drawerOpen');
 
-    this.$backdrop = $('<div/>')
-      .addClass('drawer-backdrop fade')
-      .appendTo('body')
-      .click(() => this.hide());
+    this.$backdrop = $('<div/>').addClass('drawer-backdrop fade').appendTo('body').on('click', this.hide.bind(this));
 
     setTimeout(() => this.$backdrop.addClass('in'));
   }

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -87,7 +87,7 @@ export default class Drawer {
 
     this.appElement.classList.remove('drawerOpen');
 
-    this.$backdrop.remove?.();
+    this.$backdrop?.remove?.();
   }
 
   /**

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -63,6 +63,8 @@ export default class Drawer {
 
     this.$backdrop = $('<div/>').addClass('drawer-backdrop fade').appendTo('body').on('click', this.hide.bind(this));
 
-    setTimeout(() => this.$backdrop.addClass('in'));
+    requestAnimationFrame(() => {
+      this.$backdrop.addClass('in');
+    });
   }
 }

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -1,9 +1,16 @@
+import { createFocusTrap } from './focusTrap';
+
 /**
  * The `Drawer` class controls the page's drawer. The drawer is the area the
  * slides out from the left on mobile devices; it contains the header and the
  * footer.
  */
 export default class Drawer {
+  /**
+   * @type {import('./focusTrap').FocusTrap}
+   */
+  focusTrap;
+
   constructor() {
     // Set up an event handler so that whenever the content area is tapped,
     // the drawer will close.
@@ -13,6 +20,8 @@ export default class Drawer {
         this.hide();
       }
     });
+
+    this.focusTrap = createFocusTrap('#drawer', { allowOutsideClick: true });
   }
 
   /**
@@ -41,6 +50,8 @@ export default class Drawer {
 
     const $app = $('#app');
 
+    this.focusTrap.deactivate();
+
     if (!this.isOpen()) return;
 
     const $drawer = $('#drawer');
@@ -65,6 +76,8 @@ export default class Drawer {
 
     requestAnimationFrame(() => {
       this.$backdrop.addClass('in');
+
+      this.focusTrap.activate();
     });
   }
 }

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -1,4 +1,5 @@
 import { createFocusTrap } from './focusTrap';
+import { throttle } from './throttleDebounce';
 
 /**
  * The `Drawer` class controls the page's drawer. The drawer is the area the
@@ -23,6 +24,17 @@ export default class Drawer {
 
     this.focusTrap = createFocusTrap('#drawer', { allowOutsideClick: true });
   }
+
+  resizeHandler(e) {
+    if (this.isOpen()) {
+      if (document.documentElement.style.getPropertyValue('--flarum-screen') !== 'phone') {
+        // Drawer is open but we've made window bigger, so hide it.
+        this.hide();
+      }
+    }
+  }
+
+  throttledResizeHandler = throttle(500, this.resizeHandler.bind(this));
 
   /**
    * Check whether or not the drawer is currently open.
@@ -51,6 +63,7 @@ export default class Drawer {
     const $app = $('#app');
 
     this.focusTrap.deactivate();
+    window.removeEventListener('resize', this.throttledResizeHandler);
 
     if (!this.isOpen()) return;
 
@@ -71,6 +84,8 @@ export default class Drawer {
    */
   show() {
     $('#app').addClass('drawerOpen');
+
+    window.addEventListener('resize', this.throttledResizeHandler, { passive: true });
 
     this.$backdrop = $('<div/>').addClass('drawer-backdrop fade').appendTo('body').on('click', this.hide.bind(this));
 

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -25,6 +25,16 @@ export default class Drawer {
     this.focusTrap = createFocusTrap('#drawer', { allowOutsideClick: true });
   }
 
+  /**
+   * Handler for the `resize` event on `window`.
+   *
+   * This is used to close the drawer when the viewport is widened past the `phone` size.
+   * At this point, the drawer turns into the standard header that we see on desktop, but
+   * the drawer is still registered as 'open' internally.
+   *
+   * This causes issues with the focus trap, resulting in focus becoming trapped within
+   * the header on desktop viewports.
+   */
   resizeHandler(e) {
     if (this.isOpen() && app.screen() !== 'phone') {
       // Drawer is open but we've made window bigger, so hide it.

--- a/js/src/common/utils/Drawer.js
+++ b/js/src/common/utils/Drawer.js
@@ -74,7 +74,7 @@ export default class Drawer {
 
     $app.removeClass('drawerOpen');
 
-    if (this.$backdrop) this.$backdrop.remove();
+    this.$backdrop.remove?.();
   }
 
   /**

--- a/js/src/common/utils/focusTrap.ts
+++ b/js/src/common/utils/focusTrap.ts
@@ -1,0 +1,29 @@
+import { createFocusTrap as _createFocusTrap } from 'focus-trap';
+
+/**
+ * Creates a focus trap for the given element with the given options.
+ * 
+ * This function applies some default options that are different to the library.
+ * Your own options still override these custom defaults:
+ * 
+ * ```json
+ * {
+     escapeDeactivates: false,
+ * }
+ * ```
+ * 
+ * @param element The element to be the focus trap, or a selector that will be used to find the element.
+ * 
+ * @see https://github.com/focus-trap/focus-trap#readme - Library documentation
+ */
+function createFocusTrap(...args: Parameters<typeof _createFocusTrap>): ReturnType<typeof _createFocusTrap> {
+  args[1] = {
+    escapeDeactivates: false,
+    ...args[1],
+  };
+
+  return _createFocusTrap(...args);
+}
+
+export * from 'focus-trap';
+export { createFocusTrap };

--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -202,7 +202,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
     this.navigator
       .onUp(() => this.setIndex(this.getCurrentNumericIndex() - 1, true))
       .onDown(() => this.setIndex(this.getCurrentNumericIndex() + 1, true))
-      .onSelect(this.selectResult.bind(this))
+      .onSelect(this.selectResult.bind(this), true)
       .onCancel(this.clear.bind(this))
       .bindTo($input);
 

--- a/js/src/forum/utils/KeyboardNavigatable.ts
+++ b/js/src/forum/utils/KeyboardNavigatable.ts
@@ -1,6 +1,18 @@
 type KeyboardEventHandler = (event: KeyboardEvent) => void;
 type ShouldHandle = (event: KeyboardEvent) => boolean;
 
+enum Keys {
+  Enter = 13,
+  Escape = 27,
+  Space = 32,
+  ArrowUp = 38,
+  ArrowDown = 40,
+  ArrowLeft = 37,
+  ArrowRight = 39,
+  Tab = 9,
+  Backspace = 8,
+}
+
 /**
  * The `KeyboardNavigatable` class manages lists that can be navigated with the
  * keyboard, calling callbacks for each actions.
@@ -26,7 +38,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Up key.
    */
   onUp(callback: KeyboardEventHandler): KeyboardNavigatable {
-    this.callbacks.set(38, (e) => {
+    this.callbacks.set(Keys.ArrowUp, (e) => {
       e.preventDefault();
       callback(e);
     });
@@ -40,7 +52,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Down key.
    */
   onDown(callback: KeyboardEventHandler): KeyboardNavigatable {
-    this.callbacks.set(40, (e) => {
+    this.callbacks.set(Keys.ArrowDown, (e) => {
       e.preventDefault();
       callback(e);
     });
@@ -51,15 +63,16 @@ export default class KeyboardNavigatable {
   /**
    * Provide a callback to be executed when the current item is selected..
    *
-   * This will be triggered by the Return key.
+   * This will be triggered by the Return key (and Tab key, if not disabled).
    */
-  onSelect(callback: KeyboardEventHandler): KeyboardNavigatable {
+  onSelect(callback: KeyboardEventHandler, ignoreTabPress: boolean = false): KeyboardNavigatable {
     const handler: KeyboardEventHandler = (e) => {
       e.preventDefault();
       callback(e);
     };
 
-    this.callbacks.set(13, handler);
+    if (!ignoreTabPress) this.callbacks.set(Keys.Tab, handler);
+    this.callbacks.set(Keys.Enter, handler);
 
     return this;
   }
@@ -86,7 +99,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Escape key.
    */
   onCancel(callback: KeyboardEventHandler): KeyboardNavigatable {
-    this.callbacks.set(27, (e) => {
+    this.callbacks.set(Keys.Escape, (e) => {
       e.stopPropagation();
       e.preventDefault();
       callback(e);
@@ -101,7 +114,7 @@ export default class KeyboardNavigatable {
    * This will be triggered by the Backspace key.
    */
   onRemove(callback: KeyboardEventHandler): KeyboardNavigatable {
-    this.callbacks.set(8, (e) => {
+    this.callbacks.set(Keys.Backspace, (e) => {
       if (e instanceof KeyboardEvent && e.target instanceof HTMLInputElement && e.target.selectionStart === 0 && e.target.selectionEnd === 0) {
         callback(e);
         e.preventDefault();

--- a/js/src/forum/utils/KeyboardNavigatable.ts
+++ b/js/src/forum/utils/KeyboardNavigatable.ts
@@ -51,7 +51,7 @@ export default class KeyboardNavigatable {
   /**
    * Provide a callback to be executed when the current item is selected..
    *
-   * This will be triggered by the Return and Tab keys..
+   * This will be triggered by the Return key.
    */
   onSelect(callback: KeyboardEventHandler): KeyboardNavigatable {
     const handler: KeyboardEventHandler = (e) => {
@@ -59,8 +59,23 @@ export default class KeyboardNavigatable {
       callback(e);
     };
 
-    this.callbacks.set(9, handler);
     this.callbacks.set(13, handler);
+
+    return this;
+  }
+
+  /**
+   * Provide a callback to be executed when the current item is tabbed into.
+   *
+   * This will be triggered by the Tab key.
+   */
+  onTab(callback: KeyboardEventHandler): KeyboardNavigatable {
+    const handler: KeyboardEventHandler = (e) => {
+      e.preventDefault();
+      callback(e);
+    };
+
+    this.callbacks.set(9, handler);
 
     return this;
   }
@@ -84,10 +99,6 @@ export default class KeyboardNavigatable {
    * Provide a callback to be executed when previous input is removed.
    *
    * This will be triggered by the Backspace key.
-   *
-   * @public
-   * @param {KeyboardNavigatable~keyCallback} callback
-   * @return {KeyboardNavigatable}
    */
   onRemove(callback: KeyboardEventHandler): KeyboardNavigatable {
     this.callbacks.set(8, (e) => {
@@ -112,7 +123,7 @@ export default class KeyboardNavigatable {
   /**
    * Set up the navigation key bindings on the given jQuery element.
    */
-  bindTo($element: JQuery) {
+  bindTo($element: JQuery<HTMLElement>) {
     // Handle navigation key events on the navigatable element.
     $element[0].addEventListener('keydown', this.navigate.bind(this));
   }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1404,6 +1404,7 @@ __metadata:
     expose-loader: ^3.1.0
     flarum-tsconfig: ^1.0.2
     flarum-webpack-config: ^2.0.0
+    focus-trap: ^6.7.1
     jquery: ^3.6.0
     jquery.hotkeys: ^0.1.0
     mithril: ^2.0.4
@@ -2562,6 +2563,15 @@ __metadata:
   peerDependencies:
     webpack: ^5.60.0
   checksum: c3eae2b85bfecd00c2fd5b30a606dd8c8c67e15a7c22dc421b317fd3daf5d600ee9f21f4a5b5c23fa178adbaa2819a4713bae3f3af31150ab258bbadd5ecd2c9
+  languageName: node
+  linkType: hard
+
+"focus-trap@npm:^6.7.1":
+  version: 6.7.1
+  resolution: "focus-trap@npm:6.7.1"
+  dependencies:
+    tabbable: ^5.2.1
+  checksum: b96c54a6a2976f8509ed8447ce3a8b76db3801b9c170f278f60b0c878478f2bb2ebc6dbe3ccd7157006b9a7ad9a86c18283efff0f3e387e29ba3ea89d8687b9c
   languageName: node
   linkType: hard
 
@@ -3893,6 +3903,13 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "tabbable@npm:5.2.1"
+  checksum: d26e9eeb880c4c78b59244bac2c931ad46f6c64a01e5c15ba6da348dc86442222912733846a9e63373342a81fa15d4afb31267606b38431510d10b0fb9ec9bba
   languageName: node
   linkType: hard
 

--- a/less/common/root.less
+++ b/less/common/root.less
@@ -105,6 +105,13 @@
   // available to the JS code.
   --flarum-screen:                 none;
 
+  --screen-phone-max:   @screen-phone-max;
+  --screen-tablet:      @screen-tablet;
+  --screen-tablet-max:  @screen-tablet-max;
+  --screen-desktop:     @screen-desktop;
+  --screen-desktop-max: @screen-desktop-max;
+  --screen-desktop-hd:  @screen-desktop-hd;
+
   @media @phone { --flarum-screen: phone; }
   @media @tablet { --flarum-screen: tablet; }
   @media @desktop { --flarum-screen: desktop; }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2663**
**Fixes #2665**

> ### **Please merge #3007 before this PR!**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Add focus trap to modals
- Add focus trap to drawer on phone viewports
- Auto close drawer when leaving phone viewport
- Replace deprecated JQuer (`$.click()` -> `$.on('click')`)
- Use `requestAnimationFrame` instead of `setTimeout`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

