### PR TITLE
fix: clicking three dots on post opens all dropdowns in `.Post-actions`

### DIFF
--- a/js/src/forum/components/Post.js
+++ b/js/src/forum/components/Post.js
@@ -66,8 +66,8 @@ export default class Post extends Component {
                     buttonClassName="Button Button--icon Button--flat"
                     menuClassName="Dropdown-menu--right"
                     icon="fas fa-ellipsis-h"
-                    onshow={() => this.$('.Post-actions').addClass('open')}
-                    onhide={() => this.$('.Post-actions').removeClass('open')}
+                    onshow={() => this.$('.Post-controls').addClass('open')}
+                    onhide={() => this.$('.Post-controls').removeClass('open')}
                     accessibleToggleLabel={app.translator.trans('core.forum.post_controls.toggle_dropdown_accessible_label')}
                   >
                     {controls}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- When clicking three dots under a Post, only add the `.open` class to `.Post-controls`, not the entire `.Post-actions` container

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Screenshot (before)**
<!-- include an image of the most relevant user-facing change, if any -->

https://user-images.githubusercontent.com/7406822/144326442-86093f36-f908-484c-9dbe-eb1e2b9d8b9e.mp4

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
