### PR TITLE
fix: Modal typings complicate inheritance

### DIFF
--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -78,6 +78,9 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     }
   }
 
+  /**
+   * @todo split into FormModal and Modal in 2.0
+   */
   view() {
     if (this.alertAttrs) {
       this.alertAttrs.dismissible = false;
@@ -124,9 +127,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
   /**
    * Get the content of the modal.
    */
-  content(): Mithril.Children {
-    return null;
-  }
+ abstract content(): Mithril.Children;
 
   /**
    * Handle the modal form's submit event.

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -126,7 +126,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
    */
   content(): Mithril.Children {
     return null;
-  };
+  }
 
   /**
    * Handle the modal form's submit event.

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -129,7 +129,9 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
   /**
    * Handle the modal form's submit event.
    */
-  abstract onsubmit(e: Event): void;
+  onsubmit(e: Event): void {
+    // ...
+  }
 
   /**
    * Callback executed when the modal is shown and ready to be interacted with.

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -9,7 +9,7 @@ import type RequestError from '../utils/RequestError';
 import type ModalManager from './ModalManager';
 import fireDebugWarning from '../helpers/fireDebugWarning';
 
-interface IInternalModalAttrs {
+export interface IInternalModalAttrs {
   state: ModalManagerState;
   animateShow: ModalManager['animateShow'];
   animateHide: ModalManager['animateHide'];
@@ -19,7 +19,7 @@ interface IInternalModalAttrs {
  * The `Modal` component displays a modal dialog, wrapped in a form. Subclasses
  * should implement the `className`, `title`, and `content` methods.
  */
-export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttrs & IInternalModalAttrs> {
+export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IInternalModalAttrs> extends Component<ModalAttrs> {
   /**
    * Determine whether or not the modal should be dismissible via an 'x' button.
    */
@@ -32,7 +32,7 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
    */
   alertAttrs!: AlertAttrs;
 
-  oninit(vnode: Mithril.VnodeDOM<ModalAttrs & IInternalModalAttrs, this>) {
+  oninit(vnode: Mithril.VnodeDOM<ModalAttrs, this>) {
     super.oninit(vnode);
 
     // TODO: [Flarum 2.0] Remove the code below.
@@ -57,13 +57,13 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
     }
   }
 
-  oncreate(vnode: Mithril.VnodeDOM<ModalAttrs & IInternalModalAttrs, this>) {
+  oncreate(vnode: Mithril.VnodeDOM<ModalAttrs, this>) {
     super.oncreate(vnode);
 
     this.attrs.animateShow(() => this.onready());
   }
 
-  onbeforeremove(vnode: Mithril.VnodeDOM<ModalAttrs & IInternalModalAttrs, this>): Promise<void> | void {
+  onbeforeremove(vnode: Mithril.VnodeDOM<ModalAttrs, this>): Promise<void> | void {
     super.onbeforeremove(vnode);
 
     // If the global modal state currently contains a modal,

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -127,7 +127,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
   /**
    * Get the content of the modal.
    */
- abstract content(): Mithril.Children;
+  abstract content(): Mithril.Children;
 
   /**
    * Handle the modal form's submit event.

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -124,7 +124,9 @@ export default abstract class Modal<ModalAttrs = {}> extends Component<ModalAttr
   /**
    * Get the content of the modal.
    */
-  abstract content(): Mithril.Children;
+  content(): Mithril.Children {
+    return null;
+  };
 
   /**
    * Handle the modal form's submit event.


### PR DESCRIPTION
**Changes proposed in this pull request:**
Not all modals contain forms needing these methods: `content` `onsubmit`.
Also exports the modal attrs interface so that inheritance works without errors.

I suppose a better solutions would be to have two separate modal components, a `Modal` and a `FormModal` but that would be breaking.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.