### PR TITLE
[1.x] chore(core, tags): resolve `a11y` warnings in Admin Frontend

### DIFF
--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -16,7 +16,12 @@ function tagItem(tag) {
       <div className="TagListItem-info">
         {tagIcon(tag)}
         <span className="TagListItem-name">{tag.name()}</span>
-        <Button className="Button Button--link" icon="fas fa-pencil-alt" onclick={() => app.modal.show(EditTagModal, { model: tag })} />
+        <Button
+          className="Button Button--link"
+          icon="fas fa-pencil-alt"
+          aria-label={app.translator.trans('flarum-tags.admin.tags.edit_tag_label', { tag: tag.name() })}
+          onclick={() => app.modal.show(EditTagModal, { model: tag })}
+        />
       </div>
       {!tag.isChild() && tag.position() !== null && (
         <ol className="TagListItem-children TagList">

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -56,6 +56,7 @@ flarum-tags:
       about_tags_text: "Tags are used to categorize discussions. Primary tags are like traditional forum categories: they can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization."
       create_primary_tag_button: Create Primary Tag
       create_secondary_tag_button: Create Secondary Tag
+      edit_tag_label: Edit Tag {tag}
       primary_heading: Primary Tags
       secondary_heading: Secondary Tags
       settings_heading: Settings

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -57,7 +57,12 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
               <th>
                 {scope.label}{' '}
                 {!!scope.onremove && (
-                  <Button icon="fas fa-times" className="Button Button--text PermissionGrid-removeScope" onclick={scope.onremove} />
+                  <Button
+                    icon="fas fa-times"
+                    className="Button Button--text PermissionGrid-removeScope"
+                    aria-label={app.translator.trans('core.admin.permissions.remove_scope_label', { scope: scope.label })}
+                    onclick={scope.onremove}
+                  />
                 )}
               </th>
             ))}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -226,6 +226,7 @@ core:
       participate_heading: Participate
       post_without_throttle_label: Reply multiple times without waiting
       read_heading: Read
+      remove_scope_label: Remove scope of {scope}
       rename_discussions_label: Rename discussions
       reply_to_discussions_label: Reply to discussions
       search_users_label: => core.ref.search_users


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Progresses https://github.com/flarum/framework/issues/3360**
The Permission Scope Removal -and Edit Tag Buttons don't have content or an a11y label, which resulted in a bunch of warnings being logged in the console on those pages, which is a minor nuisance while developing/debugging the admin frontend.

<img width="1004" alt="Screenshot 2024-11-15 at 11 48 33" src="https://github.com/user-attachments/assets/bfd5f65a-26c1-4425-86e7-04fce0d79317">

**Changes proposed in this pull request:**
This PR adds the `aria-label` attribute to two different Buttons, which were the cause for the Flarum Accessibility Warnings and improves QOL for extension developers.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
