### PR TITLE
Centralize pagination/canonical meta URL generation in Document

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -628,6 +628,11 @@ core:
       submit_button: => core.ref.save_changes
       title: => core.ref.reset_your_password
 
+    # Translations in this namespace are used to format page meta titles.
+    meta_titles:
+      with_page_title: "{pageNumber, plural, =1 {{pageTitle} - {forumName}} other {{pageTitle}: Page # - {forumName}}}"
+      without_page_title: "{pageNumber, plural, =1 {{forumName}} other {Page # - {forumName}}}"
+
   # Translations in this namespace are used in messages output by the API.
   api:
     invalid_username_message: "The username may only contain letters, numbers, and dashes."

--- a/src/Forum/Content/Discussion.php
+++ b/src/Forum/Content/Discussion.php
@@ -97,9 +97,12 @@ class Discussion
         $hasNextPage = $page < 1 + intval($apiDocument->data->attributes->commentCount / 20);
 
         $document->title = $apiDocument->data->attributes->title;
-        $document->canonicalUrl = $url(['page' => $page]);
         $document->content = $this->view->make('flarum.forum::frontend.content.discussion', compact('apiDocument', 'page', 'hasPrevPage', 'hasNextPage', 'getResource', 'posts', 'url'));
         $document->payload['apiDocument'] = $apiDocument;
+
+        $document->canonicalUrl = $url([]);
+        $document->page = $page;
+        $document->hasNextPage = $hasNextPage;
 
         return $document;
     }

--- a/src/Forum/Content/Index.php
+++ b/src/Forum/Content/Index.php
@@ -88,7 +88,10 @@ class Index
         $document->title = $this->translator->trans('core.forum.index.meta_title_text');
         $document->content = $this->view->make('flarum.forum::frontend.content.index', compact('apiDocument', 'page'));
         $document->payload['apiDocument'] = $apiDocument;
+
         $document->canonicalUrl = $this->url->to('forum')->base().($defaultRoute === '/all' ? '' : $request->getUri()->getPath());
+        $document->page = $page;
+        $document->hasNextPage = isset($apiDocument->links->next);
 
         return $document;
     }

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -97,19 +97,19 @@ class Document implements Renderable
 
     /**
      * Which page of content are we on?
-     * 
+     *
      * This is used to build prev/next meta links for SEO.
-     * 
+     *
      * @var null|int
      */
     public $page;
 
     /**
      * Is there a next page?
-     * 
+     *
      * This is used with $page to build next meta links for SEO.
-     * 
-     * @var null|boolean
+     *
+     * @var null|bool
      */
     public $hasNextPage;
 
@@ -263,10 +263,10 @@ class Document implements Renderable
 
         if ($this->page) {
             if ($this->page > 1) {
-                $head[] = '<link rel="prev" href="' . e(self::setPageParam($this->canonicalUrl, $this->page - 1)) . '">';
+                $head[] = '<link rel="prev" href="'.e(self::setPageParam($this->canonicalUrl, $this->page - 1)).'">';
             }
             if ($this->hasNextPage) {
-                $head[] = '<link rel="next" href="' . e(self::setPageParam($this->canonicalUrl, $this->page + 1)) . '">';
+                $head[] = '<link rel="next" href="'.e(self::setPageParam($this->canonicalUrl, $this->page + 1)).'">';
             }
         }
 
@@ -317,8 +317,9 @@ class Document implements Renderable
         $this->forumApiDocument = $forumApiDocument;
     }
 
-    public static function setPageParam(string $url, ?int $page) {
-        if (!$page || $page === 1) {
+    public static function setPageParam(string $url, ?int $page)
+    {
+        if (! $page || $page === 1) {
             return self::setQueryParam($url, 'page', null);
         }
 
@@ -342,13 +343,13 @@ class Document implements Renderable
                 }
 
                 $urlParts['query'] = http_build_query($urlQueryArgs);
-                $newUrl = $urlParts['scheme'] . '://' . $urlParts['host'] . $urlParts['path'] . '?' . $urlParts['query'];
+                $newUrl = $urlParts['scheme'].'://'.$urlParts['host'].$urlParts['path'].'?'.$urlParts['query'];
             } elseif ($value !== null) {
-                $newUrl = $url . '?' . http_build_query([$key => $value]);
+                $newUrl = $url.'?'.http_build_query([$key => $value]);
             } else {
                 return $url;
             }
-        
+
             return $newUrl;
         } else {
             return $url;

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * A view which renders a HTML skeleton for Flarum's frontend app.
@@ -218,7 +219,7 @@ class Document implements Renderable
     protected function makeTitle(): string
     {
         // @todo v2.0 inject as dependency instead
-        return resolve(TitleDriverInterface::class)->makeTitle($this, $this->request, $this->forumApiDocument);
+        return resolve(TitleDriverInterface::class)->makeTitle($this, $this->request, resolve(TranslatorInterface::class), $this->forumApiDocument);
     }
 
     /**
@@ -329,7 +330,7 @@ class Document implements Renderable
     /**
      * Set or override a query param on a string URL to a particular value.
      */
-    public static function setQueryParam(string $url, string $key, ?string $value)
+    protected static function setQueryParam(string $url, string $key, ?string $value)
     {
         if (filter_var($url, FILTER_VALIDATE_URL)) {
             $urlParts = parse_url($url);

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -15,7 +15,6 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * A view which renders a HTML skeleton for Flarum's frontend app.
@@ -219,7 +218,7 @@ class Document implements Renderable
     protected function makeTitle(): string
     {
         // @todo v2.0 inject as dependency instead
-        return resolve(TitleDriverInterface::class)->makeTitle($this, $this->request, resolve(TranslatorInterface::class), $this->forumApiDocument);
+        return resolve(TitleDriverInterface::class)->makeTitle($this, $this->request, $this->forumApiDocument);
     }
 
     /**

--- a/src/Frontend/Document.php
+++ b/src/Frontend/Document.php
@@ -96,6 +96,24 @@ class Document implements Renderable
     public $canonicalUrl;
 
     /**
+     * Which page of content are we on?
+     * 
+     * This is used to build prev/next meta links for SEO.
+     * 
+     * @var null|int
+     */
+    public $page;
+
+    /**
+     * Is there a next page?
+     * 
+     * This is used with $page to build next meta links for SEO.
+     * 
+     * @var null|boolean
+     */
+    public $hasNextPage;
+
+    /**
      * An array of strings to append to the page's <head>.
      *
      * @var array
@@ -243,8 +261,17 @@ class Document implements Renderable
             return '<link rel="stylesheet" href="'.e($url).'">';
         }, $this->css);
 
+        if ($this->page) {
+            if ($this->page > 1) {
+                $head[] = '<link rel="prev" href="' . e(self::setPageParam($this->canonicalUrl, $this->page - 1)) . '">';
+            }
+            if ($this->hasNextPage) {
+                $head[] = '<link rel="next" href="' . e(self::setPageParam($this->canonicalUrl, $this->page + 1)) . '">';
+            }
+        }
+
         if ($this->canonicalUrl) {
-            $head[] = '<link rel="canonical" href="'.e($this->canonicalUrl).'">';
+            $head[] = '<link rel="canonical" href="'.e(self::setPageParam($this->canonicalUrl, $this->page)).'">';
         }
 
         $head = array_merge($head, $this->makePreloads());
@@ -288,5 +315,43 @@ class Document implements Renderable
     public function setForumApiDocument(array $forumApiDocument)
     {
         $this->forumApiDocument = $forumApiDocument;
+    }
+
+    public static function setPageParam(string $url, ?int $page) {
+        if (!$page || $page === 1) {
+            return self::setQueryParam($url, 'page', null);
+        }
+
+        return self::setQueryParam($url, 'page', (string) $page);
+    }
+
+    /**
+     * Set or override a query param on a string URL to a particular value.
+     */
+    public static function setQueryParam(string $url, string $key, ?string $value)
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+            $urlParts = parse_url($url);
+            if (isset($urlParts['query'])) {
+                parse_str($urlParts['query'], $urlQueryArgs);
+
+                if ($value === null) {
+                    unset($urlQueryArgs[$key]);
+                } else {
+                    $urlQueryArgs[$key] = $value;
+                }
+
+                $urlParts['query'] = http_build_query($urlQueryArgs);
+                $newUrl = $urlParts['scheme'] . '://' . $urlParts['host'] . $urlParts['path'] . '?' . $urlParts['query'];
+            } elseif ($value !== null) {
+                $newUrl = $url . '?' . http_build_query([$key => $value]);
+            } else {
+                return $url;
+            }
+        
+            return $newUrl;
+        } else {
+            return $url;
+        }
     }
 }

--- a/src/Frontend/Driver/BasicTitleDriver.php
+++ b/src/Frontend/Driver/BasicTitleDriver.php
@@ -16,7 +16,17 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BasicTitleDriver implements TitleDriverInterface
 {
-    public function makeTitle(Document $document, ServerRequestInterface $request, TranslatorInterface $translator, array $forumApiDocument): string
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function makeTitle(Document $document, ServerRequestInterface $request, array $forumApiDocument): string
     {
         $onHomePage = rtrim($request->getUri()->getPath(), '/') === '';
 
@@ -27,7 +37,7 @@ class BasicTitleDriver implements TitleDriverInterface
         ];
 
         return $onHomePage || ! $document->title
-            ? $translator->trans('core.views.meta_titles.without_page_title', $params)
-            : $translator->trans('core.views.meta_titles.with_page_title', $params);
+            ? $this->translator->trans('core.views.meta_titles.without_page_title', $params)
+            : $this->translator->trans('core.views.meta_titles.with_page_title', $params);
     }
 }

--- a/src/Frontend/Driver/BasicTitleDriver.php
+++ b/src/Frontend/Driver/BasicTitleDriver.php
@@ -12,13 +12,22 @@ namespace Flarum\Frontend\Driver;
 use Flarum\Frontend\Document;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BasicTitleDriver implements TitleDriverInterface
 {
-    public function makeTitle(Document $document, ServerRequestInterface $request, array $forumApiDocument): string
+    public function makeTitle(Document $document, ServerRequestInterface $request, TranslatorInterface $translator, array $forumApiDocument): string
     {
         $onHomePage = rtrim($request->getUri()->getPath(), '/') === '';
 
-        return ($document->title && ! $onHomePage ? $document->title.' - ' : '').Arr::get($forumApiDocument, 'data.attributes.title');
+        $params = [
+            'pageTitle' => $document->title ?? '',
+            'forumName' => Arr::get($forumApiDocument, 'data.attributes.title'),
+            'pageNumber' => $document->page ?? 1,
+        ];
+
+        return $onHomePage || !$document->title
+            ? $translator->trans('core.views.meta_titles.without_page_title', $params)
+            : $translator->trans('core.views.meta_titles.with_page_title', $params);
     }
 }

--- a/src/Frontend/Driver/BasicTitleDriver.php
+++ b/src/Frontend/Driver/BasicTitleDriver.php
@@ -26,7 +26,7 @@ class BasicTitleDriver implements TitleDriverInterface
             'pageNumber' => $document->page ?? 1,
         ];
 
-        return $onHomePage || !$document->title
+        return $onHomePage || ! $document->title
             ? $translator->trans('core.views.meta_titles.without_page_title', $params)
             : $translator->trans('core.views.meta_titles.with_page_title', $params);
     }

--- a/src/Frontend/Driver/TitleDriverInterface.php
+++ b/src/Frontend/Driver/TitleDriverInterface.php
@@ -11,9 +11,8 @@ namespace Flarum\Frontend\Driver;
 
 use Flarum\Frontend\Document;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 interface TitleDriverInterface
 {
-    public function makeTitle(Document $document, ServerRequestInterface $request, TranslatorInterface $translator, array $forumApiDocument): string;
+    public function makeTitle(Document $document, ServerRequestInterface $request, array $forumApiDocument): string;
 }

--- a/src/Frontend/Driver/TitleDriverInterface.php
+++ b/src/Frontend/Driver/TitleDriverInterface.php
@@ -11,8 +11,9 @@ namespace Flarum\Frontend\Driver;
 
 use Flarum\Frontend\Document;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 interface TitleDriverInterface
 {
-    public function makeTitle(Document $document, ServerRequestInterface $request, array $forumApiDocument): string;
+    public function makeTitle(Document $document, ServerRequestInterface $request, TranslatorInterface $translator, array $forumApiDocument): string;
 }


### PR DESCRIPTION
Currently, our Document class does not support generating meta prev/next URLs. With this PR, content can set `page` and `hasNextPage` on the `Document` object. This, in turn, will appropriately generate next/prev links, and configure the canonical URL properly.

**Questions for Reviewers:**
As part of this, we introduce a helper function to add/override/remove params from URLs. Is this the best place for it?

As an alternative approach, we could create a generic `AbstractPaginatedContent` class with methods, and move logic into there. Then, Document would just have public fields for `nextPageUrl` and `prevPageUrl`. This would let Document focus on arrangement/presentation, and avoid hardcoding logic for a pagination scheme. On the other hand, if we have centralized, defined logic for a pagination scheme, we're less likely to run into issues.