### PR TITLE
chore(notification): hide actions on empty state

### DIFF
--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -34,7 +34,7 @@ export default class NotificationList extends Component {
     const state = this.attrs.state;
 
     if (!state.hasItems()) {
-      return;
+      return items;
     }
 
     items.add(

--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -33,6 +33,10 @@ export default class NotificationList extends Component {
     const items = new ItemList();
     const state = this.attrs.state;
 
+    if (!state.hasItems()) {
+      return;
+    }
+
     items.add(
       'mark_all_as_read',
       <Tooltip text={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}>


### PR DESCRIPTION
Hide actions when notification is empty

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
