### PR TITLE
fix: don't fire deprecation warnings for Mithril-originating action

### DIFF
--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -76,7 +76,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
     return this.searchState;
   }
   protected set state(state: SearchState) {
-    fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
+    state !== undefined && fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
     this.searchState = state;
   }
 

--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -76,6 +76,8 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
     return this.searchState;
   }
   protected set state(state: SearchState) {
+    // Workaround to prevent triggering deprecation warnings due to Mithril
+    // setting state to undefined when creating components
     state !== undefined && fireDeprecationWarning('`state` property of the Search component is deprecated', '3212');
     this.searchState = state;
   }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Don't fire a deprecation warning when Search state is set to `undefined`.

Mithril does this when instantiating every component, which is triggering this dep warning when no extension or core have done anything wrong.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
