### PR TITLE
[1.x] [extensibility] feat: provide an 'actions' dropdown for extensions to add their additional buttons to the admin `UserListPage`

### DIFF
--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -18,6 +18,7 @@ import extractText from '../../common/utils/extractText';
 import AdminPage from './AdminPage';
 import { debounce } from '../../common/utils/throttleDebounce';
 import CreateUserModal from './CreateUserModal';
+import Dropdown from '../../common/components/Dropdown';
 
 type ColumnData = {
   /**
@@ -425,17 +426,18 @@ export default class UserListPage extends AdminPage {
     );
 
     columns.add(
-      'editUser',
+      'userActions',
       {
-        name: app.translator.trans('core.admin.users.grid.columns.edit_user.title'),
+        name: app.translator.trans('core.admin.users.grid.columns.user_actions.title'),
         content: (user: User) => (
-          <Button
-            className="Button UserList-editModalBtn"
-            title={app.translator.trans('core.admin.users.grid.columns.edit_user.tooltip', { username: user.username() })}
-            onclick={() => app.modal.show(EditUserModal, { user })}
+          <Dropdown
+            className="User-controls"
+            buttonClassName="Button Button--icon Button--flat"
+            menuClassName="Dropdown-menu--right"
+            icon="fas fa-ellipsis-h"
           >
-            {app.translator.trans('core.admin.users.grid.columns.edit_user.button')}
-          </Button>
+            {this.userActionItems(user).toArray()}
+          </Dropdown>
         ),
       },
       -90
@@ -451,6 +453,24 @@ export default class UserListPage extends AdminPage {
       title: app.translator.trans('core.admin.users.title'),
       description: app.translator.trans('core.admin.users.description'),
     };
+  }
+
+  userActionItems(user: User): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'editUser',
+      <Button
+        icon="fas fa-pencil-alt"
+        className="Button UserList-editModalBtn"
+        title={app.translator.trans('core.admin.users.grid.columns.edit_user.tooltip', { username: user.username() })}
+        onclick={() => app.modal.show(EditUserModal, { user })}
+      >
+        {app.translator.trans('core.admin.users.grid.columns.edit_user.button')}
+      </Button>
+    );
+
+    return items;
   }
 
   /**

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -271,7 +271,6 @@ core:
 
           edit_user:
             button: => core.ref.edit
-            title: => core.ref.edit_user
             tooltip: Edit {username}
 
           email:
@@ -285,6 +284,9 @@ core:
 
           join_time:
             title: Joined
+
+          user_actions:
+            title: Actions
 
           user_id:
             title: ID


### PR DESCRIPTION
**Changes proposed in this pull request:**
Removes the `Edit User` button, and creates a new `Actions` dropdown, the old `Edit User` is located in here.

This allows a convenient place for 3rd party extensions to add additional actions for the user, without continuously expanding the grid. `GDPR Actions` for example can now be placed in this new dropdown...

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![image](https://github.com/user-attachments/assets/97c1994a-93a3-4cea-b977-79110e9eeb6f)


**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
