### PR TITLE
fix: respect user theme preference

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -377,7 +377,7 @@ export default class Application {
   }
 
   private initColorScheme(forumDefault: string | null = null): void {
-    forumDefault ??= document.documentElement.getAttribute('data-theme') ?? 'auto';
+    forumDefault ??= app.forum.attribute('colorSchema') ?? 'auto';
     this.allowUserColorScheme = forumDefault === 'auto';
     const userConfiguredPreference = this.session.user?.preferences()?.colorScheme;
 

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -377,7 +377,7 @@ export default class Application {
   }
 
   private initColorScheme(forumDefault: string | null = null): void {
-    forumDefault ??= app.forum.attribute('colorSchema') ?? 'auto';
+    forumDefault ??= app.forum.attribute('colorScheme') ?? 'auto';
     this.allowUserColorScheme = forumDefault === 'auto';
     const userConfiguredPreference = this.session.user?.preferences()?.colorScheme;
 

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -101,7 +101,7 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn () => $this->settings->get('theme_primary_color')),
             Schema\Str::make('themeSecondaryColor')
                 ->get(fn () => $this->settings->get('theme_secondary_color')),
-            Schema\Str::make('colorSchema')
+            Schema\Str::make('colorScheme')
                 ->get(fn () => $this->settings->get('color_scheme')),
             Schema\Str::make('logoUrl')
                 ->get(fn () => $this->getLogoUrl()),

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -101,6 +101,8 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn () => $this->settings->get('theme_primary_color')),
             Schema\Str::make('themeSecondaryColor')
                 ->get(fn () => $this->settings->get('theme_secondary_color')),
+            Schema\Str::make('colorSchema')
+                ->get(fn () => $this->settings->get('color_scheme')),
             Schema\Str::make('logoUrl')
                 ->get(fn () => $this->getLogoUrl()),
             Schema\Str::make('faviconUrl')

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -102,7 +102,11 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     $settings = $container->make(SettingsRepositoryInterface::class);
 
                     // Add document classes/attributes for design use cases.
-                    $document->extraAttributes['data-theme'] = $settings->get('color_scheme');
+                    $document->extraAttributes['data-theme'] = function (ServerRequestInterface $request) use ($settings) {
+                        return $settings->get('color_scheme') === 'auto'
+                            ? RequestUtil::getActor($request)->getPreference('colorScheme')
+                            : $settings->get('color_scheme');
+                    };
                     $document->extraAttributes['data-colored-header'] = $settings->get('theme_colored_header') ? 'true' : 'false';
                     $document->extraAttributes['class'][] = function (ServerRequestInterface $request) {
                         return RequestUtil::getActor($request)->isGuest() ? 'guest-user' : 'logged-in';


### PR DESCRIPTION
This PR fixes the issue where `data-theme` defaulted to `auto`, causing a flash of light mode before switching to dark. It ensures the theme respects the user's preference for a smoother experience.

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
