### PR TITLE
Fix permission check in user edit modal

### DIFF
--- a/js/src/common/components/EditUserModal.tsx
+++ b/js/src/common/components/EditUserModal.tsx
@@ -61,7 +61,7 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
   fields() {
     const items = new ItemList();
 
-    if (app.session.user?.canEditCredentials()) {
+    if (this.attrs.user.canEditCredentials()) {
       items.add(
         'username',
         <div className="Form-group">
@@ -145,7 +145,7 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
       }
     }
 
-    if (app.session.user?.canEditGroups()) {
+    if (this.attrs.user.canEditGroups()) {
       items.add(
         'groups',
         <div className="Form-group EditUserModal-groups">


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixes the permission check that shows/hides fields in the edit modal.

The correct logic was already used in `EditUserModal.data`, but in `EditUserModal.fields`, permissions were checked against the current session user rather than the edited user.

This causes no issue on a bare Flarum installation because all users have the same `canEditCredentials` boolean value since it's extracted from the actor's permissions. But if the gate has been customized by an extension this leads to inconsistent behavior. This is most noticeable if you customize the gate to disallow a user to edit themselves:

```php
class UserPolicy extends AbstractPolicy {
    public function editCredentials($actor, $user) {
        if ($actor->id === $user->id) {
            return $this->deny();
        }
    }
}
```

With this gate in place, moderators don't see the fields when editing any user, but they should see it on users that aren't themselves. This is fixed with the PR.

**Reviewers should focus on:**
If there's a reason for the old implementation, it completely eludes me.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
