### PR TITLE
Hide webkit search button

### DIFF
--- a/less/common/Search.less
+++ b/less/common/Search.less
@@ -1,6 +1,12 @@
 .Search {
   position: relative;
 
+  // TODO v2.0 check if this is supported by Firefox,
+  // if so, consider switching to it.
+  ::-webkit-search-cancel-button {
+    display: none;
+  }
+
   &-clear {
     // It looks very weird due to the padding given to the button..
     &:focus {


### PR DESCRIPTION
**Fixes #3126**

**Changes proposed in this pull request:**
Hide the button, as it's not standard. Add a comment so we revisit it eventually, in case more browsers add support.

Tested locally.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
