### PR TITLE
[1.x] fix: js error as guest on DiscussionListItem

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -74,7 +74,7 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     const discussion = this.attrs.discussion;
     const controls = DiscussionControls.controls(discussion, this).toArray();
 
-    items.add('controls', this.controlsView(controls), 100);
+    !!controls.length && items.add('controls', this.controlsView(controls), 100);
     items.add('slidableUnderneath', this.slidableUnderneathView(), 90);
     items.add('content', this.contentView(), 80);
 
@@ -83,16 +83,14 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
 
   controlsView(controls: Mithril.ChildArray): Mithril.Children {
     return (
-      !!controls.length && (
-        <Dropdown
-          icon="fas fa-ellipsis-v"
-          className="DiscussionListItem-controls"
-          buttonClassName="Button Button--icon Button--flat Slidable-underneath Slidable-underneath--right"
-          accessibleToggleLabel={app.translator.trans('core.forum.discussion_controls.toggle_dropdown_accessible_label')}
-        >
-          {controls}
-        </Dropdown>
-      )
+      <Dropdown
+        icon="fas fa-ellipsis-v"
+        className="DiscussionListItem-controls"
+        buttonClassName="Button Button--icon Button--flat Slidable-underneath Slidable-underneath--right"
+        accessibleToggleLabel={app.translator.trans('core.forum.discussion_controls.toggle_dropdown_accessible_label')}
+      >
+        {controls}
+      </Dropdown>
     );
   }
 


### PR DESCRIPTION
Resolves an issue introduced by #4048 where the discussion list is unavailable to users who don't have access to any `DiscussionControls`

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
