### PR TITLE
perf: Allow loading relations in other discussion endpoints

### DIFF
--- a/src/Api/Controller/AbstractSerializeController.php
+++ b/src/Api/Controller/AbstractSerializeController.php
@@ -157,7 +157,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @return string[]
      */
-    protected function getRelationsToLoad(): array
+    protected function getRelationsToLoad(Collection $models): array
     {
         $addedRelations = [];
 
@@ -175,7 +175,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      *
      * @return array<string, callable>
      */
-    protected function getRelationCallablesToLoad(): array
+    protected function getRelationCallablesToLoad(Collection $models): array
     {
         $addedRelationCallables = [];
 
@@ -193,8 +193,8 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
      */
     protected function loadRelations(Collection $models, array $relations, ServerRequestInterface $request = null): void
     {
-        $addedRelations = $this->getRelationsToLoad();
-        $addedRelationCallables = $this->getRelationCallablesToLoad();
+        $addedRelations = $this->getRelationsToLoad($models);
+        $addedRelationCallables = $this->getRelationCallablesToLoad($models);
 
         foreach ($addedRelationCallables as $name => $relation) {
             $addedRelations[] = $name;

--- a/src/Api/Controller/CreateDiscussionController.php
+++ b/src/Api/Controller/CreateDiscussionController.php
@@ -14,6 +14,7 @@ use Flarum\Discussion\Command\ReadDiscussion;
 use Flarum\Discussion\Command\StartDiscussion;
 use Flarum\Http\RequestUtil;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -69,6 +70,8 @@ class CreateDiscussionController extends AbstractCreateController
                 new ReadDiscussion($discussion->id, $actor, 1)
             );
         }
+
+        $this->loadRelations(new Collection([$discussion]), $this->extractInclude($request), $request);
 
         return $discussion;
     }


### PR DESCRIPTION
**Related to #3116**

**Changes proposed in this pull request:**
Missed the other two endpoints which also attempt to load the `tags.state` relationship. The impact is the same.

**Reviewers should focus on:**
I really dislike the implementation in ShowDiscussionsController, it's becoming very bloated, and that's mostly due to how the posts of the discussion are loaded. I feel like it would be better to load those posts by directly getting the result from the posts endpoint, we should look into refactoring it in another major version.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
