### PR TITLE
Only retain scroll position if coming from discussion

### DIFF
--- a/js/src/forum/components/IndexPage.js
+++ b/js/src/forum/components/IndexPage.js
@@ -89,9 +89,9 @@ export default class IndexPage extends Page {
     // Let browser handle scrolling on page reload.
     if (app.previous.type == null) return;
 
-    // When on mobile, only retain scroll if we're coming from a discussion page.
+    // Only retain scroll position if we're coming from a discussion page.
     // Otherwise, we've just changed the filter, so we should go to the top of the page.
-    if (app.screen() == 'desktop' || app.screen() == 'desktop-hd' || this.lastDiscussion) {
+    if (this.lastDiscussion) {
       $(window).scrollTop(scrollTop - oldHeroHeight + heroHeight);
     } else {
       $(window).scrollTop(0);


### PR DESCRIPTION
Fixes https://discuss.flarum.org/d/29596-make-tag-hero-visible/8.

If a user has just switched from one tag to another, they want to see the entire new discussion list, and information about which tag that discussion list corresponds to. There's no good reason to not display the hero header when switching tags.
