### PR TITLE
Fix mail settings select component never being used

### DIFF
--- a/js/src/admin/components/MailPage.js
+++ b/js/src/admin/components/MailPage.js
@@ -79,7 +79,7 @@ export default class MailPage extends AdminPage {
 
                 return [
                   this.buildSettingComponent({
-                    type: typeof this.setting(field)() === 'string' ? 'text' : 'select',
+                    type: typeof fieldInfo === 'string' ? 'text' : 'select',
                     label: app.translator.trans(`core.admin.email.${field}_label`),
                     setting: field,
                     options: fieldInfo,


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixes a regression introduced in beta 16 with #2593 where the select-style mail settings stopped being rendered as selects. This affects the Mailgun region select which becomes a text input without any help as to what should be entered.

**Screenshot**
Beta 15:
![image](https://user-images.githubusercontent.com/5264300/138558192-1188a4c4-0aad-44a6-9de2-84cc63114cf9.png)

Flarum 1.1:
![image](https://user-images.githubusercontent.com/5264300/138558208-0286d272-9137-471b-82ea-d3515d17120a.png)

After fix:
![image](https://user-images.githubusercontent.com/5264300/138558223-08306db4-ecd8-4e5f-9374-9061f15dccc0.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
