### PR TITLE
fix: breaking change in Search component - renaming of `state` property

### DIFF
--- a/js/src/common/Store.ts
+++ b/js/src/common/Store.ts
@@ -1,6 +1,6 @@
 import app from '../common/app';
 import { FlarumRequestOptions } from './Application';
-import fireDebugWarning from './helpers/fireDebugWarning';
+import { fireDeprecationWarning } from './helpers/fireDebugWarning';
 import Model, { ModelData, SavedModelData } from './Model';
 
 export interface MetaInformation {
@@ -123,11 +123,7 @@ export default class Store {
     if (!this.models[data.type]) {
       if (!allowUnregistered) {
         setTimeout(() =>
-          fireDebugWarning(
-            `[Flarum 2.0 Deprecation] Cannot push object of type \`${data.type}\`, as that type has not yet been registered in the store. This will throw an error in Flarum 2.0 and later.
-
-For more information, see https://github.com/flarum/core/pull/3206.`
-          )
+          fireDeprecationWarning(`Pushing object of type \`${data.type}\` not allowed, as type not yet registered in the store.`, '3206')
         );
       }
 

--- a/js/src/common/helpers/fireDebugWarning.ts
+++ b/js/src/common/helpers/fireDebugWarning.ts
@@ -27,7 +27,7 @@ export default function fireDebugWarning(...args: Parameters<typeof console.warn
  * @param githubId The PR or Issue ID with more info in relation to this change.
  * @param [removedFrom] The version in which this feature will be completely removed. (default: 2.0)
  * @param [repo] The repo which the issue or PR is located in. (default: flarum/core)
- * 
+ *
  * @see {@link fireDebugWarning}
  */
 export function fireDeprecationWarning(message: string, githubId: string, removedFrom: string = '2.0', repo: string = 'flarum/core'): void {

--- a/js/src/common/helpers/fireDebugWarning.ts
+++ b/js/src/common/helpers/fireDebugWarning.ts
@@ -16,3 +16,20 @@ export default function fireDebugWarning(...args: Parameters<typeof console.warn
 
   console.warn(...args);
 }
+
+/**
+ * Fire a Flarum deprecation warning which is shown in the JS console.
+ *
+ * These warnings are only shown when the forum is in debug mode, and the function exists to
+ * reduce bundle size caused by multiple warnings across our JavaScript.
+ *
+ * @param message The message to display. (Short, but sweet, please!)
+ * @param githubId The PR or Issue ID with more info in relation to this change.
+ * @param [removedFrom] The version in which this feature will be completely removed. (default: 2.0)
+ * @param [repo] The repo which the issue or PR is located in. (default: flarum/core)
+ * 
+ * @see {@link fireDebugWarning}
+ */
+export function fireDeprecationWarning(message: string, githubId: string, removedFrom: string = '2.0', repo: string = 'flarum/core'): void {
+  fireDebugWarning(`[Flarum ${removedFrom} Deprecation] ${message}\n\nSee: https://github.com/${repo}/issue/${githubId}`);
+}

--- a/js/src/common/helpers/fireDebugWarning.ts
+++ b/js/src/common/helpers/fireDebugWarning.ts
@@ -31,5 +31,6 @@ export default function fireDebugWarning(...args: Parameters<typeof console.warn
  * @see {@link fireDebugWarning}
  */
 export function fireDeprecationWarning(message: string, githubId: string, removedFrom: string = '2.0', repo: string = 'flarum/core'): void {
-  fireDebugWarning(`[Flarum ${removedFrom} Deprecation] ${message}\n\nSee: https://github.com/${repo}/issue/${githubId}`);
+  // GitHub auto-redirects between `/pull` and `/issues` for us, so using `/pull` saves 2 bytes!
+  fireDebugWarning(`[Flarum ${removedFrom} Deprecation] ${message}\n\nSee: https://github.com/${repo}/pull/${githubId}`);
 }

--- a/js/src/common/utils/evented.js
+++ b/js/src/common/utils/evented.js
@@ -1,15 +1,14 @@
+import { fireDeprecationWarning } from '../helpers/fireDebugWarning';
+
+const deprecatedNotice = 'The `evented` util is deprecated and no longer supported.';
+const deprecationIssueId = '2547';
+
 /**
  * The `evented` mixin provides methods allowing an object to trigger events,
  * running externally registered event handlers.
  *
  * @deprecated v1.2, to be removed in v2.0
  */
-
-import fireDebugWarning from '../helpers/fireDebugWarning';
-
-const deprecatedNotice =
-  'The `evented` util is deprecated and will be removed in Flarum 2.0. For more info, please see https://github.com/flarum/core/issues/2547';
-
 export default {
   /**
    * Arrays of registered event handlers, grouped by the event name.
@@ -27,7 +26,7 @@ export default {
    * @protected
    */
   getHandlers(event) {
-    fireDebugWarning(deprecatedNotice);
+    fireDeprecationWarning(deprecatedNotice, deprecationIssueId);
 
     this.handlers = this.handlers || {};
 
@@ -44,7 +43,7 @@ export default {
    * @public
    */
   trigger(event, ...args) {
-    fireDebugWarning(deprecatedNotice);
+    fireDeprecationWarning(deprecatedNotice, deprecationIssueId);
 
     this.getHandlers(event).forEach((handler) => handler.apply(this, args));
   },
@@ -56,7 +55,7 @@ export default {
    * @param {function} handler The function to handle the event.
    */
   on(event, handler) {
-    fireDebugWarning(deprecatedNotice);
+    fireDeprecationWarning(deprecatedNotice, deprecationIssueId);
 
     this.getHandlers(event).push(handler);
   },
@@ -69,7 +68,7 @@ export default {
    * @param {function} handler The function to handle the event.
    */
   one(event, handler) {
-    fireDebugWarning(deprecatedNotice);
+    fireDeprecationWarning(deprecatedNotice, deprecationIssueId);
 
     const wrapper = function () {
       handler.apply(this, arguments);
@@ -87,7 +86,7 @@ export default {
    * @param {function} handler The function that handles the event.
    */
   off(event, handler) {
-    fireDebugWarning(deprecatedNotice);
+    fireDeprecationWarning(deprecatedNotice, deprecationIssueId);
 
     const handlers = this.getHandlers(event);
     const index = handlers.indexOf(handler);

--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -74,6 +74,9 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
   protected get state() {
     return this.searchState;
   }
+  protected set state(state: SearchState) {
+    this.searchState = state;
+  }
 
   /**
    * Whether or not the search input has focus.

--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -53,13 +53,27 @@ export interface SearchAttrs extends ComponentAttrs {
  *
  * - state: SearchState instance.
  */
-export default class Search<T extends SearchAttrs = SearchAttrs> extends Component<T> {
+export default class Search<T extends SearchAttrs = SearchAttrs> extends Component<T, SearchState> {
   /**
    * The minimum query length before sources are searched.
    */
   protected static MIN_SEARCH_LEN = 3;
 
+  /**
+   * The instance of `SearchState` for this component.
+   */
   protected searchState!: SearchState;
+
+  /**
+   * The instance of `SearchState` for this component.
+   *
+   * @deprecated Replace with`this.searchState` instead.
+   */
+  // TODO: [Flarum 2.0] Remove this.
+  // @ts-expect-error This is a get accessor, while superclass defines this as a property. This is needed to prevent breaking changes, however.
+  protected get state() {
+    return this.searchState;
+  }
 
   /**
    * Whether or not the search input has focus.

--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -9,8 +9,8 @@ import icon from '../../common/helpers/icon';
 import SearchState from '../states/SearchState';
 import DiscussionsSearchSource from './DiscussionsSearchSource';
 import UsersSearchSource from './UsersSearchSource';
+import { fireDeprecationWarning } from '../../common/helpers/fireDebugWarning';
 import type Mithril from 'mithril';
-import Model from '../../common/Model';
 
 /**
  * The `SearchSource` interface defines a section of search results in the
@@ -72,9 +72,11 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
   // TODO: [Flarum 2.0] Remove this.
   // @ts-expect-error This is a get accessor, while superclass defines this as a property. This is needed to prevent breaking changes, however.
   protected get state() {
+    fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
     return this.searchState;
   }
   protected set state(state: SearchState) {
+    fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
     this.searchState = state;
   }
 


### PR DESCRIPTION
**Extension developers:**
Accessing the `state` property of the `Search` component is now deprecated, and will be removed in Flarum 2.0. Please replace usages of this property with `searchState`. You do not need to change any of your code's implementation -- just a simple rename of the property works fine.

When doing so, be aware that you **must** update your `flarum/core` constraint to `^1.2.0` in order to not cause errors on older versions of Flarum.

_Old example:_
```tsx
if (typeof this.state.getValue() === 'undefined') {
  this.state.setValue('');
}
```

_New example:_
```tsx
if (typeof this.searchState.getValue() === 'undefined') {
  this.searchState.setValue('');
}
```

----

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
A breaking change was implemented as part of the model TS refactor to the Search component. Any components which inherited from this class would be met with forum-breaking errors when accessing the `state` property, as this was unexpectedly renamed to `searchState`.

This PR implements getters and setters for the old `state` property, which get/set the new `searchState` property. This also fires a debug warning with a deprecation notice, and a link to this PR for extension developers to read.

_As an example, this change would break FoF/Byobu._

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
