### PR TITLE
fix: mark render method in RouteResolver as optional

### DIFF
--- a/js/src/common/Application.tsx
+++ b/js/src/common/Application.tsx
@@ -106,14 +106,21 @@ export interface RouteResolver<
    *
    * Returns the component class, and **not** a Vnode or JSX
    * expression.
+   *
+   * @see https://mithril.js.org/route.html#routeresolveronmatch
    */
   onmatch(this: this, args: RouteArgs, requestedPath: string, route: string): { new (): Comp };
   /**
    * A function which renders the provided component.
    *
+   * If not specified, the route will default to rendering the
+   * component on its own, inside of a fragment.
+   *
    * Returns a Mithril Vnode or other children.
+   *
+   * @see https://mithril.js.org/route.html#routeresolverrender
    */
-  render(this: this, vnode: Mithril.Vnode<Attrs, Comp>): Mithril.Children;
+  render?(this: this, vnode: Mithril.Vnode<Attrs, Comp>): Mithril.Children;
 }
 
 /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
`render` is optional in route resolver objects, as per Mithril docs: https://mithril.js.org/route.html#routeresolverrender

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
