### PR TITLE
fix: getPlainContent causes external content to be fetched

### DIFF
--- a/js/src/common/utils/string.ts
+++ b/js/src/common/utils/string.ts
@@ -37,7 +37,7 @@ export function getPlainContent(string: string): string {
     });
   });
 
-  return element.textContent.replace(/\s+/g, ' ').trim();
+  return element.innerText.replace(/\s+/g, ' ').trim();
 }
 
 /**

--- a/js/src/common/utils/string.ts
+++ b/js/src/common/utils/string.ts
@@ -28,13 +28,13 @@ export function slug(string: string): string {
 export function getPlainContent(string: string): string {
   const html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/gi, ' ');
 
-  const element = new DOMParser().parseFromString(html, "text/html").documentElement;
+  const element = new DOMParser().parseFromString(html, 'text/html').documentElement;
 
   getPlainContent.removeSelectors.forEach((selector) => {
     const el = element.querySelectorAll(selector);
     el.forEach((e) => {
       e.parentNode?.removeChild(e);
-    })
+    });
   });
 
   return element.textContent.replace(/\s+/g, ' ').trim();

--- a/js/src/common/utils/string.ts
+++ b/js/src/common/utils/string.ts
@@ -33,7 +33,7 @@ export function getPlainContent(string: string): string {
   getPlainContent.removeSelectors.forEach((selector) => {
     const el = element.querySelectorAll(selector);
     el.forEach((e) => {
-      e.parentNode?.removeChild(e);
+      e.remove();
     });
   });
 

--- a/js/src/common/utils/string.ts
+++ b/js/src/common/utils/string.ts
@@ -28,11 +28,16 @@ export function slug(string: string): string {
 export function getPlainContent(string: string): string {
   const html = string.replace(/(<\/p>|<br>)/g, '$1 &nbsp;').replace(/<img\b[^>]*>/gi, ' ');
 
-  const dom = $('<div/>').html(html);
+  const element = new DOMParser().parseFromString(html, "text/html").documentElement;
 
-  dom.find(getPlainContent.removeSelectors.join(',')).remove();
+  getPlainContent.removeSelectors.forEach((selector) => {
+    const el = element.querySelectorAll(selector);
+    el.forEach((e) => {
+      e.parentNode?.removeChild(e);
+    })
+  });
 
-  return dom.text().replace(/\s+/g, ' ').trim();
+  return element.textContent.replace(/\s+/g, ' ').trim();
 }
 
 /**


### PR DESCRIPTION


**Changes proposed in this pull request:**
`getPlainContent` renders the element using `jQuery`, which when an image is included in the content, causes this image to be fetched from the server unneccessarily. 

Impact can be seen for example when a post `excerpt` is present, either from `flarum/sticky` or `ianm/synopsis`. If several posts are stickied, or if synopsis is enabled, many images or videos, etc are fetched.

Taking advice from @davwheat , I've refactored this util to not use jQuery at all.


**Reviewers should focus on:**
`js` is not my strong suit, this appears to work, but please let me know if I've missed something!


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
