### PR TITLE
fix: 3 char hex color is incorrectly modified to 6

### DIFF
--- a/framework/core/js/src/common/utils/isDark.ts
+++ b/framework/core/js/src/common/utils/isDark.ts
@@ -17,7 +17,7 @@ export default function isDark(hexcolor: string | null): boolean {
   let hexnumbers = hexcolor.replace('#', '');
 
   if (hexnumbers.length === 3) {
-    hexnumbers += hexnumbers;
+    hexnumbers = hexnumbers.split('').map(char => char.repeat(2)).join('');
   }
 
   const r = parseInt(hexnumbers.slice(0, 2), 16);


### PR DESCRIPTION
The current logic creates `cdecde` from `cde`, it should be `ccddee`.

@dsevillamartin said this is the code to use instead and chat gpt said he's brilliant so..

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
