### PR TITLE
Allow extensions to modify MIN_SEARCH_LENGTH in Search component

### DIFF
--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -52,7 +52,10 @@ export interface SearchAttrs extends ComponentAttrs {
  * - state: SearchState instance.
  */
 export default class Search<T extends SearchAttrs = SearchAttrs> extends Component<T> {
-  static MIN_SEARCH_LEN = 3;
+  /**
+   * The minimum query length before sources are searched.
+   */
+  protected static MIN_SEARCH_LEN = 3;
 
   protected state!: SearchState;
 
@@ -211,7 +214,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
         search.searchTimeout = setTimeout(() => {
           if (state.isCached(query)) return;
 
-          if (query.length >= Search.MIN_SEARCH_LEN) {
+          if (query.length >= (search.constructor as typeof Search).MIN_SEARCH_LEN) {
             search.sources.map((source) => {
               if (!source.search) return;
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3129**

**Changes proposed in this pull request:**
- Use `this.constructor` instead of accessing the parent class directly to allow subclasses to modify `MIN_SEARCH_LEN` static

**Reviewers should focus on:**
- Perhaps clarifying wording of docblock

**Screenshot**
No user facing changes in core itself. This is helpful for `fof/merge-discussions`, changing the min search length to 1:

![image](https://user-images.githubusercontent.com/6401250/139093453-4e23bdc5-c6a3-45dc-97c5-1805c7f4f4b3.png)



**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.
