### PR TITLE
fix: prevent unwarranted a11y warnings on custom Button subclasses

### DIFF
--- a/js/src/admin/components/UploadImageButton.js
+++ b/js/src/admin/components/UploadImageButton.js
@@ -3,7 +3,6 @@ import Button from '../../common/components/Button';
 
 export default class UploadImageButton extends Button {
   loading = false;
-  ignoreNoChildrenWarning = true;
 
   view(vnode) {
     this.attrs.loading = this.loading;

--- a/js/src/admin/components/UploadImageButton.js
+++ b/js/src/admin/components/UploadImageButton.js
@@ -3,6 +3,7 @@ import Button from '../../common/components/Button';
 
 export default class UploadImageButton extends Button {
   loading = false;
+  ignoreNoChildrenWarning = true;
 
   view(vnode) {
     this.attrs.loading = this.loading;

--- a/js/src/common/components/Button.tsx
+++ b/js/src/common/components/Button.tsx
@@ -67,6 +67,15 @@ export interface IButtonAttrs extends ComponentAttrs {
  * styles can be applied by providing `className="Button"` to the Button component.
  */
 export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> extends Component<CustomAttrs> {
+  /**
+   * Prevents firing of accessibility warnings for this Button component.
+   * 
+   * This should be set to `true` when creating a custom Button class component which
+   * does not expect any children to be provided to it because, for example, it has a
+   * custom `view` method with its own content baked-in.
+   */
+  protected ignoreNoChildrenWarning: boolean = false;
+
   view(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
     let { type, title, 'aria-label': ariaLabel, icon: iconName, disabled, loading, className, class: _class, ...attrs } = this.attrs;
 
@@ -107,7 +116,7 @@ export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> ext
 
     const { 'aria-label': ariaLabel } = this.attrs;
 
-    if (!ariaLabel && !extractText(vnode.children) && !this.element?.getAttribute?.('aria-label')) {
+    if (!this.ignoreNoChildrenWarning && !ariaLabel && !extractText(vnode.children) && !this.element?.getAttribute?.('aria-label')) {
       fireDebugWarning(
         '[Flarum Accessibility Warning] Button has no content and no accessible label. This means that screen-readers will not be able to interpret its meaning and just read "Button". Consider providing accessible text via the `aria-label` attribute. https://web.dev/button-name',
         this.element

--- a/js/src/common/components/Button.tsx
+++ b/js/src/common/components/Button.tsx
@@ -69,7 +69,7 @@ export interface IButtonAttrs extends ComponentAttrs {
 export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> extends Component<CustomAttrs> {
   /**
    * Prevents firing of accessibility warnings for this Button component.
-   * 
+   *
    * This should be set to `true` when creating a custom Button class component which
    * does not expect any children to be provided to it because, for example, it has a
    * custom `view` method with its own content baked-in.

--- a/js/src/common/components/Button.tsx
+++ b/js/src/common/components/Button.tsx
@@ -67,15 +67,6 @@ export interface IButtonAttrs extends ComponentAttrs {
  * styles can be applied by providing `className="Button"` to the Button component.
  */
 export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> extends Component<CustomAttrs> {
-  /**
-   * Prevents firing of accessibility warnings for this Button component.
-   *
-   * This should be set to `true` when creating a custom Button class component which
-   * does not expect any children to be provided to it because, for example, it has a
-   * custom `view` method with its own content baked-in.
-   */
-  protected ignoreNoChildrenWarning: boolean = false;
-
   view(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
     let { type, title, 'aria-label': ariaLabel, icon: iconName, disabled, loading, className, class: _class, ...attrs } = this.attrs;
 

--- a/js/src/common/components/Button.tsx
+++ b/js/src/common/components/Button.tsx
@@ -116,7 +116,7 @@ export default class Button<CustomAttrs extends IButtonAttrs = IButtonAttrs> ext
 
     const { 'aria-label': ariaLabel } = this.attrs;
 
-    if (!this.ignoreNoChildrenWarning && !ariaLabel && !extractText(vnode.children) && !this.element?.getAttribute?.('aria-label')) {
+    if (this.view === Button.prototype.view && !ariaLabel && !extractText(vnode.children) && !this.element?.getAttribute?.('aria-label')) {
       fireDebugWarning(
         '[Flarum Accessibility Warning] Button has no content and no accessible label. This means that screen-readers will not be able to interpret its meaning and just read "Button". Consider providing accessible text via the `aria-label` attribute. https://web.dev/button-name',
         this.element


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
UploadImageButton has its own content in the `view` method, so we don't need the empty children a11y warning.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
