### PR TITLE
chore: remove frontend scoping in `Modal`

### DIFF
--- a/framework/core/js/src/common/components/Modal.tsx
+++ b/framework/core/js/src/common/components/Modal.tsx
@@ -34,15 +34,15 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
    *
    * If `false`, no close button is shown.
    */
-  protected static readonly isDismissibleViaCloseButton: boolean = true;
+  static isDismissibleViaCloseButton: boolean = true;
   /**
    * Can the modal be dismissed by pressing the Esc key on a keyboard?
    */
-  protected static readonly isDismissibleViaEscKey: boolean = true;
+  static isDismissibleViaEscKey: boolean = true;
   /**
    * Can the modal be dismissed via a click on the backdrop.
    */
-  protected static readonly isDismissibleViaBackdropClick: boolean = true;
+  static isDismissibleViaBackdropClick: boolean = true;
 
   static get dismissibleOptions(): IDismissibleOptions {
     return {
@@ -52,7 +52,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     };
   }
 
-  protected loading: boolean = false;
+  loading: boolean = false;
 
   /**
    * Attributes for an alert component to show below the header.
@@ -103,11 +103,11 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     );
   }
 
-  protected wrapper(children: Mithril.Children): Mithril.Children {
+  wrapper(children: Mithril.Children): Mithril.Children {
     return <>{children}</>;
   }
 
-  protected inner(): Mithril.Children {
+  inner(): Mithril.Children {
     return (
       <>
         <div className="Modal-header">
@@ -162,7 +162,7 @@ export default abstract class Modal<ModalAttrs extends IInternalModalAttrs = IIn
     m.redraw();
   }
 
-  protected get dismissibleOptions(): IDismissibleOptions {
+  get dismissibleOptions(): IDismissibleOptions {
     return (this.constructor as typeof Modal).dismissibleOptions;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
TS will throw errors of various kinds if a third-party extension tries to customize the behaviour of existing Modals. For example, a third-party implementation might want to remove the ability to close the `SignUpModal` via the close button:

```tsx
import SignUpModal from 'flarum/forum/components/SignUpModal';

export default function () {
    SignUpModal.isDismissibleViaCloseButton = false;
  }
```

This will result in the following error: 

`Cannot assign to 'isDismissibleViaCloseButton' because it is a read-only property.ts(2540)`

**Changes proposed in this pull request:**
- Remove explicit scoping of properties, methods and getter in the `Modal` class and remove `readonly` modifier.

**Reviewers should focus on:**
This change got me thinking... Do we really need to constrain scopes in the JS of the framework, like at all? I think in the spirit of Flarum it would be a welcome change for extension developers if such scoping is removed and TS workarounds related to this were no longer required.

I would be happy to amend this PR do the change across the whole codebase 

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
