### PR TITLE
fix: use app `baseUrl` instead of `location.origin`

### DIFF
--- a/js/src/forum/components/PostMeta.js
+++ b/js/src/forum/components/PostMeta.js
@@ -55,6 +55,6 @@ export default class PostMeta extends Component {
    * @returns {String}
    */
   getPermalink(post) {
-    return window.location.origin + app.route.post(post);
+    return app.forum.attribute('baseUrl') + app.route.post(post);
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
PostMeta contains a permalink to a post, however this link is generated with `window.location.origin` instead of `app.forum.attribute('baseUrl')`, meaning that if Flarum is installed as a subdirectory, these links would be invalid as they would miss the subdirectory.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
