### PR TITLE
[1.x] [extensibility] feat: make it easier to add content after the first post

### DIFF
--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -78,11 +78,24 @@ export default class PostStream extends Component {
         content = <PostLoading />;
       }
 
-      return (
+      const postStreamElement = (
         <div className="PostStream-item" {...attrs}>
           {content}
         </div>
       );
+
+      // If we're on the first post, call the afterFirstPostItems method and add any additional elements.
+      if (i === 0 && this.afterFirstPostItems().toArray().length > 0) {
+        // Using m.fragment to return multiple elements without an enclosing container
+        return m.fragment({ ...attrs }, [
+          postStreamElement,
+          <div className="PostStream-item PostStream-afterFirstPost" key="afterFirstPost">
+            {this.afterFirstPostItems().toArray()}
+          </div>,
+        ]);
+      }
+
+      return postStreamElement;
     });
 
     if (!viewingEnd && posts[this.stream.visibleEnd - this.stream.visibleStart - 1]) {
@@ -115,6 +128,15 @@ export default class PostStream extends Component {
         {items}
       </div>
     );
+  }
+
+  /**
+   * @returns {ItemList<import('mithril').Children>}
+   */
+  afterFirstPostItems() {
+    const items = new ItemList();
+
+    return items;
   }
 
   /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
