### PR TITLE
Use revision versioner to allow custom asset versioning

### DIFF
--- a/src/Frontend/Compiler/FileVersioner.php
+++ b/src/Frontend/Compiler/FileVersioner.php
@@ -14,7 +14,10 @@ use Illuminate\Support\Arr;
 
 class FileVersioner implements VersionerInterface
 {
-    protected Filesystem $filesystem;
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
     const REV_MANIFEST = 'rev-manifest.json';
 
     public function __construct(Filesystem $filesystem)

--- a/src/Frontend/Compiler/FileVersioner.php
+++ b/src/Frontend/Compiler/FileVersioner.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Frontend\Compiler;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -14,7 +21,6 @@ class FileVersioner implements VersionerInterface
     {
         $this->filesystem = $filesystem;
     }
-
 
     public function putRevision(string $file, ?string $revision)
     {

--- a/src/Frontend/Compiler/FileVersioner.php
+++ b/src/Frontend/Compiler/FileVersioner.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Flarum\Frontend\Compiler;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+
+class FileVersioner implements VersionerInterface
+{
+    protected Filesystem $filesystem;
+    const REV_MANIFEST = 'rev-manifest.json';
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+
+    public function putRevision(string $file, ?string $revision)
+    {
+        if ($this->filesystem->has(static::REV_MANIFEST)) {
+            $manifest = json_decode($this->filesystem->read(static::REV_MANIFEST), true);
+        } else {
+            $manifest = [];
+        }
+
+        if ($revision) {
+            $manifest[$file] = $revision;
+        } else {
+            unset($manifest[$file]);
+        }
+
+        $this->filesystem->put(static::REV_MANIFEST, json_encode($manifest));
+    }
+
+    public function getRevision(string $file): ?string
+    {
+        if ($this->filesystem->has(static::REV_MANIFEST)) {
+            $manifest = json_decode($this->filesystem->read(static::REV_MANIFEST), true);
+
+            return Arr::get($manifest, $file);
+        }
+
+        return null;
+    }
+}

--- a/src/Frontend/Compiler/RevisionCompiler.php
+++ b/src/Frontend/Compiler/RevisionCompiler.php
@@ -12,7 +12,6 @@ namespace Flarum\Frontend\Compiler;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Frontend\Compiler\Source\SourceInterface;
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Support\Arr;
 
 /**
  * @internal

--- a/src/Frontend/Compiler/RevisionCompiler.php
+++ b/src/Frontend/Compiler/RevisionCompiler.php
@@ -24,8 +24,9 @@ class RevisionCompiler implements CompilerInterface
      * @var Filesystem
      */
     protected $assetsDir;
-
-    /** @var VersionerInterface */
+    /**
+     * @var VersionerInterface
+     */
     protected $versioner;
 
     /**
@@ -41,6 +42,7 @@ class RevisionCompiler implements CompilerInterface
     /**
      * @param Filesystem $assetsDir
      * @param string $filename
+     * @param VersionerInterface|null $versioner @deprecated nullable will be removed at v2.0
      */
     public function __construct(Filesystem $assetsDir, string $filename, VersionerInterface $versioner = null)
     {

--- a/src/Frontend/Compiler/VersionerInterface.php
+++ b/src/Frontend/Compiler/VersionerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Flarum\Frontend\Compiler;
+
+interface VersionerInterface
+{
+    public function putRevision(string $file, ?string $revision);
+    public function getRevision(string $file): ?string;
+}

--- a/src/Frontend/Compiler/VersionerInterface.php
+++ b/src/Frontend/Compiler/VersionerInterface.php
@@ -1,9 +1,17 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Frontend\Compiler;
 
 interface VersionerInterface
 {
     public function putRevision(string $file, ?string $revision);
+
     public function getRevision(string $file): ?string;
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**

Allows asset compilation to use a different version hasher implementation. This allows easier implementation of rev-manifest.json storage locations. Eg on our stack if we override where assets are stored, the rev-manifest.json is stored there too (s3). This causes each request to read from the s3 bucket as well. A better location for something like that would be either the settings table or redis. For normal local-file based Flarum instances, the default rev-manifest handler is sufficient.

**Reviewers should focus on:**

Is this okay?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
