### PR TITLE
Move email confirmation to POST request

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -545,6 +545,11 @@ core:
 
   # Translations in this namespace are used in views other than Flarum's normal JS client.
   views:
+    # Translations in this namespace are displayed by the Confirm Email interface.
+    confirm_email:
+      submit_button: => core.ref.confirm_email
+      text: Click the button below to confirm your account's email.
+      title: => core.ref.confirm_email
 
     # Translations in this namespace are displayed by the basic HTML content loader.
     content:
@@ -656,6 +661,7 @@ core:
     change_password: Change Password
     color: Color                                 # Referenced by flarum-tags.yml
     confirm_password: Confirm Password
+    confirm_email: Confirm Email
     confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
     custom_footer_text: Add HTML to be displayed at the very bottom of the page.
     custom_footer_title: Edit Custom Footer

--- a/src/Forum/Controller/ConfirmEmailViewController.php
+++ b/src/Forum/Controller/ConfirmEmailViewController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Forum\Controller;
+
+use Flarum\Http\Controller\AbstractHtmlController;
+use Flarum\Http\SessionAccessToken;
+use Flarum\Http\SessionAuthenticator;
+use Flarum\Http\UrlGenerator;
+use Flarum\User\Command\ConfirmEmail;
+use Flarum\User\EmailToken;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ConfirmEmailViewController extends AbstractHtmlController
+{
+    /**
+     * @var Factory
+     */
+    protected $view;
+
+    /**
+     * @param Factory $view
+     */
+    public function __construct(Factory $view)
+    {
+        $this->view = $view;
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function render(Request $request)
+    {
+        $token = Arr::get($request->getQueryParams(), 'token');
+
+        $token = EmailToken::validOrFail($token);
+
+        return $this->view->make('flarum.forum::confirm-email')
+            ->with('csrfToken', $request->getAttribute('session')->token());
+    }
+}

--- a/src/Forum/Controller/ConfirmEmailViewController.php
+++ b/src/Forum/Controller/ConfirmEmailViewController.php
@@ -10,18 +10,10 @@
 namespace Flarum\Forum\Controller;
 
 use Flarum\Http\Controller\AbstractHtmlController;
-use Flarum\Http\SessionAccessToken;
-use Flarum\Http\SessionAuthenticator;
-use Flarum\Http\UrlGenerator;
-use Flarum\User\Command\ConfirmEmail;
 use Flarum\User\EmailToken;
-use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
-use Laminas\Diactoros\Response\RedirectResponse;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Server\RequestHandlerInterface;
 
 class ConfirmEmailViewController extends AbstractHtmlController
 {

--- a/src/Forum/routes.php
+++ b/src/Forum/routes.php
@@ -64,7 +64,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
     $map->get(
         '/confirm/{token}',
         'confirmEmail',
-        $route->toController(Controller\ConfirmEmailController::class)
+        $route->toController(Controller\ConfirmEmailViewController::class),
+    );
+
+    $map->post(
+        '/confirm/{token}',
+        'confirmEmail.submit',
+        $route->toController(Controller\ConfirmEmailController::class),
     );
 
     $map->get(

--- a/views/confirm-email.blade.php
+++ b/views/confirm-email.blade.php
@@ -1,0 +1,25 @@
+@extends('flarum.forum::layouts.basic')
+
+@section('title', $translator->trans('core.views.confirm_email.title'))
+
+@section('content')
+    @if ($errors->any())
+        <div class="errors">
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form class="form" method="POST" action="">
+        <input type="hidden" name="csrfToken" value="{{ $csrfToken }}" />
+
+        <p>{{ $translator->trans('core.views.confirm_email.text') }}</p>
+
+        <p class="form-group">
+            <button type="submit" class="button">{{ $translator->trans('core.views.confirm_email.submit_button') }}</button>
+        </p>
+    </form>
+@endsection


### PR DESCRIPTION
**Fixes #2969**

**Changes proposed in this pull request:**
- Create blade view for GET request
- Keep POST request at same URL (don't want to change to /confirm because that could be breaking if another ext uses that route)


**Reviewers should focus on:**
- Do we want more blade views or to move this to JS routes?

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/130291350-9b08fc30-249c-429e-b60e-591a1aca584c.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
