### PR TITLE
Fix Alert component layout

### DIFF
--- a/framework/core/js/src/common/components/Alert.tsx
+++ b/framework/core/js/src/common/components/Alert.tsx
@@ -61,17 +61,19 @@ export default class Alert<T extends AlertAttrs = AlertAttrs> extends Component<
     return (
       <div {...attrs}>
         <div className={classList('Alert-container', attrs.containerClassName)}>
-          {!!title && (
-            <div className="Alert-title">
-              {!!icon && (
-                <span className="Alert-title-icon">
-                  <Icon name={icon} />
-                </span>
-              )}
-              <span className="Alert-title-text">{title}</span>
-            </div>
-          )}
-          <span className="Alert-body">{content}</span>
+          <div className="Alert-content">
+            {!!title && (
+              <div className="Alert-title">
+                {!!icon && (
+                  <span className="Alert-title-icon">
+                    <Icon name={icon} />
+                  </span>
+                )}
+                <span className="Alert-title-text">{title}</span>
+              </div>
+            )}
+            <span className="Alert-body">{content}</span>
+          </div>
           <ul className="Alert-controls">{listItems(controls.concat(dismissControl))}</ul>
         </div>
       </div>

--- a/framework/core/less/common/Alert.less
+++ b/framework/core/less/common/Alert.less
@@ -67,14 +67,17 @@
     display: none;
   }
 }
+.Alert-content {
+  flex-direction: column;
+}
 .Alert-title {
   margin-bottom: 8px;
   font-weight: bold;
-  display: flex;
   align-items: center;
   gap: 8px;
 }
-.Alert-container {
+.Alert-container,
+.Alert-content,
+.Alert-title {
   display: flex;
-  gap: 8px;
 }

--- a/framework/core/less/common/Alert.less
+++ b/framework/core/less/common/Alert.less
@@ -76,4 +76,5 @@
 }
 .Alert-container {
   display: flex;
+  gap: 8px;
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Adds `gap` for `.Alert-container` in admin styles.

This change improves the readability of the alert.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before
![image](https://github.com/user-attachments/assets/ade42e23-9a62-4d0b-b485-1d5bb5240fb3)
After
![image](https://github.com/user-attachments/assets/618c49a5-1154-46d9-a877-c03633c7f07d)

**QA**
<!-- include a list of checks that we can go through during QA to confirm this feature/fix still works as intended -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
