### PR TITLE
[1.x] fix: resolve regression in TS typing errors

### DIFF
--- a/extensions/approval/js/src/@types/shims.d.ts
+++ b/extensions/approval/js/src/@types/shims.d.ts
@@ -1,3 +1,6 @@
+import 'flarum/common/models/Discussion';
+import 'flarum/common/models/Post';
+
 declare module 'flarum/common/models/Discussion' {
   export default interface Discussion {
     isApproved(): boolean;

--- a/extensions/flags/js/src/@types/shims.d.ts
+++ b/extensions/flags/js/src/@types/shims.d.ts
@@ -1,3 +1,7 @@
+import 'flarum/common/models/Post';
+import 'flarum/forum/ForumApplication';
+import 'flarum/forum/components/Post';
+
 import Flag from '../forum/models/Flag';
 import FlagListState from '../forum/states/FlagListState';
 import Mithril from 'mithril';

--- a/extensions/likes/js/src/@types/shims.d.ts
+++ b/extensions/likes/js/src/@types/shims.d.ts
@@ -1,3 +1,5 @@
+import 'flarum/common/models/Post';
+
 import User from 'flarum/common/models/User';
 
 declare module 'flarum/common/models/Post' {

--- a/extensions/lock/js/src/@types/shims.d.ts
+++ b/extensions/lock/js/src/@types/shims.d.ts
@@ -1,3 +1,5 @@
+import 'flarum/common/models/Discussion';
+
 declare module 'flarum/common/models/Discussion' {
   export default interface Discussion {
     isLocked(): boolean;

--- a/extensions/mentions/js/src/@types/shims.d.ts
+++ b/extensions/mentions/js/src/@types/shims.d.ts
@@ -1,3 +1,7 @@
+import 'flarum/forum/ForumApplication';
+import 'flarum/common/models/User';
+import 'flarum/common/models/Post';
+
 import MentionFormats from '../forum/mentionables/formats/MentionFormats';
 import type BasePost from 'flarum/common/models/Post';
 

--- a/extensions/nicknames/js/src/@types/shims.d.ts
+++ b/extensions/nicknames/js/src/@types/shims.d.ts
@@ -1,3 +1,5 @@
+import 'flarum/common/models/User';
+
 declare module 'flarum/common/models/User' {
   export default interface User {
     canEditNickname(): boolean;

--- a/extensions/sticky/js/src/@types/shims.d.ts
+++ b/extensions/sticky/js/src/@types/shims.d.ts
@@ -1,3 +1,5 @@
+import 'flarum/common/models/Discussion';
+
 declare module 'flarum/common/models/Discussion' {
   export default interface Discussion {
     isSticky(): boolean;

--- a/extensions/suspend/js/src/@types/shims.d.ts
+++ b/extensions/suspend/js/src/@types/shims.d.ts
@@ -1,3 +1,5 @@
+import 'flarum/common/models/User';
+
 declare module 'flarum/common/models/User' {
   export default interface User {
     canSuspend(): boolean;

--- a/extensions/tags/js/src/@types/shims.d.ts
+++ b/extensions/tags/js/src/@types/shims.d.ts
@@ -1,3 +1,9 @@
+import 'flarum/forum/routes';
+import 'flarum/common/Application';
+import 'flarum/common/models/Discussion';
+import 'flarum/forum/components/IndexPage';
+import 'flarum/admin/components/PermissionGrid';
+
 import type Tag from '../common/models/Tag';
 import type TagListState from '../common/states/TagListState';
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
_Resolves regression introduced in https://github.com/flarum/framework/pull/4027_

**Fixes #0000**
If a `shims.d.ts` declaration file doesn't include any import statement, the TS compiler will treat it as an ambient declaration — _a type-only interface with no associated value at runtime_ — which causes regression in other parts of the codebase (notably `extend.ts`).

**Changes proposed in this pull request:**
- Add dummy imports to `shims` to work around TypeScript's module augmentation mechanism.

**Reviewers should focus on:**
- For consistency reasons, I always included all module declaration imports, even if only one or no additional were required. 

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
