### PR TITLE
[1.x] feat: allow to customize time formats through translations

### DIFF
--- a/framework/core/js/src/common/utils/humanTime.ts
+++ b/framework/core/js/src/common/utils/humanTime.ts
@@ -1,4 +1,6 @@
+import app from '../../common/app';
 import dayjs from 'dayjs';
+import extractText from "./extractText";
 
 /**
  * The `humanTime` utility converts a date to a localized, human-readable time-
@@ -23,9 +25,9 @@ export default function humanTime(time: dayjs.ConfigType): string {
   // in the string. If it wasn't this year, we'll show the year as well.
   if (diff < -30 * day) {
     if (d.year() === dayjs().year()) {
-      ago = d.format('D MMM');
+      ago = d.format(extractText(app.translator.trans('core.lib.datetime_formats.humanTimeShort')));
     } else {
-      ago = d.format('ll');
+      ago = d.format(extractText(app.translator.trans('core.lib.datetime_formats.humanTimeLong')));
     }
   } else {
     ago = d.fromNow();

--- a/framework/core/js/src/common/utils/humanTime.ts
+++ b/framework/core/js/src/common/utils/humanTime.ts
@@ -1,6 +1,6 @@
 import app from '../../common/app';
 import dayjs from 'dayjs';
-import extractText from "./extractText";
+import extractText from './extractText';
 
 /**
  * The `humanTime` utility converts a date to a localized, human-readable time-

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -5,6 +5,7 @@ import PostLoading from './LoadingPost';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
 import ItemList from '../../common/utils/ItemList';
+import extractText from "../../common/utils/extractText";
 
 /**
  * The `PostStream` component displays an infinitely-scrollable wall of posts in
@@ -292,7 +293,7 @@ export default class PostStream extends Component {
     // set the index to the last post.
     this.stream.index = indexFromViewPort !== null ? indexFromViewPort + 1 : this.stream.count();
     this.stream.visible = visible;
-    if (period) this.stream.description = dayjs(period).format('MMMM YYYY');
+    if (period) this.stream.description = dayjs(period).format(extractText(app.translator.trans('core.lib.datetime_formats.scrubber')));
   }
 
   /**

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -5,7 +5,7 @@ import PostLoading from './LoadingPost';
 import ReplyPlaceholder from './ReplyPlaceholder';
 import Button from '../../common/components/Button';
 import ItemList from '../../common/utils/ItemList';
-import extractText from "../../common/utils/extractText";
+import extractText from '../../common/utils/extractText';
 
 /**
  * The `PostStream` component displays an infinitely-scrollable wall of posts in

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -653,6 +653,12 @@ core:
       kilo_text: K
       mega_text: M
 
+    # These translations are used for formatting dates using dayjs.
+    datetime_formats:
+      humanTimeShort: D MMM
+      humanTimeLong: ll
+      scrubber: MMMM YYYY
+
     # These translations are used to punctuate a series of items.
     series:
       glue_text: ", "


### PR DESCRIPTION
Alternative PR for #4029, which implements concept from https://github.com/flarum/framework/pull/4029#issuecomment-2381297643. 

It introduces 3 new keys to translate - now date formats can be adjusted by language pack or forum owner (for example through Linguist extension).

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
