### PR TITLE
fix: Extension admin page erroring out

### DIFF
--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -106,7 +106,7 @@ export type SettingsComponentOptions = HTMLInputSettingsComponentOptions | Switc
 export type AdminHeaderAttrs = AdminHeaderOptions & Partial<Omit<Mithril.Attributes, 'class'>>;
 
 export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends Page<CustomAttrs> {
-  settings!: Record<string, Stream<string>>;
+  settings: Record<string, Stream<string>> = {};
   loading: boolean = false;
 
   view(vnode: Mithril.Vnode<CustomAttrs, this>): Mithril.Children {


### PR DESCRIPTION
**Changes proposed in this pull request:**
Extension admin pages are currently not working because of a JS error.
The `settings` record is never defined but directly used, it used to be defined as an empty object in `oninit`.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
