### PR TITLE
[1.x] fix(core): revert extensibility improvement for `replyCountItem()`

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -128,7 +128,7 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     items.add('authorAvatar', this.authorAvatarView(), 100);
     items.add('badges', this.badgesView(), 90);
     items.add('main', this.mainView(), 80);
-    items.add('replyCount', this.replyCountItem().toArray(), 70);
+    items.add('replyCount', this.replyCountItem(), 70);
 
     return items;
   }
@@ -274,38 +274,30 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     return items;
   }
 
-  replyCountItem(): ItemList<Mithril.Children> {
-    const items = new ItemList<Mithril.Children>();
-
+  replyCountItem() {
     const discussion = this.attrs.discussion;
     const showUnread = !this.showRepliesCount() && discussion.isUnread();
 
     if (showUnread) {
-      items.add(
-        'unreadCount',
+      return (
         <button className="Button--ua-reset DiscussionListItem-count" onclick={this.markAsRead.bind(this)}>
           <span aria-hidden="true">{abbreviateNumber(discussion.unreadCount())}</span>
 
           <span className="visually-hidden">
             {app.translator.trans('core.forum.discussion_list.unread_replies_a11y_label', { count: discussion.replyCount() })}
           </span>
-        </button>,
-        100
-      );
-    } else {
-      items.add(
-        'count',
-        <span className="DiscussionListItem-count">
-          <span aria-hidden="true">{abbreviateNumber(discussion.replyCount())}</span>
-
-          <span className="visually-hidden">
-            {app.translator.trans('core.forum.discussion_list.total_replies_a11y_label', { count: discussion.replyCount() })}
-          </span>
-        </span>,
-        100
+        </button>
       );
     }
 
-    return items;
+    return (
+      <span className="DiscussionListItem-count">
+        <span aria-hidden="true">{abbreviateNumber(discussion.replyCount())}</span>
+
+        <span className="visually-hidden">
+          {app.translator.trans('core.forum.discussion_list.total_replies_a11y_label', { count: discussion.replyCount() })}
+        </span>
+      </span>
+    );
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This fixes a breaking change in #4048 with third-party extensions calling `replyCountItem()` and not expecting it to be an array.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
_No differences_

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
