### PR TITLE
Support blade namespaces for easier overriding of blade views

### DIFF
--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -44,12 +44,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
             };
         });
 
-        $this->container->singleton('flarum.frontend.factory', function (Container $container) {
-            return function (string $name) use ($container) {
+        $this->container->singleton('flarum.frontend.factory', function (Container $container, string $namespace = 'flarum') {
+            return function (string $name) use ($container, $namespace) {
                 $frontend = $container->make(Frontend::class);
 
                 $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = 'flarum::frontend.'.$name;
+                    $document->layoutView = sprintf('%s:frontend.%s', $namespace, $name);
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -44,12 +44,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
             };
         });
 
-        $this->container->singleton('flarum.frontend.factory', function (Container $container, string $namespace = 'flarum') {
-            return function (string $name) use ($container, $namespace) {
+        $this->container->singleton('flarum.frontend.factory', function (Container $container) {
+            return function (string $name, string $namespace = 'flarum') use ($container) {
                 $frontend = $container->make(Frontend::class);
 
-                $frontend->content(function (Document $document) use ($name) {
-                    $document->layoutView = sprintf('%s:frontend.%s', $namespace, $name);
+                $frontend->content(function (Document $document) use ($name, $namespace) {
+                    $document->layoutView = sprintf('%s::frontend.%s', $namespace, $name);
                 });
 
                 $frontend->content($container->make(Content\Assets::class)->forFrontend($name));


### PR DESCRIPTION
**Changes proposed in this pull request:**

Adds optional `$namespace` argument to `flarum.frontend.factory` closure in `FrontendServiceProvider` to make it cleaner to override blade files via custom service provider if desired.


**Usage**

In the case of overriding `frontend/forum.blade.php`; add `views/frontend/forum.blade.php` in your installation and register a custom service provider in `extend.php` as follows:
```php
<?php

use Flarum\Foundation\AbstractServiceProvider;
use Illuminate\Contracts\Container\Container;

class CustomServiceProvider extends AbstractServiceProvider
{
    public function register()
    {
        // Override forum.blade.php with a custom one.
        $this->container->bind('flarum.frontend.forum', function (Container $container) {
            return $container->make('flarum.frontend.factory')('forum', 'my-namespace');
        });
    }

    public function boot(Container $container)
    {
        $this->loadViewsFrom(__DIR__.'/../views', 'my-namespace');
    }
}

```

**Reviewers should focus on:**

Ensure that existing blade views in `flarum` namespace continue to load as expected.

**Related**
https://discuss.flarum.org/d/6910-overriding-blade-files-with-an-extension
https://discuss.flarum.org/d/21275-have-any-way-to-custom-flarum-core-frontend-views-blade-php
https://discuss.flarum.org/d/7015-extend-blade-templates

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
