### PR TITLE
Allow eager loading posts relations of GET discussion endpoint

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -148,13 +148,9 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
     abstract protected function createElement($data, SerializerInterface $serializer);
 
     /**
-     * Eager loads the required relationships.
-     *
-     * @param Collection $models
-     * @param array $relations
-     * @return void
+     * Returns the relations to load added by extenders.
      */
-    protected function loadRelations(Collection $models, array $relations): void
+    protected function getRelationsToLoad(): array
     {
         $addedRelations = [];
 
@@ -163,6 +159,20 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
                 $addedRelations = array_merge($addedRelations, static::$loadRelations[$class]);
             }
         }
+
+        return $addedRelations;
+    }
+
+    /**
+     * Eager loads the required relationships.
+     *
+     * @param Collection $models
+     * @param array $relations
+     * @return void
+     */
+    protected function loadRelations(Collection $models, array $relations): void
+    {
+        $addedRelations = $this->getRelationsToLoad();
 
         if (! empty($addedRelations)) {
             usort($addedRelations, function ($a, $b) {

--- a/src/Api/Controller/ShowDiscussionController.php
+++ b/src/Api/Controller/ShowDiscussionController.php
@@ -187,12 +187,21 @@ class ShowDiscussionController extends AbstractShowController
 
         $query->orderBy('created_at')->skip($offset)->take($limit)->with($include);
 
-        $posts = $query->get()->all();
+        $posts = $query->get();
 
         foreach ($posts as $post) {
             $post->discussion = $discussion;
         }
 
-        return $posts;
+        $this->loadRelations($posts, $include);
+
+        return $posts->all();
+    }
+
+    protected function getRelationsToLoad(): array
+    {
+        $addedRelations = parent::getRelationsToLoad();
+
+        return $this->getPostRelationships($addedRelations);
     }
 }


### PR DESCRIPTION
**Related to #3047**

**Changes proposed in this pull request:**
Allows using the `load` method to eager load relations of `posts` in the `GET /discussion/{id}` endpoint.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] Related core extension PRs: (Remove if irrelevant): **flarum/mentions#72**
