### PR TITLE
Use `author` filter parameter instead of `q` with gambit to get a user's discussions on the `DiscussionsUserPage`

### DIFF
--- a/js/src/forum/components/DiscussionsUserPage.js
+++ b/js/src/forum/components/DiscussionsUserPage.js
@@ -17,7 +17,7 @@ export default class DiscussionsUserPage extends UserPage {
     super.show(user);
 
     this.state = new DiscussionListState({
-      q: 'author:' + user.username(),
+      filter: { author: user.username() },
       sort: 'newest',
     });
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Changed the way the request for listing discussions on the user profile is constructed: before a gambit was used with the `q` filter parameter, now the `author` parameter is used instead. This makes it possible for extensions to use other filter parameters for this request because if the `q` parameter is used, all the other filter parameters are ignored.

**Reviewers should focus on:**
Checking if `DiscussionsUserPage` still works as expected.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
