### PR TITLE
Use calculated offset when loading page in PaginatedListState

### DIFF
--- a/js/src/common/states/PaginatedListState.ts
+++ b/js/src/common/states/PaginatedListState.ts
@@ -93,8 +93,8 @@ export default abstract class PaginatedListState<T extends Model> {
   protected loadPage(page = 1): Promise<T[]> {
     const params = this.requestParams();
     params.page = {
-      offset: this.pageSize * (page - 1),
       ...params.page,
+      offset: this.pageSize * (page - 1),
     };
 
     if (Array.isArray(params.include)) {


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/3158**

**Changes proposed in this pull request:**
Previously, the old offset was overriding the new one, so the same page was loaded over and over again. 

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
