### PR TITLE
fix: reset save button state when an error occurs in admin page

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -181,6 +181,13 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
   }
 
   /**
+   * Called when `saveSettings` fails to complete.
+   */
+  onsavefailed(): void {
+    this.loading = false;
+  }
+
+  /**
    * Returns a function that fetches the setting from the `app` global.
    */
   setting(key: string, fallback: string = ''): Stream<string> {
@@ -232,7 +239,8 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
           app.modal.show(LoadingModal);
           window.location.reload();
         }
-      });
+      })
+      .catch(this.onsavefailed.bind(this));
   }
 
   modelLocale(): Record<string, string> {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3962**

**Changes proposed in this pull request:**
This PR contains changes to `AdminPage` component, which makes sure the state of the save button is reset if an error occurs.

**Reviewers should focus on:**
Is the implementation correct and matches the standard way of Flarum?

**Screenshot**
*None*

**QA**
Trigger a server-side error while saving settings in admin page, check if the state of the save button is reset.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
