### PR TITLE
[messages] datetime is incorrectly formatted in dialogs API

### DIFF
--- a/extensions/messages/src/Dialog.php
+++ b/extensions/messages/src/Dialog.php
@@ -42,6 +42,10 @@ class Dialog extends AbstractModel
 
     protected $table = 'dialogs';
 
+    protected $casts = [
+        'last_message_at' => 'datetime'
+    ];
+
     public $timestamps = true;
 
     public static array $types = ['direct'];

--- a/extensions/messages/src/UserDialogState.php
+++ b/extensions/messages/src/UserDialogState.php
@@ -36,6 +36,7 @@ class UserDialogState extends AbstractModel
         'user_id' => 'integer',
         'dialog_id' => 'integer',
         'joined_at' => 'datetime',
+        'last_read_at' => 'datetime',
         'last_read_message_id' => 'integer'
     ];
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Add correct casts to `Dialog` and `UserDialogState` so that the datetime from database is converted to Carbon instead of string.

Without casting, the time displayed on the frontend will be the UTC time treated as local time.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before
![2c957f77bfb4c5ba0124756178fd7d19](https://github.com/user-attachments/assets/81bb33ca-165d-4237-83f2-ae03c85d190e)

After
![9b0b9fbd54df524d31f81313cc2d6c6b](https://github.com/user-attachments/assets/51dc12c1-9b19-4fdd-b110-5ac4dfe5861e)

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
