### PR TITLE
perf: include request info in first accesstoken touch

### DIFF
--- a/src/Http/Middleware/RememberFromCookie.php
+++ b/src/Http/Middleware/RememberFromCookie.php
@@ -41,7 +41,7 @@ class RememberFromCookie implements Middleware
             $token = AccessToken::findValid($id);
 
             if ($token && $token instanceof RememberAccessToken) {
-                $token->touch();
+                $token->touch($request);
 
                 /** @var \Illuminate\Contracts\Session\Session $session */
                 $session = $request->getAttribute('session');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes: #3234**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Prevents two separate DB updates as a result of sequential token `->touch()`es.

![image](https://user-images.githubusercontent.com/7406822/147514750-3b8a49c7-c984-4fd6-a02f-58b121b9f299.png)

If a user selects the Remember option, the last activity timestamp is updated in that middleware, then the IP and user agent is updated in the session auth middleware.

These two separate requests can be merged by actually providing the request info to the touch method in the remember middleware.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
