### PR TITLE
Pass null/falsy values through Model.getIdentifier

### DIFF
--- a/js/src/common/Model.js
+++ b/js/src/common/Model.js
@@ -313,9 +313,11 @@ export default class Model {
    * @protected
    */
   static getIdentifier(model) {
-    return {
-      type: model.data.type,
-      id: model.data.id,
-    };
+    return (
+      model && {
+        type: model.data.type,
+        id: model.data.id,
+      }
+    );
   }
 }

--- a/js/src/common/Model.js
+++ b/js/src/common/Model.js
@@ -313,11 +313,11 @@ export default class Model {
    * @protected
    */
   static getIdentifier(model) {
-    return (
-      model && {
-        type: model.data.type,
-        id: model.data.id,
-      }
-    );
+    if (!model) return model;
+
+    return {
+      type: model.data.type,
+      id: model.data.id,
+    };
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #2876**

**Changes proposed in this pull request:**
- Return `model` in `Model.getIdentifier` if falsy

**Reviewers should focus on:**
- Do we just want to handle `null` or all falsy values?
  - I think handling all is better as they're still visible in the request data, so should be easy to debug
  - I also think we should pass through the actual value instead of returning `null`, so that we don't modify the data (would add confusion)
- Do we want to handle falsy/non-object `model.data`?
  - Personally I don't think so, as that would probably be an actual bug and not intentional. Having the error appear is probably the preferred situation.
- Do we want an `if` statement instead to make the code clearer?
- Do we want to handle this in `getIdentifier` method?

**Screenshots**
Before
![image](https://user-images.githubusercontent.com/6401250/139100626-37f9247a-f4be-4807-abb6-3fdf3448818b.png)

After
![image](https://user-images.githubusercontent.com/6401250/139100785-841828f0-2049-4d80-9f5d-00c92d812117.png)



**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.
