### PR TITLE
[1.x] [likes] fix: Ignore isLiked when post is not comment post.

### DIFF
--- a/extensions/likes/migrations/2024_10_18_000000_detach_likes_from_non_comment_posts.php
+++ b/extensions/likes/migrations/2024_10_18_000000_detach_likes_from_non_comment_posts.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        // Detach likes on non-comment posts
+        $schema->getConnection()
+            ->table('post_likes')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw(1)->from('posts')->whereColumn('id', 'post_id')->where('type', 'comment');
+            })
+            ->delete();
+    },
+    'down' => function (Builder $schema) {
+    }
+];

--- a/extensions/likes/src/Listener/SaveLikesToDatabase.php
+++ b/extensions/likes/src/Listener/SaveLikesToDatabase.php
@@ -34,7 +34,7 @@ class SaveLikesToDatabase
         $post = $event->post;
         $data = $event->data;
 
-        if ($post->exists && isset($data['attributes']['isLiked'])) {
+        if ($post->exists && isset($data['attributes']['isLiked']) && $post->type === 'comment') {
             $actor = $event->actor;
             $liked = (bool) $data['attributes']['isLiked'];
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

When someone set `isLiked` attribute on a post that's not a `comment` (e.g. type `discussionTagged`) through api, it will be saved and send the notification to user. Then in `PostLikedNotification` component, the method `excerpt` is trying to get the `plainContent` to truncate, which will lead to a frontend error.

According to `addLikeAction.js`, user should only be able to like a comment post, so it should be ignore if target post is not a comment post.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.