### PR TITLE
fix: sort posts by number instead of creation datetime

### DIFF
--- a/js/src/forum/components/DiscussionPage.tsx
+++ b/js/src/forum/components/DiscussionPage.tsx
@@ -210,7 +210,7 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
             record.relationships.discussion.data.id === discussionId
         )
         .map((record) => app.store.getById<Post>('posts', record.id))
-        .sort((a?: Post, b?: Post) => (a?.createdAt()?.getTime() ?? 0) - (b?.createdAt()?.getTime() ?? 0))
+        .sort((a?: Post, b?: Post) => (a?.number() ?? 0) - (b?.number() ?? 0))
         .slice(0, 20);
     }
 

--- a/js/src/forum/states/PostStreamState.js
+++ b/js/src/forum/states/PostStreamState.js
@@ -289,7 +289,7 @@ class PostStreamState {
 
     if (loadIds.length) {
       return app.store.find('posts', loadIds).then((newPosts) => {
-        return loaded.concat(newPosts).sort((a, b) => a.createdAt() - b.createdAt());
+        return loaded.concat(newPosts).sort((a, b) => a.number() - b.number());
       });
     }
 

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -41,7 +41,7 @@ class ListPostsController extends AbstractListController
     /**
      * {@inheritdoc}
      */
-    public $sortFields = ['number'];
+    public $sortFields = ['number', 'createdAt'];
 
     /**
      * @var PostFilterer

--- a/src/Api/Controller/ListPostsController.php
+++ b/src/Api/Controller/ListPostsController.php
@@ -41,7 +41,7 @@ class ListPostsController extends AbstractListController
     /**
      * {@inheritdoc}
      */
-    public $sortFields = ['createdAt'];
+    public $sortFields = ['number'];
 
     /**
      * @var PostFilterer

--- a/src/Api/Controller/ShowDiscussionController.php
+++ b/src/Api/Controller/ShowDiscussionController.php
@@ -132,7 +132,7 @@ class ShowDiscussionController extends AbstractShowController
      */
     private function loadPostIds(Discussion $discussion, User $actor)
     {
-        return $discussion->posts()->whereVisibleTo($actor)->orderBy('created_at')->pluck('id')->all();
+        return $discussion->posts()->whereVisibleTo($actor)->orderBy('number')->pluck('id')->all();
     }
 
     /**
@@ -186,7 +186,7 @@ class ShowDiscussionController extends AbstractShowController
     {
         $query = $discussion->posts()->whereVisibleTo($actor);
 
-        $query->orderBy('created_at')->skip($offset)->take($limit)->with($include);
+        $query->orderBy('number')->skip($offset)->take($limit)->with($include);
 
         $posts = $query->get();
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3281**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Replaces instances of `createdAt` sorting with `number` sorting for posts.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Anywhere I've missed? Not too familiar with this area of core, personally. Does this affect/break anything else?

While this has the slim chance of breaking one or more extensions, I'm in favour of taking this approach sooner rather than later for the reasoning of sanity. If we have a dedicated `number` field, we should use that instead of `createdAt` as it is what most extension developers would assume is used in the first place. The fact that this hasn't been reported before suggests that no extensions have run into this issues, thus it shouldn't affect any common extensions.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Times are no longer seen as the source of ordering:

![](https://u.davwheat.dev/TWTRACyS.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

