### PR TITLE
fix: Only update notifications that are not already marked as read

### DIFF
--- a/src/Notification/NotificationRepository.php
+++ b/src/Notification/NotificationRepository.php
@@ -50,6 +50,8 @@ class NotificationRepository
      */
     public function markAllAsRead(User $user)
     {
-        Notification::where('user_id', $user->id)->update(['read_at' => Carbon::now()]);
+        Notification::where('user_id', $user->id)
+            ->whereNull('read_at')
+            ->update(['read_at' => Carbon::now()]);
     }
 }


### PR DESCRIPTION
Currently `markAllAsRead` updates the `read_at` column with the current timestamp for **all** notifications for a given user. That sucks, especially on a forum which may have a large number of notifications for each user.

We only need to mark notifications as read for those which are not already marked as such.
