### PR TITLE
[1.x] Implement Support for Translatable Validation Attribute Errors

### DIFF
--- a/extensions/package-manager/locale/en.yml
+++ b/extensions/package-manager/locale/en.yml
@@ -161,3 +161,23 @@ flarum-extension-manager:
 
     why_not_modal:
       title: Why Won't it Update
+
+  validation:
+    attributes:
+      minimum_stability: minimum stability
+      repositories: repositories
+      repositories.*: repositories
+      repositories.*.type: repository type
+      repositories.*.url: repository URL
+      extension_id: extension ID
+      update_mode: update mode
+      package: package
+      version: version
+      github_oauth: GitHub OAuth
+      github_oauth.*: GitHub OAuth
+      gitlab_oauth: GitLab OAuth
+      gitlab_oauth.*: GitLab OAuth
+      gitlab_token: GitLab Token
+      gitlab_token.*: GitLab Token
+      bearer: HTTP Bearer
+      bearer.*: HTTP Bearer

--- a/extensions/suspend/locale/en.yml
+++ b/extensions/suspend/locale/en.yml
@@ -69,3 +69,7 @@ flarum-suspend:
         You have been unsuspended. You can head back to the forum by clicking on the following link:
 
         {forum_url}
+
+  validation:
+    attributes:
+      suspended_until: suspended until

--- a/extensions/suspend/locale/en.yml
+++ b/extensions/suspend/locale/en.yml
@@ -72,4 +72,4 @@ flarum-suspend:
 
   validation:
     attributes:
-      suspended_until: suspended until
+      suspendedUntil: suspended until

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -126,3 +126,13 @@ flarum-tags:
     choose_tags_placeholder: "{count, plural, one {Choose 1 more tag} other {Choose # more tags}}"
     name: Name
     tags: Tags
+
+  validation:
+    attributes:
+      name: name
+      slug: slug
+      is_hidden: hidden
+      description: description
+      color: color
+      tag_count_primary: => validation.attributes.tag_count_primary
+      tag_count_secondary: => validation.attributes.tag_count_secondary

--- a/framework/core/locale/validation.yml
+++ b/framework/core/locale/validation.yml
@@ -79,6 +79,7 @@ validation:
   present: "The :attribute field must be present."
   regex: "The :attribute format is invalid."
   required: "The :attribute field is required."
+  required_array_keys: "The :attribute array must contain entries for: :values."
   required_if: "The :attribute field is required when :other is :value."
   required_unless: "The :attribute field is required unless :other is in :values."
   required_with: "The :attribute field is required when :values is present."

--- a/framework/core/src/Extension/Extension.php
+++ b/framework/core/src/Extension/Extension.php
@@ -334,6 +334,19 @@ class Extension implements Arrayable
     }
 
     /**
+     * @return string|null
+     */
+    public function getNamespace(): ?string
+    {
+        return Collection::make($this->composerJsonAttribute('autoload.psr-4'))
+            ->filter(function ($source) {
+                return $source === 'src/';
+            })
+            ->keys()
+            ->first();
+    }
+
+    /**
      * @return string
      */
     public function getPath()

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Foundation;
 
+use Illuminate\Contracts\Cache\Store as Cache;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -17,6 +18,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 abstract class AbstractValidator
 {
     use ExtensionIdTrait;
+
+    public static string $CORE_VALIDATION_CACHE_KEY = 'core.validation.extension_id_class_names';
 
     /**
      * @var array
@@ -44,13 +47,19 @@ abstract class AbstractValidator
     protected $translator;
 
     /**
+     * @var Cache
+     */
+    protected $cache;
+
+    /**
      * @param Factory $validator
      * @param TranslatorInterface $translator
      */
-    public function __construct(Factory $validator, TranslatorInterface $translator)
+    public function __construct(Factory $validator, TranslatorInterface $translator, Cache $cache)
     {
         $this->validator = $validator;
         $this->translator = $translator;
+        $this->cache = $cache;
     }
 
     /**
@@ -88,6 +97,10 @@ abstract class AbstractValidator
      */
     protected function getAttributeNames()
     {
+        if ($this->cache->get(self::$CORE_VALIDATION_CACHE_KEY) !== null) {
+            return $this->cache->get(self::$CORE_VALIDATION_CACHE_KEY);
+        }
+
         $extId = $this->getClassExtensionId();
         $attributeNames = [];
 
@@ -95,6 +108,8 @@ abstract class AbstractValidator
             $key = $extId ? "$extId.validation.attributes.$attribute" : "validation.attributes.$attribute";
             $attributeNames[$attribute] = $this->translator->trans($key);
         }
+
+        $this->cache->forever(self::$CORE_VALIDATION_CACHE_KEY, $attributeNames);
 
         return $attributeNames;
     }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -19,7 +19,10 @@ abstract class AbstractValidator
 {
     use ExtensionIdTrait;
 
-    public static string $CORE_VALIDATION_CACHE_KEY = 'core.validation.extension_id_class_names';
+    /**
+     * @var string
+     */
+    public static $CORE_VALIDATION_CACHE_KEY = 'core.validation.extension_id_class_names';
 
     /**
      * @var array
@@ -47,19 +50,13 @@ abstract class AbstractValidator
     protected $translator;
 
     /**
-     * @var Cache
-     */
-    protected $cache;
-
-    /**
      * @param Factory $validator
      * @param TranslatorInterface $translator
      */
-    public function __construct(Factory $validator, TranslatorInterface $translator, Cache $cache)
+    public function __construct(Factory $validator, TranslatorInterface $translator)
     {
         $this->validator = $validator;
         $this->translator = $translator;
-        $this->cache = $cache;
     }
 
     /**
@@ -97,8 +94,10 @@ abstract class AbstractValidator
      */
     protected function getAttributeNames()
     {
-        if ($this->cache->get(self::$CORE_VALIDATION_CACHE_KEY) !== null) {
-            return $this->cache->get(self::$CORE_VALIDATION_CACHE_KEY);
+        $cache = resolve(Cache::class);
+        
+        if ($cache->get(self::$CORE_VALIDATION_CACHE_KEY) !== null) {
+            return $cache->get(self::$CORE_VALIDATION_CACHE_KEY);
         }
 
         $extId = $this->getClassExtensionId();
@@ -109,7 +108,7 @@ abstract class AbstractValidator
             $attributeNames[$attribute] = $this->translator->trans($key);
         }
 
-        $this->cache->forever(self::$CORE_VALIDATION_CACHE_KEY, $attributeNames);
+        $cache->forever(self::$CORE_VALIDATION_CACHE_KEY, $attributeNames);
 
         return $attributeNames;
     }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Foundation;
 
+use Flarum\Foundation\ExtensionIdTrait;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -16,6 +17,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractValidator
 {
+    use ExtensionIdTrait;
+
     /**
      * @var array
      */
@@ -82,6 +85,22 @@ abstract class AbstractValidator
     }
 
     /**
+     * @return array
+     */
+    protected function getAttributeNames()
+    {
+        $extId = $this->getClassExtensionId();
+        $attributeNames = [];
+
+        foreach(array_keys($this->rules) as $attribute) {
+            $key = $extId ? "$extId.validation.attributes.$attribute" : "validation.attributes.$attribute";
+            $attributeNames[$attribute] = $this->translator->trans($key);
+        }
+
+        return $attributeNames;
+    }
+
+    /**
      * Make a new validator instance for this model.
      *
      * @param array $attributes
@@ -92,6 +111,7 @@ abstract class AbstractValidator
         $rules = Arr::only($this->getRules(), array_keys($attributes));
 
         $validator = $this->validator->make($attributes, $rules, $this->getMessages());
+        $validator->setAttributeNames($this->getAttributeNames());
 
         foreach ($this->configuration as $callable) {
             $callable($this, $validator);

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Foundation;
 
-use Flarum\Foundation\ExtensionIdTrait;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
@@ -92,7 +91,7 @@ abstract class AbstractValidator
         $extId = $this->getClassExtensionId();
         $attributeNames = [];
 
-        foreach(array_keys($this->rules) as $attribute) {
+        foreach (array_keys($this->rules) as $attribute) {
             $key = $extId ? "$extId.validation.attributes.$attribute" : "validation.attributes.$attribute";
             $attributeNames[$attribute] = $this->translator->trans($key);
         }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -95,7 +95,7 @@ abstract class AbstractValidator
     protected function getAttributeNames()
     {
         $cache = resolve(Cache::class);
-        
+
         if ($cache->get(self::$CORE_VALIDATION_CACHE_KEY) !== null) {
             return $cache->get(self::$CORE_VALIDATION_CACHE_KEY);
         }

--- a/framework/core/src/Foundation/ExtensionIdTrait.php
+++ b/framework/core/src/Foundation/ExtensionIdTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+ namespace Flarum\Foundation;
+
+use Flarum\Extension\ExtensionManager;
+use Flarum\Extension\Extension;
+
+trait ExtensionIdTrait
+{
+    protected function getClassExtensionId(): ?string
+    {
+        $extensions = resolve(ExtensionManager::class);
+
+        return $extensions->getExtensions()
+                ->mapWithKeys(function (Extension $extension) {
+                    return [$extension->getId() => $extension->getNamespace()];
+                })
+                ->filter(function ($namespace) {
+                    return $namespace && str_starts_with(static::class, $namespace);
+                })
+                ->keys()
+                ->first();
+    }
+}

--- a/framework/core/src/Foundation/ExtensionIdTrait.php
+++ b/framework/core/src/Foundation/ExtensionIdTrait.php
@@ -7,10 +7,10 @@
  * LICENSE file that was distributed with this source code.
  */
 
- namespace Flarum\Foundation;
+namespace Flarum\Foundation;
 
-use Flarum\Extension\ExtensionManager;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 
 trait ExtensionIdTrait
 {


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
- Implement support for translating **attributes** of backend validation errors. 
- Add English translations for new attributes

**Reviewers should focus on:**

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->
1. Install a language pack such as `flarum-lang/german` or `flarum-lang/dutch`
2. Switch the Forum UI to another language (not english)
3. Try to submit a new discussions with no title or content. You should now see the translated version of `title` or `content`

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
