### PR TITLE
Catch errors when uploading white avatar

### DIFF
--- a/js/src/common/models/User.js
+++ b/js/src/common/models/User.js
@@ -89,8 +89,18 @@ Object.assign(User.prototype, {
     const user = this;
 
     image.onload = function () {
-      const colorThief = new ColorThief();
-      user.avatarColor = colorThief.getColor(this);
+      try {
+        const colorThief = new ColorThief();
+        user.avatarColor = colorThief.getColor(this);
+      } catch (e) {
+        // Completely white avatars throw errors due to a glitch in color thief
+        // See https://github.com/lokesh/color-thief/issues/40
+        if (e instanceof TypeError) {
+          user.avatarColor = [255, 255, 255];
+        } else {
+          throw e;
+        }
+      }
       user.freshness = new Date();
       m.redraw();
     };


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2714**

**Changes proposed in this pull request:**
Catch errors in color thief; if the error corresponds to the one thrown when completely white avatars are uploaded, silence the error and directly set the `avatarColor` value.

**Reviewers should focus on:**
Unfortunately JS doesn't really provide us with a cleaner way to catch only this error. I'm hesitant to check for the contents of the error message since it's quite generic.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
