### PR TITLE
[1.x] [extensibility] refactor(core, flags): improve & use extensibility of `CommentPost` & `Post`

### DIFF
--- a/extensions/flags/js/src/forum/addFlagsToPosts.js
+++ b/extensions/flags/js/src/forum/addFlagsToPosts.js
@@ -75,7 +75,7 @@ export default function () {
     return items;
   };
 
-  extend(Post.prototype, 'content', function (vdom) {
+  extend(Post.prototype, 'viewItems', function (items) {
     const post = this.attrs.post;
     const flags = post.flags();
 
@@ -83,7 +83,8 @@ export default function () {
 
     if (post.isHidden()) this.revealContent = true;
 
-    vdom.unshift(
+    items.add(
+      'flagged',
       <div className="Post-flagged">
         <div className="Post-flagged-flags">
           {flags.map((flag) => (
@@ -91,7 +92,8 @@ export default function () {
           ))}
         </div>
         <div className="Post-flagged-actions">{this.flagActionItems().toArray()}</div>
-      </div>
+      </div>,
+      110
     );
   });
 

--- a/framework/core/js/src/forum/components/CommentPost.js
+++ b/framework/core/js/src/forum/components/CommentPost.js
@@ -51,11 +51,11 @@ export default class CommentPost extends Post {
       <header className="Post-header">
         <ul>{listItems(this.headerItems().toArray())}</ul>
       </header>,
-      <div className="Post-body">{this.contentItems().toArray()}</div>,
+      <div className="Post-body">{this.bodyItems().toArray()}</div>,
     ]);
   }
 
-  contentItems() {
+  bodyItems() {
     const items = new ItemList();
 
     items.add(

--- a/framework/core/js/src/forum/components/CommentPost.js
+++ b/framework/core/js/src/forum/components/CommentPost.js
@@ -51,10 +51,20 @@ export default class CommentPost extends Post {
       <header className="Post-header">
         <ul>{listItems(this.headerItems().toArray())}</ul>
       </header>,
-      <div className="Post-body">
-        {this.isEditing() ? <ComposerPostPreview className="Post-preview" composer={app.composer} /> : m.trust(this.attrs.post.contentHtml())}
-      </div>,
+      <div className="Post-body">{this.contentItems().toArray()}</div>,
     ]);
+  }
+
+  contentItems() {
+    const items = new ItemList();
+
+    items.add(
+      'content',
+      this.isEditing() ? <ComposerPostPreview className="Post-preview" composer={app.composer} /> : m.trust(this.attrs.post.contentHtml()),
+      100
+    );
+
+    return items;
   }
 
   refreshContent() {

--- a/framework/core/js/src/forum/components/CommentPost.js
+++ b/framework/core/js/src/forum/components/CommentPost.js
@@ -47,12 +47,23 @@ export default class CommentPost extends Post {
   }
 
   content() {
-    return super.content().concat([
+    return super.content().concat(this.contentItems().toArray());
+  }
+
+  contentItems() {
+    const items = new ItemList();
+
+    items.add(
+      'header',
       <header className="Post-header">
         <ul>{listItems(this.headerItems().toArray())}</ul>
       </header>,
-      <div className="Post-body">{this.bodyItems().toArray()}</div>,
-    ]);
+      100
+    );
+
+    items.add('body', <div className="Post-body">{this.bodyItems().toArray()}</div>, 90);
+
+    return items;
   }
 
   bodyItems() {

--- a/framework/core/js/src/forum/components/Post.tsx
+++ b/framework/core/js/src/forum/components/Post.tsx
@@ -3,7 +3,7 @@ import Component, { ComponentAttrs } from '../../common/Component';
 import SubtreeRetainer from '../../common/utils/SubtreeRetainer';
 import Dropdown from '../../common/components/Dropdown';
 import PostControls from '../utils/PostControls';
-import listItems from '../../common/helpers/listItems';
+import listItems, { ModdedChildrenWithItemName } from '../../common/helpers/listItems';
 import ItemList from '../../common/utils/ItemList';
 import type PostModel from '../../common/models/Post';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -55,32 +55,44 @@ export default abstract class Post<CustomAttrs extends IPostAttrs = IPostAttrs> 
 
     return (
       <article {...attrs}>
-        <div>
-          {this.loading ? <LoadingIndicator /> : this.content()}
-          <aside className="Post-actions">
-            <ul>
-              {listItems(this.actionItems().toArray())}
-              {!!controls.length && (
-                <li>
-                  <Dropdown
-                    className="Post-controls"
-                    buttonClassName="Button Button--icon Button--flat"
-                    menuClassName="Dropdown-menu--right"
-                    icon="fas fa-ellipsis-h"
-                    onshow={() => this.$('.Post-controls').addClass('open')}
-                    onhide={() => this.$('.Post-controls').removeClass('open')}
-                    accessibleToggleLabel={app.translator.trans('core.forum.post_controls.toggle_dropdown_accessible_label')}
-                  >
-                    {controls}
-                  </Dropdown>
-                </li>
-              )}
-            </ul>
-          </aside>
-          <footer className="Post-footer">{footerItems.length ? <ul>{listItems(footerItems)}</ul> : null}</footer>
-        </div>
+        <div>{this.viewItems(controls, footerItems).toArray()}</div>
       </article>
     );
+  }
+
+  viewItems(controls: Mithril.Children[], footerItems: ModdedChildrenWithItemName[]): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('content', this.loading ? <LoadingIndicator /> : this.content(), 100);
+
+    items.add(
+      'actions',
+      <aside className="Post-actions">
+        <ul>
+          {listItems(this.actionItems().toArray())}
+          {!!controls.length && (
+            <li>
+              <Dropdown
+                className="Post-controls"
+                buttonClassName="Button Button--icon Button--flat"
+                menuClassName="Dropdown-menu--right"
+                icon="fas fa-ellipsis-h"
+                onshow={() => this.$('.Post-controls').addClass('open')}
+                onhide={() => this.$('.Post-controls').removeClass('open')}
+                accessibleToggleLabel={app.translator.trans('core.forum.post_controls.toggle_dropdown_accessible_label')}
+              >
+                {controls}
+              </Dropdown>
+            </li>
+          )}
+        </ul>
+      </aside>,
+      90
+    );
+
+    items.add('footer', <footer className="Post-footer">{footerItems.length > 0 ? <ul>{listItems(footerItems)}</ul> : <ul></ul>}</footer>, 80);
+
+    return items;
   }
 
   onbeforeupdate(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
@@ -147,7 +159,7 @@ export default abstract class Post<CustomAttrs extends IPostAttrs = IPostAttrs> 
   /**
    * Build an item list for the post's footer.
    */
-  footerItems(): ItemList<Mithril.Children> {
-    return new ItemList();
+  footerItems(): ItemList<ModdedChildrenWithItemName> {
+    return new ItemList<ModdedChildrenWithItemName>();
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Improve extensibility in the frontend to allow third-party extensions to more easily customize those components.

**Reviewers should focus on:**
- Verify that the backwards compatibility is working as expected. The DOM must be exactly the same.
- On the `2.x` the `CommentPost` and `Post` components have already been changed quite substantially and made more extensible. I don't think there is a need to "forward-port" this to `2.x`

**Screenshot**
_No differences_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
