### PR TITLE
fix: issue with CSS styles when in-between whole pixel values for viewport width

### DIFF
--- a/less/common/variables.less
+++ b/less/common/variables.less
@@ -121,7 +121,7 @@
 
 // We use `-0.02` here to fix an odd rendering glitch with specific operating system UI scaling, and combined
 // with specific viewport sizes. This can result in the browser actually being 'between' media queries, which
-/ breaks our UI. See: https://github.com/flarum/core/issues/2915
+// breaks our UI. See: https://github.com/flarum/core/issues/2915
 
 @screen-phone-max:                 (@screen-tablet - 0.02);
 


### PR DESCRIPTION
**Fixes #2915**

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Fixes issue where custom UI scaling, combined with specific viewport widths, would result in a broken UI.

This will not fix extensions which use explicit media queries rather than our built-in variable-based ones.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
