### PR TITLE
[1.x] [extensibility] feat: allow classes that extends `AbstractJob` to be placed on a specified queue

### DIFF
--- a/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
+++ b/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
@@ -48,7 +48,7 @@ class SendMentionsNotificationsJob extends AbstractJob
     public function __construct(CommentPost $post, array $userMentions, array $postMentions, array $groupMentions)
     {
         parent::__construct();
-        
+
         $this->post = $post;
         $this->userMentions = $userMentions;
         $this->postMentions = $postMentions;

--- a/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
+++ b/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
@@ -47,6 +47,8 @@ class SendMentionsNotificationsJob extends AbstractJob
 
     public function __construct(CommentPost $post, array $userMentions, array $postMentions, array $groupMentions)
     {
+        parent::__construct();
+        
         $this->post = $post;
         $this->userMentions = $userMentions;
         $this->postMentions = $postMentions;

--- a/extensions/package-manager/src/Job/ComposerCommandJob.php
+++ b/extensions/package-manager/src/Job/ComposerCommandJob.php
@@ -33,7 +33,7 @@ class ComposerCommandJob extends AbstractJob implements ShouldBeUnique
     public function __construct(AbstractActionCommand $command, string $phpVersion)
     {
         parent::__construct();
-        
+
         $this->command = $command;
         $this->phpVersion = $phpVersion;
     }

--- a/extensions/package-manager/src/Job/ComposerCommandJob.php
+++ b/extensions/package-manager/src/Job/ComposerCommandJob.php
@@ -32,6 +32,8 @@ class ComposerCommandJob extends AbstractJob implements ShouldBeUnique
 
     public function __construct(AbstractActionCommand $command, string $phpVersion)
     {
+        parent::__construct();
+        
         $this->command = $command;
         $this->phpVersion = $phpVersion;
     }

--- a/extensions/pusher/src/SendPusherNotificationsJob.php
+++ b/extensions/pusher/src/SendPusherNotificationsJob.php
@@ -28,6 +28,8 @@ class SendPusherNotificationsJob extends AbstractJob
 
     public function __construct(BlueprintInterface $blueprint, array $recipients)
     {
+        parent::__construct();
+        
         $this->blueprint = $blueprint;
         $this->recipients = $recipients;
     }

--- a/extensions/pusher/src/SendPusherNotificationsJob.php
+++ b/extensions/pusher/src/SendPusherNotificationsJob.php
@@ -29,7 +29,7 @@ class SendPusherNotificationsJob extends AbstractJob
     public function __construct(BlueprintInterface $blueprint, array $recipients)
     {
         parent::__construct();
-        
+
         $this->blueprint = $blueprint;
         $this->recipients = $recipients;
     }

--- a/framework/core/src/Mail/Job/SendRawEmailJob.php
+++ b/framework/core/src/Mail/Job/SendRawEmailJob.php
@@ -22,7 +22,7 @@ class SendRawEmailJob extends AbstractJob
     public function __construct(string $email, string $subject, string $body)
     {
         parent::__construct();
-        
+
         $this->email = $email;
         $this->subject = $subject;
         $this->body = $body;

--- a/framework/core/src/Mail/Job/SendRawEmailJob.php
+++ b/framework/core/src/Mail/Job/SendRawEmailJob.php
@@ -21,6 +21,8 @@ class SendRawEmailJob extends AbstractJob
 
     public function __construct(string $email, string $subject, string $body)
     {
+        parent::__construct();
+        
         $this->email = $email;
         $this->subject = $subject;
         $this->body = $body;

--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -29,7 +29,7 @@ class SendEmailNotificationJob extends AbstractJob
     public function __construct(MailableInterface $blueprint, User $recipient)
     {
         parent::__construct();
-        
+
         $this->blueprint = $blueprint;
         $this->recipient = $recipient;
     }

--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -28,6 +28,8 @@ class SendEmailNotificationJob extends AbstractJob
 
     public function __construct(MailableInterface $blueprint, User $recipient)
     {
+        parent::__construct();
+        
         $this->blueprint = $blueprint;
         $this->recipient = $recipient;
     }

--- a/framework/core/src/Notification/Job/SendNotificationsJob.php
+++ b/framework/core/src/Notification/Job/SendNotificationsJob.php
@@ -28,6 +28,8 @@ class SendNotificationsJob extends AbstractJob
 
     public function __construct(BlueprintInterface $blueprint, array $recipients = [])
     {
+        parent::__construct();
+        
         $this->blueprint = $blueprint;
         $this->recipients = $recipients;
     }

--- a/framework/core/src/Notification/Job/SendNotificationsJob.php
+++ b/framework/core/src/Notification/Job/SendNotificationsJob.php
@@ -29,7 +29,7 @@ class SendNotificationsJob extends AbstractJob
     public function __construct(BlueprintInterface $blueprint, array $recipients = [])
     {
         parent::__construct();
-        
+
         $this->blueprint = $blueprint;
         $this->recipients = $recipients;
     }

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -28,5 +28,4 @@ class AbstractJob implements ShouldQueue
             $this->onQueue(static::$onQueue);
         }
     }
-
 }

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -23,12 +23,12 @@ class AbstractJob implements ShouldQueue
     /**
      * @var string|null
      */
-    public static $onQueue = null;
+    public static $sendOnQueue = null;
 
     public function __construct()
     {
-        if (static::$onQueue) {
-            $this->onQueue(static::$onQueue);
+        if (static::$sendOnQueue) {
+            $this->onQueue(static::$sendOnQueue);
         }
     }
 }

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -23,7 +23,7 @@ class AbstractJob implements ShouldQueue
     /**
      * @var string|null
      */
-    public static  $onQueue = null;
+    public static $onQueue = null;
 
     public function __construct()
     {

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -22,9 +22,9 @@ class AbstractJob implements ShouldQueue
 
     /**
      * The name of the queue on which the job should be placed.
-     * 
+     *
      * This is only effective on jobs dispatched via Redis.
-     * 
+     *
      * @var string|null
      */
     public static $sendOnQueue = null;

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -20,7 +20,10 @@ class AbstractJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public static ?string $onQueue = null;
+    /**
+     * @var string|null
+     */
+    public static  $onQueue = null;
 
     public function __construct()
     {

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -22,9 +22,9 @@ class AbstractJob implements ShouldQueue
 
     /**
      * The name of the queue on which the job should be placed.
-     * 
+     *
      * This is only effective on jobs that extend `\Flarum\Queue\AbstractJob` and dispatched via Redis.
-     * 
+     *
      * @var string|null
      */
     public static $sendOnQueue = null;

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -19,4 +19,14 @@ class AbstractJob implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+
+    public static ?string $onQueue = null;
+
+    public function __construct()
+    {
+        if (static::$onQueue) {
+            $this->onQueue(static::$onQueue);
+        }
+    }
+
 }

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -21,6 +21,10 @@ class AbstractJob implements ShouldQueue
     use SerializesModels;
 
     /**
+     * The name of the queue on which the job should be placed.
+     * 
+     * This is only effective on jobs dispatched via Redis.
+     * 
      * @var string|null
      */
     public static $sendOnQueue = null;

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -22,9 +22,9 @@ class AbstractJob implements ShouldQueue
 
     /**
      * The name of the queue on which the job should be placed.
-     *
-     * This is only effective on jobs dispatched via Redis.
-     *
+     * 
+     * This is only effective on jobs that extend `\Flarum\Queue\AbstractJob` and dispatched via Redis.
+     * 
      * @var string|null
      */
     public static $sendOnQueue = null;

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -27,6 +27,8 @@ class RequestPasswordResetJob extends AbstractJob
 
     public function __construct(string $email)
     {
+        parent::__construct();
+        
         $this->email = $email;
     }
 

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -28,7 +28,7 @@ class RequestPasswordResetJob extends AbstractJob
     public function __construct(string $email)
     {
         parent::__construct();
-        
+
         $this->email = $email;
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add a static property to `AbstractJob`, so that any class extending it may specify which queue it should be dispatched on.

**Reviewers should focus on:**
All jobs within core and extensions have had their constructor updated to also call `parent::__construct()`. My understanding that if a 3rd party does not call the parent constructor, it simply means that the `$onQueue` won't be set, therefore not breaking any compatibility? 

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: TBC

