### PR TITLE
Add aria-label attribute to navigation drawer button.

### DIFF
--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -93,7 +93,7 @@ export default class Navigation extends Component {
         drawer.show();
       },
       icon: 'fas fa-bars',
-      ariaLabel: 'Open Navigation Drawer',
+      ariaLabel: app.translator.trans('core.lib.nav.drawer_button'),
     });
   }
 }

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -93,7 +93,7 @@ export default class Navigation extends Component {
         drawer.show();
       },
       icon: 'fas fa-bars',
-      ariaLabel: app.translator.trans('core.lib.nav.drawer_button'),
+      'aria-label': app.translator.trans('core.lib.nav.drawer_button'),
     });
   }
 }

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -93,6 +93,7 @@ export default class Navigation extends Component {
         drawer.show();
       },
       icon: 'fas fa-bars',
+      ariaLabel: 'Open Navigation Drawer',
     });
   }
 }

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -539,6 +539,10 @@ core:
     loading_indicator:
       accessible_label: => core.ref.loading
 
+    # These translations are used in the loading navigation component.
+    nav:
+      drawer_button: Open Navigation Drawer
+
     # These translations are used as suffixes when abbreviating numbers.
     number_suffix:
       kilo_text: K

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -539,7 +539,7 @@ core:
     loading_indicator:
       accessible_label: => core.ref.loading
 
-    # These translations are used in the loading navigation component.
+    # These translations are used in the navigation header.
     nav:
       drawer_button: Open Navigation Drawer
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds `aria-label` attribute to navigation drawer button to improve accessibility and satisfy this warning in Chrome.

<img width="1235" alt="Screen Shot 2021-11-08 at 8 12 14 AM" src="https://user-images.githubusercontent.com/376199/140778033-3ba9e980-6af5-42ee-9af7-329550f68b7a.png">

**Reviewers should focus on:**
Affects every page that the navigation drawer button is visible.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
