### PR TITLE
[1.x] [suspend] fix: previously suspended admin users cannot remove their avatar after suspension

### DIFF
--- a/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
+++ b/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
@@ -18,7 +18,7 @@ class PreventAvatarDeletionBySuspendedUser
         $actor = $event->actor;
         $user = $event->user;
 
-        if ($actor->id === $user->id && $user->suspended_until) {
+        if (!$actor->isAdmin() && $actor->id === $user->id && $user->suspended_until && $user->suspended_until->isFuture()) {
             throw new PermissionDeniedException();
         }
     }

--- a/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
+++ b/extensions/suspend/src/Listener/PreventAvatarDeletionBySuspendedUser.php
@@ -18,7 +18,7 @@ class PreventAvatarDeletionBySuspendedUser
         $actor = $event->actor;
         $user = $event->user;
 
-        if (!$actor->isAdmin() && $actor->id === $user->id && $user->suspended_until && $user->suspended_until->isFuture()) {
+        if (! $actor->isAdmin() && $actor->id === $user->id && $user->suspended_until && $user->suspended_until->isFuture()) {
             throw new PermissionDeniedException();
         }
     }

--- a/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
+++ b/extensions/suspend/tests/integration/api/users/RemoveAvatarTest.php
@@ -31,12 +31,14 @@ class RemoveAvatarTest extends TestCase
                 ['id' => 3, 'username' => 'acme', 'email' => 'acme@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->addDay(), 'suspend_message' => 'You have been suspended.', 'suspend_reason' => 'Suspended for acme reasons.'],
                 ['id' => 4, 'username' => 'acme4', 'email' => 'acme4@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 5, 'username' => 'acme5', 'email' => 'acme5@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->subDay(), 'suspend_message' => 'You have been suspended.', 'suspend_reason' => 'Suspended for acme reasons.'],
+                ['id' => 6, 'username' => 'acme6', 'email' => 'acme6@machine.local', 'is_email_confirmed' => 1, 'suspended_until' => Carbon::now()->subWeek(), 'suspend_message' => 'You have been suspended.', 'suspend_reason' => 'Suspended for acme reasons.'],
             ],
             'groups' => [
                 ['id' => 5, 'name_singular' => 'can_edit_users', 'name_plural' => 'can_edit_users', 'is_hidden' => 0]
             ],
             'group_user' => [
-                ['user_id' => 2, 'group_id' => 5]
+                ['user_id' => 2, 'group_id' => 5],
+                ['user_id' => 6, 'group_id' => 1],
             ],
             'group_permission' => [
                 ['permission' => 'user.edit', 'group_id' => 5],
@@ -73,6 +75,9 @@ class RemoveAvatarTest extends TestCase
             [4, 4, 'Normal user can remove their own avatar'],
             [1, 3, 'Admin can remove avatar of suspended user'],
             [2, 3, 'Normal user with permission can remove avatar of suspended user'],
+            [1, 6, 'Admin can remove avatar of expired suspended user'],
+            [2, 6, 'Normal user with permission can remove avatar of expired suspended user'],
+            [6, 6, 'Admin user can remove avatar if they have an expired suspension'],
         ];
     }
 


### PR DESCRIPTION

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

https://discuss.flarum.org/d/32901-staff-diary-v20-cycle/246

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
