### PR TITLE
feat: add `List-Unsubscribe` header to emails

### DIFF
--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -12,8 +12,10 @@ namespace Flarum\Mail;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
@@ -81,5 +83,10 @@ class MailServiceProvider extends AbstractServiceProvider
         });
 
         $this->container->alias('mailer', MailerContract::class);
+    }
+
+    public function boot(Dispatcher $events): void
+    {
+        $events->listen(MessageSending::class, MutateEmail::class);
     }
 }

--- a/framework/core/src/Mail/MutateEmail.php
+++ b/framework/core/src/Mail/MutateEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Flarum\Mail;
+
+use Illuminate\Mail\Events\MessageSending;
+
+class MutateEmail
+{
+    public function handle(MessageSending $event): bool
+    {
+        if (! empty($link = $event->data['unsubscribeLink'])) {
+            $headers = $event->message->getHeaders();
+
+            $headers->addTextHeader('List-Unsubscribe', '<'.$link.'>');
+        }
+
+        return true;
+    }
+}

--- a/framework/core/src/Mail/MutateEmail.php
+++ b/framework/core/src/Mail/MutateEmail.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Mail;
 
 use Illuminate\Mail\Events\MessageSending;


### PR DESCRIPTION
**Closes https://github.com/flarum/issue-archive/issues/447**

**Changes proposed in this pull request:**
In 2.0 we added email unsubscribe links. This PR adds that link to the email headers following standards.

![image](https://github.com/user-attachments/assets/54473b01-751a-4a8a-a1a7-262c9dc1ad69)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
