### PR TITLE
Move colorItems to ItemList

### DIFF
--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -82,7 +82,7 @@ export default class AppearancePage extends AdminPage {
     items.add('helpText', <div className="helpText">{app.translator.trans('core.admin.appearance.colors_text')}</div>, 80);
 
     items.add(
-      'color-input',
+      'theme-colors',
       <div className="AppearancePage-colors-input">
         {this.buildSettingComponent({
           type: 'color-preview',

--- a/js/src/admin/components/AppearancePage.js
+++ b/js/src/admin/components/AppearancePage.js
@@ -5,6 +5,7 @@ import EditCustomHeaderModal from './EditCustomHeaderModal';
 import EditCustomFooterModal from './EditCustomFooterModal';
 import UploadImageButton from './UploadImageButton';
 import AdminPage from './AdminPage';
+import ItemList from '../../common/utils/ItemList';
 
 export default class AppearancePage extends AdminPage {
   headerInfo() {
@@ -21,34 +22,7 @@ export default class AppearancePage extends AdminPage {
       <div className="Form">
         <fieldset className="AppearancePage-colors">
           <legend>{app.translator.trans('core.admin.appearance.colors_heading')}</legend>
-          <div className="helpText">{app.translator.trans('core.admin.appearance.colors_text')}</div>
-
-          <div className="AppearancePage-colors-input">
-            {this.buildSettingComponent({
-              type: 'color-preview',
-              setting: 'theme_primary_color',
-              placeholder: '#aaaaaa',
-            })}
-            {this.buildSettingComponent({
-              type: 'color-preview',
-              setting: 'theme_secondary_color',
-              placeholder: '#aaaaaa',
-            })}
-          </div>
-
-          {this.buildSettingComponent({
-            type: 'switch',
-            setting: 'theme_dark_mode',
-            label: app.translator.trans('core.admin.appearance.dark_mode_label'),
-          })}
-
-          {this.buildSettingComponent({
-            type: 'switch',
-            setting: 'theme_colored_header',
-            label: app.translator.trans('core.admin.appearance.colored_header_label'),
-          })}
-
-          {this.submitButton()}
+          {this.colorItems().toArray()}
         </fieldset>
       </div>,
 
@@ -100,6 +74,53 @@ export default class AppearancePage extends AdminPage {
         )}
       </fieldset>,
     ];
+  }
+
+  colorItems() {
+    const items = new ItemList();
+
+    items.add('helpText', <div className="helpText">{app.translator.trans('core.admin.appearance.colors_text')}</div>, 80);
+
+    items.add(
+      'color-input',
+      <div className="AppearancePage-colors-input">
+        {this.buildSettingComponent({
+          type: 'color-preview',
+          setting: 'theme_primary_color',
+          placeholder: '#aaaaaa',
+        })}
+        {this.buildSettingComponent({
+          type: 'color-preview',
+          setting: 'theme_secondary_color',
+          placeholder: '#aaaaaa',
+        })}
+      </div>,
+      70
+    );
+
+    items.add(
+      'dark-mode',
+      this.buildSettingComponent({
+        type: 'switch',
+        setting: 'theme_dark_mode',
+        label: app.translator.trans('core.admin.appearance.dark_mode_label'),
+      }),
+      60
+    );
+
+    items.add(
+      'colored-header',
+      this.buildSettingComponent({
+        type: 'switch',
+        setting: 'theme_colored_header',
+        label: app.translator.trans('core.admin.appearance.colored_header_label'),
+      }),
+      50
+    );
+
+    items.add('submit', this.submitButton(), 0);
+
+    return items;
   }
 
   onsaved() {


### PR DESCRIPTION
**Changes proposed in this pull request:**
At present, if an extension or theme wishes to add/remove any items from `Colors`, dom traversal is required.
To allow for extensions/themes to better integrate with the `Appearance Page`, each element under `Colors` is now built within an `ItemList`.


**Screenshot**
Visibly, no changes
![image](https://user-images.githubusercontent.com/16573496/144384699-3838c935-c217-4038-8d5d-66e8f157b2ce.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
