### PR TITLE
[1.x] fix: postfooter did not apply the empty subclass

### DIFF
--- a/framework/core/js/src/forum/components/Post.tsx
+++ b/framework/core/js/src/forum/components/Post.tsx
@@ -90,7 +90,7 @@ export default abstract class Post<CustomAttrs extends IPostAttrs = IPostAttrs> 
       90
     );
 
-    items.add('footer', <footer className="Post-footer">{footerItems.length > 0 ? <ul>{listItems(footerItems)}</ul> : <ul></ul>}</footer>, 80);
+    items.add('footer', <footer className="Post-footer">{footerItems.length > 0 ? <ul>{listItems(footerItems)}</ul> : null}</footer>, 80);
 
     return items;
   }


### PR DESCRIPTION
When the empty `footerItems` was returned, `<ul></ul>` was rendered, causing the `Post-footer:empty` class not to apply

Discovered on [discuss](https://discuss.flarum.org/d/36123-difficulties-i-faced-in-version-187/8)