### PR TITLE
Improve avatar upload experience

### DIFF
--- a/js/src/forum/components/AvatarEditor.js
+++ b/js/src/forum/components/AvatarEditor.js
@@ -149,7 +149,7 @@ export default class AvatarEditor extends Component {
 
     // Create a hidden HTML input element and click on it so the user can select
     // an avatar file. Once they have, we will upload it via the API.
-    const $input = $('<input type="file">');
+    const $input = $('<input type="file" accept=".jpg, .jpeg, .png, .bmp, .gif">');
 
     $input
       .appendTo('body')

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -67,8 +67,8 @@ class AvatarValidator extends AbstractValidator
         $guessedExtension = MimeTypes::getDefault()->getExtensions($file->getClientMediaType())[0] ?? null;
 
         $stream = $file->getStream();
-        $tmpFilename = $stream->getMetadata("uri");
-        $notImage = !getimagesize($tmpFilename);
+        $tmpFilename = $stream->getMetadata('uri');
+        $notImage = ! getimagesize($tmpFilename);
 
         if ($notImage || ! in_array($guessedExtension, $allowedTypes)) {
             $this->raise('mimes', [':values' => implode(', ', $allowedTypes)]);

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -66,7 +66,11 @@ class AvatarValidator extends AbstractValidator
 
         $guessedExtension = MimeTypes::getDefault()->getExtensions($file->getClientMediaType())[0] ?? null;
 
-        if (! in_array($guessedExtension, $allowedTypes)) {
+        $stream = $file->getStream();
+        $tmpFilename = $stream->getMetadata("uri");
+        $notImage = !getimagesize($tmpFilename);
+
+        if ($notImage || ! in_array($guessedExtension, $allowedTypes)) {
             $this->raise('mimes', [':values' => implode(', ', $allowedTypes)]);
         }
     }
@@ -103,6 +107,6 @@ class AvatarValidator extends AbstractValidator
 
     protected function getAllowedTypes()
     {
-        return ['jpg', 'png', 'bmp', 'gif'];
+        return ['jpeg', 'jpg', 'png', 'bmp', 'gif'];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/3055

- On the frontend, accept only image types as a hint to the OS file picker
- On the backend, use `getimagesize` as an additional validation guard against non-image files with image extensions. This isn't necessary for security, but results in less confusing error mesages.