### PR TITLE
feat: Add events for Notification read / read all

### DIFF
--- a/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -27,6 +27,7 @@ class ReadAllNotificationsHandler
 
     /**
      * @param NotificationRepository $notifications
+     * @param Dispatcher $events
      */
     public function __construct(NotificationRepository $notifications, Dispatcher $events)
     {

--- a/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -12,6 +12,7 @@ namespace Flarum\Notification\Command;
 use Flarum\Notification\Event\ReadAll;
 use Flarum\Notification\NotificationRepository;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Carbon;
 
 class ReadAllNotificationsHandler
 {
@@ -47,6 +48,6 @@ class ReadAllNotificationsHandler
 
         $this->notifications->markAllAsRead($actor);
 
-        $this->events->dispatch(new ReadAll($actor));
+        $this->events->dispatch(new ReadAll($actor, Carbon::now()));
     }
 }

--- a/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -9,7 +9,9 @@
 
 namespace Flarum\Notification\Command;
 
+use Flarum\Notification\Event\ReadAll;
 use Flarum\Notification\NotificationRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class ReadAllNotificationsHandler
 {
@@ -19,11 +21,17 @@ class ReadAllNotificationsHandler
     protected $notifications;
 
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
      * @param NotificationRepository $notifications
      */
-    public function __construct(NotificationRepository $notifications)
+    public function __construct(NotificationRepository $notifications, Dispatcher $events)
     {
         $this->notifications = $notifications;
+        $this->events = $events;
     }
 
     /**
@@ -37,5 +45,7 @@ class ReadAllNotificationsHandler
         $actor->assertRegistered();
 
         $this->notifications->markAllAsRead($actor);
+
+        $this->events->dispatch(new ReadAll($actor));
     }
 }

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -17,7 +17,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 class ReadNotificationHandler
 {
     /**
-     * @var DIspatcher
+     * @var Dispatcher
      */
     protected $events;
 

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -10,10 +10,19 @@
 namespace Flarum\Notification\Command;
 
 use Carbon\Carbon;
+use Flarum\Notification\Event\Read;
 use Flarum\Notification\Notification;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class ReadNotificationHandler
 {
+    protected $events;
+
+    public function __construct(Dispatcher $events)
+    {
+        $this->events = $events;
+    }
+    
     /**
      * @param ReadNotification $command
      * @return \Flarum\Notification\Notification
@@ -36,6 +45,8 @@ class ReadNotificationHandler
 
         $notification->read_at = Carbon::now();
 
+        $this->events->dispatch(new Read($actor, $notification));
+        
         return $notification;
     }
 }

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -16,8 +16,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 class ReadNotificationHandler
 {
+    /**
+     * @var DIspatcher
+     */
     protected $events;
 
+    /**
+     * @param Dispatcher $events
+     */
     public function __construct(Dispatcher $events)
     {
         $this->events = $events;

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -51,7 +51,7 @@ class ReadNotificationHandler
 
         $notification->read_at = Carbon::now();
 
-        $this->events->dispatch(new Read($actor, $notification));
+        $this->events->dispatch(new Read($actor, $notification, Carbon::now()));
 
         return $notification;
     }

--- a/src/Notification/Command/ReadNotificationHandler.php
+++ b/src/Notification/Command/ReadNotificationHandler.php
@@ -22,7 +22,7 @@ class ReadNotificationHandler
     {
         $this->events = $events;
     }
-    
+
     /**
      * @param ReadNotification $command
      * @return \Flarum\Notification\Notification
@@ -46,7 +46,7 @@ class ReadNotificationHandler
         $notification->read_at = Carbon::now();
 
         $this->events->dispatch(new Read($actor, $notification));
-        
+
         return $notification;
     }
 }

--- a/src/Notification/Event/Read.php
+++ b/src/Notification/Event/Read.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Event;
+
+use Flarum\Notification\Notification;
+use Flarum\User\User;
+
+class Read
+{
+    /**
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @var Notification
+     */
+    public $notification;
+
+    public function __construct(User $user, Notification $notification)
+    {
+        $this->user = $user;
+        $this->notification = $notification;
+    }
+}

--- a/src/Notification/Event/Read.php
+++ b/src/Notification/Event/Read.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Notification\Event;
 
+use DateTime;
 use Flarum\Notification\Notification;
 use Flarum\User\User;
 
@@ -24,9 +25,15 @@ class Read
      */
     public $notification;
 
-    public function __construct(User $user, Notification $notification)
+    /**
+     * @var DateTime
+     */
+    public $timestamp;
+
+    public function __construct(User $user, Notification $notification, DateTime $timestamp)
     {
         $this->user = $user;
         $this->notification = $notification;
+        $this->timestamp = $timestamp;
     }
 }

--- a/src/Notification/Event/ReadAll.php
+++ b/src/Notification/Event/ReadAll.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Event;
+
+use Flarum\User\User;
+
+class ReadAll
+{
+    /**
+     * @var User
+     */
+    public $actor;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Notification/Event/ReadAll.php
+++ b/src/Notification/Event/ReadAll.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Notification\Event;
 
+use DateTime;
 use Flarum\User\User;
 
 class ReadAll
@@ -18,8 +19,14 @@ class ReadAll
      */
     public $actor;
 
-    public function __construct(User $user)
+    /**
+     * @var DateTime
+     */
+    public $timestamp;
+
+    public function __construct(User $user, DateTime $timestamp)
     {
         $this->user = $user;
+        $this->timestamp = $timestamp;
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds events for `Notification` read and readall actions, for extensions to listen for.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
