### PR TITLE
[1.x] [extensibility] refactor(core): allow labels of `PostStreamScrubber` to be customized

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -3,6 +3,7 @@ import Component from '../../common/Component';
 import icon from '../../common/helpers/icon';
 import formatNumber from '../../common/utils/formatNumber';
 import ScrollListener from '../../common/utils/ScrollListener';
+import { NestedStringArray } from '@askvortsov/rich-icu-message-formatter';
 
 /**
  * The `PostStreamScrubber` component displays a scrubber which can be used to
@@ -64,7 +65,7 @@ export default class PostStreamScrubber extends Component {
         <div className="Dropdown-menu dropdown-menu">
           <div className="Scrubber">
             <a className="Scrubber-first" onclick={this.goToFirst.bind(this)}>
-              {icon('fas fa-angle-double-up')} {app.translator.trans('core.forum.post_scrubber.original_post_link')}
+              {icon('fas fa-angle-double-up')} {this.firstPostLabel()}
             </a>
 
             <div className="Scrubber-scrollbar">
@@ -79,17 +80,39 @@ export default class PostStreamScrubber extends Component {
               <div className="Scrubber-after" />
 
               <div className="Scrubber-unread" oncreate={styleUnread} onupdate={styleUnread}>
-                {app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount })}
+                {this.unreadLabel(unreadCount)}
               </div>
             </div>
 
             <a className="Scrubber-last" onclick={this.goToLast.bind(this)}>
-              {icon('fas fa-angle-double-down')} {app.translator.trans('core.forum.post_scrubber.now_link')}
+              {icon('fas fa-angle-double-down')} {this.lastPostLabel()}
             </a>
           </div>
         </div>
       </div>
     );
+  }
+
+  /**
+   * @returns {NestedStringArray}
+   */
+  firstPostLabel() {
+    return app.translator.trans('core.forum.post_scrubber.original_post_link');
+  }
+
+  /**
+   * @param {number} unreadCount
+   * @returns {NestedStringArray}
+   */
+  unreadLabel(unreadCount) {
+    return app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount });
+  }
+
+  /**
+   * @returns {NestedStringArray}
+   */
+  lastPostLabel() {
+    return app.translator.trans('core.forum.post_scrubber.now_link');
   }
 
   onupdate(vnode) {

--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -3,7 +3,6 @@ import Component from '../../common/Component';
 import icon from '../../common/helpers/icon';
 import formatNumber from '../../common/utils/formatNumber';
 import ScrollListener from '../../common/utils/ScrollListener';
-import { NestedStringArray } from '@askvortsov/rich-icu-message-formatter';
 
 /**
  * The `PostStreamScrubber` component displays a scrubber which can be used to
@@ -93,24 +92,14 @@ export default class PostStreamScrubber extends Component {
     );
   }
 
-  /**
-   * @returns {NestedStringArray|string}
-   */
   firstPostLabel() {
     return app.translator.trans('core.forum.post_scrubber.original_post_link');
   }
 
-  /**
-   * @param {number} unreadCount
-   * @returns {NestedStringArray|string}
-   */
   unreadLabel(unreadCount) {
     return app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount });
   }
 
-  /**
-   * @returns {NestedStringArray|string}
-   */
   lastPostLabel() {
     return app.translator.trans('core.forum.post_scrubber.now_link');
   }

--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -94,7 +94,7 @@ export default class PostStreamScrubber extends Component {
   }
 
   /**
-   * @returns {NestedStringArray}
+   * @returns {NestedStringArray|string}
    */
   firstPostLabel() {
     return app.translator.trans('core.forum.post_scrubber.original_post_link');
@@ -102,14 +102,14 @@ export default class PostStreamScrubber extends Component {
 
   /**
    * @param {number} unreadCount
-   * @returns {NestedStringArray}
+   * @returns {NestedStringArray|string}
    */
   unreadLabel(unreadCount) {
     return app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount });
   }
 
   /**
-   * @returns {NestedStringArray}
+   * @returns {NestedStringArray|string}
    */
   lastPostLabel() {
     return app.translator.trans('core.forum.post_scrubber.now_link');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Improve extensibility in the frontend to allow third-party extensions to more easily customize this component.

**Reviewers should focus on:**
- Verify that the backwards compatibility is working as expected. The DOM must be exactly the same.
- I think that change would also be a good addition to the `2.x` branch. Opinions?

**Screenshot**
_No differences_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
