### PR TITLE
[tags] Fix wrong tag input width for CJK characters

### DIFF
--- a/extensions/tags/js/src/common/components/TagSelectionModal.tsx
+++ b/extensions/tags/js/src/common/components/TagSelectionModal.tsx
@@ -77,7 +77,7 @@ export default class TagSelectionModal<
 
   protected textMeasurementCanvas: HTMLCanvasElement | undefined;
   protected textMeasurementCanvasCtx: CanvasRenderingContext2D | undefined;
-  protected textMeasurementFont: string = "";
+  protected textMeasurementFont: string = '';
 
   static initAttrs(attrs: ITagSelectionModalAttrs) {
     super.initAttrs(attrs);

--- a/extensions/tags/js/src/common/components/TagSelectionModal.tsx
+++ b/extensions/tags/js/src/common/components/TagSelectionModal.tsx
@@ -75,6 +75,10 @@ export default class TagSelectionModal<
   protected navigator = new KeyboardNavigatable();
   protected indexTag?: Tag;
 
+  protected textMeasurementCanvas: HTMLCanvasElement | undefined;
+  protected textMeasurementCanvasCtx: CanvasRenderingContext2D | undefined;
+  protected textMeasurementFont: string = "";
+
   static initAttrs(attrs: ITagSelectionModalAttrs) {
     super.initAttrs(attrs);
 
@@ -102,6 +106,9 @@ export default class TagSelectionModal<
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
 
+    this.textMeasurementCanvas = document.createElement('canvas');
+    this.textMeasurementCanvasCtx = this.textMeasurementCanvas.getContext('2d') ?? undefined;
+
     this.navigator
       .onUp(() => this.setIndex(this.getCurrentNumericIndex() - 1, true))
       .onDown(() => this.setIndex(this.getCurrentNumericIndex() + 1, true))
@@ -127,6 +134,26 @@ export default class TagSelectionModal<
     });
   }
 
+  onupdate(vnode: Mithril.VnodeDOM<CustomAttrs, this>): void {
+    super.onupdate(vnode);
+
+    if (!this.textMeasurementCanvasCtx) return;
+    const inputEl = vnode.dom.querySelector('.TagsInput > input.FormControl') as HTMLInputElement;
+    if (!inputEl) return;
+    const style = getComputedStyle(inputEl);
+    const font = `${style.getPropertyValue('font-weight')} ${style.getPropertyValue('font-size')} ${style.getPropertyValue('font-family')}`;
+    if (this.textMeasurementFont != font) {
+      this.textMeasurementCanvasCtx.font = this.textMeasurementFont = font;
+      m.redraw();
+    }
+  }
+
+  onremove(vnode: Mithril.VnodeDOM<CustomAttrs, this>): void {
+    super.onremove(vnode);
+
+    this.textMeasurementCanvas?.remove();
+  }
+
   className() {
     return classList('TagSelectionModal Modal--simple', this.attrs.className);
   }
@@ -140,12 +167,16 @@ export default class TagSelectionModal<
       return <LoadingIndicator />;
     }
 
-    const filter = this.filter().toLowerCase();
+    const filterText = this.filter();
+    const filter = filterText.toLowerCase();
     const primaryCount = this.primaryCount();
     const secondaryCount = this.secondaryCount();
     const tags = this.getFilteredTags();
 
-    const inputWidth = Math.max(extractText(this.getInstruction(primaryCount, secondaryCount)).length, this.filter().length);
+    const instructionText = extractText(this.getInstruction(primaryCount, secondaryCount));
+    const inputChars = Math.max(instructionText.length, filterText.length);
+    const textWidth = filterText ? this.measureText(filterText)?.width : this.measureText(instructionText)?.width;
+    const inputWidth = textWidth ? `${textWidth}px` : `${inputChars}ch`;
 
     return [
       <div className="Modal-body">
@@ -169,7 +200,7 @@ export default class TagSelectionModal<
                 className="FormControl"
                 placeholder={extractText(this.getInstruction(primaryCount, secondaryCount))}
                 bidi={this.filter}
-                style={{ width: inputWidth + 'ch' }}
+                style={{ width: inputWidth }}
                 onkeydown={this.navigator.navigate.bind(this.navigator)}
                 onfocus={() => (this.focused = true)}
                 onblur={() => (this.focused = false)}
@@ -383,6 +414,13 @@ export default class TagSelectionModal<
     }
 
     return '';
+  }
+
+  /**
+   * Measures the metrics of the given text for tag input control and returns it in pixels.
+   */
+  protected measureText(text: string) {
+    return this.textMeasurementCanvasCtx?.measureText(text);
   }
 
   /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Add a text measurement utility function in `TagSelectionModal` that is based on canvas's `measureText`. And make input width prefer this instead of `ch` unit.

The reason of `ch` unit doesn't work:
> Equal to the used advance measure of the “0” (ZERO, U+0030) glyph found in the font used to render it. (The advance measure of a glyph is its advance width or height, whichever is in the inline axis of the element.)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Do you think should we make the measurement utility a globally available function?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Before
![image](https://github.com/user-attachments/assets/8d2f3122-dd31-426f-b2bf-1902d92e04ab)

After
![image](https://github.com/user-attachments/assets/eb021034-90c1-4ffe-854b-9cf247a7015a)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
