### PR TITLE
[1.x] fix(tags): load correct user tag state and prevent N+1 queries in `stateFor`

### DIFF
--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -36,7 +36,7 @@ use Illuminate\Database\Eloquent\Collection;
  * @property int $last_posted_user_id
  * @property string $icon
  *
- * @property TagState $state
+ * @property TagState|null $state
  * @property Tag|null $parent
  * @property-read Collection<Tag> $children
  * @property-read Collection<Discussion> $discussions

--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -163,9 +163,18 @@ class Tag extends AbstractModel
      * @param User $user
      * @return TagState
      */
-    public function stateFor(User $user)
+    public function stateFor(User $user): TagState
     {
-        $state = $this->state()->where('user_id', $user->id)->first();
+        // Use the loaded state if the relation is loaded, and either:
+        // 1. The state is null, or
+        // 2. The state belongs to the given user.
+        // This ensures that if a non-null state is loaded, it belongs to the correct user.
+        // If these conditions are not met, we query the database for the user's state.
+        if ($this->relationLoaded('state') && (! $this->state || $this->state->user_id === $user->id)) {
+            $state = $this->state;
+        } else {
+            $state = $this->state()->where('user_id', $user->id)->first();
+        }
 
         if (! $state) {
             $state = new TagState;

--- a/extensions/tags/src/TagRepository.php
+++ b/extensions/tags/src/TagRepository.php
@@ -57,7 +57,13 @@ class TagRepository
                     $query->whereVisibleTo($actor);
                 };
             } else {
-                $relationsArray[] = $relation;
+                if ($relation === 'state') {
+                    $relationsArray['state'] = function ($query) use ($actor) {
+                        $query->where('user_id', $actor->id);
+                    };
+                } else {
+                    $relationsArray[] = $relation;
+                }
             }
         }
 


### PR DESCRIPTION
**Fixes #4007**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
As described in the title. For more details, please refer to issue #4007.

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Backend changes.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

Thanks to @SychO9 for assistance on Discord!