### PR TITLE
Add priority order to controls

### DIFF
--- a/js/src/forum/components/DiscussionPage.tsx
+++ b/js/src/forum/components/DiscussionPage.tsx
@@ -252,7 +252,8 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
           accessibleToggleLabel: app.translator.trans('core.forum.discussion_controls.toggle_dropdown_accessible_label'),
         },
         DiscussionControls.controls(this.discussion, this).toArray()
-      )
+      ),
+      100
     );
 
     items.add(


### PR DESCRIPTION
When extending `sidebarItems`, it is currently not possible to easily define where new components should appear in the `ItemList` due to no priority being set on `controls`.

**Changes proposed in this pull request:**
Set an initial priority on the `controls` item to `100`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
