### PR TITLE
Split up application error handling

### DIFF
--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -516,27 +516,31 @@ export default class Application {
         try {
           options.errorHandler(error);
         } catch (e) {
-          if (e instanceof RequestError) {
-            if (isDebug && e.xhr) {
-              const { method, url } = e.options;
-              const { status = '' } = e.xhr;
-
-              console.group(`${method} ${url} ${status}`);
-
-              console.error(...(formattedError || [e]));
-
-              console.groupEnd();
-            }
-
-            this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
-          } else {
-            throw e;
-          }
+          this.fallbackRequestErrorHandler(isDebug, formattedError, e);
         }
 
         return Promise.reject(error);
       }
     );
+  }
+
+  protected fallbackRequestErrorHandler(isDebug: boolean, formattedError: string, e: unknown) {
+    if (e instanceof RequestError) {
+      if (isDebug && e.xhr) {
+        const { method, url } = e.options;
+        const { status = '' } = e.xhr;
+
+        console.group(`${method} ${url} ${status}`);
+
+        console.error(...(formattedError || [e]));
+
+        console.groupEnd();
+      }
+
+      this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
+    } else {
+      throw e;
+    }
   }
 
   private showDebug(error: RequestError, formattedError?: string[]) {

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -508,13 +508,13 @@ export default class Application {
     if (customErrorHandler) {
       customErrorHandler(error);
     } else {
-      this.requestErrorHandlerFallback(error, isDebug, formattedErrors);
+      this.requestErrorDefaultHandler(error, isDebug, formattedErrors);
     }
 
     return Promise.reject(error);
   }
 
-  protected requestErrorHandlerFallback(e: unknown, isDebug: boolean, formattedErrors: string[]): void {
+  protected requestErrorDefaultHandler(e: unknown, isDebug: boolean, formattedErrors: string[]): void {
     if (e instanceof RequestError) {
       if (isDebug && e.xhr) {
         const { method, url } = e.options;

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -466,10 +466,9 @@ export default class Application {
     const formattedErrors = error.response?.errors?.map((e) => decodeURI(e.detail ?? '')) ?? [];
 
     let content;
-
     switch (error.status) {
       case 422:
-        content = formattedErrors.map((detail) => [detail, <br />]).flat();
+        content = formattedErrors.map((detail) => [detail, <br />]).flat().slice(0, -1);
         break;
 
       case 401:

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -524,7 +524,7 @@ export default class Application {
     );
   }
 
-  protected fallbackRequestErrorHandler(isDebug: boolean, formattedError: string, e: unknown) {
+  protected fallbackRequestErrorHandler(isDebug: boolean, formattedError: string, e: unknown): void {
     if (e instanceof RequestError) {
       if (isDebug && e.xhr) {
         const { method, url } = e.options;

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -468,7 +468,10 @@ export default class Application {
     let content;
     switch (error.status) {
       case 422:
-        content = formattedErrors.map((detail) => [detail, <br />]).flat().slice(0, -1);
+        content = formattedErrors
+          .map((detail) => [detail, <br />])
+          .flat()
+          .slice(0, -1);
         break;
 
       case 401:

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -515,22 +515,22 @@ export default class Application {
 
         try {
           options.errorHandler(error);
-        } catch (error) {
-          if (error instanceof RequestError) {
-            if (isDebug && error.xhr) {
-              const { method, url } = error.options;
-              const { status = '' } = error.xhr;
+        } catch (e) {
+          if (e instanceof RequestError) {
+            if (isDebug && e.xhr) {
+              const { method, url } = e.options;
+              const { status = '' } = e.xhr;
 
               console.group(`${method} ${url} ${status}`);
 
-              console.error(...(formattedError || [error]));
+              console.error(...(formattedError || [e]));
 
               console.groupEnd();
             }
 
-            this.requestErrorAlert = this.alerts.show(error.alert, error.alert.content);
+            this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
           } else {
-            throw error;
+            throw e;
           }
         }
 

--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -366,7 +366,7 @@ export default class Application {
   }
 
   protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType> {
-    const { background, deserialize, errorHandler, extract, modifyText, ...tmpOptions } = { ...flarumOptions };
+    const { background, deserialize, extract, modifyText, ...tmpOptions } = { ...flarumOptions };
 
     // Unless specified otherwise, requests should run asynchronously in the
     // background, so that they don't prevent redraws from occurring.
@@ -380,10 +380,6 @@ export default class Application {
     // so it errors due to Mithril's typings
     const defaultDeserialize = (response: string) => response as ResponseType;
 
-    const defaultErrorHandler = (error: RequestError) => {
-      throw error;
-    };
-
     // When extracting the data from the response, we can check the server
     // response code and show an error message to the user if something's gone
     // awry.
@@ -392,7 +388,6 @@ export default class Application {
     const options: InternalFlarumRequestOptions<ResponseType> = {
       background: background ?? defaultBackground,
       deserialize: deserialize ?? defaultDeserialize,
-      errorHandler: errorHandler ?? defaultErrorHandler,
       ...tmpOptions,
     };
 
@@ -459,72 +454,78 @@ export default class Application {
     const options = this.transformRequestOptions(originalOptions);
 
     if (this.requestErrorAlert) this.alerts.dismiss(this.requestErrorAlert);
-
-    // Now make the request. If it's a failure, inspect the error that was
-    // returned and show an alert containing its contents.
-    return m.request(options).then(
-      (response) => response,
-      (error: RequestError) => {
-        let content;
-
-        switch (error.status) {
-          case 422:
-            content = ((error.response?.errors ?? {}) as Record<string, unknown>[])
-              .map((error) => [error.detail, <br />])
-              .flat()
-              .slice(0, -1);
-            break;
-
-          case 401:
-          case 403:
-            content = app.translator.trans('core.lib.error.permission_denied_message');
-            break;
-
-          case 404:
-          case 410:
-            content = app.translator.trans('core.lib.error.not_found_message');
-            break;
-
-          case 413:
-            content = app.translator.trans('core.lib.error.payload_too_large_message');
-            break;
-
-          case 429:
-            content = app.translator.trans('core.lib.error.rate_limit_exceeded_message');
-            break;
-
-          default:
-            content = app.translator.trans('core.lib.error.generic_message');
-        }
-
-        const isDebug = app.forum.attribute('debug');
-        // contains a formatted errors if possible, response must be an JSON API array of errors
-        // the details property is decoded to transform escaped characters such as '\n'
-        const errors = error.response && error.response.errors;
-        const formattedError = (Array.isArray(errors) && errors?.[0]?.detail && errors.map((e) => decodeURI(e.detail ?? ''))) || undefined;
-
-        error.alert = {
-          type: 'error',
-          content,
-          controls: isDebug && [
-            <Button className="Button Button--link" onclick={this.showDebug.bind(this, error, formattedError)}>
-              {app.translator.trans('core.lib.debug_button')}
-            </Button>,
-          ],
-        };
-
-        try {
-          options.errorHandler(error);
-        } catch (e) {
-          this.fallbackRequestErrorHandler(isDebug, formattedError, e);
-        }
-
-        return Promise.reject(error);
-      }
+  
+    return m.request(options).catch(
+      (e) => this.requestErrorCatch(e, originalOptions.errorHandler)
     );
   }
 
-  protected fallbackRequestErrorHandler(isDebug: boolean, formattedError: string, e: unknown): void {
+  /**
+   * By default, show an error alert, and log the error to the console. 
+   */
+  protected requestErrorCatch<ResponseType>(error: RequestError, customErrorHandler: FlarumRequestOptions<ResponseType>['errorHandler']) {
+    let content;
+
+    switch (error.status) {
+      case 422:
+        content = ((error.response?.errors ?? {}) as Record<string, unknown>[])
+          .map((error) => [error.detail, <br />])
+          .flat()
+          .slice(0, -1);
+        break;
+
+      case 401:
+      case 403:
+        content = app.translator.trans('core.lib.error.permission_denied_message');
+        break;
+
+      case 404:
+      case 410:
+        content = app.translator.trans('core.lib.error.not_found_message');
+        break;
+
+      case 413:
+        content = app.translator.trans('core.lib.error.payload_too_large_message');
+        break;
+
+      case 429:
+        content = app.translator.trans('core.lib.error.rate_limit_exceeded_message');
+        break;
+
+      default:
+        content = app.translator.trans('core.lib.error.generic_message');
+    }
+
+    const isDebug = app.forum.attribute('debug');
+    // contains a formatted errors if possible, response must be an JSON API array of errors
+    // the details property is decoded to transform escaped characters such as '\n'
+    const errors = error.response && error.response.errors;
+    const formattedError = (Array.isArray(errors) && errors?.[0]?.detail && errors.map((e) => decodeURI(e.detail ?? ''))) || undefined;
+
+    error.alert = {
+      type: 'error',
+      content,
+      controls: isDebug && [
+        <Button className="Button Button--link" onclick={this.showDebug.bind(this, error, formattedError)}>
+          {app.translator.trans('core.lib.debug_button')}
+        </Button>,
+      ],
+    };
+
+    if (customErrorHandler) {
+      try {
+        customErrorHandler(error);
+      } catch (e) {
+        this.requestErrorHandlerFallback(e, isDebug, formattedError);
+      }
+    } else {
+      this.requestErrorHandlerFallback(error, isDebug, formattedError);
+    }
+
+    return Promise.reject(error);
+  }
+
+  protected requestErrorHandlerFallback(e: unknown, isDebug: boolean, formattedError: string): void {
     if (e instanceof RequestError) {
       if (isDebug && e.xhr) {
         const { method, url } = e.options;

--- a/js/src/common/utils/RequestError.ts
+++ b/js/src/common/utils/RequestError.ts
@@ -1,5 +1,5 @@
 import type Mithril from 'mithril';
-import { AlertAttrs } from '../components/Alert';
+import type { AlertAttrs } from '../components/Alert';
 
 export type InternalFlarumRequestOptions<ResponseType> = Mithril.RequestOptions<ResponseType> & {
   url: string;

--- a/js/src/common/utils/RequestError.ts
+++ b/js/src/common/utils/RequestError.ts
@@ -1,7 +1,6 @@
 import type Mithril from 'mithril';
 
 export type InternalFlarumRequestOptions<ResponseType> = Mithril.RequestOptions<ResponseType> & {
-  errorHandler: (error: RequestError) => void;
   url: string;
 };
 

--- a/js/src/common/utils/RequestError.ts
+++ b/js/src/common/utils/RequestError.ts
@@ -1,4 +1,5 @@
 import type Mithril from 'mithril';
+import { AlertAttrs } from '../components/Alert';
 
 export type InternalFlarumRequestOptions<ResponseType> = Mithril.RequestOptions<ResponseType> & {
   url: string;
@@ -19,7 +20,7 @@ export default class RequestError<ResponseType = string> {
     }[];
   } | null;
 
-  alert: any;
+  alert: AlertAttrs | null;
 
   constructor(status: number, responseText: string | null, options: InternalFlarumRequestOptions<ResponseType>, xhr: XMLHttpRequest) {
     this.status = status;

--- a/js/src/forum/ForumApplication.ts
+++ b/js/src/forum/ForumApplication.ts
@@ -80,7 +80,7 @@ export default class ForumApplication extends Application {
 
     routes(this);
 
-    this.route = Object.assign({}, (Object.getPrototypeOf(Object.getPrototypeOf(this)) as Application).route.bind(this), makeRouteHelpers(this));
+    this.route = Object.assign((Object.getPrototypeOf(Object.getPrototypeOf(this)) as Application).route.bind(this), makeRouteHelpers(this));
   }
 
   /**

--- a/js/src/forum/ForumApplication.ts
+++ b/js/src/forum/ForumApplication.ts
@@ -80,7 +80,7 @@ export default class ForumApplication extends Application {
 
     routes(this);
 
-    this.route = Object.assign((Object.getPrototypeOf(Object.getPrototypeOf(this)) as Application).route.bind(this), makeRouteHelpers(this));
+    this.route = Object.assign({}, (Object.getPrototypeOf(Object.getPrototypeOf(this)) as Application).route.bind(this), makeRouteHelpers(this));
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2742

- Use a `catch` instead of a `then` with a vacuous `onfulfilled`
- Instead of setting a default `errorHandler` that throws the error, just run the fallback handler if no error handler is explicitly provided
- Split `requestErrorCatch` and `requestErrorDefaultHandler` into separate methods. 
- Clean up some messy duplicate code with `formattedErrors` and `content` on 422 errors
- Properly typehint `AlertAttrs`