### PR TITLE
fix: Component.component argument typings

### DIFF
--- a/js/src/common/Component.ts
+++ b/js/src/common/Component.ts
@@ -121,8 +121,8 @@ export default abstract class Component<Attrs extends ComponentAttrs = Component
    *
    * @see https://mithril.js.org/hyperscript.html#mselector,-attributes,-children
    */
-  static component(attrs = {}, children = null): Mithril.Vnode {
-    const componentAttrs = Object.assign({}, attrs) as Record<string, unknown>;
+  static component(attrs: Attrs = {}, children: Mithril.Children = null): Mithril.Vnode {
+    const componentAttrs = { ...attrs };
 
     return m(this as any, componentAttrs, children);
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Fix typings for the `.component()` helper method -- `children` was typed as `undefined | null` due to a lack of explicit typings on the method.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
None.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
