### PR TITLE
[1.x] [extensibility] feat: allow modifying the discussion title on PostsUserPage

### DIFF
--- a/framework/core/js/src/forum/components/PostsUserPage.tsx
+++ b/framework/core/js/src/forum/components/PostsUserPage.tsx
@@ -70,7 +70,7 @@ export default class PostsUserPage extends UserPage {
             <li>
               <div className="PostsUserPage-discussion">
                 {app.translator.trans('core.forum.user.in_discussion_text', {
-                  discussion: <Link href={app.route.post(post)}>{post.discussion().title()}</Link>,
+                  discussion: <Link href={app.route.post(post)}>{this.discussionTitle(post)}</Link>,
                 })}
               </div>
 
@@ -141,5 +141,9 @@ export default class PostsUserPage extends UserPage {
     m.redraw();
 
     return results;
+  }
+
+  discussionTitle(post: Post): string {
+    return post.discussion().title();
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
As title says, extract the discussion title from the view and place it into a function, so that it can be updated from 3rd party extensions

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

