### PR TITLE
[A11Y] Explicitly state `aria-hidden` value; hide icons from screenreaders

### DIFF
--- a/js/src/admin/components/UserListPage.tsx
+++ b/js/src/admin/components/UserListPage.tsx
@@ -286,7 +286,7 @@ export default class UserListPage extends AdminPage {
 
           return (
             <div class="UserList-email" key={user.id()} data-email-shown="false">
-              <span class="UserList-emailAddress" aria-hidden onclick={() => setEmailVisibility(true)}>
+              <span class="UserList-emailAddress" aria-hidden="true" onclick={() => setEmailVisibility(true)}>
                 {user.email()}
               </span>
               <button

--- a/js/src/common/components/LoadingIndicator.tsx
+++ b/js/src/common/components/LoadingIndicator.tsx
@@ -73,7 +73,7 @@ export default class LoadingIndicator extends Component<LoadingIndicatorAttrs> {
         data-size={size}
         className={completeContainerClassName}
       >
-        <div aria-hidden className={completeClassName} {...attrs} />
+        <div aria-hidden="true" className={completeClassName} {...attrs} />
       </div>
     );
   }

--- a/js/src/common/helpers/icon.tsx
+++ b/js/src/common/helpers/icon.tsx
@@ -9,5 +9,5 @@ import * as Mithril from 'mithril';
 export default function icon(fontClass: string, attrs: Mithril.Attributes = {}): Mithril.Vnode {
   attrs.className = 'icon ' + fontClass + ' ' + (attrs.className || '');
 
-  return <i {...attrs} />;
+  return <i aria-hidden="true" {...attrs} />;
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Explicitly state the value of `aria-hidden` (needed for Talkback on Android)
- Hide icons from screenreaders as these are purely visual elements

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
🤷 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
  - tested on Android 11 
