### PR TITLE
[1.x] [QOL] chore: point fontawesome links at v5 free

### DIFF
--- a/extensions/tags/js/src/admin/components/EditTagModal.tsx
+++ b/extensions/tags/js/src/admin/components/EditTagModal.tsx
@@ -117,7 +117,7 @@ export default class EditTagModal extends Modal<EditTagModalAttrs> {
       <div className="Form-group">
         <label>{app.translator.trans('flarum-tags.admin.edit_tag.icon_label')}</label>
         <div className="helpText">
-          {app.translator.trans('flarum-tags.admin.edit_tag.icon_text', { a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1" /> })}
+          {app.translator.trans('flarum-tags.admin.edit_tag.icon_text', { a: <a href={app.refs.fontawesome} tabindex="-1" /> })}
         </div>
         <input className="FormControl" placeholder="fas fa-bolt" bidi={this.icon} />
       </div>,

--- a/framework/core/js/src/admin/components/EditGroupModal.tsx
+++ b/framework/core/js/src/admin/components/EditGroupModal.tsx
@@ -88,7 +88,7 @@ export default class EditGroupModal<CustomAttrs extends IEditGroupModalAttrs = I
       <div className="Form-group">
         <label>{app.translator.trans('core.admin.edit_group.icon_label')}</label>
         <div className="helpText">
-          {app.translator.trans('core.admin.edit_group.icon_text', { a: <a href="https://fontawesome.com/v5/search?m=free" tabindex="-1" /> })}
+          {app.translator.trans('core.admin.edit_group.icon_text', { a: <a href={app.refs.fontawesome} tabindex="-1" /> })}
         </div>
         <input className="FormControl" placeholder="fas fa-bolt" bidi={this.icon} />
       </div>,

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -237,6 +237,10 @@ export default class Application {
 
   data!: ApplicationData;
 
+  refs: Record<string, string> = {
+    fontawesome: 'https://fontawesome.com/v5/search?o=r&m=free',
+  };
+
   private _title: string = '';
   private _titleCount: number = 0;
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Backport of https://github.com/flarum/framework/pull/4036 to correctly link to FontAwesome 5 free.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
