### PR TITLE
fix: Empty settings don't return defaults

### DIFF
--- a/src/Settings/DatabaseSettingsRepository.php
+++ b/src/Settings/DatabaseSettingsRepository.php
@@ -27,7 +27,7 @@ class DatabaseSettingsRepository implements SettingsRepositoryInterface
 
     public function get($key, $default = null)
     {
-        if (is_null($value = $this->database->table('settings')->where('key', $key)->value('value'))) {
+        if (empty($value = $this->database->table('settings')->where('key', $key)->value('value'))) {
             return $default;
         }
 

--- a/src/Settings/MemoryCacheSettingsRepository.php
+++ b/src/Settings/MemoryCacheSettingsRepository.php
@@ -37,7 +37,10 @@ class MemoryCacheSettingsRepository implements SettingsRepositoryInterface
     public function get($key, $default = null)
     {
         if (array_key_exists($key, $this->cache)) {
-            if (empty($this->cache[$key])) return $default;
+            if (empty($this->cache[$key])) {
+                return $default;
+            }
+
             return $this->cache[$key];
         } elseif (! $this->isCached) {
             return Arr::get($this->all(), $key, $default);

--- a/src/Settings/MemoryCacheSettingsRepository.php
+++ b/src/Settings/MemoryCacheSettingsRepository.php
@@ -37,6 +37,7 @@ class MemoryCacheSettingsRepository implements SettingsRepositoryInterface
     public function get($key, $default = null)
     {
         if (array_key_exists($key, $this->cache)) {
+            if (empty($this->cache[$key])) return $default;
             return $this->cache[$key];
         } elseif (! $this->isCached) {
             return Arr::get($this->all(), $key, $default);


### PR DESCRIPTION
**Changes proposed in this pull request:**
This has been an annoyance forever, as an extention developer.

For example, we have a setting, a string let's say. We can provide a default value for that, great. However, if that setting is saved as simply an empty string `''`, I would expect the provided default to be returned. That's not currently the case.

At present, the logic for deciding if the default should be returned is based on `is_null`, which only works if that setting key does not exist on the table. By using `empty()`, we can check for `null` or empty string at the same time, and return the default, if provided.

**Reviewers should focus on:**
Are there any unexpected side effects of doing this?

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
