### PR TITLE
fix: mark `near` as optional in discussion route

### DIFF
--- a/js/src/forum/routes.ts
+++ b/js/src/forum/routes.ts
@@ -34,7 +34,7 @@ export function makeRouteHelpers(app: ForumApplication) {
     /**
      * Generate a URL to a discussion.
      */
-    discussion: (discussion: Discussion, near: number) => {
+    discussion: (discussion: Discussion, near?: number) => {
       return app.route(near && near !== 1 ? 'discussion.near' : 'discussion', {
         id: discussion.slug(),
         near: near && near !== 1 ? near : undefined,


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Correctly mark the `near` parameter of `app.route.discussion` as optional in typings

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
