### PR TITLE
[1.x] [extensibility] refactor(core): backport & improve extensibility of `DiscussionListItem`

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -63,18 +63,22 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
   }
 
   view() {
-    const discussion = this.attrs.discussion;
-
-    const controls = DiscussionControls.controls(discussion, this).toArray();
     const attrs = this.elementAttrs();
 
-    return (
-      <div {...attrs}>
-        {this.controlsView(controls)}
-        {this.slidableUnderneathView()}
-        {this.contentView()}
-      </div>
-    );
+    return <div {...attrs}>{this.viewItems().toArray()}</div>;
+  }
+
+  viewItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    const discussion = this.attrs.discussion;
+    const controls = DiscussionControls.controls(discussion, this).toArray();
+
+    items.add('controls', this.controlsView(controls), 100);
+    items.add('slidableUnderneath', this.slidableUnderneathView(), 90);
+    items.add('content', this.contentView(), 80);
+
+    return items;
   }
 
   controlsView(controls: Mithril.ChildArray): Mithril.Children {
@@ -113,12 +117,20 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
 
     return (
       <div className={classList('DiscussionListItem-content', 'Slidable-content', { unread: isUnread, read: isRead })}>
-        {this.authorAvatarView()}
-        {this.badgesView()}
-        {this.mainView()}
-        {this.replyCountItem()}
+        {this.contentItems().toArray()}
       </div>
     );
+  }
+
+  contentItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('authorAvatar', this.authorAvatarView(), 100);
+    items.add('badges', this.badgesView(), 90);
+    items.add('main', this.mainView(), 80);
+    items.add('replyCount', this.replyCountItem().toArray(), 70);
+
+    return items;
   }
 
   authorAvatarView(): Mithril.Children {
@@ -149,10 +161,20 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
 
     return (
       <Link href={app.route.discussion(discussion, jumpTo)} className="DiscussionListItem-main">
-        <h2 className="DiscussionListItem-title">{highlight(discussion.title(), this.highlightRegExp)}</h2>
-        <ul className="DiscussionListItem-info">{listItems(this.infoItems().toArray())}</ul>
+        {this.mainItems().toArray()}
       </Link>
     );
+  }
+
+  mainItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    const discussion = this.attrs.discussion;
+
+    items.add('title', <h2 className="DiscussionListItem-title">{highlight(discussion.title(), this.highlightRegExp)}</h2>, 100);
+    items.add('info', <ul className="DiscussionListItem-info">{listItems(this.infoItems().toArray())}</ul>, 90);
+
+    return items;
   }
 
   getJumpTo() {
@@ -252,30 +274,38 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     return items;
   }
 
-  replyCountItem() {
+  replyCountItem(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
     const discussion = this.attrs.discussion;
     const showUnread = !this.showRepliesCount() && discussion.isUnread();
 
     if (showUnread) {
-      return (
+      items.add(
+        'unreadCount',
         <button className="Button--ua-reset DiscussionListItem-count" onclick={this.markAsRead.bind(this)}>
           <span aria-hidden="true">{abbreviateNumber(discussion.unreadCount())}</span>
 
           <span className="visually-hidden">
             {app.translator.trans('core.forum.discussion_list.unread_replies_a11y_label', { count: discussion.replyCount() })}
           </span>
-        </button>
+        </button>,
+        100
+      );
+    } else {
+      items.add(
+        'count',
+        <span className="DiscussionListItem-count">
+          <span aria-hidden="true">{abbreviateNumber(discussion.replyCount())}</span>
+
+          <span className="visually-hidden">
+            {app.translator.trans('core.forum.discussion_list.total_replies_a11y_label', { count: discussion.replyCount() })}
+          </span>
+        </span>,
+        100
       );
     }
 
-    return (
-      <span className="DiscussionListItem-count">
-        <span aria-hidden="true">{abbreviateNumber(discussion.replyCount())}</span>
-
-        <span className="visually-hidden">
-          {app.translator.trans('core.forum.discussion_list.total_replies_a11y_label', { count: discussion.replyCount() })}
-        </span>
-      </span>
-    );
+    return items;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Improve extensibility in the frontend to allow third-party extensions to more easily customize this component.

**Reviewers should focus on:**
- Verify that the backwards compatibility is working as expected. The DOM must be exactly the same.
- Targeting against `2.x` not applicable here

**Screenshot**
_No differences_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
