### PR TITLE
fix: error in funding `composer.json` block bricks frontend

### DIFF
--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -263,11 +263,11 @@ class Extension implements Arrayable
             return $icon;
         }
 
-        $file = $this->path.'/'.$file;
+        $file = $this->path . '/' . $file;
 
         if (file_exists($file)) {
             $extension = pathinfo($file, PATHINFO_EXTENSION);
-            if (! array_key_exists($extension, self::LOGO_MIMETYPES)) {
+            if (!array_key_exists($extension, self::LOGO_MIMETYPES)) {
                 throw new \RuntimeException('Invalid image type');
             }
 
@@ -372,13 +372,13 @@ class Extension implements Arrayable
     {
         $extenderFile = $this->getExtenderFile();
 
-        if (! $extenderFile) {
+        if (!$extenderFile) {
             return [];
         }
 
         $extenders = require $extenderFile;
 
-        if (! is_array($extenders)) {
+        if (!is_array($extenders)) {
             $extenders = [$extenders];
         }
 
@@ -436,7 +436,7 @@ class Extension implements Arrayable
             $links['support'] = "mailto:$supportEmail";
         }
 
-        if (($funding = $this->composerJsonAttribute('funding')) && count($funding)) {
+        if (($funding = $this->composerJsonAttribute('funding')) && count($funding) && is_array($funding[0]) && Arr::has($funding[0], 'url')) {
             $links['donate'] = $funding[0]['url'];
         }
 
@@ -445,7 +445,7 @@ class Extension implements Arrayable
         foreach ((array) $this->composerJsonAttribute('authors') as $author) {
             $links['authors'][] = [
                 'name' => Arr::get($author, 'name'),
-                'link' => Arr::get($author, 'homepage') ?? (Arr::get($author, 'email') ? 'mailto:'.Arr::get($author, 'email') : ''),
+                'link' => Arr::get($author, 'homepage') ?? (Arr::get($author, 'email') ? 'mailto:' . Arr::get($author, 'email') : ''),
             ];
         }
 
@@ -459,7 +459,7 @@ class Extension implements Arrayable
      */
     public function hasAssets()
     {
-        return realpath($this->path.'/assets/') !== false;
+        return realpath($this->path . '/assets/') !== false;
     }
 
     /**
@@ -467,7 +467,7 @@ class Extension implements Arrayable
      */
     public function copyAssetsTo(FilesystemInterface $target)
     {
-        if (! $this->hasAssets()) {
+        if (!$this->hasAssets()) {
             return;
         }
 
@@ -488,7 +488,7 @@ class Extension implements Arrayable
      */
     public function hasMigrations()
     {
-        return realpath($this->path.'/migrations/') !== false;
+        return realpath($this->path . '/migrations/') !== false;
     }
 
     /**
@@ -496,14 +496,14 @@ class Extension implements Arrayable
      */
     public function migrate(Migrator $migrator, $direction = 'up')
     {
-        if (! $this->hasMigrations()) {
+        if (!$this->hasMigrations()) {
             return;
         }
 
         if ($direction == 'up') {
-            return $migrator->run($this->getPath().'/migrations', $this);
+            return $migrator->run($this->getPath() . '/migrations', $this);
         } else {
-            return $migrator->reset($this->getPath().'/migrations', $this);
+            return $migrator->reset($this->getPath() . '/migrations', $this);
         }
     }
 

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -436,8 +436,8 @@ class Extension implements Arrayable
             $links['support'] = "mailto:$supportEmail";
         }
 
-        if (($funding = $this->composerJsonAttribute('funding')) && count($funding) && is_array($funding[0]) && Arr::has($funding[0], 'url')) {
-            $links['donate'] = $funding[0]['url'];
+        if (($funding = $this->composerJsonAttribute('funding')) && is_array($funding) && ($fundingUrl = Arr::get($funding, '0.url'))) {
+            $links['donate'] = $fundingUrl;
         }
 
         $links['authors'] = [];

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -263,11 +263,11 @@ class Extension implements Arrayable
             return $icon;
         }
 
-        $file = $this->path . '/' . $file;
+        $file = $this->path.'/'.$file;
 
         if (file_exists($file)) {
             $extension = pathinfo($file, PATHINFO_EXTENSION);
-            if (!array_key_exists($extension, self::LOGO_MIMETYPES)) {
+            if (! array_key_exists($extension, self::LOGO_MIMETYPES)) {
                 throw new \RuntimeException('Invalid image type');
             }
 
@@ -372,13 +372,13 @@ class Extension implements Arrayable
     {
         $extenderFile = $this->getExtenderFile();
 
-        if (!$extenderFile) {
+        if (! $extenderFile) {
             return [];
         }
 
         $extenders = require $extenderFile;
 
-        if (!is_array($extenders)) {
+        if (! is_array($extenders)) {
             $extenders = [$extenders];
         }
 
@@ -445,7 +445,7 @@ class Extension implements Arrayable
         foreach ((array) $this->composerJsonAttribute('authors') as $author) {
             $links['authors'][] = [
                 'name' => Arr::get($author, 'name'),
-                'link' => Arr::get($author, 'homepage') ?? (Arr::get($author, 'email') ? 'mailto:' . Arr::get($author, 'email') : ''),
+                'link' => Arr::get($author, 'homepage') ?? (Arr::get($author, 'email') ? 'mailto:'.Arr::get($author, 'email') : ''),
             ];
         }
 
@@ -459,7 +459,7 @@ class Extension implements Arrayable
      */
     public function hasAssets()
     {
-        return realpath($this->path . '/assets/') !== false;
+        return realpath($this->path.'/assets/') !== false;
     }
 
     /**
@@ -467,7 +467,7 @@ class Extension implements Arrayable
      */
     public function copyAssetsTo(FilesystemInterface $target)
     {
-        if (!$this->hasAssets()) {
+        if (! $this->hasAssets()) {
             return;
         }
 
@@ -488,7 +488,7 @@ class Extension implements Arrayable
      */
     public function hasMigrations()
     {
-        return realpath($this->path . '/migrations/') !== false;
+        return realpath($this->path.'/migrations/') !== false;
     }
 
     /**
@@ -496,14 +496,14 @@ class Extension implements Arrayable
      */
     public function migrate(Migrator $migrator, $direction = 'up')
     {
-        if (!$this->hasMigrations()) {
+        if (! $this->hasMigrations()) {
             return;
         }
 
         if ($direction == 'up') {
-            return $migrator->run($this->getPath() . '/migrations', $this);
+            return $migrator->run($this->getPath().'/migrations', $this);
         } else {
-            return $migrator->reset($this->getPath() . '/migrations', $this);
+            return $migrator->reset($this->getPath().'/migrations', $this);
         }
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Any error in `composer.json`'s `funding` block syntax will brick the admin frontend.

Oddly, this error seems to persist after correcting the error, `composer update` and a cache clear on my local dev forum. I had to implement this to allow me to toggle the extension, which then fixed the error.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
