### PR TITLE
Fix active search jumping to last item during loading

### DIFF
--- a/js/src/forum/components/Search.tsx
+++ b/js/src/forum/components/Search.tsx
@@ -324,9 +324,10 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
 
   /**
    * Get the position of the currently selected search result item.
+   * Returns zero if not found.
    */
   getCurrentNumericIndex(): number {
-    return this.selectableItems().index(this.getItem(this.index));
+    return Math.max(0, this.selectableItems().index(this.getItem(this.index)));
   }
 
   /**


### PR DESCRIPTION
**Fixes #3082**

**Changes proposed in this pull request:**
This PR solves the mysterious jump to last result that sometimes happens during search.

The problem was that `getCurrentNumericIndex` would return `-1` if the current item was not found, and since during result loading there is never any result, `-1` would be sent to `setIndex`. And `setIndex` contains logic to loop through to the last index intended for the UP/DOWN logic. It's then a race between the `onupdate` hook and the results loading. A first `onupdate` would run to hide the search results, then a second one would run to display the results again. But if the results have already loaded when the first hook runs, the loop through would happen.

**Reviewers should focus on:**
This is a pretty simple change to make sure `0` is always returned in place of `-1`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

