### PR TITLE
[1.x] fix new search term not being passed

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionsSearchSource.tsx
+++ b/framework/core/js/src/forum/components/DiscussionsSearchSource.tsx
@@ -35,6 +35,8 @@ export default class DiscussionsSearchSource implements SearchSource {
   view(query: string): Array<Mithril.Vnode> {
     query = query.toLowerCase();
 
+    this.setQueryString(query);
+
     const results = (this.results.get(query) || []).map((discussion) => {
       const mostRelevantPost = discussion.mostRelevantPost();
 


### PR DESCRIPTION
Addresses an issue introduced in 1.8.6/7 in #4025 and reported on [discuss](https://discuss.flarum.org/d/36100-search-issue-since-187)