### PR TITLE
Fix pinned pane broken after discussion creation

### DIFF
--- a/js/src/forum/components/DiscussionComposer.js
+++ b/js/src/forum/components/DiscussionComposer.js
@@ -101,7 +101,7 @@ export default class DiscussionComposer extends ComposerBody {
       .save(data)
       .then((discussion) => {
         this.composer.hide();
-        app.discussions.refresh({ deferClear: true });
+        app.discussions.refresh();
         m.route.set(app.route.discussion(discussion));
       }, this.loaded.bind(this));
   }

--- a/js/src/forum/components/DiscussionPage.tsx
+++ b/js/src/forum/components/DiscussionPage.tsx
@@ -53,7 +53,9 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
     // page, then we don't want Mithril to redraw the whole page – if it did,
     // then the pane would redraw which would be slow and would cause problems with
     // event handlers.
-    if (app.discussions.hasItems()) {
+    // We will also enable the pane if the discussion list is empty but loading,
+    // because the DiscussionComposer refreshes the list and redirects to the new discussion at the same time.
+    if (app.discussions.hasItems() || app.discussions.isLoading()) {
       app.pane?.enable();
       app.pane?.hide();
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixes an issue I have experienced regularly on Discuss and other forums.

After a discussion has been created and the page has been redirected to the new discussion, the pinned pane would appear but the page content would not shift to the right, resulting in content being hidden by the pane.

This is because the `DiscussionPage` looks at the number of discussions in the list to decide whether to render the pane, but at that exact moment it's empty because a refresh has been triggered by `DiscussionComposer`.

The solution is to also look for the loading state, because if the discussions are loading it means the same thing, that we were coming from a page that shows the discussion list.

The bug can also be triggered by directly running the following code in console while on the homepage: `app.discussions.refresh() && m.route.set(app.route.discussion(app.store.all('discussions')[0]));`

The issue is less noticable when the pane isn't pinned, in that situation the pane was simply unavailable.

**Reviewers should focus on:**
I have also removed an invalid parameter to `app.discussions.refresh()` where the bug "originates" from. This wasn't causing any issue except IDE warnings due to the typings not matching.

**Screenshot**
Before fix:
![Screen Shot 2022-02-21 at 19 44 37](https://user-images.githubusercontent.com/5264300/155011520-cdd7ad4b-3080-4529-a9e5-4c22e27932e9.png)

After fix:
![Screen Shot 2022-02-21 at 19 44 22](https://user-images.githubusercontent.com/5264300/155011532-114af4d4-e2bc-4760-87b1-4ffa7f7d4bc6.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
