### PR TITLE
Adjust boolean check of is_email_confirmed to suppress extraneous user activation events

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -358,7 +358,7 @@ class User extends AbstractModel
      */
     public function activate()
     {
-        if ($this->is_email_confirmed !== true) {
+        if (!$this->is_email_confirmed) {
             $this->is_email_confirmed = true;
 
             $this->raise(new Activated($this));

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -358,7 +358,7 @@ class User extends AbstractModel
      */
     public function activate()
     {
-        if (!$this->is_email_confirmed) {
+        if (! $this->is_email_confirmed) {
             $this->is_email_confirmed = true;
 
             $this->raise(new Activated($this));


### PR DESCRIPTION
**Fixes #2713**

**Changes proposed in this pull request:**

Instead of explicilty checking for a `true` value, adjust to check if `is_email_confirmed` _evaluates_ to `true`.  This matches the approach currently being used elsewhere in the `User` model, and will prevent the `Activated` event from being fired every time a user confirms their email.

Existing usage of this approach:
https://github.com/flarum/core/blob/5f110f73e7858741907665b1ec8b5c372be99796/src/User/User.php#L725-L727

**Reviewers should focus on:**

Activating an already activated user.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
