### PR TITLE
fix: prevent wiping out existing database on install

### DIFF
--- a/framework/core/src/Install/Steps/RunMigrations.php
+++ b/framework/core/src/Install/Steps/RunMigrations.php
@@ -33,7 +33,7 @@ class RunMigrations implements Step
     {
         $migrator = $this->getMigrator();
 
-        if (! $migrator->installFromSchema($this->path, $this->driver)) {
+        if (! $migrator->repositoryExists() && ! $migrator->installFromSchema($this->path, $this->driver)) {
             $migrator->getRepository()->createRepository();
         }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4018**

**Changes proposed in this pull request:**
* Checks for the existence of the migrations table (this is how we checked before we added the install.sql dumps).

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
