### PR TITLE
Added new translations for the user editting issue

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -516,7 +516,7 @@ core:
       title: => core.ref.edit_user
       username_heading: => core.ref.username
       username_label: => core.ref.username
-      nothing_available: You are not allowed to edit this user.,
+      nothing_available: You are not allowed to edit this user.
 
     # These translations are displayed as error messages.
     error:


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2899**

**Changes proposed in this pull request:**
Added a new translation key and value that will tell the user they are not allowed to edit the `user`.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
