### PR TITLE
fix: Unable to use permission grid dropdowns

### DIFF
--- a/less/admin/PermissionsPage.less
+++ b/less/admin/PermissionsPage.less
@@ -78,7 +78,7 @@
       position: sticky;
       left: 0;
       padding-right: 50px;
-      z-index: 2;
+      z-index: 4;
       background: inherit;
 
       .icon {
@@ -143,7 +143,6 @@
 
   td, th {
     position: relative;
-    z-index: 0;
   }
   th {
     font-weight: normal;


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixes a regression introduced in #2887, I had suggested a change here: https://github.com/flarum/core/pull/2887#pullrequestreview-690047538

But that ended up preventing clicking on dropdown items, making the permission grid unusable.

**Screenshot**

Before | After
--- | ---
![flarum lan_admin (3)](https://user-images.githubusercontent.com/20267363/132091602-e8820ddb-a5a3-4f4c-ab28-e7ad231a1c62.png) | ![flarum lan_admin (2)](https://user-images.githubusercontent.com/20267363/132091605-50d35847-2aed-43fb-84ce-51390c1e5896.png)


**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
