### PR TITLE
feat: Allow switching the ImageManager driver

### DIFF
--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -56,7 +56,8 @@ class UploadFaviconController extends UploadImageController
             ]);
         }
 
-        $manager = new ImageManager();
+        /** @var ImageManager $manager */
+        $manager = resolve(ImageManager::class);
 
         $encodedImage = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
             $constraint->aspectRatio();

--- a/src/Api/Controller/UploadFaviconController.php
+++ b/src/Api/Controller/UploadFaviconController.php
@@ -29,14 +29,20 @@ class UploadFaviconController extends UploadImageController
     protected $translator;
 
     /**
+     * @var ImageManager
+     */
+    protected $imageManager;
+
+    /**
      * @param SettingsRepositoryInterface $settings
      * @param Factory $filesystemFactory
      */
-    public function __construct(SettingsRepositoryInterface $settings, Factory $filesystemFactory, TranslatorInterface $translator)
+    public function __construct(SettingsRepositoryInterface $settings, Factory $filesystemFactory, TranslatorInterface $translator, ImageManager $imageManager)
     {
         parent::__construct($settings, $filesystemFactory);
 
         $this->translator = $translator;
+        $this->imageManager = $imageManager;
     }
 
     /**
@@ -56,10 +62,7 @@ class UploadFaviconController extends UploadImageController
             ]);
         }
 
-        /** @var ImageManager $manager */
-        $manager = resolve(ImageManager::class);
-
-        $encodedImage = $manager->make($file->getStream())->resize(64, 64, function ($constraint) {
+        $encodedImage = $this->imageManager->make($file->getStream())->resize(64, 64, function ($constraint) {
             $constraint->aspectRatio();
             $constraint->upsize();
         })->encode('png');

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -24,7 +24,8 @@ class UploadLogoController extends UploadImageController
      */
     protected function makeImage(UploadedFileInterface $file): Image
     {
-        $manager = new ImageManager();
+        /** @var ImageManager $manager */
+        $manager = resolve(ImageManager::class);
 
         $encodedImage = $manager->make($file->getStream())->heighten(60, function ($constraint) {
             $constraint->upsize();

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Api\Controller;
 
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Filesystem\Factory;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
@@ -20,14 +22,23 @@ class UploadLogoController extends UploadImageController
     protected $filenamePrefix = 'logo';
 
     /**
+     * @var ImageManager
+     */
+    protected $imageManager;
+
+    public function __construct(SettingsRepositoryInterface $settings, Factory $filesystemFactory, ImageManager $imageManager)
+    {
+        parent::__construct($settings, $filesystemFactory);
+
+        $this->imageManager = $imageManager;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function makeImage(UploadedFileInterface $file): Image
     {
-        /** @var ImageManager $manager */
-        $manager = resolve(ImageManager::class);
-
-        $encodedImage = $manager->make($file->getStream())->heighten(60, function ($constraint) {
+        $encodedImage = $this->imageManager->make($file->getStream())->heighten(60, function ($constraint) {
             $constraint->upsize();
         })->encode('png');
 

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -80,7 +80,7 @@ class FilesystemServiceProvider extends AbstractServiceProvider
             }
 
             if (! Arr::has(self::INTERVENTION_DRIVERS, $driver)) {
-                throw new RuntimeException('intervention/image: invalid driver');
+                throw new RuntimeException("intervention/image: $driver is not valid");
             }
 
             return new ImageManager([

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -24,7 +24,7 @@ class FilesystemServiceProvider extends AbstractServiceProvider
     const gdDriver = 'gd';
     const imagickDriver = 'imagick';
     const interventionDrivers = ['gd' => 'gd', 'imagick' => 'imagick'];
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -12,12 +12,12 @@ namespace Flarum\Filesystem;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Config;
 use Flarum\Foundation\Paths;
-use Flarum\Foundation\ValidationException;
 use Flarum\Http\UrlGenerator;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Intervention\Image\ImageManager;
+use RuntimeException;
 
 class FilesystemServiceProvider extends AbstractServiceProvider
 {
@@ -80,7 +80,7 @@ class FilesystemServiceProvider extends AbstractServiceProvider
             }
 
             if (! Arr::has(self::INTERVENTION_DRIVERS, $driver)) {
-                throw new ValidationException(['intervention' => 'invalid driver']);
+                throw new RuntimeException('intervention/image: invalid driver');
             }
 
             return new ImageManager([

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -21,8 +21,6 @@ use Intervention\Image\ImageManager;
 
 class FilesystemServiceProvider extends AbstractServiceProvider
 {
-    const gdDriver = 'gd';
-    const imagickDriver = 'imagick';
     const interventionDrivers = ['gd' => 'gd', 'imagick' => 'imagick'];
 
     /**

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -21,7 +21,7 @@ use Intervention\Image\ImageManager;
 
 class FilesystemServiceProvider extends AbstractServiceProvider
 {
-    const interventionDrivers = ['gd' => 'gd', 'imagick' => 'imagick'];
+    protected const INTERVENTION_DRIVERS = ['gd' => 'gd', 'imagick' => 'imagick'];
 
     /**
      * {@inheritdoc}
@@ -72,14 +72,14 @@ class FilesystemServiceProvider extends AbstractServiceProvider
             $config = $this->container->make(Config::class);
 
             $intervention = $config->offsetGet('intervention');
-            $driver = Arr::get($intervention, 'driver', self::interventionDrivers['gd']);
+            $driver = Arr::get($intervention, 'driver', self::INTERVENTION_DRIVERS['gd']);
 
             // Check that the imagick library is actually available, else default back to gd.
-            if ($driver === self::interventionDrivers['imagick'] && ! extension_loaded(self::interventionDrivers['imagick'])) {
-                $driver = self::interventionDrivers['gd'];
+            if ($driver === self::INTERVENTION_DRIVERS['imagick'] && ! extension_loaded(self::INTERVENTION_DRIVERS['imagick'])) {
+                $driver = self::INTERVENTION_DRIVERS['gd'];
             }
 
-            if (! Arr::has(self::interventionDrivers, $driver)) {
+            if (! Arr::has(self::INTERVENTION_DRIVERS, $driver)) {
                 throw new ValidationException(['intervention' => 'invalid driver']);
             }
 

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -13,7 +13,6 @@ use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
-use Flarum\Foundation\Config;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
 use Flarum\Foundation\ErrorHandling\ViewFormatter;
@@ -35,8 +34,6 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Support\Arr;
-use Intervention\Image\ImageManager;
 use Laminas\Stratigility\MiddlewarePipe;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -131,22 +128,6 @@ class ForumServiceProvider extends AbstractServiceProvider
 
         $this->container->bind('flarum.frontend.forum', function (Container $container) {
             return $container->make('flarum.frontend.factory')('forum');
-        });
-
-        $this->container->singleton(ImageManager::class, function (Container $container) {
-            /** @var Config $config */
-            $config = $this->container->make(Config::class);
-
-            $intervention = $config->offsetGet('intervention');
-            $driver = Arr::get($intervention, 'driver', 'gd');
-
-            // Check that the imagick library is actually available, else default back to gd.
-            if ($driver === 'imagick' && ! extension_loaded('imagick')) {
-                $driver = 'gd';
-            }
-            return new ImageManager([
-                'driver' => $driver
-            ]);
         });
     }
 

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -140,6 +140,7 @@ class ForumServiceProvider extends AbstractServiceProvider
             $intervention = $config->offsetGet('intervention');
             $driver = Arr::get($intervention, 'driver', 'gd');
 
+            // Check that the imagick library is actually available, else default back to gd.
             if ($driver === 'imagick' && ! extension_loaded('imagick')) {
                 $driver = 'gd';
             }

--- a/src/Forum/ForumServiceProvider.php
+++ b/src/Forum/ForumServiceProvider.php
@@ -13,6 +13,7 @@ use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
 use Flarum\Foundation\ErrorHandling\ViewFormatter;
@@ -34,6 +35,8 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Arr;
+use Intervention\Image\ImageManager;
 use Laminas\Stratigility\MiddlewarePipe;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -128,6 +131,21 @@ class ForumServiceProvider extends AbstractServiceProvider
 
         $this->container->bind('flarum.frontend.forum', function (Container $container) {
             return $container->make('flarum.frontend.factory')('forum');
+        });
+
+        $this->container->singleton(ImageManager::class, function (Container $container) {
+            /** @var Config $config */
+            $config = $this->container->make(Config::class);
+
+            $intervention = $config->offsetGet('intervention');
+            $driver = Arr::get($intervention, 'driver', 'gd');
+
+            if ($driver === 'imagick' && ! extension_loaded('imagick')) {
+                $driver = 'gd';
+            }
+            return new ImageManager([
+                'driver' => $driver
+            ]);
         });
     }
 

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -73,7 +73,7 @@ class AvatarValidator extends AbstractValidator
         }
 
         try {
-            (new ImageManager)->make($file->getStream());
+            (resolve(ImageManager::class))->make($file->getStream());
         } catch (NotReadableException $_e) {
             $this->raise('image');
         }

--- a/src/User/AvatarValidator.php
+++ b/src/User/AvatarValidator.php
@@ -11,10 +11,12 @@ namespace Flarum\User;
 
 use Flarum\Foundation\AbstractValidator;
 use Flarum\Foundation\ValidationException;
+use Illuminate\Validation\Factory;
 use Intervention\Image\Exception\NotReadableException;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
 use Symfony\Component\Mime\MimeTypes;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AvatarValidator extends AbstractValidator
 {
@@ -22,6 +24,18 @@ class AvatarValidator extends AbstractValidator
      * @var \Illuminate\Validation\Validator
      */
     protected $laravelValidator;
+
+    /**
+     * @var ImageManager
+     */
+    protected $imageManager;
+
+    public function __construct(Factory $validator, TranslatorInterface $translator, ImageManager $imageManager)
+    {
+        parent::__construct($validator, $translator);
+
+        $this->imageManager = $imageManager;
+    }
 
     /**
      * Throw an exception if a model is not valid.
@@ -73,7 +87,7 @@ class AvatarValidator extends AbstractValidator
         }
 
         try {
-            (resolve(ImageManager::class))->make($file->getStream());
+            $this->imageManager->make($file->getStream());
         } catch (NotReadableException $_e) {
             $this->raise('image');
         }

--- a/src/User/Command/RegisterUserHandler.php
+++ b/src/User/Command/RegisterUserHandler.php
@@ -50,18 +50,24 @@ class RegisterUserHandler
     private $validator;
 
     /**
+     * @var ImageManager
+     */
+    protected $imageManager;
+
+    /**
      * @param Dispatcher $events
      * @param SettingsRepositoryInterface $settings
      * @param UserValidator $validator
      * @param AvatarUploader $avatarUploader
      */
-    public function __construct(Dispatcher $events, SettingsRepositoryInterface $settings, UserValidator $userValidator, AvatarUploader $avatarUploader, Factory $validator)
+    public function __construct(Dispatcher $events, SettingsRepositoryInterface $settings, UserValidator $userValidator, AvatarUploader $avatarUploader, Factory $validator, ImageManager $imageManager)
     {
         $this->events = $events;
         $this->settings = $settings;
         $this->userValidator = $userValidator;
         $this->avatarUploader = $avatarUploader;
         $this->validator = $validator;
+        $this->imageManager = $imageManager;
     }
 
     /**
@@ -160,7 +166,7 @@ class RegisterUserHandler
             throw new InvalidArgumentException("Provided avatar URL must have scheme http or https. Scheme provided was $scheme.", 503);
         }
 
-        $image = resolve(ImageManager::class)->make($url);
+        $image = $this->imageManager->make($url);
 
         $this->avatarUploader->upload($user, $image);
     }

--- a/src/User/Command/RegisterUserHandler.php
+++ b/src/User/Command/RegisterUserHandler.php
@@ -160,7 +160,7 @@ class RegisterUserHandler
             throw new InvalidArgumentException("Provided avatar URL must have scheme http or https. Scheme provided was $scheme.", 503);
         }
 
-        $image = (new ImageManager)->make($url);
+        $image = resolve(ImageManager::class)->make($url);
 
         $this->avatarUploader->upload($user, $image);
     }

--- a/src/User/Command/UploadAvatarHandler.php
+++ b/src/User/Command/UploadAvatarHandler.php
@@ -68,7 +68,7 @@ class UploadAvatarHandler
 
         $this->validator->assertValid(['avatar' => $command->file]);
 
-        $image = (new ImageManager)->make($command->file->getStream());
+        $image = resolve(ImageManager::class)->make($command->file->getStream());
 
         $this->events->dispatch(
             new AvatarSaving($user, $actor, $image)

--- a/src/User/Command/UploadAvatarHandler.php
+++ b/src/User/Command/UploadAvatarHandler.php
@@ -37,17 +37,23 @@ class UploadAvatarHandler
     protected $validator;
 
     /**
+     * @var ImageManager
+     */
+    protected $imageManager;
+
+    /**
      * @param Dispatcher $events
      * @param UserRepository $users
      * @param AvatarUploader $uploader
      * @param AvatarValidator $validator
      */
-    public function __construct(Dispatcher $events, UserRepository $users, AvatarUploader $uploader, AvatarValidator $validator)
+    public function __construct(Dispatcher $events, UserRepository $users, AvatarUploader $uploader, AvatarValidator $validator, ImageManager $imageManager)
     {
         $this->events = $events;
         $this->users = $users;
         $this->uploader = $uploader;
         $this->validator = $validator;
+        $this->imageManager = $imageManager;
     }
 
     /**
@@ -68,7 +74,7 @@ class UploadAvatarHandler
 
         $this->validator->assertValid(['avatar' => $command->file]);
 
-        $image = resolve(ImageManager::class)->make($command->file->getStream());
+        $image = $this->imageManager->make($command->file->getStream());
 
         $this->events->dispatch(
             new AvatarSaving($user, $actor, $image)


### PR DESCRIPTION
I recently identified an issue where image uploads were rendered with different color gamuts if they had been processed by Intervention in any way (resized, etc), if they had an embedded icc color profile. By switching to `imagick`, this profile was respected. Therefore, I'd like to introduce the option to use either driver everywhere in Flarum.

We use the `ImageManager` from Intervention in plently of places, both in core and extensions. Intervention supports two drivers - `gd` (default) and `imagick`. [ref](http://image.intervention.io/getting_started/configuration)

This PR adds the possibility to switch to `imagick`, if this is required.

By default `gd` will still be used, however, adding the following to `config.php`, one can specify the alternative:
```php
'intervention' =>
  array (
    'driver' => 'imagick',
  )
```

Extensions should update their code and refrain from `new ImageManager()` and resolve the singleton from the container instead.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
