### PR TITLE
fix: incorrect typings for Modal `hide()` method

### DIFF
--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -93,7 +93,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
             <div className="Modal-close App-backControl">
               {Button.component({
                 icon: 'fas fa-times',
-                onclick: this.hide.bind(this),
+                onclick: () => this.hide(),
                 className: 'Button Button--icon Button--link',
                 'aria-label': app.translator.trans('core.lib.modal.close'),
               })}
@@ -148,7 +148,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
   /**
    * Hides the modal.
    */
-  hide(e?: MouseEvent): void {
+  hide(): void {
     this.attrs.state.close();
   }
 

--- a/js/src/common/components/Modal.tsx
+++ b/js/src/common/components/Modal.tsx
@@ -148,14 +148,14 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
   /**
    * Hides the modal.
    */
-  hide() {
+  hide(e?: MouseEvent): void {
     this.attrs.state.close();
   }
 
   /**
    * Sets `loading` to false and triggers a redraw.
    */
-  loaded() {
+  loaded(): void {
     this.loading = false;
     m.redraw();
   }
@@ -164,7 +164,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
    * Shows an alert describing an error returned from the API, and gives focus to
    * the first relevant field involved in the error.
    */
-  onerror(error: RequestError) {
+  onerror(error: RequestError): void {
     this.alertAttrs = error.alert;
 
     m.redraw();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
The `hide()` method of the Modal class will have an event passed as the first param when clicking the Modal's close button due to how the onclick handler is set.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Should we change the `this.hide.bind(this)` to `() => this.hide()` instead of this? Could be breaking, but I'd argue this param was never public API, really.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
