### PR TITLE
fix: `Until reply` renaming permission of discussions broken in php 8

### DIFF
--- a/src/Discussion/Access/DiscussionPolicy.php
+++ b/src/Discussion/Access/DiscussionPolicy.php
@@ -55,7 +55,7 @@ class DiscussionPolicy extends AbstractPolicy
 
             if ($allowRenaming === '-1'
                 || ($allowRenaming === 'reply' && $discussion->participant_count <= 1)
-                || ($discussion->created_at->diffInMinutes() < $allowRenaming)) {
+                || (is_numeric($allowRenaming) && $discussion->created_at->diffInMinutes() < $allowRenaming)) {
                 return $this->allow();
             }
         }

--- a/tests/integration/policy/DiscussionPolicyTest.php
+++ b/tests/integration/policy/DiscussionPolicyTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\policy;
+
+use Carbon\Carbon;
+use Flarum\Bus\Dispatcher;
+use Flarum\Discussion\Discussion;
+use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Post\Command\PostReply;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+
+class DiscussionPolicyTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use DispatchEventsTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 1, 'post_number_index' => 1, 'participant_count' => 1],
+                ['id' => 2, 'title' => 'Editable discussion', 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 2, 'comment_count' => 2, 'is_private' => 0, 'last_post_number' => 2, 'participant_count' => 2],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:00')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t></t>'],
+                ['id' => 3, 'discussion_id' => 2, 'number' => 2, 'created_at' => Carbon::parse('2021-11-01 13:00:03')->toDateTimeString(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t></t>'],
+            ],
+            'users' => [
+                $this->normalUser(),
+            ]
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @test
+     */
+    public function rename_indefinitely()
+    {
+        $this->setting('allow_renaming', '-1');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $discussion = Discussion::findOrFail(1);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue($user->can('rename', $discussion));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertTrue($user->can('rename', $discussion));
+    }
+
+    /**
+     * @test
+     */
+    public function rename_until_reply()
+    {
+        $this->setting('allow_renaming', 'reply');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $discussion = Discussion::findOrFail(1);
+        $discussionWithReply = Discussion::findOrFail(2);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue($user->can('rename', $discussion));
+        $this->assertFalse($user->can('rename', $discussionWithReply));
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(
+            new PostReply(1, User::findOrFail(1), ['attributes' => ['content' => 'test']], null)
+        );
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse($user->can('rename', $discussion->fresh()));
+        $this->assertFalse($user->can('rename', $discussionWithReply));
+    }
+
+    /**
+     * @test
+     */
+    public function rename_10_minutes()
+    {
+        $this->setting('allow_renaming', '10');
+        $this->app();
+
+        $user = User::findOrFail(2);
+        $discussion = Discussion::findOrFail(1);
+
+        // Date close to "now"
+        Carbon::setTestNow('2021-11-01 13:00:05');
+
+        $this->assertTrue($user->can('rename', $discussion));
+
+        // Date further into the future
+        Carbon::setTestNow('2025-01-01 13:00:00');
+
+        $this->assertFalse($user->can('rename', $discussion));
+    }
+}

--- a/tests/integration/policy/PostPolicyTest.php
+++ b/tests/integration/policy/PostPolicyTest.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-namespace Flarum\Tests\integration\post;
+namespace Flarum\Tests\integration\policy;
 
 use Carbon\Carbon;
 use Flarum\Post\Post;


### PR DESCRIPTION
**Changes proposed in this pull request:**
Indirectly caught in QA, a while back we fixed the `until reply` permission option in PHP 8 for editing posts #3144, but didn't notice that the issue is the same for renaming discussions.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
