### PR TITLE
Fix post policy for PHP 8

### DIFF
--- a/src/Post/Access/PostPolicy.php
+++ b/src/Post/Access/PostPolicy.php
@@ -58,7 +58,7 @@ class PostPolicy extends AbstractPolicy
 
             if ($allowEditing === '-1'
                 || ($allowEditing === 'reply' && $post->number >= $post->discussion->last_post_number)
-                || ($post->created_at->diffInMinutes(new Carbon) < $allowEditing)) {
+                || (is_numeric($allowEditing) && $post->created_at->diffInMinutes(new Carbon) < $allowEditing)) {
                 return $this->allow();
             }
         }

--- a/tests/integration/post/PostPolicyTest.php
+++ b/tests/integration/post/PostPolicyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\post;
+
+use Carbon\Carbon;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+
+class PostPolicyTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 2],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
+            ],
+            'users' => [
+                $this->normalUser(),
+            ]
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @test
+     */
+    public function edit_indefinitely()
+    {
+        $this->setting('allow_post_editing', '-1');
+        $this->app();
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+    }
+
+    /**
+     * @test
+     */
+    public function edit_until_reply()
+    {
+        $this->setting('allow_post_editing', 'reply');
+        $this->app();
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+    }
+
+    /**
+     * @test
+     */
+    public function edit_10_minutes()
+    {
+        $this->setting('allow_post_editing', '10');
+        $this->app();
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
+        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+    }
+}

--- a/tests/integration/post/PostPolicyTest.php
+++ b/tests/integration/post/PostPolicyTest.php
@@ -55,17 +55,21 @@ class PostPolicyTest extends TestCase
         $this->setting('allow_post_editing', '-1');
         $this->app();
 
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
         // Date close to "now"
         Carbon::setTestNow('2021-11-01 13:00:05');
 
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertTrue($user->can('edit', $earlierPost));
+        $this->assertTrue($user->can('edit', $lastPost));
 
         // Date further into the future
         Carbon::setTestNow('2025-01-01 13:00:00');
 
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertTrue($user->can('edit', $earlierPost));
+        $this->assertTrue($user->can('edit', $lastPost));
     }
 
     /**
@@ -76,17 +80,21 @@ class PostPolicyTest extends TestCase
         $this->setting('allow_post_editing', 'reply');
         $this->app();
 
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
         // Date close to "now"
         Carbon::setTestNow('2021-11-01 13:00:05');
 
-        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertFalse($user->can('edit', $earlierPost));
+        $this->assertTrue($user->can('edit', $lastPost));
 
         // Date further into the future
         Carbon::setTestNow('2025-01-01 13:00:00');
 
-        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertFalse($user->can('edit', $earlierPost));
+        $this->assertTrue($user->can('edit', $lastPost));
     }
 
     /**
@@ -97,16 +105,20 @@ class PostPolicyTest extends TestCase
         $this->setting('allow_post_editing', '10');
         $this->app();
 
+        $user = User::findOrFail(2);
+        $earlierPost = Post::findOrFail(1);
+        $lastPost = Post::findOrFail(2);
+
         // Date close to "now"
         Carbon::setTestNow('2021-11-01 13:00:05');
 
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertTrue(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertTrue($user->can('edit', $earlierPost));
+        $this->assertTrue($user->can('edit', $lastPost));
 
         // Date further into the future
         Carbon::setTestNow('2025-01-01 13:00:00');
 
-        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(1)));
-        $this->assertFalse(User::findOrFail(2)->can('edit', Post::findOrFail(2)));
+        $this->assertFalse($user->can('edit', $earlierPost));
+        $this->assertFalse($user->can('edit', $lastPost));
     }
 }


### PR DESCRIPTION

**Fixes #3144**

**Changes proposed in this pull request:**
Add unit tests and fix post policy for PHP 8

**Reviewers should focus on:**
I'm really not sure if that's the best way to built the tests, but it does cover the original issue.

Would this best be covered by a test of the edit post API endpoint directly instead of testing just the gate?

Should I namespace the test differently?

Should I use more test methods instead of grouping the time tests?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
