### PR TITLE
fix: `Post--by-actor` not showing when comparing user instances

### DIFF
--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -120,7 +120,7 @@ export default class Post extends Component {
   /**
    * Get the post's classes.
    *
-   * @param string classes
+   * @param existing string
    * @returns {string[]}
    */
   classes(existing) {
@@ -137,7 +137,7 @@ export default class Post extends Component {
       classes.push('Post--by-actor');
     }
 
-    if (user && user === discussion.user()) {
+    if (user && user.id() === discussion.attribute('startUserId')) {
       classes.push('Post--by-start-user');
     }
 


### PR DESCRIPTION
**Fixes #2750**

**Changes proposed in this pull request:**
Compare IDs since the discussion author relation can be unavailable.

**Necessity**
- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
