### PR TITLE
[1.x] fix: return empty object if selected mail driver is unavailable

### DIFF
--- a/framework/core/js/src/admin/components/MailPage.tsx
+++ b/framework/core/js/src/admin/components/MailPage.tsx
@@ -98,7 +98,7 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
 
   contentItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
-    const fields = this.driverFields![this.setting('mail_driver')()];
+    const fields = this.driverFields![this.setting('mail_driver')()] || {};
     const fieldKeys = Object.keys(fields);
 
     items.add(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

The email page is broken in the following scenario:
1. An extension is installed which adds a new email driver (e.g. https://github.com/glowingblue/flarum-ext-null-driver)
2. The new email driver is selected in the email page
3. The extension which added the new email driver is disabled/uninstalled
4. The email page is broken with the following error:

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at MailPage.contentItems (MailPage.tsx:102:30)
    ...
```

**Changes proposed in this pull request:**
Return an empty object if the previously selected mail driver is unavailable.

**Reviewers should focus on:**
While no driver is selected in the frontend after this change and the page is working again, `mail_driver` in the DB still has the previously selected driver as the value. What we **shouldn't** do here is change this to another valid driver in core (such as `log`) because extensions might remove existing core drivers.  Besides that, it will cause unexpected side effects.

The only thing that could be looked at is if this value should be reset to `NULL`. As I see it, resetting it to `NULL` would just be a cosmetic change, as Flarum doesn't error when trying to send emails using an inexistent driver (though perhaps it should?).

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
