### PR TITLE
test: php 8.4

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -32,7 +32,7 @@ on:
         type: string
         required: false
         # Keep PHP versions synced with build-install-packages.yml
-        default: '["8.2", "8.3"]'
+        default: '["8.2", "8.3", "8.4"]'
 
       php_extensions:
         description: PHP extensions to install.

--- a/.github/workflows/build-install-packages.yml
+++ b/.github/workflows/build-install-packages.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   VERSION: ${{ github.event.release.tag_name }}
-  PHP_VERSIONS: '8.2 8.3'
+  PHP_VERSIONS: '8.2 8.3 8.4'
   INSTALL_PACKAGES_INPUTS: '{ "flarum_version": "{0}", "php_versions": "{1}" }'
 
 jobs:

--- a/extensions/akismet/tests/phpunit.integration.xml
+++ b/extensions/akismet/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/akismet/tests/phpunit.unit.xml
+++ b/extensions/akismet/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/approval/tests/phpunit.integration.xml
+++ b/extensions/approval/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/approval/tests/phpunit.unit.xml
+++ b/extensions/approval/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/flags/tests/phpunit.integration.xml
+++ b/extensions/flags/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/flags/tests/phpunit.unit.xml
+++ b/extensions/flags/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/likes/tests/integration/api/LikePostTest.php
+++ b/extensions/likes/tests/integration/api/LikePostTest.php
@@ -64,7 +64,7 @@ class LikePostTest extends TestCase
 
     #[Test]
     #[DataProvider('allowedUsersToLike')]
-    public function can_like_a_post_if_allowed(int $postId, ?int $authenticatedAs, string $message, bool $canLikeOwnPost = null)
+    public function can_like_a_post_if_allowed(int $postId, ?int $authenticatedAs, string $message, ?bool $canLikeOwnPost = null)
     {
         if (! is_null($canLikeOwnPost)) {
             $this->setting('flarum-likes.like_own_post', $canLikeOwnPost);
@@ -82,7 +82,7 @@ class LikePostTest extends TestCase
 
     #[Test]
     #[DataProvider('unallowedUsersToLike')]
-    public function cannot_like_a_post_if_not_allowed(int $postId, ?int $authenticatedAs, string $message, bool $canLikeOwnPost = null)
+    public function cannot_like_a_post_if_not_allowed(int $postId, ?int $authenticatedAs, string $message, ?bool $canLikeOwnPost = null)
     {
         if (! is_null($canLikeOwnPost)) {
             $this->setting('flarum-likes.like_own_post', $canLikeOwnPost);
@@ -100,7 +100,7 @@ class LikePostTest extends TestCase
 
     #[Test]
     #[DataProvider('allowedUsersToLike')]
-    public function can_dislike_a_post_if_liked_and_allowed(int $postId, ?int $authenticatedAs, string $message, bool $canLikeOwnPost = null)
+    public function can_dislike_a_post_if_liked_and_allowed(int $postId, ?int $authenticatedAs, string $message, ?bool $canLikeOwnPost = null)
     {
         if (! is_null($canLikeOwnPost)) {
             $this->setting('flarum-likes.like_own_post', $canLikeOwnPost);

--- a/extensions/likes/tests/phpunit.integration.xml
+++ b/extensions/likes/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/likes/tests/phpunit.unit.xml
+++ b/extensions/likes/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/lock/src/Post/DiscussionLockedPost.php
+++ b/extensions/lock/src/Post/DiscussionLockedPost.php
@@ -18,7 +18,7 @@ class DiscussionLockedPost extends AbstractEventPost implements MergeableInterfa
 {
     public static string $type = 'discussionLocked';
 
-    public function saveAfter(Post $previous = null): static
+    public function saveAfter(?Post $previous = null): static
     {
         // If the previous post is another 'discussion locked' post, and it's
         // by the same user, then we can merge this post into it. If we find

--- a/extensions/mentions/src/Formatter/FormatTagMentions.php
+++ b/extensions/mentions/src/Formatter/FormatTagMentions.php
@@ -17,7 +17,7 @@ use s9e\TextFormatter\Utils;
 
 class FormatTagMentions
 {
-    public function __invoke(Renderer $renderer, mixed $context, string $xml, Request $request = null): string
+    public function __invoke(Renderer $renderer, mixed $context, string $xml, ?Request $request = null): string
     {
         return Utils::replaceAttributes($xml, 'TAGMENTION', function ($attributes) use ($context) {
             /** @var Tag|null $tag */

--- a/extensions/mentions/tests/phpunit.integration.xml
+++ b/extensions/mentions/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/mentions/tests/phpunit.unit.xml
+++ b/extensions/mentions/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/messages/tests/phpunit.integration.xml
+++ b/extensions/messages/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/messages/tests/phpunit.unit.xml
+++ b/extensions/messages/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/nicknames/tests/phpunit.integration.xml
+++ b/extensions/nicknames/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/nicknames/tests/phpunit.unit.xml
+++ b/extensions/nicknames/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/package-manager/tests/integration/SetupComposer.php
+++ b/extensions/package-manager/tests/integration/SetupComposer.php
@@ -17,7 +17,7 @@ class SetupComposer
 
     private $config;
 
-    public function __construct(array $config = null)
+    public function __construct(?array $config = null)
     {
         $this->config = $config;
     }

--- a/extensions/package-manager/tests/phpunit.integration.xml
+++ b/extensions/package-manager/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/package-manager/tests/phpunit.unit.xml
+++ b/extensions/package-manager/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/statistics/tests/phpunit.integration.xml
+++ b/extensions/statistics/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/statistics/tests/phpunit.unit.xml
+++ b/extensions/statistics/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/sticky/src/Post/DiscussionStickiedPost.php
+++ b/extensions/sticky/src/Post/DiscussionStickiedPost.php
@@ -18,7 +18,7 @@ class DiscussionStickiedPost extends AbstractEventPost implements MergeableInter
 {
     public static string $type = 'discussionStickied';
 
-    public function saveAfter(Post $previous = null): static
+    public function saveAfter(?Post $previous = null): static
     {
         // If the previous post is another 'discussion stickied' post, and it's
         // by the same user, then we can merge this post into it. If we find

--- a/extensions/sticky/tests/phpunit.integration.xml
+++ b/extensions/sticky/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/sticky/tests/phpunit.unit.xml
+++ b/extensions/sticky/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/subscriptions/tests/phpunit.integration.xml
+++ b/extensions/subscriptions/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/subscriptions/tests/phpunit.unit.xml
+++ b/extensions/subscriptions/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/suspend/tests/phpunit.integration.xml
+++ b/extensions/suspend/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/suspend/tests/phpunit.unit.xml
+++ b/extensions/suspend/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/tags/src/Post/DiscussionTaggedPost.php
+++ b/extensions/tags/src/Post/DiscussionTaggedPost.php
@@ -18,7 +18,7 @@ class DiscussionTaggedPost extends AbstractEventPost implements MergeableInterfa
 {
     public static string $type = 'discussionTagged';
 
-    public function saveAfter(Post $previous = null): static
+    public function saveAfter(?Post $previous = null): static
     {
         // If the previous post is another 'discussion tagged' post, and it's
         // by the same user, then we can merge this post into it. If we find

--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -146,7 +146,7 @@ class Tag extends AbstractModel
         return $this;
     }
 
-    public function setLastPostedDiscussion(Discussion $discussion = null): static
+    public function setLastPostedDiscussion(?Discussion $discussion = null): static
     {
         $this->last_posted_at = optional($discussion)->last_posted_at;
         $this->last_posted_discussion_id = optional($discussion)->id;

--- a/extensions/tags/src/TagRepository.php
+++ b/extensions/tags/src/TagRepository.php
@@ -32,7 +32,7 @@ class TagRepository
      * Find a tag by ID, optionally making sure it is visible to a certain
      * user, or throw an exception.
      */
-    public function findOrFail(int $id, User $actor = null): Tag
+    public function findOrFail(int $id, ?User $actor = null): Tag
     {
         $query = Tag::where('id', $id);
 
@@ -45,7 +45,7 @@ class TagRepository
      *
      * @return Collection<int, Tag>
      */
-    public function all(User $user = null): Collection
+    public function all(?User $user = null): Collection
     {
         $query = Tag::query();
 
@@ -55,7 +55,7 @@ class TagRepository
     /**
      * Get the ID of a tag with the given slug.
      */
-    public function getIdForSlug(string $slug, User $user = null): ?int
+    public function getIdForSlug(string $slug, ?User $user = null): ?int
     {
         $query = Tag::where('slug', $slug);
 

--- a/extensions/tags/tests/phpunit.integration.xml
+++ b/extensions/tags/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/extensions/tags/tests/phpunit.unit.xml
+++ b/extensions/tags/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/framework/core/src/Api/Resource/Concerns/HasHooks.php
+++ b/framework/core/src/Api/Resource/Concerns/HasHooks.php
@@ -180,7 +180,7 @@ trait HasHooks
         //
     }
 
-    public function dispatchEventsFor(mixed $entity, User $actor = null): void
+    public function dispatchEventsFor(mixed $entity, ?User $actor = null): void
     {
         if (method_exists($entity, 'releaseEvents')) {
             $this->traitDispatchEventsFor($entity, $actor);

--- a/framework/core/src/Database/Exception/MigrationKeyMissing.php
+++ b/framework/core/src/Database/Exception/MigrationKeyMissing.php
@@ -13,13 +13,13 @@ use Exception;
 
 class MigrationKeyMissing extends Exception
 {
-    public function __construct(protected string $direction, string $file = null)
+    public function __construct(protected string $direction, ?string $file = null)
     {
         $fileNameWithSpace = $file ? ' '.realpath($file) : '';
         parent::__construct("Migration file $fileNameWithSpace should contain an array with up/down (looking for $direction)");
     }
 
-    public function withFile(string $file = null): self
+    public function withFile(?string $file = null): self
     {
         return new self($this->direction, $file);
     }

--- a/framework/core/src/Database/Exception/MigrationKeyMissing.php
+++ b/framework/core/src/Database/Exception/MigrationKeyMissing.php
@@ -19,7 +19,7 @@ class MigrationKeyMissing extends Exception
         parent::__construct("Migration file $fileNameWithSpace should contain an array with up/down (looking for $direction)");
     }
 
-    public function withFile(?string $file = null): self
+    public function withFile(string $file): self
     {
         return new self($this->direction, $file);
     }

--- a/framework/core/src/Discussion/Discussion.php
+++ b/framework/core/src/Discussion/Discussion.php
@@ -117,7 +117,7 @@ class Discussion extends AbstractModel
     /**
      * Start a new discussion. Raises the DiscussionWasStarted event.
      */
-    public static function start(?string $title, User $user, self $model = null): self
+    public static function start(?string $title, User $user, ?self $model = null): self
     {
         $discussion = $model ?? new static;
 

--- a/framework/core/src/Extend/ApiResource.php
+++ b/framework/core/src/Extend/ApiResource.php
@@ -59,7 +59,7 @@ class ApiResource implements ExtenderInterface
      * @param array $endpoints must be an array of names of the endpoints.
      * @param callable|class-string|null $condition a callable that returns a boolean or a string that represents whether this should be applied.
      */
-    public function removeEndpoints(array $endpoints, callable|string $condition = null): self
+    public function removeEndpoints(array $endpoints, callable|string|null $condition = null): self
     {
         $this->removeEndpoints[] = [$endpoints, $condition];
 
@@ -99,7 +99,7 @@ class ApiResource implements ExtenderInterface
      * @param array $fields must be an array of field names.
      * @param callable|class-string|null $condition a callable that returns a boolean or a string that represents whether this should be applied.
      */
-    public function removeFields(array $fields, callable|string $condition = null): self
+    public function removeFields(array $fields, callable|string|null $condition = null): self
     {
         $this->removeFields[] = [$fields, $condition];
 
@@ -139,7 +139,7 @@ class ApiResource implements ExtenderInterface
      * @param array $sorts must be an array of sort names.
      * @param callable|class-string|null $condition a callable that returns a boolean or a string that represents whether this should be applied.
      */
-    public function removeSorts(array $sorts, callable|string $condition = null): self
+    public function removeSorts(array $sorts, callable|string|null $condition = null): self
     {
         $this->removeSorts[] = [$sorts, $condition];
 
@@ -161,7 +161,7 @@ class ApiResource implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (! (new ReflectionClass($this->resourceClass))->isAbstract()) {
             $container->extend('flarum.api.resources', function (array $resources) {

--- a/framework/core/src/Extend/Auth.php
+++ b/framework/core/src/Extend/Auth.php
@@ -58,7 +58,7 @@ class Auth implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.user.password_checkers', function ($passwordCheckers) use ($container) {
             foreach ($this->removePasswordCheckers as $identifier) {

--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -86,7 +86,7 @@ class Conditional implements ExtenderInterface
      * @param Extension|null $extension
      * @return void
      */
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         foreach ($this->conditions as $condition) {
             if (is_callable($condition['condition'])) {

--- a/framework/core/src/Extend/Console.php
+++ b/framework/core/src/Extend/Console.php
@@ -57,7 +57,7 @@ class Console implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.console.commands', function ($existingCommands) {
             return array_merge($existingCommands, $this->addCommands);

--- a/framework/core/src/Extend/Csrf.php
+++ b/framework/core/src/Extend/Csrf.php
@@ -29,7 +29,7 @@ class Csrf implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.http.csrfExemptPaths', function ($existingExemptPaths) {
             return array_merge($existingExemptPaths, $this->csrfExemptRoutes);

--- a/framework/core/src/Extend/ErrorHandling.php
+++ b/framework/core/src/Extend/ErrorHandling.php
@@ -108,7 +108,7 @@ class ErrorHandling implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (count($this->statuses)) {
             $container->extend('flarum.error.statuses', function ($statuses) {

--- a/framework/core/src/Extend/Event.php
+++ b/framework/core/src/Extend/Event.php
@@ -56,7 +56,7 @@ class Event implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $events = $container->make(Dispatcher::class);
 

--- a/framework/core/src/Extend/ExtenderInterface.php
+++ b/framework/core/src/Extend/ExtenderInterface.php
@@ -14,5 +14,5 @@ use Illuminate\Contracts\Container\Container;
 
 interface ExtenderInterface
 {
-    public function extend(Container $container, Extension $extension = null): void;
+    public function extend(Container $container, ?Extension $extension = null): void;
 }

--- a/framework/core/src/Extend/Filesystem.php
+++ b/framework/core/src/Extend/Filesystem.php
@@ -77,7 +77,7 @@ class Filesystem implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.filesystem.disks', function ($existingDisks) use ($container) {
             foreach ($this->disks as $name => $disk) {

--- a/framework/core/src/Extend/Formatter.php
+++ b/framework/core/src/Extend/Formatter.php
@@ -116,7 +116,7 @@ class Formatter implements ExtenderInterface, LifecycleInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.formatter', function ($formatter, $container) {
             foreach ($this->configurationCallbacks as $callback) {

--- a/framework/core/src/Extend/Frontend.php
+++ b/framework/core/src/Extend/Frontend.php
@@ -101,7 +101,7 @@ class Frontend implements ExtenderInterface
      *
      * @return self
      */
-    public function route(string $path, string $name, callable|string $content = null): self
+    public function route(string $path, string $name, callable|string|null $content = null): self
     {
         $this->routes[] = compact('path', 'name', 'content');
 
@@ -217,7 +217,7 @@ class Frontend implements ExtenderInterface
         return $this->extraDocumentAttributes(['class' => $classes]);
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $this->registerAssets($container, $this->getModuleName($extension));
         $this->registerRoutes($container);

--- a/framework/core/src/Extend/LanguagePack.php
+++ b/framework/core/src/Extend/LanguagePack.php
@@ -36,7 +36,7 @@ class LanguagePack implements ExtenderInterface, LifecycleInterface
     ) {
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (is_null($extension)) {
             throw new InvalidArgumentException(

--- a/framework/core/src/Extend/Link.php
+++ b/framework/core/src/Extend/Link.php
@@ -36,7 +36,7 @@ class Link implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $siteUrl = $container->make(Config::class)->url();
 

--- a/framework/core/src/Extend/Locales.php
+++ b/framework/core/src/Extend/Locales.php
@@ -25,7 +25,7 @@ class Locales implements ExtenderInterface, LifecycleInterface
     ) {
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->resolving(
             LocaleManager::class,

--- a/framework/core/src/Extend/Mail.php
+++ b/framework/core/src/Extend/Mail.php
@@ -31,7 +31,7 @@ class Mail implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('mail.supported_drivers', function ($existingDrivers) {
             return array_merge($existingDrivers, $this->drivers);

--- a/framework/core/src/Extend/Middleware.php
+++ b/framework/core/src/Extend/Middleware.php
@@ -104,7 +104,7 @@ class Middleware implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend("flarum.$this->frontend.middleware", function ($existingMiddleware) {
             foreach ($this->addMiddlewares as $addMiddleware) {

--- a/framework/core/src/Extend/Model.php
+++ b/framework/core/src/Extend/Model.php
@@ -177,7 +177,7 @@ class Model implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         foreach ($this->customRelations as $name => $callback) {
             /** @var class-string<AbstractModel> $modelClass */

--- a/framework/core/src/Extend/ModelPrivate.php
+++ b/framework/core/src/Extend/ModelPrivate.php
@@ -65,7 +65,7 @@ class ModelPrivate implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (! class_exists($this->modelClass)) {
             return;

--- a/framework/core/src/Extend/ModelUrl.php
+++ b/framework/core/src/Extend/ModelUrl.php
@@ -41,7 +41,7 @@ class ModelUrl implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if ($this->slugDrivers) {
             $container->extend('flarum.http.slugDrivers', function ($existingDrivers) {

--- a/framework/core/src/Extend/ModelVisibility.php
+++ b/framework/core/src/Extend/ModelVisibility.php
@@ -92,7 +92,7 @@ class ModelVisibility implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (! class_exists($this->modelClass)) {
             return;

--- a/framework/core/src/Extend/Notification.php
+++ b/framework/core/src/Extend/Notification.php
@@ -71,7 +71,7 @@ class Notification implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.notification.blueprints', function ($existingBlueprints) {
             $existingBlueprints = array_merge($existingBlueprints, $this->blueprints);

--- a/framework/core/src/Extend/Policy.php
+++ b/framework/core/src/Extend/Policy.php
@@ -50,7 +50,7 @@ class Policy implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.policies', function ($existingPolicies) {
             foreach ($this->modelPolicies as $modelClass => $addPolicies) {

--- a/framework/core/src/Extend/Post.php
+++ b/framework/core/src/Extend/Post.php
@@ -31,7 +31,7 @@ class Post implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         foreach ($this->postTypes as $postType) {
             PostModel::setModel($postType::$type, $postType);

--- a/framework/core/src/Extend/Routes.php
+++ b/framework/core/src/Extend/Routes.php
@@ -169,7 +169,7 @@ class Routes implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (empty($this->routes) && empty($this->removedRoutes)) {
             return;

--- a/framework/core/src/Extend/SearchDriver.php
+++ b/framework/core/src/Extend/SearchDriver.php
@@ -131,7 +131,7 @@ class SearchDriver implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.search.drivers', function (array $oldDrivers) {
             $oldDrivers[$this->driverClass] = array_merge(

--- a/framework/core/src/Extend/SearchIndex.php
+++ b/framework/core/src/Extend/SearchIndex.php
@@ -30,7 +30,7 @@ class SearchIndex implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (empty($this->indexers)) {
             return;

--- a/framework/core/src/Extend/ServiceProvider.php
+++ b/framework/core/src/Extend/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $app = $container->make('flarum');
 

--- a/framework/core/src/Extend/Session.php
+++ b/framework/core/src/Extend/Session.php
@@ -34,7 +34,7 @@ class Session implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.session.drivers', function ($drivers) {
             return array_merge($drivers, $this->drivers);

--- a/framework/core/src/Extend/Settings.php
+++ b/framework/core/src/Extend/Settings.php
@@ -43,7 +43,7 @@ class Settings implements ExtenderInterface
      *
      * @return self
      */
-    public function serializeToForum(string $attributeName, string $key, callable|string $callback = null): self
+    public function serializeToForum(string $attributeName, string $key, callable|string|null $callback = null): self
     {
         $this->settings[$key] = compact('attributeName', 'callback');
 
@@ -94,7 +94,7 @@ class Settings implements ExtenderInterface
      *
      * @return self
      */
-    public function registerLessConfigVar(string $configName, string $key, callable|string $callback = null): self
+    public function registerLessConfigVar(string $configName, string $key, callable|string|null $callback = null): self
     {
         $this->lessConfigs[$configName] = compact('key', 'callback');
 
@@ -114,7 +114,7 @@ class Settings implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (! empty($this->defaults)) {
             $container->extend('flarum.settings.default', function (Collection $defaults) {

--- a/framework/core/src/Extend/Theme.php
+++ b/framework/core/src/Extend/Theme.php
@@ -48,7 +48,7 @@ class Theme implements ExtenderInterface
      * @param string|null $extensionId : If overriding an extension file, specify its ID, for example: `flarum-tags`.
      * @return self
      */
-    public function overrideFileSource(string $file, string $newFilePath, string $extensionId = null): self
+    public function overrideFileSource(string $file, string $newFilePath, ?string $extensionId = null): self
     {
         $this->fileSourceOverrides[] = compact('file', 'newFilePath', 'extensionId');
 
@@ -136,7 +136,7 @@ class Theme implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.frontend.custom_less_functions', function (array $customFunctions) {
             return array_merge($customFunctions, $this->customFunctions);

--- a/framework/core/src/Extend/ThrottleApi.php
+++ b/framework/core/src/Extend/ThrottleApi.php
@@ -59,7 +59,7 @@ class ThrottleApi implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.api.throttlers', function ($throttlers) use ($container) {
             $throttlers = array_diff_key($throttlers, array_flip($this->removeThrottlers));

--- a/framework/core/src/Extend/User.php
+++ b/framework/core/src/Extend/User.php
@@ -72,7 +72,7 @@ class User implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend('flarum.user.display_name.supported_drivers', function ($existingDrivers) {
             return array_merge($existingDrivers, $this->displayNameDrivers);

--- a/framework/core/src/Extend/Validator.php
+++ b/framework/core/src/Extend/Validator.php
@@ -48,7 +48,7 @@ class Validator implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->resolving($this->validatorClass, function ($validator, $container) {
             foreach ($this->configurationCallbacks as $callback) {

--- a/framework/core/src/Extend/View.php
+++ b/framework/core/src/Extend/View.php
@@ -64,7 +64,7 @@ class View implements ExtenderInterface, LifecycleInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->resolving(Factory::class, function (FactoryImplementation $view) {
             foreach ($this->namespaces as $namespace => $hints) {

--- a/framework/core/src/Extension/Exception/ExtensionBootError.php
+++ b/framework/core/src/Extension/Exception/ExtensionBootError.php
@@ -18,7 +18,7 @@ class ExtensionBootError extends Exception
     public function __construct(
         public Extension $extension,
         public object $extender,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         $extenderClass = $extender::class;
 

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -63,7 +63,7 @@ class Formatter
         $this->renderingCallbacks[] = $callback;
     }
 
-    public function parse(string $text, mixed $context = null, User $user = null): string
+    public function parse(string $text, mixed $context = null, ?User $user = null): string
     {
         $parser = $this->getParser($context);
 
@@ -81,7 +81,7 @@ class Formatter
         return $parser->parse($text);
     }
 
-    public function render(string $xml, mixed $context = null, ServerRequestInterface $request = null): string
+    public function render(string $xml, mixed $context = null, ?ServerRequestInterface $request = null): string
     {
         $renderer = $this->getRenderer();
 

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -57,7 +57,7 @@ class Application extends IlluminateContainer implements LaravelApplication
         return $config[$key] ?? $default;
     }
 
-    public function url(string $path = null): string
+    public function url(?string $path = null): string
     {
         $config = $this->make('flarum.config');
         $url = (string) $config->url();

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -101,7 +101,7 @@ class InfoCommand extends AbstractCommand
      * If the package seems to be a Git version, we extract the currently
      * checked out commit using the command line.
      */
-    private function findPackageVersion(string $path, string $fallback = null): ?string
+    private function findPackageVersion(string $path, ?string $fallback = null): ?string
     {
         if (file_exists("$path/.git")) {
             $cwd = getcwd();

--- a/framework/core/src/Foundation/DispatchEventsTrait.php
+++ b/framework/core/src/Foundation/DispatchEventsTrait.php
@@ -16,7 +16,7 @@ trait DispatchEventsTrait
     /**
      * Dispatch all events for an entity.
      */
-    public function dispatchEventsFor(mixed $entity, User $actor = null): void
+    public function dispatchEventsFor(mixed $entity, ?User $actor = null): void
     {
         if (! method_exists($entity, 'releaseEvents')) {
             throw new \InvalidArgumentException(

--- a/framework/core/src/Frontend/Assets.php
+++ b/framework/core/src/Frontend/Assets.php
@@ -86,7 +86,7 @@ class Assets
         $this->sources[$type][] = $callback;
     }
 
-    private function populate(CompilerInterface $compiler, string $type, string $locale = null): void
+    private function populate(CompilerInterface $compiler, string $type, ?string $locale = null): void
     {
         $compiler->addSources(function (SourceCollector $sources) use ($type, $locale) {
             foreach ($this->sources[$type] as $callback) {

--- a/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
+++ b/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
@@ -26,7 +26,7 @@ class SourceCollector
      */
     protected array $sources = [];
 
-    public function addFile(string $file, string $extensionId = null): static
+    public function addFile(string $file, ?string $extensionId = null): static
     {
         $this->sources[] = $this->validateSourceType(
             new FileSource($file, $extensionId)
@@ -44,7 +44,7 @@ class SourceCollector
         return $this;
     }
 
-    public function addDirectory(string $directory, string $extensionId = null): static
+    public function addDirectory(string $directory, ?string $extensionId = null): static
     {
         $this->sources[] = $this->validateSourceType(
             new DirectorySource($directory, $extensionId)

--- a/framework/core/src/Http/AccessToken.php
+++ b/framework/core/src/Http/AccessToken.php
@@ -107,7 +107,7 @@ class AccessToken extends AbstractModel
      * Update the time of last usage of a token.
      * If a request object is provided, the IP address and User Agent will also be logged.
      */
-    public function touch($attribute = null, ServerRequestInterface $request = null): bool
+    public function touch($attribute = null, ?ServerRequestInterface $request = null): bool
     {
         $now = Carbon::now();
 
@@ -192,7 +192,7 @@ class AccessToken extends AbstractModel
     /**
      * This query scope is intended to be used on the base AccessToken object to query for expired tokens of any type.
      */
-    public function scopeWhereExpired(Builder $query, Carbon $date = null): void
+    public function scopeWhereExpired(Builder $query, ?Carbon $date = null): void
     {
         if (is_null($date)) {
             $date = Carbon::now();

--- a/framework/core/src/Http/RouteHandlerFactory.php
+++ b/framework/core/src/Http/RouteHandlerFactory.php
@@ -66,12 +66,12 @@ class RouteHandlerFactory
         });
     }
 
-    public function toForum(string $content = null): Closure
+    public function toForum(?string $content = null): Closure
     {
         return $this->toFrontend('forum', $content);
     }
 
-    public function toAdmin(string $content = null): Closure
+    public function toAdmin(?string $content = null): Closure
     {
         return $this->toFrontend('admin', $content);
     }

--- a/framework/core/src/Install/Console/UserDataProvider.php
+++ b/framework/core/src/Install/Console/UserDataProvider.php
@@ -119,7 +119,7 @@ class UserDataProvider implements DataProviderInterface
         ];
     }
 
-    private function ask(string $question, string $default = null): mixed
+    private function ask(string $question, ?string $default = null): mixed
     {
         $question = new Question("<question>$question</question> ", $default);
 

--- a/framework/core/src/Locale/LocaleManager.php
+++ b/framework/core/src/Locale/LocaleManager.php
@@ -49,7 +49,7 @@ class LocaleManager
         return isset($this->locales[$locale]);
     }
 
-    public function addTranslations(string $locale, string $file, string $module = null): void
+    public function addTranslations(string $locale, string $file, ?string $module = null): void
     {
         $prefix = $module ? $module.'::' : '';
 

--- a/framework/core/src/Mail/FlarumLogTransport.php
+++ b/framework/core/src/Mail/FlarumLogTransport.php
@@ -19,7 +19,7 @@ class FlarumLogTransport extends LogTransport
     /**
      * {@inheritdoc}
      */
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         $string = $message->toString();
 

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -21,7 +21,7 @@ class Mailer extends IlluminateMailer
         string $name,
         Factory $views,
         TransportInterface $transport,
-        Dispatcher $events = null,
+        ?Dispatcher $events,
         protected SettingsRepositoryInterface $settings
     ) {
         parent::__construct($name, $views, $transport, $events);

--- a/framework/core/src/Mail/MutateEmail.php
+++ b/framework/core/src/Mail/MutateEmail.php
@@ -15,10 +15,12 @@ class MutateEmail
 {
     public function handle(MessageSending $event): bool
     {
-        if (! empty($event->data['unsubscribeLink'])) {
+        $unsubscribeLink = $event->data['unsubscribeLink'] ?? null;
+
+        if ($unsubscribeLink) {
             $headers = $event->message->getHeaders();
 
-            $headers->addTextHeader('List-Unsubscribe', '<'.$event->data['unsubscribeLink'].'>');
+            $headers->addTextHeader('List-Unsubscribe', '<'.$unsubscribeLink.'>');
         }
 
         return true;

--- a/framework/core/src/Mail/MutateEmail.php
+++ b/framework/core/src/Mail/MutateEmail.php
@@ -15,10 +15,10 @@ class MutateEmail
 {
     public function handle(MessageSending $event): bool
     {
-        if (! empty($link = $event->data['unsubscribeLink'])) {
+        if (! empty($event->data['unsubscribeLink'])) {
             $headers = $event->message->getHeaders();
 
-            $headers->addTextHeader('List-Unsubscribe', '<'.$link.'>');
+            $headers->addTextHeader('List-Unsubscribe', '<'.$event->data['unsubscribeLink'].'>');
         }
 
         return true;

--- a/framework/core/src/Post/DiscussionRenamedPost.php
+++ b/framework/core/src/Post/DiscussionRenamedPost.php
@@ -21,7 +21,7 @@ class DiscussionRenamedPost extends AbstractEventPost implements MergeableInterf
 {
     public static string $type = 'discussionRenamed';
 
-    public function saveAfter(Post $previous = null): static
+    public function saveAfter(?Post $previous = null): static
     {
         // If the previous post is another 'discussion renamed' post, and it's
         // by the same user, then we can merge this post into it. If we find

--- a/framework/core/src/Post/MergeableInterface.php
+++ b/framework/core/src/Post/MergeableInterface.php
@@ -26,5 +26,5 @@ interface MergeableInterface
      *     unsuccessful, this should be the current model instance. Otherwise,
      *     it should be the model that was merged into.
      */
-    public function saveAfter(Post $previous = null): static;
+    public function saveAfter(?Post $previous = null): static;
 }

--- a/framework/core/src/Post/PostRepository.php
+++ b/framework/core/src/Post/PostRepository.php
@@ -53,7 +53,7 @@ class PostRepository
      * Find posts that match certain conditions, optionally making sure they
      * are visible to a certain user, and/or using other criteria.
      */
-    public function findWhere(array $where = [], User $actor = null, array $sort = [], int $count = null, int $start = 0): Collection
+    public function findWhere(array $where = [], ?User $actor = null, array $sort = [], ?int $count = null, int $start = 0): Collection
     {
         $query = $this->queryVisibleTo($actor)
             ->where($where)
@@ -110,7 +110,7 @@ class PostRepository
      * @param int[] $ids
      * @return Builder<Post>
      */
-    protected function queryIds(array $ids, User $actor = null): Builder
+    protected function queryIds(array $ids, ?User $actor = null): Builder
     {
         return $this->queryVisibleTo($actor)->whereIn('posts.id', $ids);
     }

--- a/framework/core/src/User/AvatarValidator.php
+++ b/framework/core/src/User/AvatarValidator.php
@@ -90,7 +90,7 @@ class AvatarValidator extends AbstractValidator
         }
     }
 
-    protected function raise(string $error, array $parameters = [], string $rule = null): void
+    protected function raise(string $error, array $parameters = [], ?string $rule = null): void
     {
         // When we switched to intl ICU message format, the translation parameters
         // have become required to be in the format `{param}`.

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -650,7 +650,7 @@ class User extends AbstractModel
      *
      * @internal
      */
-    public static function registerPreference(string $key, callable $transformer = null, mixed $default = null): void
+    public static function registerPreference(string $key, ?callable $transformer = null, mixed $default = null): void
     {
         static::$preferences[$key] = compact('transformer', 'default');
     }

--- a/framework/core/src/User/UserRepository.php
+++ b/framework/core/src/User/UserRepository.php
@@ -33,7 +33,7 @@ class UserRepository
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail(int|string $id, User $actor = null): Model
+    public function findOrFail(int|string $id, ?User $actor = null): Model
     {
         $query = $this->query()->where('id', $id);
 
@@ -48,7 +48,7 @@ class UserRepository
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFailByUsername(string $username, User $actor = null): Model
+    public function findOrFailByUsername(string $username, ?User $actor = null): Model
     {
         $query = $this->query()->where('username', $username);
 
@@ -75,14 +75,14 @@ class UserRepository
         return $this->query()->where('email', $email)->first();
     }
 
-    public function getIdForUsername(string $username, User $actor = null): ?int
+    public function getIdForUsername(string $username, ?User $actor = null): ?int
     {
         $query = $this->query()->where('username', $username);
 
         return $this->scopeVisibleTo($query, $actor)->value('id');
     }
 
-    public function getIdsForUsernames(array $usernames, User $actor = null): array
+    public function getIdsForUsernames(array $usernames, ?User $actor = null): array
     {
         $query = $this->query()->whereIn('username', $usernames);
 
@@ -93,7 +93,7 @@ class UserRepository
      * Find users by matching a string of words against their username,
      * optionally making sure they are visible to a certain user.
      */
-    public function getIdsForUsername(string $string, User $actor = null): array
+    public function getIdsForUsername(string $string, ?User $actor = null): array
     {
         $string = $this->escapeLikeString($string);
 
@@ -107,7 +107,7 @@ class UserRepository
     /**
      * @return Builder<User>
      */
-    protected function scopeVisibleTo(Builder $query, User $actor = null): Builder
+    protected function scopeVisibleTo(Builder $query, ?User $actor = null): Builder
     {
         if ($actor !== null) {
             $query->whereVisibleTo($actor);

--- a/framework/core/tests/integration/api/users/GroupSearchTest.php
+++ b/framework/core/tests/integration/api/users/GroupSearchTest.php
@@ -210,7 +210,7 @@ class GroupSearchTest extends TestCase
         $this->assertEqualsCanonicalizing([1, 99, 4, 5, 6], array_column($responseBodyContents['included'], 'id'));
     }
 
-    private function createRequest(array $group, int $userId = null)
+    private function createRequest(array $group, ?int $userId = null)
     {
         $auth = $userId ? ['authenticatedAs' => $userId] : [];
 

--- a/framework/core/tests/integration/extenders/PostTest.php
+++ b/framework/core/tests/integration/extenders/PostTest.php
@@ -40,7 +40,7 @@ class PostTestCustomPost extends AbstractEventPost implements MergeableInterface
 {
     public static string $type = 'customPost';
 
-    public function saveAfter(Post $previous = null): static
+    public function saveAfter(?Post $previous = null): static
     {
         $this->save();
 

--- a/framework/core/tests/phpunit.integration.xml
+++ b/framework/core/tests/phpunit.integration.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnPhpunitDeprecation="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/framework/core/tests/phpunit.unit.xml
+++ b/framework/core/tests/phpunit.unit.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnPhpunitDeprecation="true"
     colors="true"
     processIsolation="false"
     stopOnFailure="false"

--- a/framework/core/tests/unit/Http/CookieFactoryTest.php
+++ b/framework/core/tests/unit/Http/CookieFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 
 class CookieFactoryTest extends TestCase
 {
-    protected function factory(array $config = null): CookieFactory
+    protected function factory(?array $config = null): CookieFactory
     {
         $config = new Config(array_merge([
             'url' => 'http://flarum.test'

--- a/framework/core/tests/unit/Locale/TranslatorTest.php
+++ b/framework/core/tests/unit/Locale/TranslatorTest.php
@@ -11,6 +11,7 @@ namespace Flarum\Tests\unit\Locale;
 
 use Flarum\Locale\Translator;
 use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 
@@ -23,7 +24,7 @@ class TranslatorTest extends TestCase
      * translator works in the same way as JS translator.
      */
 
-    /** @test */
+    #[Test]
     public function placeholders_encoding()
     {
         $translator = new Translator('en');
@@ -37,7 +38,7 @@ class TranslatorTest extends TestCase
         $this->assertSame("test1 test2 ' test2 test1", $translator->trans('test1', ['placeholder' => $translator->trans('test2', ['placeholder' => "'"])]));
     }
 
-    /** @test */
+    #[Test]
     public function missing_placeholders()
     {
         $translator = new Translator('en');
@@ -49,7 +50,7 @@ class TranslatorTest extends TestCase
         $this->assertSame('test1 {placeholder} test1', $translator->trans('test1', []));
     }
 
-    /** @test */
+    #[Test]
     public function escaped_placeholders()
     {
         $translator = new Translator('en');
@@ -61,7 +62,7 @@ class TranslatorTest extends TestCase
         $this->assertSame("test1 ' {placeholder} test1", $translator->trans('test3', ['placeholder' => "'"]));
     }
 
-    /** @test */
+    #[Test]
     public function plural_rules()
     {
         $translator = new Translator('en');
@@ -74,7 +75,7 @@ class TranslatorTest extends TestCase
         $this->assertSame('Page 2 - A & B', $translator->trans('test4', ['forumName' => 'A & B', 'pageNumber' => 2]));
     }
 
-    /** @test */
+    #[Test]
     public function plural_rules_2()
     {
         $translator = new Translator('pl');

--- a/php-packages/testing/src/integration/Extend/BeginTransactionAndSetDatabase.php
+++ b/php-packages/testing/src/integration/Extend/BeginTransactionAndSetDatabase.php
@@ -27,7 +27,7 @@ class BeginTransactionAndSetDatabase implements ExtenderInterface
         $this->setDbOnTestCase = $setDbOnTestCase;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         /** @var Connection $db */
         $db = $container->make(ConnectionInterface::class);

--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -27,7 +27,7 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
         $this->extensions = $extensions;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->when(ExtensionManagerIncludeCurrent::class)->needs('$enabledIds')->give($this->extensions);
         if (count($this->extensions)) {

--- a/php-packages/testing/src/integration/Extend/SetSettingsBeforeBoot.php
+++ b/php-packages/testing/src/integration/Extend/SetSettingsBeforeBoot.php
@@ -26,7 +26,7 @@ class SetSettingsBeforeBoot implements ExtenderInterface
         $this->settings = $settings;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         if (count($this->settings)) {
             $settings = $container->make(SettingsRepositoryInterface::class);

--- a/php-packages/testing/tests/tests/phpunit.integration.xml
+++ b/php-packages/testing/tests/tests/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"

--- a/php-packages/testing/tests/tests/phpunit.unit.xml
+++ b/php-packages/testing/tests/tests/phpunit.unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"


### PR DESCRIPTION
Adds PHP 8.4 Compatibility (fixes deprecations)

Primarily, PHP 8.4 deprecates arguments with a null default value but no nullable type. 