### PR TITLE
[1.x] chore: resolve node deprecation warnings in workflows

### DIFF
--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.js_package_manager }}

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -105,6 +105,7 @@ env:
   ci_script: ${{ inputs.js_package_manager == 'yarn' && 'yarn install --immutable' || 'npm ci' }}
   cache_dependency_path: ${{ inputs.cache_dependency_path || format(inputs.js_package_manager == 'yarn' && '{0}/yarn.lock' || '{0}/package-lock.json', inputs.frontend_directory) }}
   COMPOSER_AUTH: ${{ secrets.composer_auth }}
+  DISABLE_V8_COMPILE_CACHE: 1
 
 jobs:
   build:

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -74,7 +74,7 @@ on:
         description: The node version to use for the workflow.
         type: number
         required: false
-        default: 16
+        default: 20
 
       js_package_manager:
         description: "Enable TypeScript?"
@@ -142,7 +142,7 @@ jobs:
         working-directory: ${{ inputs.frontend_directory }}
 
       - name: JS Checks & Production Build
-        uses: flarum/action-build@v3
+        uses: flarum/action-build@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: ${{ inputs.build_script }}

--- a/js-packages/tsconfig/tsconfig.json
+++ b/js-packages/tsconfig/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "skipLibCheck": true,
     "allowUmdGlobalAccess": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Backport of:
-  https://github.com/flarum/framework/commit/356f97641ed8d087dd1252e4cc2180484d8590cd
- https://github.com/flarum/framework/commit/257be2b9db6f5365faa017bd9cc4a0e870efb449#diff-8f0cab030414f9e64c7444c9011370f3435c52893686c91babdb72810568b0dc
- https://github.com/flarum/framework/commit/6f823731caa95439526ab7d8ec7dba13cd98e91b
- https://github.com/flarum/framework/commit/a3333320d71863b2596e0886a6eb6a81a9db61ad

Resolves deprecated Node.js version warnings