### PR TITLE
Pass IP address to API Client pipeline

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -132,6 +132,7 @@ class Client
 
         if ($this->parent) {
             $request = $request
+                ->withAttribute('ipAddress', $this->parent->getAttribute('ipAddress'))
                 ->withAttribute('session', $this->parent->getAttribute('session'));
             $request = RequestUtil::withActor($request, RequestUtil::getActor($this->parent));
         }


### PR DESCRIPTION
**Fixes #2985**

**Changes proposed in this pull request:**
Uses parent request's IP address for API client request.
The `ProcessIp` middleware won't run twice as that's in the global middleware stack, which the API client doesn't go through.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
