### PR TITLE
FIx broken post/discussion soft delete

### DIFF
--- a/js/src/common/Model.ts
+++ b/js/src/common/Model.ts
@@ -121,7 +121,7 @@ export default abstract class Model {
           fireDeprecationWarning('Providing models as attributes to `Model.pushData()` or `Model.pushAttributes()` is deprecated.', '3249');
           delete data.attributes[key];
           data.relationships ||= {};
-          data.relationships[key] = { data: Model.getIdentifier(val)};
+          data.relationships[key] = { data: Model.getIdentifier(val) };
         }
       }
 

--- a/js/src/common/Model.ts
+++ b/js/src/common/Model.ts
@@ -1,5 +1,6 @@
 import app from '../common/app';
 import { FlarumRequestOptions } from './Application';
+import fireDebugWarning from './helpers/fireDebugWarning';
 import Store, { ApiPayloadSingle, ApiResponseSingle, MetaInformation } from './Store';
 
 export interface ModelIdentifier {
@@ -111,6 +112,19 @@ export default abstract class Model {
 
     if ('attributes' in data) {
       this.data.attributes ||= {};
+
+      // @deprecated
+      // Filter out relationships that got in by accident.
+      for (const key in data.attributes) {
+        const val = data.attributes[key];
+        if (val && val instanceof Model) {
+          fireDebugWarning('Model.pushData() was passed a Model instance in the `attributes` field. This is not supported.');
+          delete data.attributes[key];
+          data.relationships ||= {};
+          data.relationships[key] = { data: Model.getIdentifier(val)};
+        }
+      }
+
       Object.assign(this.data.attributes, data.attributes);
     }
 

--- a/js/src/common/Model.ts
+++ b/js/src/common/Model.ts
@@ -1,6 +1,6 @@
 import app from '../common/app';
 import { FlarumRequestOptions } from './Application';
-import fireDebugWarning from './helpers/fireDebugWarning';
+import { fireDeprecationWarning } from './helpers/fireDebugWarning';
 import Store, { ApiPayloadSingle, ApiResponseSingle, MetaInformation } from './Store';
 
 export interface ModelIdentifier {

--- a/js/src/common/Model.ts
+++ b/js/src/common/Model.ts
@@ -118,7 +118,7 @@ export default abstract class Model {
       for (const key in data.attributes) {
         const val = data.attributes[key];
         if (val && val instanceof Model) {
-          fireDebugWarning('Model.pushData() was passed a Model instance in the `attributes` field. This is not supported.');
+          fireDeprecationWarning('Providing models as attributes to `Model.pushData()` or `Model.pushAttributes()` is deprecated.', '3249');
           delete data.attributes[key];
           data.relationships ||= {};
           data.relationships[key] = { data: Model.getIdentifier(val)};

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -213,7 +213,7 @@ export default {
    * @return {Promise<void>}
    */
   hideAction() {
-    this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
+    this.pushData({ attributes: {hiddenAt: new Date()}, relationships: {hiddenUser: app.session.user} });
 
     return this.save({ isHidden: true });
   },
@@ -224,7 +224,7 @@ export default {
    * @return {Promise<void>}
    */
   restoreAction() {
-    this.pushAttributes({ hiddenAt: null, hiddenUser: null });
+    this.pushData({ attributes: {hiddenAt: null}, relationships: {hiddenUser: null} });
 
     return this.save({ isHidden: false });
   },

--- a/js/src/forum/utils/DiscussionControls.js
+++ b/js/src/forum/utils/DiscussionControls.js
@@ -213,7 +213,7 @@ export default {
    * @return {Promise<void>}
    */
   hideAction() {
-    this.pushData({ attributes: {hiddenAt: new Date()}, relationships: {hiddenUser: app.session.user} });
+    this.pushData({ attributes: { hiddenAt: new Date() }, relationships: { hiddenUser: app.session.user } });
 
     return this.save({ isHidden: true });
   },
@@ -224,7 +224,7 @@ export default {
    * @return {Promise<void>}
    */
   restoreAction() {
-    this.pushData({ attributes: {hiddenAt: null}, relationships: {hiddenUser: null} });
+    this.pushData({ attributes: { hiddenAt: null }, relationships: { hiddenUser: null } });
 
     return this.save({ isHidden: false });
   },

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -151,7 +151,7 @@ export default {
    */
   hideAction() {
     if (!confirm(extractText(app.translator.trans('core.forum.post_controls.hide_confirmation')))) return;
-    this.pushAttributes({ hiddenAt: new Date(), hiddenUser: app.session.user });
+    this.pushData({ attributes: {hiddenAt: new Date()}, relationships: {hiddenUser: app.session.user} });
 
     return this.save({ isHidden: true }).then(() => m.redraw());
   },
@@ -162,7 +162,7 @@ export default {
    * @return {Promise<void>}
    */
   restoreAction() {
-    this.pushAttributes({ hiddenAt: null, hiddenUser: null });
+    this.pushData({ attributes: {hiddenAt: null}, relationships: {hiddenUser: null} });
 
     return this.save({ isHidden: false }).then(() => m.redraw());
   },

--- a/js/src/forum/utils/PostControls.js
+++ b/js/src/forum/utils/PostControls.js
@@ -151,7 +151,7 @@ export default {
    */
   hideAction() {
     if (!confirm(extractText(app.translator.trans('core.forum.post_controls.hide_confirmation')))) return;
-    this.pushData({ attributes: {hiddenAt: new Date()}, relationships: {hiddenUser: app.session.user} });
+    this.pushData({ attributes: { hiddenAt: new Date() }, relationships: { hiddenUser: app.session.user } });
 
     return this.save({ isHidden: true }).then(() => m.redraw());
   },
@@ -162,7 +162,7 @@ export default {
    * @return {Promise<void>}
    */
   restoreAction() {
-    this.pushData({ attributes: {hiddenAt: null}, relationships: {hiddenUser: null} });
+    this.pushData({ attributes: { hiddenAt: null }, relationships: { hiddenUser: null } });
 
     return this.save({ isHidden: false }).then(() => m.redraw());
   },


### PR DESCRIPTION
Before the Model typescript rewrite, `pushAttributes` supported including relationship objects, which is hacky but incorrect behavior. With the rewrite, this functionality was broken.

This PR deprecates the functionality, adds a deprecated BC layer with a debug warning, and removes instances of incorrect usage.