### PR TITLE
Add README documentation to ExtensionPage

### DIFF
--- a/js/src/admin/components/ExtensionPage.js
+++ b/js/src/admin/components/ExtensionPage.js
@@ -11,6 +11,7 @@ import LoadingModal from './LoadingModal';
 import ExtensionPermissionGrid from './ExtensionPermissionGrid';
 import isExtensionEnabled from '../utils/isExtensionEnabled';
 import AdminPage from './AdminPage';
+import ReadmeModal from './ReadmeModal';
 
 export default class ExtensionPage extends AdminPage {
   oninit(vnode) {
@@ -194,6 +195,21 @@ export default class ExtensionPage extends AdminPage {
         );
       }
     });
+
+    const extension = this.extension;
+    items.add(
+      'readme',
+      Button.component(
+        {
+          icon: 'fab fa-readme',
+          class: 'Readme-link',
+          onclick() {
+            app.modal.show(ReadmeModal, { extension });
+          },
+        },
+        app.translator.trans('core.admin.extension.readme.button_label')
+      )
+    );
 
     return items;
   }

--- a/js/src/admin/components/ReadmeModal.js
+++ b/js/src/admin/components/ReadmeModal.js
@@ -1,0 +1,57 @@
+import app from '../../admin/app';
+import Modal from '../../common/components/Modal';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Placeholder from '../../common/components/Placeholder';
+
+export default class ReadmeModal extends Modal {
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    this.name = this.attrs.extension.id;
+    this.displayName = this.attrs.extension.extra['flarum-extension'].title;
+
+    this.loading = true;
+
+    this.loadReadme();
+  }
+
+  className() {
+    return 'ReadmeModal Modal--large';
+  }
+
+  title() {
+    const name = this.displayName;
+    return app.translator.trans('core.admin.extension.readme.title', {
+      displayName: name,
+    });
+  }
+
+  content() {
+    const text = app.translator.trans('core.admin.extension.readme.no_readme');
+    return (
+      <div className="container">
+        {this.loading ? (
+          <div className="ReadmeModal-loading">{LoadingIndicator.component()}</div>
+        ) : (
+          <div>{this.readme.content ? m.trust(this.readme.content) : Placeholder.component({ text })}</div>
+        )}
+      </div>
+    );
+  }
+
+  loadReadme() {
+    app
+      .request({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/extensions/readme/' + this.name,
+      })
+      .then(this.parseResponse.bind(this));
+  }
+
+  parseResponse(response) {
+    this.readme = response.data.attributes;
+
+    this.loading = false;
+    m.redraw();
+  }
+}

--- a/less/admin/ExtensionPage.less
+++ b/less/admin/ExtensionPage.less
@@ -149,3 +149,16 @@
   display: inline-block;
   margin-left: 8px;
 }
+
+.Readme-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: @muted-color;
+}
+
+.ReadmeModal {
+  img {
+      max-width: 100%;
+  }
+}

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -131,6 +131,10 @@ core:
       open_modal: Open Settings
       permissions_title: Permissions
       uninstall_button: Uninstall
+      readme:
+        button_label: Documentation
+        title: "{displayName} documentation"
+        no_readme: This extension does not appear to have a README file
 
     # These translations are used in the secondary header.
     header:

--- a/src/Api/Controller/ReadmeController.php
+++ b/src/Api/Controller/ReadmeController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Api\Serializer\ReadmeSerializer;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Http\RequestUtil;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface;
+use s9e\TextFormatter\Bundles\Fatdown;
+use stdClass;
+use Tobscure\JsonApi\Document;
+
+class ReadmeController extends AbstractShowController
+{
+    protected $extensions;
+
+    public $serializer = ReadmeSerializer::class;
+
+    public function __construct(ExtensionManager $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    protected function data(ServerRequestInterface $request, Document $document)
+    {
+        $extensionName = Arr::get($request->getQueryParams(), 'name');
+
+        RequestUtil::getActor($request)->assertAdmin();
+
+        return $this->getReadme($extensionName);
+    }
+
+    private function getReadme(string $extensionName): stdClass
+    {
+        $readme = new stdClass();
+        $readme->id = $extensionName;
+
+        $ext = $this->extensions->getExtension($extensionName);
+
+        if (!$ext) {
+            return $readme;
+        }
+
+        $extPath = $ext->getPath();
+
+        if (file_exists("$extPath/README.md")) {
+            $readme->content = \file_get_contents("$extPath/README.md");
+        } else if (file_exists("$extPath/README")) {
+            $readme->content = \file_get_contents("$extPath/README");
+        } else {
+            $readme->content = null;
+        }
+
+        if ($readme->content) {
+            $xml = Fatdown::parse($readme->content);
+            $readme->content = Fatdown::render($xml);
+        }
+
+        return $readme;
+    }
+}

--- a/src/Api/Serializer/ReadmeSerializer.php
+++ b/src/Api/Serializer/ReadmeSerializer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Flarum\Api\Serializer;
+
+use Flarum\Api\Serializer\AbstractSerializer;
+
+class ReadmeSerializer extends AbstractSerializer
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $type = 'readme';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultAttributes($readme): array
+    {
+        $attributes = [];
+
+        if ($this->actor->isAdmin() && !empty($readme->content)) {
+            $attributes = [
+                'content' => $readme->content,
+            ];
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Api/routes.php
+++ b/src/Api/routes.php
@@ -258,6 +258,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\UninstallExtensionController::class)
     );
 
+    // Get readme for an extension
+    $map->get(
+        '/extensions/readme/{name}',
+        'extensions.readme',
+        $route->toController(Controller\ReadmeController::class)
+    );
+
     // Update settings
     $map->post(
         '/settings',


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds a button to display an extensions `README` file within a modal directly from the `ExtensionPage`

**Reviewers should focus on:**
This is _almost_ a "lift and shift" from `blomstra/readme`. Did I forget any core conventions when migrating this? 

**Screenshot**
![image](https://user-images.githubusercontent.com/16573496/136180875-07dfd0f7-2e82-480f-95e3-82c6fb2e2a88.png)
![image](https://user-images.githubusercontent.com/16573496/136180929-91153b9f-7106-437f-ac3f-9a46b7ea915e.png)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
