### PR TITLE
chore: wrap RepositoryModal's fields in Form component

### DIFF
--- a/extensions/package-manager/js/src/admin/components/AuthMethodModal.tsx
+++ b/extensions/package-manager/js/src/admin/components/AuthMethodModal.tsx
@@ -5,6 +5,7 @@ import Select from 'flarum/common/components/Select';
 import Stream from 'flarum/common/utils/Stream';
 import Button from 'flarum/common/components/Button';
 import extractText from 'flarum/common/utils/extractText';
+import Form from 'flarum/common/components/Form';
 
 export interface IAuthMethodModalAttrs extends IInternalModalAttrs {
   onsubmit: (type: string, host: string, token: string) => void;
@@ -45,38 +46,40 @@ export default class AuthMethodModal<CustomAttrs extends IAuthMethodModalAttrs =
 
     return (
       <div className="Modal-body">
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.type_label')}</label>
-          <Select options={types} value={this.type()} onchange={this.type} />
-        </div>
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.host_label')}</label>
-          <input
-            className="FormControl"
-            bidi={this.host}
-            placeholder={app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.host_placeholder')}
-          />
-        </div>
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.token_label')}</label>
-          <textarea
-            className="FormControl"
-            oninput={(e: InputEvent) => this.token((e.target as HTMLTextAreaElement).value)}
-            rows="6"
-            placeholder={
-              this.token().startsWith('unchanged:')
-                ? extractText(app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.unchanged_token_placeholder'))
-                : ''
-            }
-          >
-            {this.token().startsWith('unchanged:') ? '' : this.token()}
-          </textarea>
-        </div>
-        <div className="Form-group">
-          <Button className="Button Button--primary" onclick={this.submit.bind(this)}>
-            {app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.submit_button')}
-          </Button>
-        </div>
+        <Form>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.type_label')}</label>
+            <Select options={types} value={this.type()} onchange={this.type} />
+          </div>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.host_label')}</label>
+            <input
+              className="FormControl"
+              bidi={this.host}
+              placeholder={app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.host_placeholder')}
+            />
+          </div>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.token_label')}</label>
+            <textarea
+              className="FormControl"
+              oninput={(e: InputEvent) => this.token((e.target as HTMLTextAreaElement).value)}
+              rows="6"
+              placeholder={
+                this.token().startsWith('unchanged:')
+                  ? extractText(app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.unchanged_token_placeholder'))
+                  : ''
+              }
+            >
+              {this.token().startsWith('unchanged:') ? '' : this.token()}
+            </textarea>
+          </div>
+          <div className="Form-group">
+            <Button className="Button Button--primary" onclick={this.submit.bind(this)}>
+              {app.translator.trans('flarum-extension-manager.admin.auth_config.add_modal.submit_button')}
+            </Button>
+          </div>
+        </Form>
       </div>
     );
   }

--- a/extensions/package-manager/js/src/admin/components/RepositoryModal.tsx
+++ b/extensions/package-manager/js/src/admin/components/RepositoryModal.tsx
@@ -5,6 +5,7 @@ import Select from 'flarum/common/components/Select';
 import Stream from 'flarum/common/utils/Stream';
 import Button from 'flarum/common/components/Button';
 import { type Repository } from './ConfigureComposer';
+import Form from 'flarum/common/components/Form';
 
 export interface IRepositoryModalAttrs extends IInternalModalAttrs {
   onsubmit: (repository: Repository, key: string) => void;
@@ -41,31 +42,33 @@ export default class RepositoryModal<CustomAttrs extends IRepositoryModalAttrs =
 
     return (
       <div className="Modal-body">
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.name_label')}</label>
-          <input className="FormControl" bidi={this.name} />
-        </div>
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.type_label')}</label>
-          <Select
-            options={types}
-            value={this.repository().type}
-            onchange={(value: 'composer' | 'vcs' | 'path') => this.repository({ ...this.repository(), type: value })}
-          />
-        </div>
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.url')}</label>
-          <input
-            className="FormControl"
-            onchange={(e: Event) => this.repository({ ...this.repository(), url: (e.target as HTMLInputElement).value })}
-            value={this.repository().url}
-          />
-        </div>
-        <div className="Form-group">
-          <Button className="Button Button--primary" onclick={this.submit.bind(this)}>
-            {app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.submit_button')}
-          </Button>
-        </div>
+        <Form>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.name_label')}</label>
+            <input className="FormControl" bidi={this.name} />
+          </div>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.type_label')}</label>
+            <Select
+              options={types}
+              value={this.repository().type}
+              onchange={(value: 'composer' | 'vcs' | 'path') => this.repository({ ...this.repository(), type: value })}
+            />
+          </div>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.url')}</label>
+            <input
+              className="FormControl"
+              onchange={(e: Event) => this.repository({ ...this.repository(), url: (e.target as HTMLInputElement).value })}
+              value={this.repository().url}
+            />
+          </div>
+          <div className="Form-group">
+            <Button className="Button Button--primary" onclick={this.submit.bind(this)}>
+              {app.translator.trans('flarum-extension-manager.admin.composer.repositories.add_modal.submit_button')}
+            </Button>
+          </div>
+        </Form>
       </div>
     );
   }


### PR DESCRIPTION
Before:
<img width="839" alt="Screenshot 2024-09-28 at 22 49 40" src="https://github.com/user-attachments/assets/443aa740-197c-4e9f-a0a7-c8a732b5fb4e">

After:
<img width="1073" alt="Screenshot 2024-09-28 at 22 49 54" src="https://github.com/user-attachments/assets/519786db-f4d3-42a2-80f2-d6c8dc88bf37">



**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
