### PR TITLE
feat: define `FLARUM_START` constant

### DIFF
--- a/framework/core/src/Foundation/Site.php
+++ b/framework/core/src/Foundation/Site.php
@@ -18,6 +18,8 @@ class Site
     {
         $paths = new Paths($paths);
 
+        define('FLARUM_START', microtime(true));
+
         date_default_timezone_set('UTC');
 
         if (! static::hasConfigFile($paths->base)) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

This is useful for performance analysis extensions like clockwork to determine the real time it takes for the app to boot.
