### PR TITLE
feat: global logout to clear all sessions, access tokens, email tokens and password tokens

### DIFF
--- a/framework/core/js/src/forum/components/SessionDropdown.tsx
+++ b/framework/core/js/src/forum/components/SessionDropdown.tsx
@@ -67,18 +67,6 @@ export default class SessionDropdown<CustomAttrs extends ISessionDropdownAttrs =
       50
     );
 
-    items.add(
-      'security',
-      LinkButton.component(
-        {
-          icon: 'fas fa-shield-alt',
-          href: app.route('user.security', { username: user.slug() }),
-        },
-        app.translator.trans('core.forum.header.security_button')
-      ),
-      25
-    );
-
     if (app.forum.attribute('adminUrl')) {
       items.add(
         'administration',

--- a/framework/core/js/src/forum/components/SessionDropdown.tsx
+++ b/framework/core/js/src/forum/components/SessionDropdown.tsx
@@ -67,6 +67,18 @@ export default class SessionDropdown<CustomAttrs extends ISessionDropdownAttrs =
       50
     );
 
+    items.add(
+      'security',
+      LinkButton.component(
+        {
+          icon: 'fas fa-shield-alt',
+          href: app.route('user.security', { username: user.slug() }),
+        },
+        app.translator.trans('core.forum.header.security_button')
+      ),
+      25
+    );
+
     if (app.forum.attribute('adminUrl')) {
       items.add(
         'administration',

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -57,11 +57,29 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
 
       items.add(
         section,
-        <FieldSet className={`Security-${section}`} label={app.translator.trans(`core.forum.security.${sectionLocale}_heading`)}>
+        <FieldSet className={`UserSecurityPage-${section}`} label={app.translator.trans(`core.forum.security.${sectionLocale}_heading`)}>
           {this[sectionName]().toArray()}
         </FieldSet>
       );
     });
+
+    if (this.user!.id() === app.session.user!.id()) {
+      items.add(
+        'globalLogout',
+        <FieldSet className="SecurityPage-globalLogout" label={app.translator.trans('core.forum.security.global_logout.heading')}>
+          <span className="helpText">{app.translator.trans('core.forum.security.global_logout.help_text')}</span>
+          <Button
+            className="Button"
+            icon="fas fa-sign-out-alt"
+            onclick={this.globalLogout.bind(this)}
+            loading={this.loading === 'global_logout'}
+            disabled={this.loading === 'terminate_sessions'}
+          >
+            {app.translator.trans('core.forum.security.global_logout.log_out_button')}
+          </Button>
+        </FieldSet>
+      );
+    }
 
     return items;
   }
@@ -195,5 +213,16 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
         app.alerts.show({ type: 'error' }, app.translator.trans('core.forum.security.session_termination_failed'));
       })
       .finally(() => this.state.setLoading(false));
+  }
+
+  globalLogout() {
+    this.loading = 'global_logout';
+
+    return app
+      .request({
+        method: 'POST',
+        url: app.forum.attribute<string>('baseUrl') + '/global-logout',
+      })
+      .then(() => window.location.reload());
   }
 }

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -72,8 +72,8 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
             className="Button"
             icon="fas fa-sign-out-alt"
             onclick={this.globalLogout.bind(this)}
-            loading={this.loading === 'global_logout'}
-            disabled={this.loading === 'terminate_sessions'}
+            loading={this.loadingGlobalLogout}
+            disabled={this.loadingTerminateSessions}
           >
             {app.translator.trans('core.forum.security.global_logout.log_out_button')}
           </Button>
@@ -207,7 +207,6 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
 
         app.alerts.show({ type: 'success' }, app.translator.trans('core.forum.security.session_terminated', { count }));
 
-        m.redraw();
       })
       .catch(() => {
         app.alerts.show({ type: 'error' }, app.translator.trans('core.forum.security.session_termination_failed'));
@@ -216,13 +215,17 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
   }
 
   globalLogout() {
-    this.loading = 'global_logout';
+    this.loadingGlobalLogout = true;
 
     return app
       .request({
         method: 'POST',
         url: app.forum.attribute<string>('baseUrl') + '/global-logout',
       })
-      .then(() => window.location.reload());
+      .then(() => window.location.reload())
+      .finally(() => {
+        this.loadingGlobalLogout = false;
+        m.redraw();
+      });
   }
 }

--- a/framework/core/js/src/forum/states/UserSecurityPageState.ts
+++ b/framework/core/js/src/forum/states/UserSecurityPageState.ts
@@ -2,18 +2,11 @@ import AccessToken from '../../common/models/AccessToken';
 
 export default class UserSecurityPageState {
   protected tokens: AccessToken[] | null = null;
-  protected loading: boolean = false;
-
-  public isLoading(): boolean {
-    return this.loading;
-  }
+  public loadingTerminateSessions: boolean = false;
+  public loadingGlobalLogout: boolean = false;
 
   public hasLoadedTokens(): boolean {
     return this.tokens !== null;
-  }
-
-  public setLoading(loading: boolean): void {
-    this.loading = loading;
   }
 
   public getTokens(): AccessToken[] | null {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -381,6 +381,7 @@ core:
       search_clear_button_accessible_label: Clear search query
       search_placeholder: Search Forum
       search_role_label: Search Forum
+      security_button: => core.ref.security
       session_dropdown_accessible_label: Toggle session options dropdown menu
       settings_button: => core.ref.settings
       sign_up_link: => core.ref.sign_up

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -472,11 +472,12 @@ core:
 
     # These translations are used in the Security page.
     security:
-      developer_tokens_heading: Developer Tokens
-      current_active_session: Current Active Session
       browser_on_operating_system: "{browser} on {os}"
       cannot_terminate_current_session: Cannot terminate the current active session. Log out instead.
       created: Created
+      current_active_session: Current Active Session
+      developer_tokens_heading: Developer Tokens
+      empty_text: It looks like there is nothing to see here.
       hide_access_token: Hide Token
       last_activity: Last activity
       never: Never
@@ -485,7 +486,6 @@ core:
         submit_button: Create Token
         title: => core.ref.new_token
         title_placeholder: Title
-      empty_text: It looks like there is nothing to see here.
       revoke_access_token: Revoke
       revoke_access_token_confirmation: => core.ref.generic_confirmation_message
       sessions_heading: Active Sessions

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -478,6 +478,10 @@ core:
       current_active_session: Current Active Session
       developer_tokens_heading: Developer Tokens
       empty_text: It looks like there is nothing to see here.
+      global_logout:
+        heading: Global Logout
+        help_text: "Clears current cookie session, terminates all sessions, revokes developer tokens, and invalidates any email confirmation or password reset emails."
+        log_out_button: => core.ref.log_out
       hide_access_token: Hide Token
       last_activity: Last activity
       never: Never

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -381,7 +381,6 @@ core:
       search_clear_button_accessible_label: Clear search query
       search_placeholder: Search Forum
       search_role_label: Search Forum
-      security_button: => core.ref.security
       session_dropdown_accessible_label: Toggle session options dropdown menu
       settings_button: => core.ref.settings
       sign_up_link: => core.ref.sign_up

--- a/framework/core/src/Forum/Controller/GlobalLogOutController.php
+++ b/framework/core/src/Forum/Controller/GlobalLogOutController.php
@@ -67,7 +67,7 @@ class GlobalLogOutController implements RequestHandlerInterface
         $actor->emailTokens()->delete();
         $actor->passwordTokens()->delete();
 
-        $this->events->dispatch(new LoggedOut($actor));
+        $this->events->dispatch(new LoggedOut($actor, true));
 
         return $this->rememberer->forget(new EmptyResponse());
     }

--- a/framework/core/src/Forum/Controller/GlobalLogOutController.php
+++ b/framework/core/src/Forum/Controller/GlobalLogOutController.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Forum\Controller;
+
+use Flarum\Http\Rememberer;
+use Flarum\Http\RequestUtil;
+use Flarum\Http\SessionAuthenticator;
+use Flarum\Http\UrlGenerator;
+use Flarum\User\Event\LoggedOut;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class GlobalLogOutController implements RequestHandlerInterface
+{
+    /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
+     * @var SessionAuthenticator
+     */
+    protected $authenticator;
+
+    /**
+     * @var Rememberer
+     */
+    protected $rememberer;
+
+    /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    public function __construct(
+        Dispatcher $events,
+        SessionAuthenticator $authenticator,
+        Rememberer $rememberer,
+        UrlGenerator $url
+    ) {
+        $this->events = $events;
+        $this->authenticator = $authenticator;
+        $this->rememberer = $rememberer;
+        $this->url = $url;
+    }
+
+    public function handle(Request $request): ResponseInterface
+    {
+        $session = $request->getAttribute('session');
+        $actor = RequestUtil::getActor($request);
+
+        $actor->assertRegistered();
+
+        $response = new RedirectResponse(
+            $this->url->to('forum')->base()
+        );
+
+        $this->authenticator->logOut($session);
+
+        $actor->accessTokens()->delete();
+        $actor->emailTokens()->delete();
+        $actor->passwordTokens()->delete();
+
+        $this->events->dispatch(new LoggedOut($actor));
+
+        return $this->rememberer->forget($response);
+    }
+}

--- a/framework/core/src/Forum/Controller/GlobalLogOutController.php
+++ b/framework/core/src/Forum/Controller/GlobalLogOutController.php
@@ -15,7 +15,7 @@ use Flarum\Http\SessionAuthenticator;
 use Flarum\Http\UrlGenerator;
 use Flarum\User\Event\LoggedOut;
 use Illuminate\Contracts\Events\Dispatcher;
-use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -61,10 +61,6 @@ class GlobalLogOutController implements RequestHandlerInterface
 
         $actor->assertRegistered();
 
-        $response = new RedirectResponse(
-            $this->url->to('forum')->base()
-        );
-
         $this->authenticator->logOut($session);
 
         $actor->accessTokens()->delete();
@@ -73,6 +69,6 @@ class GlobalLogOutController implements RequestHandlerInterface
 
         $this->events->dispatch(new LoggedOut($actor));
 
-        return $this->rememberer->forget($response);
+        return $this->rememberer->forget(new EmptyResponse());
     }
 }

--- a/framework/core/src/Forum/Controller/LogOutController.php
+++ b/framework/core/src/Forum/Controller/LogOutController.php
@@ -108,7 +108,7 @@ class LogOutController implements RequestHandlerInterface
 
         $actor->accessTokens()->delete();
 
-        $this->events->dispatch(new LoggedOut($actor));
+        $this->events->dispatch(new LoggedOut($actor, false));
 
         return $this->rememberer->forget($response);
     }

--- a/framework/core/src/Forum/routes.php
+++ b/framework/core/src/Forum/routes.php
@@ -50,6 +50,12 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
     );
 
     $map->post(
+        '/global-logout',
+        'globalLogout',
+        $route->toController(Controller\GlobalLogOutController::class)
+    );
+
+    $map->post(
         '/login',
         'login',
         $route->toController(Controller\LogInController::class)

--- a/framework/core/src/User/Event/LoggedOut.php
+++ b/framework/core/src/User/Event/LoggedOut.php
@@ -13,10 +13,19 @@ use Flarum\User\User;
 
 class LoggedOut
 {
+    /**
+     * @var User
+     */
     public $user;
 
-    public function __construct(User $user)
+    /**
+     * @var bool
+     */
+    public $isGlobal;
+
+    public function __construct(User $user, bool $isGlobal = false)
     {
         $this->user = $user;
+        $this->isGlobal = $isGlobal;
     }
 }

--- a/framework/core/tests/integration/forum/GlobalLogoutTest.php
+++ b/framework/core/tests/integration/forum/GlobalLogoutTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\forum;
+
+use Carbon\Carbon;
+use Flarum\Extend;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\EmailToken;
+use Flarum\User\PasswordToken;
+
+class GlobalLogoutTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->extend(
+            (new Extend\Csrf)
+                ->exemptRoute('globalLogout')
+                ->exemptRoute('login')
+        );
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser()
+            ],
+            'access_tokens' => [
+                ['id' => 1, 'token' => 'a', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
+                ['id' => 2, 'token' => 'b', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session_remember'],
+                ['id' => 3, 'token' => 'c', 'user_id' => 1, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],
+
+                ['id' => 4, 'token' => 'd', 'user_id' => 2, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'session'],
+                ['id' => 5, 'token' => 'e', 'user_id' => 2, 'last_activity_at' => Carbon::parse('2021-01-01 02:00:00'), 'type' => 'developer'],
+            ],
+            'email_tokens' => [
+                ['token' => 'd', 'email' => 'test1@machine.local', 'user_id' => 1, 'created_at' => Carbon::parse('2021-01-01 02:00:00')],
+                ['token' => 'e', 'email' => 'test2@machine.local', 'user_id' => 2, 'created_at' => Carbon::parse('2021-01-01 02:00:00')],
+            ],
+            'password_tokens' => [
+                ['token' => 'd', 'user_id' => 1, 'created_at' => Carbon::parse('2021-01-01 02:00:00')],
+                ['token' => 'e', 'user_id' => 2, 'created_at' => Carbon::parse('2021-01-01 02:00:00')],
+            ]
+        ]);
+    }
+
+    /**
+     * @dataProvider canGloballyLogoutDataProvider
+     * @test
+     */
+    public function can_globally_log_out(int $authenticatedAs, string $identification, string $password)
+    {
+        $loginResponse = $this->send(
+            $this->request('POST', '/login', [
+                'json' => compact('identification', 'password')
+            ])
+        );
+
+        $response = $this->send(
+            $this->requestWithCookiesFrom(
+                $this->request('POST', '/global-logout'),
+                $loginResponse,
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+
+        $this->assertEquals(0, AccessToken::query()->where('user_id', $authenticatedAs)->count());
+        $this->assertEquals(0, EmailToken::query()->where('user_id', $authenticatedAs)->count());
+        $this->assertEquals(0, PasswordToken::query()->where('user_id', $authenticatedAs)->count());
+    }
+
+    public function canGloballyLogoutDataProvider(): array
+    {
+        return [
+            // Admin
+            [1, 'admin', 'password'],
+
+            // Normal user
+            [2, 'normal', 'too-obscure'],
+        ];
+    }
+}

--- a/framework/core/tests/integration/forum/GlobalLogoutTest.php
+++ b/framework/core/tests/integration/forum/GlobalLogoutTest.php
@@ -74,7 +74,7 @@ class GlobalLogoutTest extends TestCase
             )
         );
 
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $this->assertEquals(0, AccessToken::query()->where('user_id', $authenticatedAs)->count());
         $this->assertEquals(0, EmailToken::query()->where('user_id', $authenticatedAs)->count());


### PR DESCRIPTION
**Relies on #3587**

**Changes proposed in this pull request:**
* Adds a forum controller that clears the current session and all access tokens, email tokens, and password tokens.
* Adds a security button to link to the security page in the session dropdown.

**Screenshot**
![Screenshot from 2022-08-17 11-12-41](https://user-images.githubusercontent.com/20267363/185094660-65a84ac2-9fdb-4146-b723-f94bcdace725.png)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.