### PR TITLE
Code input fixes 

### DIFF
--- a/js/src/admin/components/EditCustomCssModal.js
+++ b/js/src/admin/components/EditCustomCssModal.js
@@ -18,7 +18,7 @@ export default class EditCustomCssModal extends SettingsModal {
         })}
       </p>,
       <div className="Form-group">
-        <textarea className="FormControl" rows="30" bidi={this.setting('custom_less')} />
+        <textarea className="FormControl" rows="30" bidi={this.setting('custom_less')} spellcheck={false} />
       </div>,
     ];
   }

--- a/js/src/common/components/ModalManager.tsx
+++ b/js/src/common/components/ModalManager.tsx
@@ -49,7 +49,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
     // e.g. via ESC key or a click on the modal backdrop.
     this.$().on('hidden.bs.modal', this.attrs.state.close.bind(this.attrs.state));
 
-    this.focusTrap = createFocusTrap(this.element as HTMLElement);
+    this.focusTrap = createFocusTrap(this.element as HTMLElement, { allowOutsideClick: true });
   }
 
   onupdate(vnode: Mithril.VnodeDOM<IModalManagerAttrs, this>): void {


### PR DESCRIPTION
1. Disable autocorrect in custom CSS textarea.
2. Allow outside click (i.e. dismissing alerts) from modal.

Fixes https://github.com/flarum/QualityAssurance/issues/40