### PR TITLE
[1.x] [tags] feat: option to display tags in DiscussionsSearchSource

### DIFF
--- a/extensions/tags/extend.php
+++ b/extensions/tags/extend.php
@@ -100,6 +100,8 @@ return [
         ->prepareDataForSerialization(LoadForumTagsRelationship::class),
 
     (new Extend\Settings())
+        ->default('flarum-tags.show_tags_in_discussion_search_results', false)
+        ->serializeToForum('showTagsInDiscussionSearchResults', 'flarum-tags.show_tags_in_discussion_search_results', 'boolVal')
         ->serializeToForum('minPrimaryTags', 'flarum-tags.min_primary_tags')
         ->serializeToForum('maxPrimaryTags', 'flarum-tags.max_primary_tags')
         ->serializeToForum('minSecondaryTags', 'flarum-tags.min_secondary_tags')

--- a/extensions/tags/js/dist-typings/forum/addTagsToDiscussionSearch.d.ts
+++ b/extensions/tags/js/dist-typings/forum/addTagsToDiscussionSearch.d.ts
@@ -1,0 +1,1 @@
+export default function addTagsToDiscussionSearch(): void;

--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -118,6 +118,14 @@ export default class TagsPage extends ExtensionPage {
                     <input className="FormControl" type="number" min={minSecondaryTags()} bidi={maxSecondaryTags} />
                   </div>
                 </div>
+                <div className="Form-group">
+                  {this.buildSettingComponent({
+                    setting: 'flarum-tags.show_tags_in_discussion_search_results',
+                    type: 'boolean',
+                    label: app.translator.trans('flarum-tags.admin.tag_settings.show_tags_in_discussion_search_results.label'),
+                    help: app.translator.trans('flarum-tags.admin.tag_settings.show_tags_in_discussion_search_results.help'),
+                  })}
+                </div>
                 <div className="Form-group">{this.submitButton()}</div>
               </div>
             </div>

--- a/extensions/tags/js/src/forum/addTagsToDiscussionSearch.tsx
+++ b/extensions/tags/js/src/forum/addTagsToDiscussionSearch.tsx
@@ -1,0 +1,16 @@
+import app from 'flarum/forum/app';
+import { extend } from 'flarum/common/extend';
+import DiscussionsSearchItem from 'flarum/forum/components/DiscussionsSearchItem';
+import DiscussionsSearchSource from 'flarum/forum/components/DiscussionsSearchSource';
+import tagsLabel from '../common/helpers/tagsLabel';
+
+export default function addTagsToDiscussionSearch() {
+  extend(DiscussionsSearchSource.prototype, 'includes', function (includes) {
+    app.forum.attribute<boolean>('showTagsInDiscussionSearchResults') && includes.push('tags');
+  });
+
+  extend(DiscussionsSearchItem.prototype, 'viewItems', function (items) {
+    app.forum.attribute<boolean>('showTagsInDiscussionSearchResults') &&
+      items.add('tags', <div className="DiscussionSearchResult-tags">{tagsLabel(this.discussion.tags())}</div>, 100);
+  });
+}

--- a/extensions/tags/js/src/forum/index.ts
+++ b/extensions/tags/js/src/forum/index.ts
@@ -7,6 +7,7 @@ import addTagFilter from './addTagFilter';
 import addTagLabels from './addTagLabels';
 import addTagControl from './addTagControl';
 import addTagComposer from './addTagComposer';
+import addTagsToDiscussionSearch from './addTagsToDiscussionSearch';
 
 export { default as extend } from './extend';
 
@@ -24,6 +25,5 @@ app.initializers.add('flarum-tags', function () {
 // Expose compat API
 import tagsCompat from './compat';
 import { compat } from '@flarum/core/forum';
-import addTagsToDiscussionSearch from './addTagsToDiscussionSearch';
 
 Object.assign(compat, tagsCompat);

--- a/extensions/tags/js/src/forum/index.ts
+++ b/extensions/tags/js/src/forum/index.ts
@@ -18,10 +18,12 @@ app.initializers.add('flarum-tags', function () {
   addTagLabels();
   addTagControl();
   addTagComposer();
+  addTagsToDiscussionSearch();
 });
 
 // Expose compat API
 import tagsCompat from './compat';
 import { compat } from '@flarum/core/forum';
+import addTagsToDiscussionSearch from './addTagsToDiscussionSearch';
 
 Object.assign(compat, tagsCompat);

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -49,6 +49,9 @@ flarum-tags:
       required_primary_text: Enter the minimum and maximum number of primary tags that may be applied to a discussion.
       required_secondary_heading: Required Number of Secondary Tags
       required_secondary_text: Enter the minimum and maximum number of secondary tags that may be applied to a discussion.
+      show_tags_in_discussion_search_results:
+        label: Show Tags in Discussion Search Results
+        help: "When enabled, tags will be displayed in the search results for discussions."
       title: Tag Settings
 
     # These translations are used in the Tags page.

--- a/framework/core/js/dist-typings/forum/components/Search.d.ts
+++ b/framework/core/js/dist-typings/forum/components/Search.d.ts
@@ -55,6 +55,12 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
      *
      * @deprecated Replace with`this.searchState` instead.
      */
+    /**
+     * The instance of `SearchState` for this component.
+     *
+     * @deprecated Replace with`this.searchState` instead.
+     */
+    // @ts-expect-error This is a get accessor, while superclass defines this as a property. This is needed to prevent breaking changes, however.
     get state(): SearchState;
     set state(state: SearchState);
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**
Introduces an option to display the tag label(s) above the discussion title in search results (`DiscussionsSearchSource`). Disabled by default to maintain current behaviour.

**Reviewers should focus on:**
@flarum/core I feel this is something to also include in `2.x`?

**Screenshot**
Search:
![search](https://github.com/user-attachments/assets/39b5585e-d642-4c9c-890c-c17b752579fd)

Tags settings:
![tags settings](https://github.com/user-attachments/assets/14c20d72-8638-479d-9881-0ae9e7b18b35)

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
