### PR TITLE
Make SlugManager available to blade template

### DIFF
--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -148,7 +148,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
 
         $views->share([
             'translator' => $container->make('translator'),
-            'url' => $container->make(UrlGenerator::class)
+            'url' => $container->make(UrlGenerator::class),
+            'slugManager' => $container->make(SlugManager::class)
         ]);
     }
 

--- a/src/Frontend/FrontendServiceProvider.php
+++ b/src/Frontend/FrontendServiceProvider.php
@@ -14,6 +14,7 @@ use Flarum\Foundation\Paths;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
 use Flarum\Frontend\Driver\BasicTitleDriver;
 use Flarum\Frontend\Driver\TitleDriverInterface;
+use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;


### PR DESCRIPTION
**Fixes #0000**

I discovered that, it is not possible to use `SlugManager` within a mail template. Example use case: https://github.com/FriendsOfFlarum/subscribed/blob/be01ea2b2259733c5e59b970e8bb6172243982bc/resources/views/emails/userCreated.blade.php#L5

This template errors if the user slugger is not `default`.

A solution is ready, but requires this PR: https://github.com/FriendsOfFlarum/subscribed/pull/15

**Changes proposed in this pull request:**
Make `SlugManager` available to `blade` templates

**Reviewers should focus on:**
I also considered adding an alias, something like `flarum.slug.manager` here, and resolving from that in the template, but I think the above solution is probably more dev friendly
https://github.com/flarum/core/blob/master/src/Http/HttpServiceProvider.php#L64-L66

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
