### PR TITLE
Filter composer icon array to only valid values

### DIFF
--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -283,6 +283,14 @@ class Extension implements Arrayable
     {
         $properties = $this->getIcon();
 
+        if (empty($properties)) {
+            return '';
+        }
+
+        $properties = array_filter($properties, function ($item) {
+            return ! is_array($item);
+        });
+
         unset($properties['name']);
 
         return implode(';', array_map(function (string $property, string $value) {

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -288,7 +288,7 @@ class Extension implements Arrayable
         }
 
         $properties = array_filter($properties, function ($item) {
-            return ! is_array($item);
+            return is_string($item);
         });
 
         unset($properties['name']);


### PR DESCRIPTION
**Fixes #3078**

**Changes proposed in this pull request:**
If an extension has objects within the icon object in composer.json, it leads to the error reported. So we filter out the values to make sure that doesn't occur.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
