### PR TITLE
fix(a11y): show post action items when focus is within the post

### DIFF
--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -322,7 +322,7 @@
       vertical-align: top;
     }
   }
-  .Post:hover &, &.open {
+  .Post:hover &, .Post:focus-within, &.open {
     opacity: 1;
   }
 }

--- a/less/forum/Post.less
+++ b/less/forum/Post.less
@@ -322,7 +322,7 @@
       vertical-align: top;
     }
   }
-  .Post:hover &, .Post:focus-within, &.open {
+  .Post:hover &, .Post:focus-within &, &.open {
     opacity: 1;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Shows post action items when the currently focused element is within the parent `.Post`.

Previously, tabbing through Flarum would result in focus being "lost" on the screen, since the post actions were invisible, even when focused. This prevents this issue.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
I considered only checking is focus was within the `.Post-actions` section, but decided that showing the actions whenever an element within the post is focused would closer match the existing hover-based functionality.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/7406822/142744901-b77f5e91-3c86-45f6-957d-e893d3fe6293.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
