### PR TITLE
[likes] Don't send liked notification for posts without plain content.

### DIFF
--- a/extensions/likes/src/Listener/SendNotificationWhenPostIsLiked.php
+++ b/extensions/likes/src/Listener/SendNotificationWhenPostIsLiked.php
@@ -22,7 +22,7 @@ class SendNotificationWhenPostIsLiked
 
     public function handle(PostWasLiked $event): void
     {
-        if ($event->post->user && $event->post->user->id != $event->user->id) {
+        if (gettype($event->post->content) == "string" && $event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 [$event->post->user]

--- a/extensions/likes/src/Listener/SendNotificationWhenPostIsLiked.php
+++ b/extensions/likes/src/Listener/SendNotificationWhenPostIsLiked.php
@@ -22,7 +22,7 @@ class SendNotificationWhenPostIsLiked
 
     public function handle(PostWasLiked $event): void
     {
-        if (gettype($event->post->content) == "string" && $event->post->user && $event->post->user->id != $event->user->id) {
+        if (gettype($event->post->content) == 'string' && $event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 [$event->post->user]

--- a/extensions/likes/src/Listener/SendNotificationWhenPostIsUnliked.php
+++ b/extensions/likes/src/Listener/SendNotificationWhenPostIsUnliked.php
@@ -22,7 +22,7 @@ class SendNotificationWhenPostIsUnliked
 
     public function handle(PostWasUnliked $event): void
     {
-        if ($event->post->user && $event->post->user->id != $event->user->id) {
+        if (gettype($event->post->content) == "string" && $event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 []

--- a/extensions/likes/src/Listener/SendNotificationWhenPostIsUnliked.php
+++ b/extensions/likes/src/Listener/SendNotificationWhenPostIsUnliked.php
@@ -22,7 +22,7 @@ class SendNotificationWhenPostIsUnliked
 
     public function handle(PostWasUnliked $event): void
     {
-        if (gettype($event->post->content) == "string" && $event->post->user && $event->post->user->id != $event->user->id) {
+        if (gettype($event->post->content) == 'string' && $event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 []


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Don't send liked notifications for posts that don't have plain content.

In this approach, the extensibility of the Likes extension won't be reduced. Since it allows all other post types to be liked, it also keeps the original notification ability from the Likes extension for all other post types that contain valid plain content.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
