### PR TITLE
feat: allow adding endpoints before/after others

### DIFF
--- a/framework/core/src/Api/Endpoint/Endpoint.php
+++ b/framework/core/src/Api/Endpoint/Endpoint.php
@@ -148,6 +148,10 @@ class Endpoint implements \Tobyz\JsonApiServer\Endpoint\Endpoint
             return json_api_response($this->showResource($context, $data));
         }
 
+        if (is_array($data)) {
+            return json_api_response($data);
+        }
+
         return null;
     }
 }

--- a/framework/core/src/Extend/ApiResource.php
+++ b/framework/core/src/Extend/ApiResource.php
@@ -22,6 +22,8 @@ use Tobyz\JsonApiServer\Schema\Sort;
 class ApiResource implements ExtenderInterface
 {
     private array $endpoints = [];
+    private array $endpointsBefore = [];
+    private array $endpointsAfter = [];
     private array $removeEndpoints = [];
     private array $endpoint = [];
     private array $fields = [];
@@ -51,6 +53,45 @@ class ApiResource implements ExtenderInterface
     public function endpoints(callable|string $endpoints): self
     {
         $this->endpoints[] = $endpoints;
+
+        return $this;
+    }
+
+    /**
+     * Add endpoints to the resource before a certain endpoint.
+     *
+     * @param string $before the name of the endpoint to add the new endpoints before.
+     * @param callable|class-string $endpoints must be a callable that returns an array of objects that implement \Flarum\Api\Endpoint\Endpoint.
+     */
+    public function endpointsBefore(string $before, callable|string $endpoints): self
+    {
+        $this->endpointsBefore[] = [$before, $endpoints];
+
+        return $this;
+    }
+
+    /**
+     * Add endpoints to the resource after a certain endpoint.
+     *
+     * @param string $after the name of the endpoint to add the new endpoints after.
+     * @param callable|class-string $endpoints must be a callable that returns an array of objects that implement \Flarum\Api\Endpoint\Endpoint.
+     */
+    public function endpointsAfter(string $after, callable|string $endpoints): self
+    {
+        $this->endpointsAfter[] = [$after, $endpoints];
+
+        return $this;
+    }
+
+    /**
+     * Add endpoints to the resource before all other endpoints.
+     *
+     * @param string $after the name of the endpoint to add the new endpoints after.
+     * @param callable|class-string $endpoints must be a callable that returns an array of objects that implement \Flarum\Api\Endpoint\Endpoint.
+     */
+    public function endpointsBeforeAll(callable|string $endpoints): self
+    {
+        $this->endpointsBefore[] = [0, $endpoints];
 
         return $this;
     }
@@ -212,6 +253,31 @@ class ApiResource implements ExtenderInterface
                 foreach ($this->endpoints as $newEndpointsCallback) {
                     $newEndpointsCallback = ContainerUtil::wrapCallback($newEndpointsCallback, $container);
                     $endpoints = array_merge($endpoints, $newEndpointsCallback());
+                }
+
+                foreach ($this->endpointsBefore as [$before, $newEndpointsCallback]) {
+                    $newEndpointsCallback = ContainerUtil::wrapCallback($newEndpointsCallback, $container);
+
+                    if ($before === 0) {
+                        array_unshift($endpoints, ...$newEndpointsCallback());
+                    } else {
+                        $newEndpoints = $newEndpointsCallback();
+                        $beforeIndex = array_search($before, array_column($endpoints, 'name'));
+
+                        if ($beforeIndex !== false) {
+                            array_splice($endpoints, $beforeIndex, 0, $newEndpoints);
+                        }
+                    }
+                }
+
+                foreach ($this->endpointsAfter as [$after, $newEndpointsCallback]) {
+                    $newEndpointsCallback = ContainerUtil::wrapCallback($newEndpointsCallback, $container);
+                    $newEndpoints = $newEndpointsCallback();
+                    $afterIndex = array_search($after, array_column($endpoints, 'name'));
+
+                    if ($afterIndex !== false) {
+                        array_splice($endpoints, $afterIndex + 1, 0, $newEndpoints);
+                    }
                 }
 
                 foreach ($this->removeEndpoints as $removeEndpointClass) {

--- a/framework/core/src/Extend/ApiResource.php
+++ b/framework/core/src/Extend/ApiResource.php
@@ -86,7 +86,6 @@ class ApiResource implements ExtenderInterface
     /**
      * Add endpoints to the resource before all other endpoints.
      *
-     * @param string $after the name of the endpoint to add the new endpoints after.
      * @param callable|class-string $endpoints must be a callable that returns an array of objects that implement \Flarum\Api\Endpoint\Endpoint.
      */
     public function endpointsBeforeAll(callable|string $endpoints): self


### PR DESCRIPTION
Similar to https://github.com/flarum/framework/pull/4106

Adds:
* `endpointsBefore('name', fn () => [ ... ])`
* `endpointsAfter('name', fn () => [ ... ])`
* `endpointsBeforeAll(fn () => [ ... ])`

It is currently impossible to add certain endpoints without breaking existing ones. For example, if you have the following endpoints:

* `DELETE /api/discussions/{id}`

You would not be able to add custom endpoints with the following paths:

* `DELETE /api/discussions/all`

because the pattern which catches the `ID` for the existing endpoint would also catch `all`. But if the custom endpoint was added before the existing, the problem would be solved.

Of course another way to solve this would be to enforce that the `id` parameter is an integer:
* `DELETE /api/discussions/{id:\d+}`

but while that might be applicable for this example, other routes such as the `GET` one allow using slugs.
