### PR TITLE
feat: add `Admin.generalIndexItems` extender

### DIFF
--- a/extensions/package-manager/js/src/admin/extend.tsx
+++ b/extensions/package-manager/js/src/admin/extend.tsx
@@ -27,5 +27,26 @@ export default [
       help: app.translator.trans('flarum-extension-manager.admin.settings.task_retention_days_help'),
       type: 'number',
     }))
-    .page(SettingsPage),
+    .page(SettingsPage)
+    .generalIndexItems('settings', () => [
+      {
+        id: 'minimum-stability',
+        label: app.translator.trans('flarum-extension-manager.admin.composer.minimum_stability.label', {}, true),
+        help: app.translator.trans('flarum-extension-manager.admin.composer.minimum_stability.help', {}, true),
+      },
+      {
+        id: 'repositories',
+        label: app.translator.trans('flarum-extension-manager.admin.composer.repositories.label', {}, true),
+        help: app.translator.trans('flarum-extension-manager.admin.composer.repositories.help', {}, true),
+      },
+      {
+        id: 'composer-auth',
+        label: app.translator.trans('flarum-extension-manager.admin.auth_config.title', {}, true),
+      },
+      {
+        id: 'updates',
+        label: app.translator.trans('flarum-extension-manager.admin.updater.updater_title', {}, true),
+        help: app.translator.trans('flarum-extension-manager.admin.updater.updater_help', {}, true),
+      },
+    ]),
 ];

--- a/framework/core/js/src/admin/states/GeneralSearchIndex.ts
+++ b/framework/core/js/src/admin/states/GeneralSearchIndex.ts
@@ -1,9 +1,28 @@
 export type GeneralIndexItem = {
+  /**
+   * The unique identifier for this index item.
+   */
   id: string;
+  /**
+   * Optional: The tree path to this item, used for grouping in the search results.
+   */
   tree?: string[];
+  /**
+   * The label to display in the search results.
+   */
   label: string;
+  /**
+   * Optional: The description to display in the search results.
+   */
   help?: string;
+  /**
+   * Optional: The URL to navigate to when this item is selected.
+   * The default is to navigate to the extension page.
+   */
   link?: string;
+  /**
+   * Optional: A callback that returns a boolean indicating whether this item should be visible in the search results.
+   */
   visible?: () => boolean;
 };
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Part of #4022**

**Changes proposed in this pull request:**
Follow-up improvements related to the admin search UI feature.
* Allows adding custom admin search index entries through the Admin extender.
* Adds custom entries for the extension manager.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
