### PR TITLE
Make StatusWidget tools dropdown extensible

### DIFF
--- a/js/src/admin/components/StatusWidget.js
+++ b/js/src/admin/components/StatusWidget.js
@@ -26,13 +26,24 @@ export default class StatusWidget extends DashboardWidget {
         buttonClassName="Button"
         menuClassName="Dropdown-menu--right"
       >
-        <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>
+        {this.toolsItems().toArray()}
       </Dropdown>
     );
 
     items.add('version-flarum', [<strong>Flarum</strong>, <br />, app.forum.attribute('version')]);
     items.add('version-php', [<strong>PHP</strong>, <br />, app.data.phpVersion]);
     items.add('version-mysql', [<strong>MySQL</strong>, <br />, app.data.mysqlVersion]);
+
+    return items;
+  }
+
+  toolsItems() {
+    const items = new ItemList();
+
+    items.add(
+      'clearCache',
+      <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>
+    );
 
     return items;
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR allows you to more easily modify the tools dropdown in the `StatusWidget` component using `ItemList`.

Until now, if you wanted to add something to this dropdown, you had to push a child:
```js
 extend(StatusWidget.prototype, 'items', (items) => {
    const tools = items.get('tools');
    tools.children.push(<Button>Test</Button>);
  });
```
If you want to remove / replace a given item it gets harder.
Now such code is enough:
```js
 extend(StatusWidget.prototype, 'toolsItems', (items) => {
    items.add('test', <Button>Test</Button>);
  });
```

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Confirm that everything works.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/25438601/144944593-bd0267f8-4ba4-45d1-a8b3-c83b2ec97b46.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
