### PR TITLE
fix: unread filter gambit does not return results when > 999 read discussions for a user

### DIFF
--- a/src/Discussion/DiscussionRepository.php
+++ b/src/Discussion/DiscussionRepository.php
@@ -49,10 +49,7 @@ class DiscussionRepository
      */
     public function getReadIds(User $user)
     {
-        return Discussion::leftJoin('discussion_user', 'discussion_user.discussion_id', '=', 'discussions.id')
-            ->where('discussion_user.user_id', $user->id)
-            ->whereColumn('last_read_post_number', '>=', 'last_post_number')
-            ->pluck('id')
+        return $this->getReadIdsQuery($user)
             ->all();
     }
 

--- a/src/Discussion/DiscussionRepository.php
+++ b/src/Discussion/DiscussionRepository.php
@@ -41,6 +41,8 @@ class DiscussionRepository
 
     /**
      * Get the IDs of discussions which a user has read completely.
+     * 
+     * @deprecated 1.3 Use `getReadIdsQuery` instead
      *
      * @param User $user
      * @return array
@@ -52,6 +54,20 @@ class DiscussionRepository
             ->whereColumn('last_read_post_number', '>=', 'last_post_number')
             ->pluck('id')
             ->all();
+    }
+
+    /**
+     * Get a query containing the IDs of discussions which a user has read completely.
+     *
+     * @param User $user
+     * @return Builder
+     */
+    public function getReadIdsQuery(User $user): Builder
+    {
+        return Discussion::leftJoin('discussion_user', 'discussion_user.discussion_id', '=', 'discussions.id')
+            ->where('discussion_user.user_id', $user->id)
+            ->whereColumn('last_read_post_number', '>=', 'last_post_number')
+            ->select('id');
     }
 
     /**

--- a/src/Discussion/DiscussionRepository.php
+++ b/src/Discussion/DiscussionRepository.php
@@ -41,7 +41,7 @@ class DiscussionRepository
 
     /**
      * Get the IDs of discussions which a user has read completely.
-     * 
+     *
      * @deprecated 1.3 Use `getReadIdsQuery` instead
      *
      * @param User $user

--- a/src/Discussion/Query/UnreadFilterGambit.php
+++ b/src/Discussion/Query/UnreadFilterGambit.php
@@ -61,7 +61,7 @@ class UnreadFilterGambit extends AbstractRegexGambit implements FilterInterface
     protected function constrain(Builder $query, User $actor, bool $negate)
     {
         if ($actor->exists) {
-            $readIds = $this->discussions->getReadIds($actor);
+            $readIds = $this->discussions->getReadIdsQuery($actor);
 
             $query->where(function ($query) use ($readIds, $negate, $actor) {
                 if (! $negate) {


### PR DESCRIPTION
When making use of the `unread` filter or gambit, I noticed that when a user has more than 999 previously read discussions, no results are returned.

**Changes proposed in this pull request:**
Taking some advice from @askvortsov1, this PR deprecates `getReadIds()` which returned an array of IDs, in favour of a new utility function `getReadIdsQuery` - returning a `Builder`. This should also be a little more performant in the constructed SQL statement.

**Reviewers should focus on:**
From a core standpoint, `getReadIds` is only used by the unread filter/gambit. So I think this is pretty safe. Is there anything else that's not been considered here?

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

