### PR TITLE
Remove color validation in appearance admin page & add color indicator

### DIFF
--- a/js/src/@types/global.d.ts
+++ b/js/src/@types/global.d.ts
@@ -16,6 +16,8 @@ declare type KeysOfType<Type extends object, Match> = {
  */
 declare type KeyOfType<Type extends object, Match> = KeysOfType<Type, Match>[keyof Type];
 
+declare type VnodeElementTag<Attrs = Record<string, unknown>, State = Record<string, unknown>> = string | ComponentTypes<Attrs, State>
+
 /**
  * @deprecated Please import `app` from a namespace instead of using it as a global variable.
  *

--- a/js/src/@types/global.d.ts
+++ b/js/src/@types/global.d.ts
@@ -16,7 +16,7 @@ declare type KeysOfType<Type extends object, Match> = {
  */
 declare type KeyOfType<Type extends object, Match> = KeysOfType<Type, Match>[keyof Type];
 
-declare type VnodeElementTag<Attrs = Record<string, unknown>, State = Record<string, unknown>> = string | ComponentTypes<Attrs, State>
+declare type VnodeElementTag<Attrs = Record<string, unknown>, State = Record<string, unknown>> = string | ComponentTypes<Attrs, State>;
 
 /**
  * @deprecated Please import `app` from a namespace instead of using it as a global variable.

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -272,9 +272,11 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
 
         if ((ColorSettingTypes as readonly string[]).includes(type)) {
           Tag = ColorInput;
+        } else {
+          componentAttrs.type = type;
         }
 
-        settingElement = <Tag id={inputId} aria-describedby={helpTextId} type={type} bidi={this.setting(setting)} {...componentAttrs} />;
+        settingElement = <Tag id={inputId} aria-describedby={helpTextId} bidi={this.setting(setting)} {...componentAttrs} />;
       }
     }
 

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -61,6 +61,7 @@ interface CommonSettingsItemOptions extends Mithril.Attributes {
   label: Mithril.Children;
   help?: Mithril.Children;
   className?: string;
+  formGroupAttrs?: Mithril.Attributes;
 }
 
 /**
@@ -218,7 +219,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       return entry.call(this);
     }
 
-    const { setting, help, type, label, ...componentAttrs } = entry;
+    const { setting, help, type, label, formGroupAttrs = {}, ...componentAttrs } = entry;
 
     const value = this.setting(setting)();
 

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -10,7 +10,7 @@ import Stream from '../../common/utils/Stream';
 import saveSettings from '../utils/saveSettings';
 import AdminHeader from './AdminHeader';
 import generateElementId from '../utils/generateElementId';
-import ColorInput from '../../common/components/ColorInput';
+import ColorPreviewInput from '../../common/components/ColorPreviewInput';
 
 export interface AdminHeaderOptions {
   title: string;
@@ -77,7 +77,7 @@ export interface HTMLInputSettingsComponentOptions extends CommonSettingsItemOpt
 const BooleanSettingTypes = ['bool', 'checkbox', 'switch', 'boolean'] as const;
 const SelectSettingTypes = ['select', 'dropdown', 'selectdropdown'] as const;
 const TextareaSettingTypes = ['textarea'] as const;
-const ColorSettingTypes = ['color-input', 'color-preview', 'custom-color'] as const;
+const ColorPreviewSettingType = 'color-preview';
 
 /**
  * Valid options for the setting component builder to generate a Switch.
@@ -107,9 +107,12 @@ export interface TextareaSettingComponentOptions extends CommonSettingsItemOptio
 
 /**
  * Valid options for the setting component builder to generate a ColorInput.
+=======
+ * Valid options for the setting component builder to generate a ColorPreviewInput.
+>>>>>>> c10922974 (Rename component to ColorPreviewInput, remove aliases in admin & export in compat)
  */
-export interface ColorSettingComponentOptions extends CommonSettingsItemOptions {
-  type: typeof ColorSettingTypes[number];
+export interface ColorPreviewSettingComponentOptions extends CommonSettingsItemOptions {
+  type: typeof ColorPreviewSettingType;
 }
 
 /**
@@ -120,7 +123,7 @@ export type SettingsComponentOptions =
   | SwitchSettingComponentOptions
   | SelectSettingComponentOptions
   | TextareaSettingComponentOptions
-  | ColorSettingComponentOptions;
+  | ColorPreviewSettingComponentOptions;
 
 /**
  * Valid attrs that can be returned by the `headerInfo` function
@@ -270,8 +273,8 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       } else {
         let Tag: any = 'input';
 
-        if ((ColorSettingTypes as readonly string[]).includes(type)) {
-          Tag = ColorInput;
+        if (type === ColorPreviewSettingType) {
+          Tag = ColorPreviewInput;
         } else {
           componentAttrs.type = type;
         }

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -10,6 +10,7 @@ import Stream from '../../common/utils/Stream';
 import saveSettings from '../utils/saveSettings';
 import AdminHeader from './AdminHeader';
 import generateElementId from '../utils/generateElementId';
+import ColorInput from '../../common/components/ColorInput';
 
 export interface AdminHeaderOptions {
   title: string;
@@ -77,6 +78,7 @@ export interface HTMLInputSettingsComponentOptions extends CommonSettingsItemOpt
 const BooleanSettingTypes = ['bool', 'checkbox', 'switch', 'boolean'] as const;
 const SelectSettingTypes = ['select', 'dropdown', 'selectdropdown'] as const;
 const TextareaSettingTypes = ['textarea'] as const;
+const ColorSettingTypes = ['color-input', 'color-preview', 'custom-color'] as const;
 
 /**
  * Valid options for the setting component builder to generate a Switch.
@@ -105,13 +107,21 @@ export interface TextareaSettingComponentOptions extends CommonSettingsItemOptio
 }
 
 /**
+ * Valid options for the setting component builder to generate a ColorInput.
+ */
+export interface ColorSettingComponentOptions extends CommonSettingsItemOptions {
+  type: typeof ColorSettingTypes[number];
+}
+
+/**
  * All valid options for the setting component builder.
  */
 export type SettingsComponentOptions =
   | HTMLInputSettingsComponentOptions
   | SwitchSettingComponentOptions
   | SelectSettingComponentOptions
-  | TextareaSettingComponentOptions;
+  | TextareaSettingComponentOptions
+  | ColorSettingComponentOptions;
 
 /**
  * Valid attrs that can be returned by the `headerInfo` function
@@ -259,7 +269,13 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       if ((TextareaSettingTypes as readonly string[]).includes(type)) {
         settingElement = <textarea id={inputId} aria-describedby={helpTextId} bidi={this.setting(setting)} {...componentAttrs} />;
       } else {
-        settingElement = <input id={inputId} aria-describedby={helpTextId} type={type} bidi={this.setting(setting)} {...componentAttrs} />;
+        let Tag: any = 'input';
+
+        if ((ColorSettingTypes as readonly string[]).includes(type)) {
+          Tag = ColorInput;
+        }
+
+        settingElement = <Tag id={inputId} aria-describedby={helpTextId} type={type} bidi={this.setting(setting)} {...componentAttrs} />;
       }
     }
 

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -62,7 +62,6 @@ interface CommonSettingsItemOptions extends Mithril.Attributes {
   label: Mithril.Children;
   help?: Mithril.Children;
   className?: string;
-  formGroupAttrs?: Mithril.Attributes;
 }
 
 /**
@@ -229,7 +228,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       return entry.call(this);
     }
 
-    const { setting, help, type, label, formGroupAttrs = {}, ...componentAttrs } = entry;
+    const { setting, help, type, label, ...componentAttrs } = entry;
 
     const value = this.setting(setting)();
 

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -268,7 +268,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
       if ((TextareaSettingTypes as readonly string[]).includes(type)) {
         settingElement = <textarea id={inputId} aria-describedby={helpTextId} bidi={this.setting(setting)} {...componentAttrs} />;
       } else {
-        let Tag: any = 'input';
+        let Tag: VnodeElementTag = 'input';
 
         if (type === ColorPreviewSettingType) {
           Tag = ColorPreviewInput;

--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -106,10 +106,7 @@ export interface TextareaSettingComponentOptions extends CommonSettingsItemOptio
 }
 
 /**
- * Valid options for the setting component builder to generate a ColorInput.
-=======
  * Valid options for the setting component builder to generate a ColorPreviewInput.
->>>>>>> c10922974 (Rename component to ColorPreviewInput, remove aliases in admin & export in compat)
  */
 export interface ColorPreviewSettingComponentOptions extends CommonSettingsItemOptions {
   type: typeof ColorPreviewSettingType;

--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -28,11 +28,17 @@ export default class AppearancePage extends AdminPage {
               type: 'text',
               setting: 'theme_primary_color',
               placeholder: '#aaaaaa',
+              formGroupAttrs: {
+                style: { '--input-value': this.setting('theme_primary_color')() },
+              },
             })}
             {this.buildSettingComponent({
               type: 'text',
               setting: 'theme_secondary_color',
               placeholder: '#aaaaaa',
+              formGroupAttrs: {
+                style: { '--input-value': this.setting('theme_secondary_color')() },
+              },
             })}
           </div>
 
@@ -104,18 +110,5 @@ export default class AppearancePage extends AdminPage {
 
   onsaved() {
     window.location.reload();
-  }
-
-  saveSettings(e) {
-    e.preventDefault();
-
-    const hex = /^#[0-9a-f]{3}([0-9a-f]{3})?$/i;
-
-    if (!hex.test(this.settings['theme_primary_color']()) || !hex.test(this.settings['theme_secondary_color']())) {
-      alert(app.translator.trans('core.admin.appearance.enter_hex_message'));
-      return;
-    }
-
-    super.saveSettings(e);
   }
 }

--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -25,20 +25,14 @@ export default class AppearancePage extends AdminPage {
 
           <div className="AppearancePage-colors-input">
             {this.buildSettingComponent({
-              type: 'text',
+              type: 'color-preview',
               setting: 'theme_primary_color',
               placeholder: '#aaaaaa',
-              formGroupAttrs: {
-                style: { '--input-value': this.setting('theme_primary_color')() },
-              },
             })}
             {this.buildSettingComponent({
-              type: 'text',
+              type: 'color-preview',
               setting: 'theme_secondary_color',
               placeholder: '#aaaaaa',
-              formGroupAttrs: {
-                style: { '--input-value': this.setting('theme_secondary_color')() },
-              },
             })}
           </div>
 

--- a/js/src/common/compat.js
+++ b/js/src/common/compat.js
@@ -56,6 +56,7 @@ import Alert from './components/Alert';
 import Link from './components/Link';
 import LinkButton from './components/LinkButton';
 import Checkbox from './components/Checkbox';
+import ColorPreviewInput from './components/ColorPreviewInput';
 import SelectDropdown from './components/SelectDropdown';
 import ModalManager from './components/ModalManager';
 import Button from './components/Button';
@@ -140,6 +141,7 @@ export default {
   'components/Link': Link,
   'components/LinkButton': LinkButton,
   'components/Checkbox': Checkbox,
+  'components/ColorPreviewInput': ColorPreviewInput,
   'components/SelectDropdown': SelectDropdown,
   'components/ModalManager': ModalManager,
   'components/Button': Button,

--- a/js/src/common/components/ColorInput.tsx
+++ b/js/src/common/components/ColorInput.tsx
@@ -11,6 +11,8 @@ export default class ColorInput extends Component {
     const { className, ...attrs } = this.attrs;
     const value = attrs.bidi?.() || attrs.value;
 
+    attrs.type ||= 'text';
+
     return (
       <div className="ColorInput">
         <input className={classList('FormControl', className)} {...attrs} />

--- a/js/src/common/components/ColorInput.tsx
+++ b/js/src/common/components/ColorInput.tsx
@@ -12,12 +12,12 @@ export default class ColorInput extends Component {
     const value = attrs.bidi?.() || attrs.value;
 
     return (
-      <div className="Color-input">
+      <div className="ColorInput">
         <input className={classList('FormControl', className)} {...attrs} />
 
-        <span className="Color-input--icon">{icon('fas fa-exclamation-circle')}</span>
+        <span className="ColorInput-icon">{icon('fas fa-exclamation-circle')}</span>
 
-        <div className="Color-input--preview" style={{ '--input-value': value }} />
+        <div className="ColorInput-preview" style={{ '--input-value': value }} />
       </div>
     );
   }

--- a/js/src/common/components/ColorInput.tsx
+++ b/js/src/common/components/ColorInput.tsx
@@ -1,0 +1,24 @@
+import type Mithril from 'mithril';
+
+import Component, { ComponentAttrs } from '../Component';
+import classList from '../utils/classList';
+import icon from '../helpers/icon';
+
+export default class ColorInput extends Component {
+  value?: string;
+
+  view(vnode: Mithril.Vnode<ComponentAttrs, this>) {
+    const { className, ...attrs } = this.attrs;
+    const value = attrs.bidi?.() || attrs.value;
+
+    return (
+      <div className="Color-input">
+        <input className={classList('FormControl', className)} {...attrs} />
+
+        <span className="Color-input--icon">{icon('fas fa-exclamation-circle')}</span>
+
+        <div className="Color-input--preview" style={{ '--input-value': value }} />
+      </div>
+    );
+  }
+}

--- a/js/src/common/components/ColorPreviewInput.tsx
+++ b/js/src/common/components/ColorPreviewInput.tsx
@@ -17,9 +17,9 @@ export default class ColorPreviewInput extends Component {
       <div className="ColorInput">
         <input className={classList('FormControl', className)} {...attrs} />
 
-        <span className="ColorInput-icon">{icon('fas fa-exclamation-circle')}</span>
+        <span className="ColorInput-icon" role="presentation">{icon('fas fa-exclamation-circle')}</span>
 
-        <div className="ColorInput-preview" style={{ '--input-value': value }} />
+        <div className="ColorInput-preview" style={{ '--input-value': value }} role="presentation" />
       </div>
     );
   }

--- a/js/src/common/components/ColorPreviewInput.tsx
+++ b/js/src/common/components/ColorPreviewInput.tsx
@@ -4,7 +4,7 @@ import Component, { ComponentAttrs } from '../Component';
 import classList from '../utils/classList';
 import icon from '../helpers/icon';
 
-export default class ColorInput extends Component {
+export default class ColorPreviewInput extends Component {
   value?: string;
 
   view(vnode: Mithril.Vnode<ComponentAttrs, this>) {

--- a/js/src/common/components/ColorPreviewInput.tsx
+++ b/js/src/common/components/ColorPreviewInput.tsx
@@ -17,7 +17,9 @@ export default class ColorPreviewInput extends Component {
       <div className="ColorInput">
         <input className={classList('FormControl', className)} {...attrs} />
 
-        <span className="ColorInput-icon" role="presentation">{icon('fas fa-exclamation-circle')}</span>
+        <span className="ColorInput-icon" role="presentation">
+          {icon('fas fa-exclamation-circle')}
+        </span>
 
         <div className="ColorInput-preview" style={{ '--input-value': value }} role="presentation" />
       </div>

--- a/less/admin/AppearancePage.less
+++ b/less/admin/AppearancePage.less
@@ -16,26 +16,12 @@
   overflow: hidden;
 
   .Form-group {
-    position: relative;
     display: inline-block;
   }
 
   .Form-group:last-child {
     margin-bottom: 24px !important;
     margin-left: 10px;
-  }
-
-  .Form-group::after {
-    content: '';
-    display: inline-block;
-    position: absolute;
-    right: 13px;
-    bottom: 8px;
-    width: 20px;
-    height: 20px;
-    background-color: var(--input-value);
-    border-radius: 15%;
-    pointer-events: none;
   }
 }
 

--- a/less/admin/AppearancePage.less
+++ b/less/admin/AppearancePage.less
@@ -16,6 +16,7 @@
   overflow: hidden;
 
   .Form-group {
+    position: relative;
     display: inline-block;
   }
 
@@ -24,12 +25,17 @@
     margin-left: 10px;
   }
 
-  input {
-    float: left;
-
-    &:first-child {
-      margin-right: 2%;
-    }
+  .Form-group::after {
+    content: '';
+    display: inline-block;
+    position: absolute;
+    right: 13px;
+    bottom: 8px;
+    width: 20px;
+    height: 20px;
+    background-color: var(--input-value);
+    border-radius: 15%;
+    pointer-events: none;
   }
 }
 

--- a/less/common/ColorInput.less
+++ b/less/common/ColorInput.less
@@ -1,0 +1,22 @@
+.Color-input {
+  position: relative;
+
+  &--preview, &--icon {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    width: 20px;
+    height: 20px;
+    pointer-events: none;
+  }
+
+  &--preview {
+    background-color: var(--input-value);
+    border-radius: 15%;
+  }
+
+  &--icon {
+    text-align: center;
+    color: @validation-error-color;
+  }
+}

--- a/less/common/ColorInput.less
+++ b/less/common/ColorInput.less
@@ -1,7 +1,7 @@
-.Color-input {
+.ColorInput {
   position: relative;
 
-  &--preview, &--icon {
+  &-preview, &-icon {
     position: absolute;
     right: 8px;
     bottom: 8px;
@@ -10,12 +10,12 @@
     pointer-events: none;
   }
 
-  &--preview {
+  &-preview {
     background-color: var(--input-value);
     border-radius: 15%;
   }
 
-  &--icon {
+  &-icon {
     text-align: center;
     color: @validation-error-color;
   }

--- a/less/common/common.less
+++ b/less/common/common.less
@@ -17,6 +17,7 @@
 @import "Badge";
 @import "Button";
 @import "Checkbox";
+@import "ColorInput";
 @import "Dropdown";
 @import "EditUserModal";
 @import "Form";


### PR DESCRIPTION
**Fixes #2121**

**Changes proposed in this pull request:**
- Remove color validation in appearance page
- Add color indicator to inputs

**Reviewers should focus on:**
- Color validation can be done with dummy HTML elements, but from the issue comments I don't think we want to validate at all.
- After making this I thought this might be a good use for a new component like `ColorInput` or something? That way it also avoids using `::after` for the box... though a component would have to be an entire form group.
  - Perhaps a setting type instead? Though `type="color"` is also a valid input type.
  - FYI, `input::after` is not valid so that's why I had to add it to Form-group

**Screenshot**

![image](https://user-images.githubusercontent.com/6401250/139504470-ab9d31ef-1bf0-4884-b3aa-e51707f064db.png)


**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
