### PR TITLE
fix: new webpack config doesn't work on windows

### DIFF
--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -9,7 +9,7 @@ class RegisterAsyncChunksPlugin {
   processUrlPath(urlPath) {
     if (path.sep == "\\") {
       // separator on windows is "\", this will cause escape issues when used in url path.
-      return urlPath.replace(/\\/g, "/");
+      return urlPath.replace(/\\/g, '/');
     }
     return urlPath;
   }

--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -6,6 +6,14 @@ const ConcatenatedModule = require('webpack/lib/optimize/ConcatenatedModule');
 class RegisterAsyncChunksPlugin {
   static registry = {};
 
+  processUrlPath(urlPath) {
+    if (path.sep == "\\") {
+      // separator on windows is "\", this will cause escape issues when used in url path.
+      return urlPath.replace(/\\/g, "/");
+    }
+    return urlPath;
+  }
+
   apply(compiler) {
     compiler.hooks.thisCompilation.tap('RegisterAsyncChunksPlugin', (compilation) => {
       let alreadyOptimized = false;
@@ -63,6 +71,8 @@ class RegisterAsyncChunksPlugin {
               // Each line that has a webpackChunkName comment.
               [...module._source._value.matchAll(/.*\/\* webpackChunkName: .* \*\/.*/gm)].forEach(([match]) => {
                 [...match.matchAll(/(.*?) webpackChunkName: '([^']*)'.*? \*\/ '([^']+)'.*?/gm)].forEach(([match, _, urlPath, importPath]) => {
+                  urlPath = this.processUrlPath(urlPath);
+
                   // Import path is relative to module.resource, so we need to resolve it
                   const importPathResolved = path.resolve(path.dirname(module.resource), importPath);
                   const thisComposerJson = require(path.resolve(process.cwd(), '../composer.json'));
@@ -118,7 +128,7 @@ class RegisterAsyncChunksPlugin {
 
                     // The path right after the src/ directory, without the extension.
                     const regPathSep = `\\${path.sep}`;
-                    const urlPath = module.resource.replace(new RegExp(`.*${regPathSep}src${regPathSep}([^.]+)\..+`), '$1');
+                    const urlPath = this.processUrlPath(module.resource.replace(new RegExp(`.*${regPathSep}src${regPathSep}([^.]+)\..+`), '$1'));
 
                     if (!registrableModulesUrlPaths.has(urlPath)) {
                       registrableModulesUrlPaths.set(urlPath, [relevantChunk.id, moduleId, namespace, urlPath]);

--- a/js-packages/webpack-config/src/autoChunkNameLoader.cjs
+++ b/js-packages/webpack-config/src/autoChunkNameLoader.cjs
@@ -63,7 +63,12 @@ module.exports = function autoChunkNameLoader(source) {
         let chunkPath = relativePathToImport;
 
         if (absolutePathToImport.includes('src')) {
-          chunkPath = absolutePathToImport.split('src/')[1];
+          chunkPath = absolutePathToImport.split(`src${path.sep}`)[1];
+        }
+
+        if (path.sep == "\\") {
+          // separator on windows is "\", the resolver only works with "/".
+          chunkPath = chunkPath.replace(/\\/g, "/");
         }
 
         const webpackCommentOptions = {

--- a/js-packages/webpack-config/src/autoChunkNameLoader.cjs
+++ b/js-packages/webpack-config/src/autoChunkNameLoader.cjs
@@ -67,8 +67,8 @@ module.exports = function autoChunkNameLoader(source) {
         }
 
         if (path.sep == "\\") {
-          // separator on windows is "\", the resolver only works with "/".
-          chunkPath = chunkPath.replace(/\\/g, "/");
+          // separator on windows is '\', the resolver only works with '/'.
+          chunkPath = chunkPath.replace(/\\/g, '/');
         }
 
         const webpackCommentOptions = {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This PR fixes the 2.0's webpack build on Windows by replacing `\` separator to `/`.

**Reviewers should focus on:**
Will this way of solving it cause new issues

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
Run webpack build on Windows to check if it's working well.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
