### PR TITLE
Remove 'typeof' in 'typeof this' from AdminPage#buildSettingComponent params

### DIFF
--- a/js/src/admin/components/AdminPage.tsx
+++ b/js/src/admin/components/AdminPage.tsx
@@ -201,7 +201,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
    *   return <p>My cool component</p>;
    * }
    */
-  buildSettingComponent(entry: ((this: typeof this) => Mithril.Children) | SettingsComponentOptions): Mithril.Children {
+  buildSettingComponent(entry: ((this: this) => Mithril.Children) | SettingsComponentOptions): Mithril.Children {
     if (typeof entry === 'function') {
       return entry.call(this);
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Jetbrains dies with `typeof this`, so I removed `typeof` as the functionality seems to remain with `this: this`
  - VSCode seems to parse it as `this: this` anyways

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Screenshots of IDEs before change:

_PhpStorm_
![image](https://user-images.githubusercontent.com/6401250/139507731-5c8141fc-c794-497c-bf1b-d454ca4446bc.png)

_VSCode_
![image](https://user-images.githubusercontent.com/6401250/139507750-5ebd47ae-d99a-4796-a520-c31100e6ba33.png)
![image](https://user-images.githubusercontent.com/6401250/139507755-e88338b9-56a5-4789-bccc-a7a8d2708d69.png)



**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
  - It can't be; it's TypeScript
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?
