### PR TITLE
Added ES6 local support for formatNumber helper as per #2951

### DIFF
--- a/js/src/common/utils/formatNumber.ts
+++ b/js/src/common/utils/formatNumber.ts
@@ -9,7 +9,5 @@ import app from '../../forum/app';
  * // 1,234
  */
 export default function formatNumber(number: number, locale: string = app.data.locale): string {
-  return new Intl
-    .NumberFormat(locale)
-    .format(number);
+  return new Intl.NumberFormat(locale).format(number);
 }


### PR DESCRIPTION
https://github.com/flarum/core/issues/2951

**Changes proposed in this pull request:**

Updated `formatNumber` helper to use ES6 method to format numbers via provided locale. Unsure how to grab the current user's locale to inject when the helper is used in `PostStreamScrubber.js`. Would `app.session.user.locale` work if it's not necessarily set?

**Confirmed**

- [x] Frontend change
