### PR TITLE
chore: remove unused JS imports

### DIFF
--- a/extensions/mentions/js/src/forum/mentionables/formats/MentionFormat.ts
+++ b/extensions/mentions/js/src/forum/mentionables/formats/MentionFormat.ts
@@ -1,5 +1,4 @@
 import type MentionableModel from '../MentionableModel';
-import type Model from 'flarum/common/Model';
 
 export default abstract class MentionFormat {
   protected instances?: MentionableModel[];

--- a/extensions/messages/js/src/forum/components/Message.tsx
+++ b/extensions/messages/js/src/forum/components/Message.tsx
@@ -1,4 +1,3 @@
-import app from 'flarum/forum/app';
 import ItemList from 'flarum/common/utils/ItemList';
 import Mithril from 'mithril';
 import AbstractPost, { type IAbstractPostAttrs } from 'flarum/forum/components/AbstractPost';

--- a/extensions/package-manager/js/src/admin/extend.tsx
+++ b/extensions/package-manager/js/src/admin/extend.tsx
@@ -1,6 +1,5 @@
 import Extend from 'flarum/common/extenders';
 import app from 'flarum/admin/app';
-import extractText from 'flarum/common/utils/extractText';
 import SettingsPage from './components/SettingsPage';
 import Task from './models/Task';
 import ExternalExtension from './models/ExternalExtension';

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -8,7 +8,6 @@ import AdminRegistry from './utils/AdminRegistry';
 import IHistory from '../common/IHistory';
 import SearchManager from '../common/SearchManager';
 import SearchState from '../common/states/SearchState';
-import app from './app';
 import BasicsPage from './components/BasicsPage';
 import GeneralSearchIndex from './states/GeneralSearchIndex';
 import AppearancePage from './components/AppearancePage';

--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -1,5 +1,4 @@
 import app from '../../admin/app';
-import FieldSet from '../../common/components/FieldSet';
 import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { IPageAttrs } from '../../common/components/Page';

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -1,7 +1,6 @@
 import app from '../../admin/app';
 import Component, { ComponentAttrs } from '../../common/Component';
 import PermissionDropdown from './PermissionDropdown';
-import SettingDropdown from './SettingDropdown';
 import Button from '../../common/components/Button';
 import ItemList from '../../common/utils/ItemList';
 import type Mithril from 'mithril';

--- a/framework/core/js/src/common/Store.ts
+++ b/framework/core/js/src/common/Store.ts
@@ -1,7 +1,6 @@
 import app from '../common/app';
 import { FlarumRequestOptions } from './Application';
 import Model, { ModelData, SavedModelData } from './Model';
-import GambitManager from './GambitManager';
 
 export interface MetaInformation {
   page?: {

--- a/framework/core/js/src/common/components/AbstractSearch.tsx
+++ b/framework/core/js/src/common/components/AbstractSearch.tsx
@@ -1,7 +1,6 @@
 import app from '../app';
 import Component, { ComponentAttrs } from '../Component';
 import SearchState from '../states/SearchState';
-import extractText from '../utils/extractText';
 import ItemList from '../utils/ItemList';
 import Input from './Input';
 import type Mithril from 'mithril';

--- a/framework/core/js/src/common/components/Modal.tsx
+++ b/framework/core/js/src/common/components/Modal.tsx
@@ -6,7 +6,6 @@ import Button from './Button';
 import type Mithril from 'mithril';
 import type ModalManagerState from '../states/ModalManagerState';
 import type ModalManager from './ModalManager';
-import fireDebugWarning from '../helpers/fireDebugWarning';
 import classList from '../utils/classList';
 
 export interface IInternalModalAttrs {

--- a/framework/core/js/src/common/helpers/listItems.tsx
+++ b/framework/core/js/src/common/helpers/listItems.tsx
@@ -1,5 +1,5 @@
 import type Mithril from 'mithril';
-import Component, { ComponentAttrs } from '../Component';
+import { ComponentAttrs } from '../Component';
 import Separator from '../components/Separator';
 import classList from '../utils/classList';
 

--- a/framework/core/js/src/common/states/PaginatedListState.ts
+++ b/framework/core/js/src/common/states/PaginatedListState.ts
@@ -2,7 +2,6 @@ import app from '../../common/app';
 import Model from '../Model';
 import { ApiQueryParamsPlural, ApiResponsePlural } from '../Store';
 import type Mithril from 'mithril';
-import setRouteWithForcedRefresh from '../utils/setRouteWithForcedRefresh';
 
 export type SortMapItem =
   | string

--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -5,7 +5,6 @@ import Page, { IPageAttrs } from '../../common/components/Page';
 import ItemList from '../../common/utils/ItemList';
 import DiscussionHero from './DiscussionHero';
 import DiscussionListPane from './DiscussionListPane';
-import LoadingIndicator from '../../common/components/LoadingIndicator';
 import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';

--- a/framework/core/js/src/forum/components/Post.tsx
+++ b/framework/core/js/src/forum/components/Post.tsx
@@ -1,4 +1,3 @@
-import app from '../../forum/app';
 import PostControls from '../utils/PostControls';
 import ItemList from '../../common/utils/ItemList';
 import type PostModel from '../../common/models/Post';


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
- Removes unused imports which were caught by temporarily adding `"noUnusedLocals": true` to the global `flarum-tsconfig` and running `tsc --noEmit --emitDeclarationOnly false`.

**Reviewers should focus on:**
It may be worth thinking about if `"noUnusedLocals": true` and/or `"noUnusedParameters": false` should become part of the official `flarum-tsconfig` or perhaps if that should just be used in the framework itself, without imposing it to everyone extending the baseline config. Thoughts on that?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
