### PR TITLE
[1.x] fix: basicspage broken when no displayname drivers enabled

### DIFF
--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -89,9 +89,9 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
       90
     );
 
-    items.add(
-      'default-locale',
-      Object.keys(this.localeOptions).length > 1 && (
+    Object.keys(this.localeOptions).length > 1 &&
+      items.add(
+        'default-locale',
         <>
           {this.buildSettingComponent({
             type: 'select',
@@ -104,10 +104,9 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
             setting: 'show_language_selector',
             label: app.translator.trans('core.admin.basics.show_language_selector_label'),
           })}
-        </>
-      ),
-      80
-    );
+        </>,
+        80
+      );
 
     items.add(
       'home-page',
@@ -136,9 +135,10 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
       60
     );
 
-    items.add(
-      'display-name-driver',
-      Object.keys(this.displayNameOptions).length > 1 &&
+    Object.keys(this.displayNameOptions).length > 1 &&
+      items.add(
+        'display-name-driver',
+
         this.buildSettingComponent({
           type: 'select',
           setting: 'display_name_driver',
@@ -146,8 +146,8 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
           label: app.translator.trans('core.admin.basics.display_name_heading'),
           help: app.translator.trans('core.admin.basics.display_name_text'),
         }),
-      50
-    );
+        50
+      );
 
     items.add(
       'slug-driver',


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
