### PR TITLE
Modernize strpos

### DIFF
--- a/framework/core/src/Api/Controller/AbstractSerializeController.php
+++ b/framework/core/src/Api/Controller/AbstractSerializeController.php
@@ -206,7 +206,7 @@ abstract class AbstractSerializeController implements RequestHandlerInterface
             });
 
             foreach ($addedRelations as $relation) {
-                if (strpos($relation, '.') !== false) {
+                if (str_contains($relation, '.')  ) {
                     $parentRelation = Str::beforeLast($relation, '.');
 
                     if (! in_array($parentRelation, $relations, true)) {

--- a/framework/core/src/Database/Console/GenerateDumpCommand.php
+++ b/framework/core/src/Database/Console/GenerateDumpCommand.php
@@ -75,7 +75,7 @@ class GenerateDumpCommand extends AbstractCommand
         $dump = file($dumpPath);
         foreach ($dump as $line) {
             foreach ($coreDataMigrations as $excludeMigrationId) {
-                if (strpos($line, $excludeMigrationId) !== false) {
+                if (str_contains($line, $excludeMigrationId)  ) {
                     continue 2;
                 }
             }

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -317,7 +317,7 @@ class User extends AbstractModel
      */
     public function getAvatarUrlAttribute(string $value = null)
     {
-        if ($value && strpos($value, '://') === false) {
+        if ($value && !str_contains($value, '://')  ) {
             return resolve(Factory::class)->disk('flarum-avatars')->url($value);
         }
 
@@ -413,7 +413,7 @@ class User extends AbstractModel
     private function checkForDeprecatedPermissions($permission)
     {
         foreach (['viewDiscussions', 'viewUserList'] as $deprecated) {
-            if (strpos($permission, $deprecated) !== false) {
+            if (str_contains($permission, $deprecated)  ) {
                 trigger_error('The `viewDiscussions` and `viewUserList` permissions have been renamed to `viewForum` and `searchUsers` respectively. Please use those instead.', E_USER_DEPRECATED);
             }
         }


### PR DESCRIPTION
Replace strpos() calls with str_starts_with() or str_contains() if possible.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
