### PR TITLE
Preload FontAwesome, JS and CSS

### DIFF
--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -281,11 +281,11 @@ class Frontend implements ExtenderInterface
         $container->resolving(
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
-                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) {
+                $frontend->content(function (Document $document) use ($container) {
                     foreach ($this->preloads as $preload) {
-                        $document->preloads[] = is_callable($preload) ? $preload($document) : $preload;
+                        $document->preloads[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container) : $preload;
                     }
-                }, $container));
+                });
             }
         );
     }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -34,7 +34,7 @@ class Frontend implements ExtenderInterface
     private $routes = [];
     private $removedRoutes = [];
     private $content = [];
-    private $preloads = [];
+    private $preloadArrs = [];
 
     /**
      * @param string $frontend: The name of the frontend.
@@ -154,7 +154,7 @@ class Frontend implements ExtenderInterface
      */
     public function preloads($preloads): self
     {
-        $this->preloads = array_merge($this->preloads, (array) $preloads);
+        $this->preloadArrs[] = $preloads;
 
         return $this;
     }
@@ -274,7 +274,7 @@ class Frontend implements ExtenderInterface
 
     private function registerPreloads(Container $container): void
     {
-        if (empty($this->preloads)) {
+        if (empty($this->preloadArrs)) {
             return;
         }
 
@@ -282,8 +282,8 @@ class Frontend implements ExtenderInterface
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
                 $frontend->content(function (Document $document) use ($container) {
-                    foreach ($this->preloads as $preloads) {
-                        $preloads = is_callable($preloads) ? ContainerUtil::wrapCallback($preloads, $container)($document) : $preloads;
+                    foreach ($this->preloadArrs as $preloadArr) {
+                        $preloads = is_callable($preloadArr) ? ContainerUtil::wrapCallback($preloadArr, $container)($document) : $preloadArr;
                         $document->preloads = array_merge($document->preloads, $preloads);
                     }
                 });

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -282,8 +282,9 @@ class Frontend implements ExtenderInterface
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
                 $frontend->content(function (Document $document) use ($container) {
-                    foreach ($this->preloads as $preload) {
-                        $document->preloads[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container)($document) : $preload;
+                    foreach ($this->preloads as $preloads) {
+                        $preloads = is_callable($preloads) ? ContainerUtil::wrapCallback($preloads, $container)($document) : $preloads;
+                        $document->preloads = array_merge($document->preloads, $preloads);
                     }
                 });
             }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -163,37 +163,6 @@ class Frontend implements ExtenderInterface
         return $this;
     }
 
-    /**
-     * Adds a single asset preload.
-     *
-     * The parameter should be a preload array, or a callable that returns one.
-     *
-     * A preload array must contain keys that pertain to the `<link rel="preload">` tag.
-     *
-     * For example, the following will add preload tags for a script:
-     * ```
-     * $frontend->preload(
-     *   [
-     *     'href' => '/assets/my-script.js',
-     *     'as' => 'script',
-     *   ]
-     * );
-     * ```
-     *
-     * @param callable|array $preload
-     * @return self
-     */
-    public function preload($preload): self
-    {
-        if (is_callable($preload)) {
-            $this->preloads[] = $preload();
-        } elseif (is_array($preload)) {
-            $this->preloads[] = $preload;
-        }
-
-        return $this;
-    }
-
     public function extend(Container $container, Extension $extension = null)
     {
         $this->registerAssets($container, $this->getModuleName($extension));

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -283,7 +283,7 @@ class Frontend implements ExtenderInterface
             function (ActualFrontend $frontend, Container $container) {
                 $frontend->content(ContainerUtil::wrapCallback(function (Document $document) use ($container) {
                     foreach ($this->preloads as $preload) {
-                        $document->preload[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container)() : $preload;
+                        $document->preloads[] = is_callable($preload) ? $preload($document) : $preload;
                     }
                 }, $container));
             }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -281,7 +281,7 @@ class Frontend implements ExtenderInterface
         $container->resolving(
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
-                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) use ($container) {
+                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) {
                     foreach ($this->preloads as $preload) {
                         $document->preloads[] = is_callable($preload) ? $preload($document) : $preload;
                     }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -154,11 +154,7 @@ class Frontend implements ExtenderInterface
      */
     public function preloads($preloads): self
     {
-        if (is_callable($preloads)) {
-            $this->preloads = array_merge($this->preloads, $preloads());
-        } elseif (is_array($preloads)) {
-            $this->preloads = array_merge($this->preloads, $preloads);
-        }
+        $this->preloads = array_merge($this->preloads, $preloads);
 
         return $this;
     }
@@ -177,7 +173,7 @@ class Frontend implements ExtenderInterface
             return;
         }
 
-        $abstract = 'flarum.assets.'.$this->frontend;
+        $abstract = 'flarum.assets.' . $this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -201,7 +197,7 @@ class Frontend implements ExtenderInterface
             }
         });
 
-        if (! $container->bound($abstract)) {
+        if (!$container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });
@@ -285,8 +281,10 @@ class Frontend implements ExtenderInterface
         $container->resolving(
             "flarum.frontend.$this->frontend",
             function (ActualFrontend $frontend, Container $container) {
-                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) {
-                    $document->preloads = array_merge($document->preloads, $this->preloads);
+                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) use ($container) {
+                    foreach ($this->preloads as $preload) {
+                        $document->preload[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container)() : $preload;
+                    }
                 }, $container));
             }
         );

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -16,6 +16,7 @@ use Flarum\Foundation\ContainerUtil;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Frontend\Assets;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Frontend\Document;
 use Flarum\Frontend\Frontend as ActualFrontend;
 use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Http\RouteCollection;
@@ -33,6 +34,7 @@ class Frontend implements ExtenderInterface
     private $routes = [];
     private $removedRoutes = [];
     private $content = [];
+    private $preloads = [];
 
     /**
      * @param string $frontend: The name of the frontend.
@@ -124,11 +126,80 @@ class Frontend implements ExtenderInterface
         return $this;
     }
 
+    /**
+     * Adds multiple asset preloads.
+     * 
+     * The parameter should be an array of preload arrays, or a callable that returns this.
+     * 
+     * A preload array must contain keys that pertain to the `<link rel="preload">` tag.
+     * 
+     * For example, the following will add preload tags for a script and font file:
+     * ```
+     * $frontend->preloads([
+     *   [
+     *     'href' => '/assets/my-script.js',
+     *     'as' => 'script',
+     *   ],
+     *   [
+     *     'href' => '/assets/fonts/my-font.woff2',
+     *     'as' => 'font',
+     *     'type' => 'font/woff2',
+     *     'crossorigin' => ''
+     *   ]
+     * ]);
+     * ```
+     *
+     * @param callable|array $preloads
+     * @return self
+     */
+    public function preloads($preloads): self
+    {
+        if (is_callable($preloads)) {
+            $this->preloads = array_merge($this->preloads, $preloads());
+        } else if (is_array($preloads)) {
+            $this->preloads = array_merge($this->preloads, $preloads);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds a single asset preload.
+     * 
+     * The parameter should be a preload array, or a callable that returns one.
+     * 
+     * A preload array must contain keys that pertain to the `<link rel="preload">` tag.
+     * 
+     * For example, the following will add preload tags for a script:
+     * ```
+     * $frontend->preload(
+     *   [
+     *     'href' => '/assets/my-script.js',
+     *     'as' => 'script',
+     *   ]
+     * );
+     * ```
+     *
+     * @param callable|array $preload
+     * @return self
+     */
+    public function preload($preload): self
+    {
+        if (is_callable($preload)) {
+            $this->preloads[] = $preload();
+        } else if (is_array($preload)) {
+            $this->preloads[] = $preload;
+        }
+
+        return $this;
+    }
+
     public function extend(Container $container, Extension $extension = null)
     {
         $this->registerAssets($container, $this->getModuleName($extension));
         $this->registerRoutes($container);
         $this->registerContent($container);
+        $this->registerPreloads($container);
     }
 
     private function registerAssets(Container $container, string $moduleName): void
@@ -137,7 +208,7 @@ class Frontend implements ExtenderInterface
             return;
         }
 
-        $abstract = 'flarum.assets.'.$this->frontend;
+        $abstract = 'flarum.assets.' . $this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -161,7 +232,7 @@ class Frontend implements ExtenderInterface
             }
         });
 
-        if (! $container->bound($abstract)) {
+        if (!$container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });
@@ -232,6 +303,22 @@ class Frontend implements ExtenderInterface
                 foreach ($this->content as $content) {
                     $frontend->content(ContainerUtil::wrapCallback($content, $container));
                 }
+            }
+        );
+    }
+
+    private function registerPreloads(Container $container): void
+    {
+        if (empty($this->preloads)) {
+            return;
+        }
+
+        $container->resolving(
+            "flarum.frontend.$this->frontend",
+            function (ActualFrontend $frontend, Container $container) {
+                $frontend->content(ContainerUtil::wrapCallback(function (Document $document) {
+                    $document->preloads = array_merge($document->preloads, $this->preloads);
+                }, $container));
             }
         );
     }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -283,7 +283,7 @@ class Frontend implements ExtenderInterface
             function (ActualFrontend $frontend, Container $container) {
                 $frontend->content(function (Document $document) use ($container) {
                     foreach ($this->preloads as $preload) {
-                        $document->preloads[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container) : $preload;
+                        $document->preloads[] = is_callable($preload) ? ContainerUtil::wrapCallback($preload, $container)($document) : $preload;
                     }
                 });
             }

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -128,11 +128,11 @@ class Frontend implements ExtenderInterface
 
     /**
      * Adds multiple asset preloads.
-     * 
+     *
      * The parameter should be an array of preload arrays, or a callable that returns this.
-     * 
+     *
      * A preload array must contain keys that pertain to the `<link rel="preload">` tag.
-     * 
+     *
      * For example, the following will add preload tags for a script and font file:
      * ```
      * $frontend->preloads([
@@ -156,7 +156,7 @@ class Frontend implements ExtenderInterface
     {
         if (is_callable($preloads)) {
             $this->preloads = array_merge($this->preloads, $preloads());
-        } else if (is_array($preloads)) {
+        } elseif (is_array($preloads)) {
             $this->preloads = array_merge($this->preloads, $preloads);
         }
 
@@ -165,11 +165,11 @@ class Frontend implements ExtenderInterface
 
     /**
      * Adds a single asset preload.
-     * 
+     *
      * The parameter should be a preload array, or a callable that returns one.
-     * 
+     *
      * A preload array must contain keys that pertain to the `<link rel="preload">` tag.
-     * 
+     *
      * For example, the following will add preload tags for a script:
      * ```
      * $frontend->preload(
@@ -187,7 +187,7 @@ class Frontend implements ExtenderInterface
     {
         if (is_callable($preload)) {
             $this->preloads[] = $preload();
-        } else if (is_array($preload)) {
+        } elseif (is_array($preload)) {
             $this->preloads[] = $preload;
         }
 
@@ -208,7 +208,7 @@ class Frontend implements ExtenderInterface
             return;
         }
 
-        $abstract = 'flarum.assets.' . $this->frontend;
+        $abstract = 'flarum.assets.'.$this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -232,7 +232,7 @@ class Frontend implements ExtenderInterface
             }
         });
 
-        if (!$container->bound($abstract)) {
+        if (! $container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -173,7 +173,7 @@ class Frontend implements ExtenderInterface
             return;
         }
 
-        $abstract = 'flarum.assets.' . $this->frontend;
+        $abstract = 'flarum.assets.'.$this->frontend;
 
         $container->resolving($abstract, function (Assets $assets) use ($moduleName) {
             if ($this->js) {
@@ -197,7 +197,7 @@ class Frontend implements ExtenderInterface
             }
         });
 
-        if (!$container->bound($abstract)) {
+        if (! $container->bound($abstract)) {
             $container->bind($abstract, function (Container $container) {
                 return $container->make('flarum.assets.factory')($this->frontend);
             });

--- a/src/Extend/Frontend.php
+++ b/src/Extend/Frontend.php
@@ -154,7 +154,7 @@ class Frontend implements ExtenderInterface
      */
     public function preloads($preloads): self
     {
-        $this->preloads = array_merge($this->preloads, $preloads);
+        $this->preloads = array_merge($this->preloads, (array) $preloads);
 
         return $this;
     }

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -124,10 +124,10 @@ class Document implements Renderable
 
     /**
      * An array of preloaded assets.
-     * 
+     *
      * Each array item should be an array containing keys that pertain to the
      * `<link rel="preload">` tag.
-     * 
+     *
      * For example, the following will add a preload tag for a FontAwesome font file:
      * ```
      * $this->preloads[] = [
@@ -137,7 +137,7 @@ class Document implements Renderable
      *   'crossorigin' => ''
      * ];
      * ```
-     * 
+     *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
      *
      * @var array
@@ -204,7 +204,7 @@ class Document implements Renderable
     {
         $onHomePage = rtrim($this->request->getUri()->getPath(), '/') === '';
 
-        return ($this->title && !$onHomePage ? $this->title . ' - ' : '') . Arr::get($this->forumApiDocument, 'data.attributes.title');
+        return ($this->title && ! $onHomePage ? $this->title.' - ' : '').Arr::get($this->forumApiDocument, 'data.attributes.title');
     }
 
     /**
@@ -228,10 +228,10 @@ class Document implements Renderable
     protected function makePreloads(): array
     {
         return array_map(function ($preload) {
-            $attributes = "";
+            $attributes = '';
 
             foreach ($preload as $key => $value) {
-                $attributes .= " $key=\"" . e($value) . '"';
+                $attributes .= " $key=\"".e($value).'"';
             }
 
             return "<link rel=\"preload\"$attributes>";
@@ -244,17 +244,17 @@ class Document implements Renderable
     protected function makeHead(): string
     {
         $head = array_map(function ($url) {
-            return '<link rel="stylesheet" href="' . e($url) . '">';
+            return '<link rel="stylesheet" href="'.e($url).'">';
         }, $this->css);
 
         if ($this->canonicalUrl) {
-            $head[] = '<link rel="canonical" href="' . e($this->canonicalUrl) . '">';
+            $head[] = '<link rel="canonical" href="'.e($this->canonicalUrl).'">';
         }
 
         $head = array_merge($head, $this->makePreloads());
 
         $head = array_merge($head, array_map(function ($content, $name) {
-            return '<meta name="' . e($name) . '" content="' . e($content) . '">';
+            return '<meta name="'.e($name).'" content="'.e($content).'">';
         }, $this->meta, array_keys($this->meta)));
 
         return implode("\n", array_merge($head, $this->head));
@@ -266,7 +266,7 @@ class Document implements Renderable
     protected function makeJs(): string
     {
         return implode("\n", array_map(function ($url) {
-            return '<script src="' . e($url) . '"></script>';
+            return '<script src="'.e($url).'"></script>';
         }, $this->js));
     }
 

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -123,6 +123,28 @@ class Document implements Renderable
     public $css = [];
 
     /**
+     * An array of preloaded assets.
+     * 
+     * Each array item should be an array containing keys that pertain to the
+     * `<link rel="preload">` tag.
+     * 
+     * For example, the following will add a preload tag for a FontAwesome font file:
+     * ```
+     * $this->preloads[] = [
+     *   'href' => '/assets/fonts/fa-solid-900.woff2',
+     *   'as' => 'font',
+     *   'type' => 'font/woff2',
+     *   'crossorigin' => ''
+     * ];
+     * ```
+     * 
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+     *
+     * @var array
+     */
+    public $preloads = [];
+
+    /**
      * @var Factory
      */
     protected $view;
@@ -182,7 +204,7 @@ class Document implements Renderable
     {
         $onHomePage = rtrim($this->request->getUri()->getPath(), '/') === '';
 
-        return ($this->title && ! $onHomePage ? $this->title.' - ' : '').Arr::get($this->forumApiDocument, 'data.attributes.title');
+        return ($this->title && !$onHomePage ? $this->title . ' - ' : '') . Arr::get($this->forumApiDocument, 'data.attributes.title');
     }
 
     /**
@@ -203,21 +225,36 @@ class Document implements Renderable
         return $this->view->make($this->contentView)->with('content', $this->content);
     }
 
+    protected function makePreloads(): array
+    {
+        return array_map(function ($preload) {
+            $attributes = "";
+
+            foreach ($preload as $key => $value) {
+                $attributes .= " $key=\"" . e($value) . '"';
+            }
+
+            return "<link rel=\"preload\"$attributes>";
+        }, $this->preloads);
+    }
+
     /**
      * @return string
      */
     protected function makeHead(): string
     {
         $head = array_map(function ($url) {
-            return '<link rel="stylesheet" href="'.e($url).'">';
+            return '<link rel="stylesheet" href="' . e($url) . '">';
         }, $this->css);
 
         if ($this->canonicalUrl) {
-            $head[] = '<link rel="canonical" href="'.e($this->canonicalUrl).'">';
+            $head[] = '<link rel="canonical" href="' . e($this->canonicalUrl) . '">';
         }
 
+        $head = array_merge($head, $this->makePreloads());
+
         $head = array_merge($head, array_map(function ($content, $name) {
-            return '<meta name="'.e($name).'" content="'.e($content).'">';
+            return '<meta name="' . e($name) . '" content="' . e($content) . '">';
         }, $this->meta, array_keys($this->meta)));
 
         return implode("\n", array_merge($head, $this->head));
@@ -229,7 +266,7 @@ class Document implements Renderable
     protected function makeJs(): string
     {
         return implode("\n", array_map(function ($url) {
-            return '<script src="'.e($url).'"></script>';
+            return '<script src="' . e($url) . '"></script>';
         }, $this->js));
     }
 

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -32,7 +32,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 );
 
                 $assets->setLessImportDirs([
-                    $paths->vendor . '/components/font-awesome/less' => ''
+                    $paths->vendor.'/components/font-awesome/less' => ''
                 ]);
 
                 $assets->css([$this, 'addBaseCss']);
@@ -47,7 +47,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = 'flarum::frontend.' . $name;
+                    $document->layoutView = 'flarum::frontend.'.$name;
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));
@@ -113,7 +113,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
      */
     public function boot(Container $container, ViewFactory $views)
     {
-        $this->loadViewsFrom(__DIR__ . '/../../views', 'flarum');
+        $this->loadViewsFrom(__DIR__.'/../../views', 'flarum');
 
         $views->share([
             'translator' => $container->make('translator'),
@@ -123,8 +123,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
     public function addBaseCss(SourceCollector $sources)
     {
-        $sources->addFile(__DIR__ . '/../../less/common/variables.less');
-        $sources->addFile(__DIR__ . '/../../less/common/mixins.less');
+        $sources->addFile(__DIR__.'/../../less/common/variables.less');
+        $sources->addFile(__DIR__.'/../../less/common/mixins.less');
 
         $this->addLessVariables($sources);
     }
@@ -142,7 +142,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
             ];
 
             return array_reduce(array_keys($vars), function ($string, $name) use ($vars) {
-                return $string . "@$name: {$vars[$name]};";
+                return $string."@$name: {$vars[$name]};";
             }, '');
         });
     }

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -10,7 +10,6 @@
 namespace Flarum\Frontend;
 
 use Flarum\Foundation\AbstractServiceProvider;
-use Flarum\Foundation\Config;
 use Flarum\Foundation\Paths;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Http\UrlGenerator;
@@ -45,8 +44,6 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
         $this->container->singleton('flarum.frontend.factory', function (Container $container) {
             return function (string $name) use ($container) {
-                $config = $container[Config::class];
-
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
@@ -57,15 +54,17 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend->content($container->make(Content\CorePayload::class));
                 $frontend->content($container->make(Content\Meta::class));
 
-                $frontend->content(function (Document $document) use ($config) {
+                $frontend->content(function (Document $document) use ($container) {
+                    $filesystem = $container->make('filesystem')->disk('flarum-assets');
+
                     $fontawesome_preloads = [
                         [
-                            'href' => $config->url()->getPath().'/assets/fonts/fa-solid-900.woff2',
+                            'href' => $filesystem->url('fonts/fa-solid-900.woff2'),
                             'as' => 'font',
                             'type' => 'font/woff2',
                             'crossorigin' => ''
                         ], [
-                            'href' => $config->url()->getPath().'/assets/fonts/fa-regular-400.woff2',
+                            'href' => $filesystem->url('fonts/fa-regular-400.woff2'),
                             'as' => 'font',
                             'type' => 'font/woff2',
                             'crossorigin' => ''

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -10,6 +10,7 @@
 namespace Flarum\Frontend;
 
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
 use Flarum\Foundation\Paths;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Http\UrlGenerator;
@@ -32,7 +33,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 );
 
                 $assets->setLessImportDirs([
-                    $paths->vendor.'/components/font-awesome/less' => ''
+                    $paths->vendor . '/components/font-awesome/less' => ''
                 ]);
 
                 $assets->css([$this, 'addBaseCss']);
@@ -44,15 +45,38 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
         $this->container->singleton('flarum.frontend.factory', function (Container $container) {
             return function (string $name) use ($container) {
+                $config = $container[Config::class];
+
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = 'flarum::frontend.'.$name;
+                    $document->layoutView = 'flarum::frontend.' . $name;
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));
                 $frontend->content($container->make(Content\CorePayload::class));
                 $frontend->content($container->make(Content\Meta::class));
+
+                $frontend->content(function (Document $document) use ($config) {
+                    $default_preloads = [
+                        [
+                            'href' => $config->url()->getPath() . '/assets/fonts/fa-solid-900.woff2',
+                            'as' => 'font',
+                            'type' => 'font/woff2',
+                            'crossorigin' => ''
+                        ], [
+                            'href' => $config->url()->getPath() . '/assets/fonts/fa-regular-400.woff2',
+                            'as' => 'font',
+                            'type' => 'font/woff2',
+                            'crossorigin' => ''
+                        ]
+                    ];
+
+                    $document->preloads = array_merge(
+                        $document->preloads,
+                        $default_preloads
+                    );
+                });
 
                 return $frontend;
             };
@@ -64,7 +88,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
      */
     public function boot(Container $container, ViewFactory $views)
     {
-        $this->loadViewsFrom(__DIR__.'/../../views', 'flarum');
+        $this->loadViewsFrom(__DIR__ . '/../../views', 'flarum');
 
         $views->share([
             'translator' => $container->make('translator'),
@@ -74,8 +98,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
     public function addBaseCss(SourceCollector $sources)
     {
-        $sources->addFile(__DIR__.'/../../less/common/variables.less');
-        $sources->addFile(__DIR__.'/../../less/common/mixins.less');
+        $sources->addFile(__DIR__ . '/../../less/common/variables.less');
+        $sources->addFile(__DIR__ . '/../../less/common/mixins.less');
 
         $this->addLessVariables($sources);
     }
@@ -93,7 +117,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
             ];
 
             return array_reduce(array_keys($vars), function ($string, $name) use ($vars) {
-                return $string."@$name: {$vars[$name]};";
+                return $string . "@$name: {$vars[$name]};";
             }, '');
         });
     }

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -58,7 +58,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend->content($container->make(Content\Meta::class));
 
                 $frontend->content(function (Document $document) use ($config) {
-                    $default_preloads = [
+                    $fontawesome_preloads = [
                         [
                             'href' => $config->url()->getPath().'/assets/fonts/fa-solid-900.woff2',
                             'as' => 'font',
@@ -72,9 +72,29 @@ class FrontendServiceProvider extends AbstractServiceProvider
                         ]
                     ];
 
+                    // Add preloads for base CSS and JS assets. Extensions should add their own via the extender.
+                    $js_preloads = [];
+                    $css_preloads = [];
+
+                    foreach ($document->css as $url) {
+                        $css_preloads[] = [
+                            'href' => $url,
+                            'as' => 'style'
+                        ];
+                    }
+                    foreach ($document->js as $url) {
+                        $css_preloads[] = [
+                            'href' => $url,
+                            'as' => 'script'
+                        ];
+                    }
+
+
                     $document->preloads = array_merge(
                         $document->preloads,
-                        $default_preloads
+                        $fontawesome_preloads,
+                        $css_preloads,
+                        $js_preloads,
                     );
                 });
 

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -33,7 +33,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 );
 
                 $assets->setLessImportDirs([
-                    $paths->vendor . '/components/font-awesome/less' => ''
+                    $paths->vendor.'/components/font-awesome/less' => ''
                 ]);
 
                 $assets->css([$this, 'addBaseCss']);
@@ -50,7 +50,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = 'flarum::frontend.' . $name;
+                    $document->layoutView = 'flarum::frontend.'.$name;
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));
@@ -60,12 +60,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend->content(function (Document $document) use ($config) {
                     $default_preloads = [
                         [
-                            'href' => $config->url()->getPath() . '/assets/fonts/fa-solid-900.woff2',
+                            'href' => $config->url()->getPath().'/assets/fonts/fa-solid-900.woff2',
                             'as' => 'font',
                             'type' => 'font/woff2',
                             'crossorigin' => ''
                         ], [
-                            'href' => $config->url()->getPath() . '/assets/fonts/fa-regular-400.woff2',
+                            'href' => $config->url()->getPath().'/assets/fonts/fa-regular-400.woff2',
                             'as' => 'font',
                             'type' => 'font/woff2',
                             'crossorigin' => ''
@@ -88,7 +88,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
      */
     public function boot(Container $container, ViewFactory $views)
     {
-        $this->loadViewsFrom(__DIR__ . '/../../views', 'flarum');
+        $this->loadViewsFrom(__DIR__.'/../../views', 'flarum');
 
         $views->share([
             'translator' => $container->make('translator'),
@@ -98,8 +98,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
     public function addBaseCss(SourceCollector $sources)
     {
-        $sources->addFile(__DIR__ . '/../../less/common/variables.less');
-        $sources->addFile(__DIR__ . '/../../less/common/mixins.less');
+        $sources->addFile(__DIR__.'/../../less/common/variables.less');
+        $sources->addFile(__DIR__.'/../../less/common/mixins.less');
 
         $this->addLessVariables($sources);
     }
@@ -117,7 +117,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
             ];
 
             return array_reduce(array_keys($vars), function ($string, $name) use ($vars) {
-                return $string . "@$name: {$vars[$name]};";
+                return $string."@$name: {$vars[$name]};";
             }, '');
         });
     }

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -90,10 +90,10 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     }
 
                     $document->preloads = array_merge(
-                        $document->preloads,
-                        $fontawesome_preloads,
                         $css_preloads,
                         $js_preloads,
+                        $fontawesome_preloads,
+                        $document->preloads,
                     );
                 });
 

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -32,7 +32,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 );
 
                 $assets->setLessImportDirs([
-                    $paths->vendor.'/components/font-awesome/less' => ''
+                    $paths->vendor . '/components/font-awesome/less' => ''
                 ]);
 
                 $assets->css([$this, 'addBaseCss']);
@@ -47,7 +47,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = 'flarum::frontend.'.$name;
+                    $document->layoutView = 'flarum::frontend.' . $name;
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));
@@ -55,21 +55,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 $frontend->content($container->make(Content\Meta::class));
 
                 $frontend->content(function (Document $document) use ($container) {
-                    $filesystem = $container->make('filesystem')->disk('flarum-assets');
-
-                    $fontawesome_preloads = [
-                        [
-                            'href' => $filesystem->url('fonts/fa-solid-900.woff2'),
-                            'as' => 'font',
-                            'type' => 'font/woff2',
-                            'crossorigin' => ''
-                        ], [
-                            'href' => $filesystem->url('fonts/fa-regular-400.woff2'),
-                            'as' => 'font',
-                            'type' => 'font/woff2',
-                            'crossorigin' => ''
-                        ]
-                    ];
+                    $default_preloads = $container->make('flarum.frontend.default_preloads');
 
                     // Add preloads for base CSS and JS assets. Extensions should add their own via the extender.
                     $js_preloads = [];
@@ -91,7 +77,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     $document->preloads = array_merge(
                         $css_preloads,
                         $js_preloads,
-                        $fontawesome_preloads,
+                        $default_preloads,
                         $document->preloads,
                     );
                 });
@@ -99,6 +85,27 @@ class FrontendServiceProvider extends AbstractServiceProvider
                 return $frontend;
             };
         });
+
+        $this->container->singleton(
+            'flarum.frontend.default_preloads',
+            function (Container $container) {
+                $filesystem = $container->make('filesystem')->disk('flarum-assets');
+
+                return [
+                    [
+                        'href' => $filesystem->url('fonts/fa-solid-900.woff2'),
+                        'as' => 'font',
+                        'type' => 'font/woff2',
+                        'crossorigin' => ''
+                    ], [
+                        'href' => $filesystem->url('fonts/fa-regular-400.woff2'),
+                        'as' => 'font',
+                        'type' => 'font/woff2',
+                        'crossorigin' => ''
+                    ]
+                ];
+            }
+        );
     }
 
     /**
@@ -106,7 +113,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
      */
     public function boot(Container $container, ViewFactory $views)
     {
-        $this->loadViewsFrom(__DIR__.'/../../views', 'flarum');
+        $this->loadViewsFrom(__DIR__ . '/../../views', 'flarum');
 
         $views->share([
             'translator' => $container->make('translator'),
@@ -116,8 +123,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
     public function addBaseCss(SourceCollector $sources)
     {
-        $sources->addFile(__DIR__.'/../../less/common/variables.less');
-        $sources->addFile(__DIR__.'/../../less/common/mixins.less');
+        $sources->addFile(__DIR__ . '/../../less/common/variables.less');
+        $sources->addFile(__DIR__ . '/../../less/common/mixins.less');
 
         $this->addLessVariables($sources);
     }
@@ -135,7 +142,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
             ];
 
             return array_reduce(array_keys($vars), function ($string, $name) use ($vars) {
-                return $string."@$name: {$vars[$name]};";
+                return $string . "@$name: {$vars[$name]};";
             }, '');
         });
     }

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -89,7 +89,6 @@ class FrontendServiceProvider extends AbstractServiceProvider
                         ];
                     }
 
-
                     $document->preloads = array_merge(
                         $document->preloads,
                         $fontawesome_preloads,

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -43,53 +43,7 @@ class FrontendPreloadTest extends TestCase
     /**
      * @test
      */
-    public function single_preload_can_be_added()
-    {
-        $url = $this->customPreloadUrls[0];
-
-        $this->extend(
-            (new Extend\Frontend('forum'))
-                ->preload([
-                    'href' => $url,
-                ])
-        );
-
-        $response = $this->send(
-            $this->request('GET', '/')
-        );
-        $body = $response->getBody()->getContents();
-
-        $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
-    }
-
-    /**
-     * @test
-     */
-    public function single_preload_can_be_added_via_callable()
-    {
-        $url = $this->customPreloadUrls[0];
-
-        $this->extend(
-            (new Extend\Frontend('forum'))
-                ->preload(function () use ($url) {
-                    return [
-                        'href' => $url,
-                    ];
-                })
-        );
-
-        $response = $this->send(
-            $this->request('GET', '/')
-        );
-        $body = $response->getBody()->getContents();
-
-        $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
-    }
-
-    /**
-     * @test
-     */
-    public function multiple_preloads_can_be_added()
+    public function preloads_can_be_added()
     {
         $urls = $this->customPreloadUrls;
 
@@ -115,7 +69,7 @@ class FrontendPreloadTest extends TestCase
     /**
      * @test
      */
-    public function multiple_preloads_can_be_added_via_callable()
+    public function preloads_can_be_added_via_callable()
     {
         $urls = $this->customPreloadUrls;
 

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -26,11 +26,11 @@ class FrontendPreloadTest extends TestCase
             $this->request('GET', '/')
         );
 
-        $assetsPath = $this->app()->getContainer()->make(Config::class)->url()->getPath() . '/assets';
+        $assetsPath = $this->app()->getContainer()->make(Config::class)->url()->getPath().'/assets';
 
         $urls = [
-            $assetsPath . '/fonts/fa-solid-900.woff2',
-            $assetsPath . '/fonts/fa-regular-400.woff2',
+            $assetsPath.'/fonts/fa-solid-900.woff2',
+            $assetsPath.'/fonts/fa-regular-400.woff2',
         ];
 
         $body = $response->getBody()->getContents();
@@ -50,7 +50,7 @@ class FrontendPreloadTest extends TestCase
         $this->extend(
             (new Extend\Frontend('forum'))
                 ->preload([
-                    "href" => $url,
+                    'href' => $url,
                 ])
         );
 
@@ -73,7 +73,7 @@ class FrontendPreloadTest extends TestCase
             (new Extend\Frontend('forum'))
                 ->preload(function () use ($url) {
                     return [
-                        "href" => $url,
+                        'href' => $url,
                     ];
                 })
         );

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -26,11 +26,11 @@ class FrontendPreloadTest extends TestCase
             $this->request('GET', '/')
         );
 
-        $assetsPath = $this->app()->getContainer()->make(Config::class)->url()->getPath().'/assets';
+        $filesystem = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
 
         $urls = [
-            $assetsPath.'/fonts/fa-solid-900.woff2',
-            $assetsPath.'/fonts/fa-regular-400.woff2',
+            $filesystem->url('fonts/fa-solid-900.woff2'),
+            $filesystem->url('fonts/fa-regular-400.woff2'),
         ];
 
         $body = $response->getBody()->getContents();

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -10,7 +10,6 @@
 namespace Flarum\Tests\integration\extenders;
 
 use Flarum\Extend;
-use Flarum\Foundation\Config;
 use Flarum\Testing\integration\TestCase;
 
 class FrontendPreloadTest extends TestCase

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -36,7 +36,7 @@ class FrontendPreloadTest extends TestCase
         $body = $response->getBody()->getContents();
 
         foreach ($urls as $url) {
-            $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\" as=\"font\" as=\"font/woff2\" crossorigin=\"\">", $body);
+            $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\" as=\"font\" type=\"font/woff2\" crossorigin=\"\">", $body);
         }
     }
 

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -95,7 +95,7 @@ class FrontendPreloadTest extends TestCase
 
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->preload(
+                ->preloads(
                     array_map(function ($url) {
                         return ['href' => $url];
                     }, $urls)
@@ -121,7 +121,7 @@ class FrontendPreloadTest extends TestCase
 
         $this->extend(
             (new Extend\Frontend('forum'))
-                ->preload(function () use ($urls) {
+                ->preloads(function () use ($urls) {
                     return array_map(function ($url) {
                         return ['href' => $url];
                     }, $urls);

--- a/tests/integration/extenders/FrontendPreloadTest.php
+++ b/tests/integration/extenders/FrontendPreloadTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extenders;
+
+use Flarum\Extend;
+use Flarum\Foundation\Config;
+use Flarum\Testing\integration\TestCase;
+
+class FrontendPreloadTest extends TestCase
+{
+    private $customPreloadUrls = ['/my-preload', '/my-preload2'];
+
+    /**
+     * @test
+     */
+    public function default_preloads_are_present()
+    {
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+
+        $assetsPath = $this->app()->getContainer()->make(Config::class)->url()->getPath() . '/assets';
+
+        $urls = [
+            $assetsPath . '/fonts/fa-solid-900.woff2',
+            $assetsPath . '/fonts/fa-regular-400.woff2',
+        ];
+
+        $body = $response->getBody()->getContents();
+
+        foreach ($urls as $url) {
+            $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\" as=\"font\" as=\"font/woff2\" crossorigin=\"\">", $body);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function single_preload_can_be_added()
+    {
+        $url = $this->customPreloadUrls[0];
+
+        $this->extend(
+            (new Extend\Frontend('forum'))
+                ->preload([
+                    "href" => $url,
+                ])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+        $body = $response->getBody()->getContents();
+
+        $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
+    }
+
+    /**
+     * @test
+     */
+    public function single_preload_can_be_added_via_callable()
+    {
+        $url = $this->customPreloadUrls[0];
+
+        $this->extend(
+            (new Extend\Frontend('forum'))
+                ->preload(function () use ($url) {
+                    return [
+                        "href" => $url,
+                    ];
+                })
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+        $body = $response->getBody()->getContents();
+
+        $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
+    }
+
+    /**
+     * @test
+     */
+    public function multiple_preloads_can_be_added()
+    {
+        $urls = $this->customPreloadUrls;
+
+        $this->extend(
+            (new Extend\Frontend('forum'))
+                ->preload(
+                    array_map(function ($url) {
+                        return ['href' => $url];
+                    }, $urls)
+                )
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+        $body = $response->getBody()->getContents();
+
+        foreach ($urls as $url) {
+            $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function multiple_preloads_can_be_added_via_callable()
+    {
+        $urls = $this->customPreloadUrls;
+
+        $this->extend(
+            (new Extend\Frontend('forum'))
+                ->preload(function () use ($urls) {
+                    return array_map(function ($url) {
+                        return ['href' => $url];
+                    }, $urls);
+                })
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+        $body = $response->getBody()->getContents();
+
+        foreach ($urls as $url) {
+            $this->assertStringContainsString("<link rel=\"preload\" href=\"$url\">", $body);
+        }
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2741**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Adds support for preloads in `Document`
- Adds `preload()` and `preloads()` methods to Frontend extender
- Adds default preloads for FontAwesome fonts
- Adds default preloads for core JS and CSS assets

The benefits of preloading FontAwesome are that these would normally only be fetched when CSS parsing is complete, which is often.

Preloading JS and CSS only makes a difference if we're preloading FontAwesome already. Browsers classify preloads as higher priority requests, meaning they would stall downloads of our JS/CSS until these are done. Adding these as preloads prevents this, and they are all fetched at once.

**Overall, preloading results in a consistently faster page load time.** Almost always 100-150ms faster, sometimes reaching 200ms+. If/when themes and other extensions begin preloading their assets, this could increase further.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
My failure to write/comprehend PHP and my blatant disregard for helpers and simplicity.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/130876531-02786c88-0210-4248-88b3-9b85c641529a.png)

## With preloads

![image](https://user-images.githubusercontent.com/7406822/130876691-cf46955e-aca8-4d5a-8a43-6922c705c2a5.png)

## Without preloads

![image](https://user-images.githubusercontent.com/7406822/130876715-6a01c2f9-7288-4da8-94e2-1f66c4c64057.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR:
