### PR TITLE
[1.x] [extensibility] chore: make WelcomeHero extensible

### DIFF
--- a/framework/core/js/src/forum/components/WelcomeHero.tsx
+++ b/framework/core/js/src/forum/components/WelcomeHero.tsx
@@ -2,6 +2,7 @@ import app from '../app';
 import Component from '../../common/Component';
 import Button from '../../common/components/Button';
 import type Mithril from 'mithril';
+import ItemList from '../../common/utils/ItemList';
 
 export interface IWelcomeHeroAttrs {}
 
@@ -24,25 +25,9 @@ export default class WelcomeHero extends Component<IWelcomeHeroAttrs> {
   view(vnode: Mithril.Vnode<IWelcomeHeroAttrs, this>) {
     if (this.isHidden()) return null;
 
-    const slideUp = () => {
-      this.$().slideUp(this.hide.bind(this));
-    };
-
     return (
       <header className="Hero WelcomeHero">
-        <div className="container">
-          <Button
-            icon="fas fa-times"
-            onclick={slideUp}
-            className="Hero-close Button Button--icon Button--link"
-            aria-label={app.translator.trans('core.forum.welcome_hero.hide')}
-          />
-
-          <div className="containerNarrow">
-            <h1 className="Hero-title">{app.forum.attribute('welcomeTitle')}</h1>
-            <div className="Hero-subtitle">{m.trust(app.forum.attribute('welcomeMessage'))}</div>
-          </div>
-        </div>
+        <div className="container">{this.viewItems().toArray()}</div>
       </header>
     );
   }
@@ -65,5 +50,38 @@ export default class WelcomeHero extends Component<IWelcomeHeroAttrs> {
     if (this.hidden) return true;
 
     return false;
+  }
+
+  viewItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    const slideUp = () => {
+      this.$().slideUp(this.hide.bind(this));
+    };
+
+    items.add(
+      'dismiss-button',
+      <Button
+        icon="fas fa-times"
+        onclick={slideUp}
+        className="Hero-close Button Button--icon Button--link"
+        aria-label={app.translator.trans('core.forum.welcome_hero.hide')}
+      />,
+      100
+    );
+
+    items.add('content', <div className="containerNarrow">{this.contentItems().toArray()}</div>, 80);
+
+    return items;
+  }
+
+  contentItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('title', <h1 className="Hero-title">{app.forum.attribute('welcomeTitle')}</h1>, 100);
+
+    items.add('subtitle', <div className="Hero-subtitle">{m.trust(app.forum.attribute('welcomeMessage'))}</div>);
+
+    return items;
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds `ItemList` components so that 3rd parties can customize the WelcomeHero as required.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
