### PR TITLE
Disallow dashes in database prefix

### DIFF
--- a/src/Install/DatabaseConfig.php
+++ b/src/Install/DatabaseConfig.php
@@ -87,8 +87,8 @@ class DatabaseConfig implements Arrayable
         }
 
         if (! empty($this->prefix)) {
-            if (! preg_match('/^[\pL\pM\pN_-]+$/u', $this->prefix)) {
-                throw new ValidationFailed('The prefix may only contain characters, dashes and underscores.');
+            if (! preg_match('/^[\pL\pM\pN_]+$/u', $this->prefix)) {
+                throw new ValidationFailed('The prefix may only contain characters and underscores.');
             }
 
             if (strlen($this->prefix) > 10) {


### PR DESCRIPTION
As a temporary fix it has been requested to disallow dashes in the database prefix. The installation process fails when the prefix does include a dash.

#3022

--
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**#3022*

**Changes proposed in this pull request:**
The install process will now throw an error when the database prefix contains a dash.


**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
