### PR TITLE
fix: Anchors should not have `type="button"`

### DIFF
--- a/js/src/common/components/LinkButton.js
+++ b/js/src/common/components/LinkButton.js
@@ -27,6 +27,7 @@ export default class LinkButton extends Button {
 
     vdom.tag = Link;
     vdom.attrs.active = String(vdom.attrs.active);
+    delete vdom.attrs.type;
 
     return vdom;
   }


### PR DESCRIPTION
**Closes #3085**

**Changes proposed in this pull request:**
#3015 introduced button appearance for any `type="button"` element, which doesn't affect styling for most browsers, except for iOS Safari, the styling only affects anchors with `type="button"`. Our `LinkButton` component extends the `Button` component which has a type attribute that defaults to `button`, which is unnecessary for anchors anyway.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
