### PR TITLE
Add 'Close' & 'Back' aria-label attributes to buttons.

### DIFF
--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -1,6 +1,8 @@
+import app from '../../forum/app';
 import Component from '../Component';
 import Alert, { AlertAttrs } from './Alert';
 import Button from './Button';
+
 
 import type Mithril from 'mithril';
 import type ModalManagerState from '../states/ModalManagerState';
@@ -91,6 +93,7 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
                 icon: 'fas fa-times',
                 onclick: this.hide.bind(this),
                 className: 'Button Button--icon Button--link',
+                'aria-label': app.translator.trans('core.lib.close_button'),
               })}
             </div>
           )}

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -92,7 +92,7 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
                 icon: 'fas fa-times',
                 onclick: this.hide.bind(this),
                 className: 'Button Button--icon Button--link',
-                'aria-label': app.translator.trans('core.lib.close_button'),
+                'aria-label': app.translator.trans('core.lib.modal.close'),
               })}
             </div>
           )}

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -3,7 +3,6 @@ import Component from '../Component';
 import Alert, { AlertAttrs } from './Alert';
 import Button from './Button';
 
-
 import type Mithril from 'mithril';
 import type ModalManagerState from '../states/ModalManagerState';
 import type RequestError from '../utils/RequestError';

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -1,4 +1,4 @@
-import app from '../../forum/app';
+import app from '../../common/app';
 import Component from '../Component';
 import Alert, { AlertAttrs } from './Alert';
 import Button from './Button';

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -53,6 +53,7 @@ export default class Navigation extends Component {
         e.preventDefault();
         history.back();
       },
+      'aria-label': app.translator.trans('core.lib.close_button'),
     });
   }
 

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -53,7 +53,7 @@ export default class Navigation extends Component {
         e.preventDefault();
         history.back();
       },
-      'aria-label': app.translator.trans('core.lib.close_button'),
+      'aria-label': app.translator.trans('core.lib.nav.back'),
     });
   }
 

--- a/js/src/common/components/Navigation.js
+++ b/js/src/common/components/Navigation.js
@@ -47,13 +47,12 @@ export default class Navigation extends Component {
       className: 'Button Navigation-back Button--icon',
       href: history.backUrl(),
       icon: 'fas fa-chevron-left',
-      title: previous.title,
+      'aria-label': previous.title,
       onclick: (e) => {
         if (e.shiftKey || e.ctrlKey || e.metaKey || e.which === 2) return;
         e.preventDefault();
         history.back();
       },
-      'aria-label': app.translator.trans('core.lib.nav.back'),
     });
   }
 

--- a/js/src/forum/components/WelcomeHero.js
+++ b/js/src/forum/components/WelcomeHero.js
@@ -27,6 +27,7 @@ export default class WelcomeHero extends Component {
             icon: 'fas fa-times',
             onclick: slideUp,
             className: 'Hero-close Button Button--icon Button--link',
+            'aria-label': app.translator.trans('core.lib.close_button'),
           })}
 
           <div className="containerNarrow">

--- a/js/src/forum/components/WelcomeHero.js
+++ b/js/src/forum/components/WelcomeHero.js
@@ -27,7 +27,7 @@ export default class WelcomeHero extends Component {
             icon: 'fas fa-times',
             onclick: slideUp,
             className: 'Hero-close Button Button--icon Button--link',
-            'aria-label': app.translator.trans('core.lib.close_button'),
+            'aria-label': app.translator.trans('core.forum.welcome_hero.hide'),
           })}
 
           <div className="containerNarrow">

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -283,7 +283,7 @@ core:
 
     # These translations are used by the composer controls.
     composer:
-      close_tooltip: => core.ref.close
+      close_tooltip: Close
       exit_full_screen_tooltip: Exit Full Screen
       full_screen_tooltip: Full Screen
       minimize_tooltip: Minimize
@@ -497,10 +497,12 @@ core:
       resend_button: Resend Confirmation Email
       sent_message: Sent
 
+    welcome_hero:
+      hide: Hide welcome message
+
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
     debug_button: Debug
-    close_button: => core.ref.close
 
     # These translations are displayed as tooltips for discussion badges.
     badge:
@@ -539,6 +541,10 @@ core:
     # These translations are used in the loading indicator component.
     loading_indicator:
       accessible_label: => core.ref.loading
+
+    # These translations are used in modals.
+    modal:
+      close: Close
 
     # These translations are used in the navigation header.
     nav:
@@ -690,7 +696,6 @@ core:
     all_discussions: All Discussions
     change_email: Change Email
     change_password: Change Password
-    close: Close
     color: Color                                 # Referenced by flarum-tags.yml
     confirm_password: Confirm Password
     confirm_email: Confirm Email

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -283,7 +283,7 @@ core:
 
     # These translations are used by the composer controls.
     composer:
-      close_tooltip: Close
+      close_tooltip: => core.ref.close
       exit_full_screen_tooltip: Exit Full Screen
       full_screen_tooltip: Full Screen
       minimize_tooltip: Minimize
@@ -500,6 +500,7 @@ core:
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
     debug_button: Debug
+    close_button: => core.ref.close
 
     # These translations are displayed as tooltips for discussion badges.
     badge:
@@ -688,6 +689,7 @@ core:
     all_discussions: All Discussions
     change_email: Change Email
     change_password: Change Password
+    close: Close
     color: Color                                 # Referenced by flarum-tags.yml
     confirm_password: Confirm Password
     confirm_email: Confirm Email

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -542,6 +542,7 @@ core:
 
     # These translations are used in the navigation header.
     nav:
+      back: Back
       drawer_button: Open Navigation Drawer
 
     # These translations are used as suffixes when abbreviating numbers.

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -548,7 +548,6 @@ core:
 
     # These translations are used in the navigation header.
     nav:
-      back: Back
       drawer_button: Open Navigation Drawer
 
     # These translations are used as suffixes when abbreviating numbers.


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds `aria-label` attribute to modal close & back buttons to improve accessibility and satisfy these warnings.

<img width="1352" alt="Screen Shot 2021-11-11 at 10 08 32 AM" src="https://user-images.githubusercontent.com/376199/141347874-6c1eaf15-157a-4dd1-918d-d28144a39323.png">

**Reviewers should focus on:**
Affects every modal and the hero welcome component.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
