### PR TITLE
[1.x] [extensibility] feat: allow `DiscussionsSearchSource` to be extended

### DIFF
--- a/framework/core/js/src/forum/compat.ts
+++ b/framework/core/js/src/forum/compat.ts
@@ -76,6 +76,7 @@ import routes from './routes';
 import ForumApplication from './ForumApplication';
 import isSafariMobile from './utils/isSafariMobile';
 import AccessTokensList from './components/AccessTokensList';
+import DiscussionsSearchItem from './components/DiscussionsSearchItem';
 
 export default Object.assign(compat, {
   'utils/PostControls': PostControls,
@@ -114,6 +115,7 @@ export default Object.assign(compat, {
   'components/IndexPage': IndexPage,
   'components/DiscussionRenamedNotification': DiscussionRenamedNotification,
   'components/DiscussionsSearchSource': DiscussionsSearchSource,
+  'components/DiscussionsSearchItem': DiscussionsSearchItem,
   'components/HeaderSecondary': HeaderSecondary,
   'components/ComposerButton': ComposerButton,
   'components/DiscussionList': DiscussionList,

--- a/framework/core/js/src/forum/components/DiscussionsSearchItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionsSearchItem.tsx
@@ -1,0 +1,61 @@
+import app from '../../forum/app';
+import Component, { ComponentAttrs } from '../../common/Component';
+import Link from '../../common/components/Link';
+import highlight from '../../common/helpers/highlight';
+import Discussion from '../../common/models/Discussion';
+import Post from '../../common/models/Post';
+import type Mithril from 'mithril';
+import ItemList from '../../common/utils/ItemList';
+
+export interface DiscussionsSearchItemAttrs extends ComponentAttrs {
+  query: string;
+  discussion: Discussion;
+  mostRelevantPost: Post;
+}
+
+export default class DiscussionsSearchItem extends Component<DiscussionsSearchItemAttrs> {
+  query!: string;
+  discussion!: Discussion;
+  mostRelevantPost!: Post | null | undefined;
+
+  oninit(vnode: Mithril.Vnode<DiscussionsSearchItemAttrs, this>) {
+    super.oninit(vnode);
+
+    this.query = this.attrs.query;
+    this.discussion = this.attrs.discussion;
+    this.mostRelevantPost = this.attrs.mostRelevantPost;
+  }
+
+  view() {
+    return (
+      <li className="DiscussionSearchResult" data-index={'discussions' + this.discussion.id()}>
+        <Link href={app.route.discussion(this.discussion, (this.mostRelevantPost && this.mostRelevantPost.number()) || 0)}>
+          {this.viewItems().toArray()}
+        </Link>
+      </li>
+    );
+  }
+
+  discussionTitle() {
+    return this.discussion.title();
+  }
+
+  mostRelevantPostContent() {
+    return this.mostRelevantPost?.contentPlain();
+  }
+
+  viewItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('discussion-title', <div className="DiscussionSearchResult-title">{highlight(this.discussionTitle(), this.query)}</div>, 90);
+
+    !!this.mostRelevantPost &&
+      items.add(
+        'most-relevant',
+        <div className="DiscussionSearchResult-excerpt">{highlight(this.mostRelevantPostContent() ?? '', this.query, 100)}</div>,
+        80
+      );
+
+    return items;
+  }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
This splits `DiscussionsSearchSource` out so that it is possible to extend/customize the following:

On `DiscussionsSearchSource`
- `includes` - allow adding additional includes from the frontend.
- `limit` - allow setting a different results limit
- `queryMutators` - allow adding additional gambits to the default query. ie, from `fof/best-answer`, we can now choose to exclude best answer results from the normal discussions results, as this extension adds it's own search source with best answer results.

New `DiscussionsSearchItem`
This handles how the elements are presented within the search dropdown. We can customize:
- `discussionTitle` - ie, for within a translation extension so that titles can be presented already translated
- `mostRelevantPostContent` - as above
- `viewItems` - add/remove/modify elements of the view by dealing with an `ItemList`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

