### PR TITLE
[1.x] [extensibility] refactor(core): improve extensibility of `IndexPage` 

### DIFF
--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -70,18 +70,10 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
   contentItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    items.add('toolbar', this.toolbarView(), 100);
-    items.add('discussionList', this.discussionListView(), 90);
+    items.add('toolbar', <div className="IndexPage-toolbar">{this.toolbarItems().toArray()}</div>, 100);
+    items.add('discussionList', <DiscussionList state={app.discussions} />, 90);
 
     return items;
-  }
-
-  toolbarView(): Mithril.Children {
-    return <div className="IndexPage-toolbar">{this.toolbarItems().toArray()}</div>;
-  }
-
-  discussionListView(): Mithril.Children {
-    return <DiscussionList state={app.discussions} />;
   }
 
   toolbarItems(): ItemList<Mithril.Children> {

--- a/framework/core/js/src/forum/components/IndexPage.tsx
+++ b/framework/core/js/src/forum/components/IndexPage.tsx
@@ -60,17 +60,37 @@ export default class IndexPage<CustomAttrs extends IIndexPageAttrs = IIndexPageA
             <nav className="IndexPage-nav sideNav">
               <ul>{listItems(this.sidebarItems().toArray())}</ul>
             </nav>
-            <div className="IndexPage-results sideNavOffset">
-              <div className="IndexPage-toolbar">
-                <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>
-                <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>
-              </div>
-              <DiscussionList state={app.discussions} />
-            </div>
+            <div className="IndexPage-results sideNavOffset">{this.contentItems().toArray()}</div>
           </div>
         </div>
       </div>
     );
+  }
+
+  contentItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('toolbar', this.toolbarView(), 100);
+    items.add('discussionList', this.discussionListView(), 90);
+
+    return items;
+  }
+
+  toolbarView(): Mithril.Children {
+    return <div className="IndexPage-toolbar">{this.toolbarItems().toArray()}</div>;
+  }
+
+  discussionListView(): Mithril.Children {
+    return <DiscussionList state={app.discussions} />;
+  }
+
+  toolbarItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('view', <ul className="IndexPage-toolbar-view">{listItems(this.viewItems().toArray())}</ul>, 100);
+    items.add('action', <ul className="IndexPage-toolbar-action">{listItems(this.actionItems().toArray())}</ul>, 90);
+
+    return items;
   }
 
   setTitle() {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Improve extensibility in the frontend to allow third-party extensions to more easily customize this component.

**Reviewers should focus on:**
- Verify that the backwards compatibility is working as expected. The DOM must be exactly the same.
- A similar PR against `2.x`  which considers the new `PageStructure` would probably be desirable. Opinions?

**Screenshot**
_No differences_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
