### PR TITLE
fix: allow queue restarting

### DIFF
--- a/src/Queue/QueueServiceProvider.php
+++ b/src/Queue/QueueServiceProvider.php
@@ -67,7 +67,7 @@ class QueueServiceProvider extends AbstractServiceProvider
             /** @var Config $config */
             $config = $container->make(Config::class);
 
-            return new Worker(
+            $worker = new Worker(
                 $container[Factory::class],
                 $container['events'],
                 $container[ExceptionHandling::class],
@@ -75,6 +75,10 @@ class QueueServiceProvider extends AbstractServiceProvider
                     return $config->inMaintenanceMode();
                 }
             );
+
+            $worker->setCache($container->make('cache.store'));
+
+            return $worker;
         });
 
         // Override the Laravel native Listener, so that we can ignore the environment


### PR DESCRIPTION
By injecting the cache store into the queue, we allow queues to be
restarted using php flarum queue:restart and similar events dispatched
from within Laravelish classes.


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
