### PR TITLE
[1.x] [extensibility] Export all missing modules in compat

### DIFF
--- a/extensions/akismet/js/tsconfig.json
+++ b/extensions/akismet/js/tsconfig.json
@@ -15,6 +15,7 @@
     "declarationDir": "./dist-typings",
     "paths": {
       "flarum/*": ["../../../framework/core/js/dist-typings/*"],
+      "@flarum/core/*": ["../../../framework/core/js/dist-typings/*"],
       "flarum/flags/*": ["../../flags/js/dist-typings/*"]
     }
   }

--- a/extensions/emoji/js/src/forum/compat.ts
+++ b/extensions/emoji/js/src/forum/compat.ts
@@ -1,0 +1,7 @@
+import AutocompleteDropdown from './fragments/AutocompleteDropdown';
+import getEmojiIconCode from './helpers/getEmojiIconCode';
+
+export default {
+  'emoji/fragments/AutocompleteDropdown': AutocompleteDropdown,
+  'emoji/helpers/getEmojiIconCode': getEmojiIconCode,
+};

--- a/extensions/emoji/js/src/forum/index.js
+++ b/extensions/emoji/js/src/forum/index.js
@@ -11,3 +11,9 @@ app.initializers.add('flarum-emoji', () => {
   // render emoji as image in Posts content and title.
   renderEmoji();
 });
+
+// Expose compat API
+import emojiCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, emojiCompat);

--- a/extensions/flags/js/src/forum/compat.js
+++ b/extensions/flags/js/src/forum/compat.js
@@ -6,6 +6,7 @@ import FlagList from './components/FlagList';
 import FlagPostModal from './components/FlagPostModal';
 import FlagsPage from './components/FlagsPage';
 import FlagsDropdown from './components/FlagsDropdown';
+import FlagListState from './states/FlagListState';
 
 export default {
   'flags/addFlagsToPosts': addFlagsToPosts,
@@ -16,4 +17,5 @@ export default {
   'flags/components/FlagPostModal': FlagPostModal,
   'flags/components/FlagsPage': FlagsPage,
   'flags/components/FlagsDropdown': FlagsDropdown,
+  'flags/states/FlagListState': FlagListState,
 };

--- a/extensions/likes/js/src/forum/compat.ts
+++ b/extensions/likes/js/src/forum/compat.ts
@@ -1,0 +1,11 @@
+import LikesUserPage from './components/LikesUserPage';
+import PostLikedNotification from './components/PostLikedNotification';
+import PostLikesModal from './components/PostLikesModal';
+import PostLikesModalState from './states/PostLikesModalState';
+
+export default {
+  'likes/components/LikesUserPage': LikesUserPage,
+  'likes/components/PostLikedNotification': PostLikedNotification,
+  'likes/components/PostLikesModal': PostLikesModal,
+  'likes/states/PostLikesModalState': PostLikesModalState,
+};

--- a/extensions/likes/js/src/forum/index.js
+++ b/extensions/likes/js/src/forum/index.js
@@ -24,3 +24,9 @@ app.initializers.add('flarum-likes', () => {
     });
   });
 });
+
+// Expose compat API
+import likesCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, likesCompat);

--- a/extensions/lock/js/src/forum/compat.ts
+++ b/extensions/lock/js/src/forum/compat.ts
@@ -1,0 +1,7 @@
+import DiscussionLockedNotification from './components/DiscussionLockedNotification';
+import DiscussionLockedPost from './components/DiscussionLockedPost';
+
+export default {
+  'lock/components/DiscussionLockedNotification': DiscussionLockedNotification,
+  'lock/components/DiscussionLockedPost': DiscussionLockedPost,
+};

--- a/extensions/lock/js/src/forum/index.js
+++ b/extensions/lock/js/src/forum/index.js
@@ -22,3 +22,9 @@ app.initializers.add('flarum-lock', () => {
     });
   });
 });
+
+// Expose compat API
+import lockCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, lockCompat);

--- a/extensions/markdown/js/src/admin/compat.ts
+++ b/extensions/markdown/js/src/admin/compat.ts
@@ -1,0 +1,5 @@
+import commonCompat from '../common/compat';
+
+export default {
+  ...commonCompat,
+};

--- a/extensions/markdown/js/src/admin/index.js
+++ b/extensions/markdown/js/src/admin/index.js
@@ -2,3 +2,9 @@ import app from 'flarum/admin/app';
 import { initialize } from '../common/index';
 
 app.initializers.add('flarum-markdown', initialize);
+
+// Expose compat API
+import markdownCompat from './compat';
+import { compat } from '@flarum/core/admin';
+
+Object.assign(compat, markdownCompat);

--- a/extensions/markdown/js/src/common/compat.ts
+++ b/extensions/markdown/js/src/common/compat.ts
@@ -1,0 +1,7 @@
+import MarkdownButton from './components/MarkdownButton';
+import MarkdownToolbar from './components/MarkdownToolbar';
+
+export default {
+  'markdown/components/MarkdownButton': MarkdownButton,
+  'markdown/components/MarkdownToolbar': MarkdownToolbar,
+};

--- a/extensions/markdown/js/src/forum/compat.ts
+++ b/extensions/markdown/js/src/forum/compat.ts
@@ -1,0 +1,5 @@
+import commonCompat from '../common/compat';
+
+export default {
+  ...commonCompat,
+};

--- a/extensions/markdown/js/src/forum/index.js
+++ b/extensions/markdown/js/src/forum/index.js
@@ -2,3 +2,9 @@ import app from 'flarum/forum/app';
 import { initialize } from '../common/index';
 
 app.initializers.add('flarum-markdown', initialize);
+
+// Expose compat API
+import markdownCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, markdownCompat);

--- a/extensions/mentions/js/src/forum/compat.js
+++ b/extensions/mentions/js/src/forum/compat.js
@@ -1,4 +1,6 @@
 import GroupMentionedNotification from './components/GroupMentionedNotification';
+import MentionedByModal from './components/MentionedByModal';
+import MentionsDropdownItem from './components/MentionsDropdownItem';
 import MentionsUserPage from './components/MentionsUserPage';
 import PostMentionedNotification from './components/PostMentionedNotification';
 import UserMentionedNotification from './components/UserMentionedNotification';
@@ -9,13 +11,24 @@ import getMentionText from './utils/getMentionText';
 import * as reply from './utils/reply';
 import selectedText from './utils/selectedText';
 import * as textFormatter from './utils/textFormatter';
+import GroupMention from './mentionables/GroupMention';
 import MentionableModel from './mentionables/MentionableModel';
+import MentionableModels from './mentionables/MentionableModels';
+import PostMention from './mentionables/PostMention';
+import TagMention from './mentionables/TagMention';
+import UserMention from './mentionables/UserMention';
+import AtMentionFormat from './mentionables/formats/AtMentionFormat';
+import HashMentionFormat from './mentionables/formats/HashMentionFormat';
 import MentionFormat from './mentionables/formats/MentionFormat';
+import MentionFormats from './mentionables/formats/MentionFormats';
 import Mentionables from './extenders/Mentionables';
+import MentionedByModalState from './state/MentionedByModalState';
 
 export default {
   'mentions/components/MentionsUserPage': MentionsUserPage,
   'mentions/components/PostMentionedNotification': PostMentionedNotification,
+  'mentions/components/MentionedByModal': MentionedByModal,
+  'mentions/components/MentionsDropdownItem': MentionsDropdownItem,
   'mentions/components/UserMentionedNotification': UserMentionedNotification,
   'mentions/components/GroupMentionedNotification': GroupMentionedNotification,
   'mentions/fragments/AutocompleteDropdown': AutocompleteDropdown,
@@ -25,7 +38,16 @@ export default {
   'mentions/utils/reply': reply,
   'mentions/utils/selectedText': selectedText,
   'mentions/utils/textFormatter': textFormatter,
+  'mentions/mentionables/GroupMention': GroupMention,
   'mentions/mentionables/MentionableModel': MentionableModel,
+  'mentions/mentionables/MentionableModels': MentionableModels,
+  'mentions/mentionables/PostMention': PostMention,
+  'mentions/mentionables/TagMention': TagMention,
+  'mentions/mentionables/UserMention': UserMention,
+  'mentions/mentionables/formats/AtMentionFormat': AtMentionFormat,
+  'mentions/mentionables/formats/HashMentionFormat': HashMentionFormat,
   'mentions/mentionables/formats/MentionFormat': MentionFormat,
+  'mentions/mentionables/formats/MentionFormats': MentionFormats,
   'mentions/extenders/Mentionables': Mentionables,
+  'mentions/state/MentionedByModalState': MentionedByModalState,
 };

--- a/extensions/nicknames/js/src/forum/compat.ts
+++ b/extensions/nicknames/js/src/forum/compat.ts
@@ -1,0 +1,5 @@
+import NicknameModal from './components/NicknameModal';
+
+export default {
+  'nicknames/components/NicknameModal': NicknameModal,
+};

--- a/extensions/nicknames/js/src/forum/index.js
+++ b/extensions/nicknames/js/src/forum/index.js
@@ -110,3 +110,9 @@ app.initializers.add('flarum/nicknames', () => {
     }
   });
 });
+
+// Expose compat API
+import nicknamesCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, nicknamesCompat);

--- a/extensions/package-manager/js/src/admin/compat.ts
+++ b/extensions/package-manager/js/src/admin/compat.ts
@@ -1,0 +1,52 @@
+import AuthMethodModal from './components/AuthMethodModal';
+import ConfigureAuth from './components/ConfigureAuth';
+import ConfigureComposer from './components/ConfigureComposer';
+import ConfigureJson from './components/ConfigureJson';
+import ControlSection from './components/ControlSection';
+import ExtensionItem from './components/ExtensionItem';
+import Installer from './components/Installer';
+import Label from './components/Label';
+import MajorUpdater from './components/MajorUpdater';
+import Pagination from './components/Pagination';
+import QueueSection from './components/QueueSection';
+import RepositoryModal from './components/RepositoryModal';
+import SettingsPage from './components/SettingsPage';
+import TaskOutputModal from './components/TaskOutputModal';
+import Updater from './components/Updater';
+import WhyNotModal from './components/WhyNotModal';
+
+import Task from './models/Task';
+
+import ControlSectionState from './states/ControlSectionState';
+import ExtensionManagerState from './states/ExtensionManagerState';
+import QueueState from './states/QueueState';
+
+import errorHandler from './utils/errorHandler';
+import humanDuration from './utils/humanDuration';
+import jumpToQueue from './utils/jumpToQueue';
+
+export default {
+  'extension-manager/components/AuthMethodModal': AuthMethodModal,
+  'extension-manager/components/ConfigureAuth': ConfigureAuth,
+  'extension-manager/components/ConfigureComposer': ConfigureComposer,
+  'extension-manager/components/ConfigureJson': ConfigureJson,
+  'extension-manager/components/ControlSection': ControlSection,
+  'extension-manager/components/ExtensionItem': ExtensionItem,
+  'extension-manager/components/Installer': Installer,
+  'extension-manager/components/Label': Label,
+  'extension-manager/components/MajorUpdater': MajorUpdater,
+  'extension-manager/components/Pagination': Pagination,
+  'extension-manager/components/QueueSection': QueueSection,
+  'extension-manager/components/RepositoryModal': RepositoryModal,
+  'extension-manager/components/SettingsPage': SettingsPage,
+  'extension-manager/components/TaskOutputModal': TaskOutputModal,
+  'extension-manager/components/Updater': Updater,
+  'extension-manager/components/WhyNotModal': WhyNotModal,
+  'extension-manager/models/Task': Task,
+  'extension-manager/states/ControlSectionState': ControlSectionState,
+  'extension-manager/states/ExtensionManagerState': ExtensionManagerState,
+  'extension-manager/states/QueueState': QueueState,
+  'extension-manager/utils/errorHandler': errorHandler,
+  'extension-manager/utils/humanDuration': humanDuration,
+  'extension-manager/utils/jumpToQueue': jumpToQueue,
+};

--- a/extensions/package-manager/js/src/admin/index.tsx
+++ b/extensions/package-manager/js/src/admin/index.tsx
@@ -82,3 +82,9 @@ app.initializers.add('flarum-extension-manager', (app) => {
     );
   });
 });
+
+// Expose compat API
+import packageManagerCompat from './compat';
+import { compat } from '@flarum/core/admin';
+
+Object.assign(compat, packageManagerCompat);

--- a/extensions/package-manager/js/tsconfig.json
+++ b/extensions/package-manager/js/tsconfig.json
@@ -10,7 +10,8 @@
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
     "paths": {
-      "flarum/*": ["../../../framework/core/js/dist-typings/*"]
+      "flarum/*": ["../../../framework/core/js/dist-typings/*"],
+      "@flarum/core/*": ["../../../framework/core/js/dist-typings/*"],
     }
   }
 }

--- a/extensions/statistics/js/src/admin/compat.ts
+++ b/extensions/statistics/js/src/admin/compat.ts
@@ -1,0 +1,11 @@
+import MiniStatisticsWidget from './components/MiniStatisticsWidget';
+import StatisticsPage from './components/StatisticsPage';
+import StatisticsWidget from './components/StatisticsWidget';
+import StatisticsWidgetDateSelectionModal from './components/StatisticsWidgetDateSelectionModal';
+
+export default {
+  'statistics/components/MiniStatisticsWidget': MiniStatisticsWidget,
+  'statistics/components/StatisticsPage': StatisticsPage,
+  'statistics/components/StatisticsWidget': StatisticsWidget,
+  'statistics/components/StatisticsWidgetDateSelectionModal': StatisticsWidgetDateSelectionModal,
+};

--- a/extensions/statistics/js/src/admin/index.tsx
+++ b/extensions/statistics/js/src/admin/index.tsx
@@ -13,3 +13,9 @@ app.initializers.add('flarum-statistics', () => {
 
   app.extensionData.for('flarum-statistics').registerPage(StatisticsPage);
 });
+
+// Expose compat API
+import statisticsCompat from './compat';
+import { compat } from '@flarum/core/admin';
+
+Object.assign(compat, statisticsCompat);

--- a/extensions/statistics/js/tsconfig.json
+++ b/extensions/statistics/js/tsconfig.json
@@ -9,7 +9,8 @@
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
     "paths": {
-      "flarum/*": ["../../../framework/core/js/dist-typings/*"]
+      "flarum/*": ["../../../framework/core/js/dist-typings/*"],
+      "@flarum/core/*": ["../../../framework/core/js/dist-typings/*"],
     }
   }
 }

--- a/extensions/sticky/js/src/forum/compat.ts
+++ b/extensions/sticky/js/src/forum/compat.ts
@@ -1,0 +1,5 @@
+import DiscussionStickiedPost from './components/DiscussionStickiedPost';
+
+export default {
+  'sticky/components/DiscussionStickiedPost': DiscussionStickiedPost,
+};

--- a/extensions/sticky/js/src/forum/index.js
+++ b/extensions/sticky/js/src/forum/index.js
@@ -13,3 +13,9 @@ app.initializers.add('flarum-sticky', () => {
   addStickyExcerpt();
   addStickyClass();
 });
+
+// Expose compat API
+import stickyCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, stickyCompat);

--- a/extensions/subscriptions/js/src/forum/compat.ts
+++ b/extensions/subscriptions/js/src/forum/compat.ts
@@ -1,0 +1,9 @@
+import NewPostNotification from './components/NewPostNotification';
+import SubscriptionMenu from './components/SubscriptionMenu';
+import SubscriptionMenuItem from './components/SubscriptionMenuItem';
+
+export default {
+  'subscriptions/components/NewPostNotification': NewPostNotification,
+  'subscriptions/components/SubscriptionMenu': SubscriptionMenu,
+  'subscriptions/components/SubscriptionMenuItem': SubscriptionMenuItem,
+};

--- a/extensions/subscriptions/js/src/forum/index.js
+++ b/extensions/subscriptions/js/src/forum/index.js
@@ -29,3 +29,9 @@ app.initializers.add('subscriptions', function () {
     });
   });
 });
+
+// Expose compat API
+import subscriptionsCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, subscriptionsCompat);

--- a/extensions/suspend/js/src/forum/compat.js
+++ b/extensions/suspend/js/src/forum/compat.js
@@ -2,6 +2,7 @@ import SuspendUserModal from './components/SuspendUserModal';
 import SuspensionInfoModal from './components/SuspensionInfoModal';
 import UserSuspendedNotification from './components/UserSuspendedNotification';
 import UserUnsuspendedNotification from './components/UserUnsuspendedNotification';
+import * as suspensionHelper from './helpers/suspensionHelper';
 import checkForSuspension from './checkForSuspension';
 
 export default {
@@ -9,5 +10,6 @@ export default {
   'suspend/components/suspensionInfoModal': SuspensionInfoModal,
   'suspend/components/UserSuspendedNotification': UserSuspendedNotification,
   'suspend/components/UserUnsuspendedNotification': UserUnsuspendedNotification,
+  'suspend/helpers/suspensionHelper': suspensionHelper,
   'suspend/checkForSuspension': checkForSuspension,
 };

--- a/extensions/tags/js/src/admin/compat.js
+++ b/extensions/tags/js/src/admin/compat.js
@@ -4,6 +4,7 @@ import addTagsHomePageOption from './addTagsHomePageOption';
 import addTagChangePermission from './addTagChangePermission';
 import TagsPage from './components/TagsPage';
 import EditTagModal from './components/EditTagModal';
+import SelectTagsSettingComponent from './components/SelectTagsSettingComponent';
 import addTagPermission from './addTagPermission';
 import addTagsPermissionScope from './addTagsPermissionScope';
 
@@ -12,6 +13,7 @@ export default Object.assign(compat, {
   'tags/addTagChangePermission': addTagChangePermission,
   'tags/components/TagsPage': TagsPage,
   'tags/components/EditTagModal': EditTagModal,
+  'tags/components/SelectTagsSettingComponent': SelectTagsSettingComponent,
   'tags/addTagPermission': addTagPermission,
   'tags/addTagsPermissionScope': addTagsPermissionScope,
 });

--- a/extensions/tags/js/src/forum/compat.js
+++ b/extensions/tags/js/src/forum/compat.js
@@ -5,6 +5,7 @@ import addTagControl from './addTagControl';
 import TagHero from './components/TagHero';
 import TagDiscussionModal from './components/TagDiscussionModal';
 import TagsPage from './components/TagsPage';
+import ToggleButton from './components/ToggleButton';
 import DiscussionTaggedPost from './components/DiscussionTaggedPost';
 import TagLinkButton from './components/TagLinkButton';
 import addTagList from './addTagList';
@@ -18,6 +19,7 @@ export default Object.assign(compat, {
   'tags/components/TagHero': TagHero,
   'tags/components/TagDiscussionModal': TagDiscussionModal,
   'tags/components/TagsPage': TagsPage,
+  'tags/components/ToggleButton': ToggleButton,
   'tags/components/DiscussionTaggedPost': DiscussionTaggedPost,
   'tags/components/TagLinkButton': TagLinkButton,
   'tags/addTagList': addTagList,

--- a/framework/core/js/src/admin/compat.ts
+++ b/framework/core/js/src/admin/compat.ts
@@ -15,6 +15,7 @@ import ExtensionsWidget from './components/ExtensionsWidget';
 import HeaderSecondary from './components/HeaderSecondary';
 import SettingsModal from './components/SettingsModal';
 import DashboardWidget from './components/DashboardWidget';
+import DebugWarningWidget from './components/DebugWarningWidget';
 import ExtensionPage from './components/ExtensionPage';
 import ExtensionLinkButton from './components/ExtensionLinkButton';
 import PermissionGrid from './components/PermissionGrid';
@@ -28,6 +29,7 @@ import UserListPage from './components/UserListPage';
 import EditCustomHeaderModal from './components/EditCustomHeaderModal';
 import PermissionsPage from './components/PermissionsPage';
 import PermissionDropdown from './components/PermissionDropdown';
+import ReadmeModal from './components/ReadmeModal';
 import AdminNav from './components/AdminNav';
 import AdminHeader from './components/AdminHeader';
 import EditCustomCssModal from './components/EditCustomCssModal';
@@ -36,6 +38,8 @@ import routes from './routes';
 import AdminApplication from './AdminApplication';
 import generateElementId from './utils/generateElementId';
 import CreateUserModal from './components/CreateUserModal';
+import ExtensionReadme from './models/ExtensionReadme';
+import ExtensionPageResolver from './resolvers/ExtensionPageResolver';
 
 export default Object.assign(compat, {
   'utils/saveSettings': saveSettings,
@@ -54,6 +58,7 @@ export default Object.assign(compat, {
   'components/HeaderSecondary': HeaderSecondary,
   'components/SettingsModal': SettingsModal,
   'components/DashboardWidget': DashboardWidget,
+  'components/DebugWarningWidget': DebugWarningWidget,
   'components/ExtensionPage': ExtensionPage,
   'components/ExtensionLinkButton': ExtensionLinkButton,
   'components/PermissionGrid': PermissionGrid,
@@ -67,11 +72,14 @@ export default Object.assign(compat, {
   'components/EditCustomHeaderModal': EditCustomHeaderModal,
   'components/PermissionsPage': PermissionsPage,
   'components/PermissionDropdown': PermissionDropdown,
+  'components/ReadmeModal': ReadmeModal,
   'components/AdminNav': AdminNav,
   'components/AdminHeader': AdminHeader,
   'components/EditCustomCssModal': EditCustomCssModal,
   'components/EditGroupModal': EditGroupModal,
   'components/CreateUserModal': CreateUserModal,
+  'models/ExtensionReadme': ExtensionReadme,
+  'resolvers/ExtensionPageResolver': ExtensionPageResolver,
   routes: routes,
   AdminApplication: AdminApplication,
 });

--- a/framework/core/js/src/common/compat.ts
+++ b/framework/core/js/src/common/compat.ts
@@ -3,6 +3,7 @@ import extenders from './extenders';
 import Session from './Session';
 import Store from './Store';
 import BasicEditorDriver from './utils/BasicEditorDriver';
+import bidi from './utils/bidi';
 import evented from './utils/evented';
 import EventEmitter from './utils/EventEmitter';
 import KeyboardNavigatable from './utils/KeyboardNavigatable';
@@ -14,6 +15,7 @@ import computed from './utils/computed';
 import insertText from './utils/insertText';
 import styleSelectedText from './utils/styleSelectedText';
 import Drawer from './utils/Drawer';
+import * as EditorDriverInterface from './utils/EditorDriverInterface';
 import anchorScroll from './utils/anchorScroll';
 import RequestError from './utils/RequestError';
 import abbreviateNumber from './utils/abbreviateNumber';
@@ -36,6 +38,7 @@ import mapRoutes from './utils/mapRoutes';
 import withAttr from './utils/withAttr';
 import * as FocusTrap from './utils/focusTrap';
 import isDark from './utils/isDark';
+import AccessToken from './models/AccessToken';
 import Notification from './models/Notification';
 import User from './models/User';
 import Post from './models/Post';
@@ -62,6 +65,7 @@ import Link from './components/Link';
 import LinkButton from './components/LinkButton';
 import Checkbox from './components/Checkbox';
 import ColorPreviewInput from './components/ColorPreviewInput';
+import ConfirmDocumentUnload from './components/ConfirmDocumentUnload';
 import SelectDropdown from './components/SelectDropdown';
 import ModalManager from './components/ModalManager';
 import Button from './components/Button';
@@ -75,6 +79,8 @@ import Model from './Model';
 import Application from './Application';
 import fullTime from './helpers/fullTime';
 import avatar from './helpers/avatar';
+import fireApplicationError from './helpers/fireApplicationError';
+import * as fireDebugWarning from './helpers/fireDebugWarning';
 import icon from './helpers/icon';
 import humanTimeHelper from './helpers/humanTime';
 import punctuateSeries from './helpers/punctuateSeries';
@@ -98,6 +104,7 @@ export default {
   Session: Session,
   Store: Store,
   'utils/BasicEditorDriver': BasicEditorDriver,
+  'utils/bidi': bidi,
   'utils/evented': evented,
   'utils/EventEmitter': EventEmitter,
   'utils/KeyboardNavigatable': KeyboardNavigatable,
@@ -109,6 +116,7 @@ export default {
   'utils/insertText': insertText,
   'utils/styleSelectedText': styleSelectedText,
   'utils/Drawer': Drawer,
+  'utils/EditorDriverInterface': EditorDriverInterface,
   'utils/anchorScroll': anchorScroll,
   'utils/RequestError': RequestError,
   'utils/abbreviateNumber': abbreviateNumber,
@@ -132,6 +140,7 @@ export default {
   'utils/isObject': isObject,
   'utils/focusTrap': FocusTrap,
   'utils/isDark': isDark,
+  'models/AccessToken': AccessToken,
   'models/Notification': Notification,
   'models/User': User,
   'models/Post': Post,
@@ -159,6 +168,7 @@ export default {
   'components/LinkButton': LinkButton,
   'components/Checkbox': Checkbox,
   'components/ColorPreviewInput': ColorPreviewInput,
+  'components/ConfirmDocumentUnload': ConfirmDocumentUnload,
   'components/SelectDropdown': SelectDropdown,
   'components/ModalManager': ModalManager,
   'components/Button': Button,
@@ -173,6 +183,8 @@ export default {
   Application: Application,
   'helpers/fullTime': fullTime,
   'helpers/avatar': avatar,
+  'helpers/fireApplicationError': fireApplicationError,
+  'helpers/fireDebugWarning': fireDebugWarning,
   'helpers/icon': icon,
   'helpers/humanTime': humanTimeHelper,
   'helpers/punctuateSeries': punctuateSeries,

--- a/framework/core/js/src/forum/compat.ts
+++ b/framework/core/js/src/forum/compat.ts
@@ -19,6 +19,7 @@ import AffixedSidebar from './components/AffixedSidebar';
 import DiscussionPage from './components/DiscussionPage';
 import DiscussionListPane from './components/DiscussionListPane';
 import LogInModal from './components/LogInModal';
+import NewAccessTokenModal from './components/NewAccessTokenModal';
 import ComposerBody from './components/ComposerBody';
 import ForgotPasswordModal from './components/ForgotPasswordModal';
 import Notification from './components/Notification';
@@ -100,6 +101,7 @@ export default Object.assign(compat, {
   'components/DiscussionPage': DiscussionPage,
   'components/DiscussionListPane': DiscussionListPane,
   'components/LogInModal': LogInModal,
+  'components/NewAccessTokenModal': NewAccessTokenModal,
   'components/ComposerBody': ComposerBody,
   'components/ForgotPasswordModal': ForgotPasswordModal,
   'components/Notification': Notification,


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://github.com/flarum/framework/pull/4006#issuecomment-2380559537**

**Changes proposed in this pull request:**
- Export all missing modules with the Compat API and therefore improve the extensibility of the framework.
- Fix tsconfig

**Reviewers should focus on:**


**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
1. Try to extend/override a newly added component from core
2. Try to extend/override a newly added component from an extension
3. Try to use a newly added util which is the default export (i.e. `fireDebugWarning`)
4. Try to use a newly added util which is a non default export (i.e. `fireDeprecationWarning`)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
