### PR TITLE
`listItems` typing fix

### DIFF
--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -28,7 +28,7 @@ function isSeparator(item: ModdedChildren): boolean {
   return isVnode(item) && item.tag === Separator;
 }
 
-function withoutUnnecessarySeparators(items: ModdedChildrenWithItemname[]): ModdedChildrenWithItemname[] {
+function withoutUnnecessarySeparators(items: ModdedChildrenWithItemName[]): ModdedChildrenWithItemName[] {
   const newItems: ModdedChildrenWithItemname[] = [];
   let prevItem: ModdedChildren;
 

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -59,7 +59,7 @@ export default function listItems<Attrs extends ComponentAttrs>(
 
   return withoutUnnecessarySeparators(items).map((item) => {
     const classes = [item.itemName && `item-${item.itemName}`];
-  
+
     if (!isVnode(item)) {
       return (
         <Tag className={classList(classes)} {...attributes}>

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -51,7 +51,7 @@ function withoutUnnecessarySeparators(items: ModdedChildrenWithItemName[]): Modd
  */
 export default function listItems<Attrs extends ComponentAttrs>(
   rawItems: ModdedChildrenWithItemName[],
-  customTag: string | (new () => Component<Attrs>) = 'li',
+  customTag: VnodeElementTag<Attrs> = 'li',
   attributes: Attrs = {} as Attrs
 ): Mithril.Vnode[] {
   const items = rawItems instanceof Array ? rawItems : [rawItems];

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -18,7 +18,7 @@ type ModdedVnode = Mithril.Vnode<ModdedVnodeAttrs> & { itemName?: string; itemCl
 type ModdedChild = ModdedVnode | string | number | boolean | null | undefined;
 type ModdedChildArray = ModdedChildren[];
 type ModdedChildren = ModdedChild | ModdedChildArray;
-type ModdedChildrenWithItemname = ModdedChildren & { itemName?: string };
+type ModdedChildrenWithItemName = ModdedChildren & { itemName?: string };
 
 function isVnode(item: ModdedChildren): item is Mithril.Vnode {
   return typeof item === 'object' && item !== null && 'tag' in item;

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -29,7 +29,7 @@ function isSeparator(item: ModdedChildren): boolean {
 }
 
 function withoutUnnecessarySeparators(items: ModdedChildrenWithItemName[]): ModdedChildrenWithItemName[] {
-  const newItems: ModdedChildrenWithItemname[] = [];
+  const newItems: ModdedChildrenWithItemName[] = [];
   let prevItem: ModdedChildren;
 
   items.filter(Boolean).forEach((item, i: number) => {

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -18,7 +18,12 @@ type ModdedVnode = Mithril.Vnode<ModdedVnodeAttrs> & { itemName?: string; itemCl
 type ModdedChild = ModdedVnode | string | number | boolean | null | undefined;
 type ModdedChildArray = ModdedChildren[];
 type ModdedChildren = ModdedChild | ModdedChildArray;
-type ModdedChildrenWithItemName = ModdedChildren & { itemName?: string };
+
+/**
+ * This type represents an element of a list returned by `ItemList.toArray()`,
+ * coupled with some static properties used on various components.
+ */
+export type ModdedChildrenWithItemName = ModdedChildren & { itemName?: string };
 
 function isVnode(item: ModdedChildren): item is Mithril.Vnode {
   return typeof item === 'object' && item !== null && 'tag' in item;

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -9,17 +9,16 @@ type ModdedVnodeAttrs = {
 };
 
 type ModdedTag = Mithril.Vnode['tag'] & {
-    isListItem?: boolean;
-    isActive?: (attrs: ComponentAttrs) => boolean;
-  };
+  isListItem?: boolean;
+  isActive?: (attrs: ComponentAttrs) => boolean;
+};
 
-type ModdedVnode = Mithril.Vnode<ModdedVnodeAttrs> & { itemName?: string, itemClassName?: string, tag: ModdedTag; };
+type ModdedVnode = Mithril.Vnode<ModdedVnodeAttrs> & { itemName?: string; itemClassName?: string; tag: ModdedTag };
 
-type ModdedChild = (ModdedVnode | string | number | boolean | null | undefined);
+type ModdedChild = ModdedVnode | string | number | boolean | null | undefined;
 interface ModdedChildArray extends Array<ModdedChildren> {}
-type ModdedChildren = (ModdedChild | ModdedChildArray);
+type ModdedChildren = ModdedChild | ModdedChildArray;
 type ModdedChildrenWithItemname = ModdedChildren & { itemName?: string };
-
 
 function isVnode(item: ModdedChildren): item is Mithril.Vnode {
   return typeof item === 'object' && item !== null && 'tag' in item;
@@ -75,11 +74,7 @@ export default function listItems<Attrs extends ComponentAttrs>(
     const className = item.attrs?.itemClassName || item.itemClassName;
 
     return (
-      <Tag
-        className={classList([className, active && 'active'])}
-        key={item?.attrs?.key || item.itemName}
-        {...attributes}
-      >
+      <Tag className={classList([className, active && 'active'])} key={item?.attrs?.key || item.itemName} {...attributes}>
         {item}
       </Tag>
     );

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -16,7 +16,7 @@ type ModdedTag = Mithril.Vnode['tag'] & {
 type ModdedVnode = Mithril.Vnode<ModdedVnodeAttrs> & { itemName?: string; itemClassName?: string; tag: ModdedTag };
 
 type ModdedChild = ModdedVnode | string | number | boolean | null | undefined;
-interface ModdedChildArray extends Array<ModdedChildren> {}
+type ModdedChildArray = ModdedChildren[];
 type ModdedChildren = ModdedChild | ModdedChildArray;
 type ModdedChildrenWithItemname = ModdedChildren & { itemName?: string };
 

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -58,8 +58,14 @@ export default function listItems<Attrs extends ComponentAttrs>(
   const Tag = customTag;
 
   return withoutUnnecessarySeparators(items).map((item) => {
+    const classes = [item.itemName && `item-${item.itemName}`];
+  
     if (!isVnode(item)) {
-      return <Tag className={item.itemName && `item-${item.itemName}`}>{item}</Tag>;
+      return (
+        <Tag className={classList(classes)} {...attributes}>
+          {item}
+        </Tag>
+      );
     }
 
     if (item.tag.isListItem) {
@@ -70,11 +76,14 @@ export default function listItems<Attrs extends ComponentAttrs>(
       return item;
     }
 
-    const active = item.tag.isActive?.(item.attrs);
-    const className = item.attrs?.itemClassName || item.itemClassName;
+    classes.push(item.attrs?.itemClassName || item.itemClassName);
+
+    if (item.tag.isActive?.(item.attrs)) {
+      classes.push('active');
+    }
 
     return (
-      <Tag className={classList([className, active && 'active'])} key={item?.attrs?.key || item.itemName} {...attributes}>
+      <Tag className={classList(classes)} key={item?.attrs?.key || item.itemName} {...attributes}>
         {item}
       </Tag>
     );

--- a/js/src/common/helpers/listItems.tsx
+++ b/js/src/common/helpers/listItems.tsx
@@ -50,7 +50,7 @@ function withoutUnnecessarySeparators(items: ModdedChildrenWithItemName[]): Modd
  * second function parameter, `customTag`.
  */
 export default function listItems<Attrs extends ComponentAttrs>(
-  rawItems: ModdedChildrenWithItemname[],
+  rawItems: ModdedChildrenWithItemName[],
   customTag: string | (new () => Component<Attrs>) = 'li',
   attributes: Attrs = {} as Attrs
 ): Mithril.Vnode[] {


### PR DESCRIPTION
Currently, `listItems` is causing issues because it does not accept all `Mithril.Children`. This PR refactors its internals and types to support any input adhering to `Mithril.Children`. It also cleans up some messy internal logic.