### PR TITLE
[1.x] fix: change condition when `unread` label is shown in Scrubber

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -41,7 +41,7 @@ export default class PostStreamScrubber extends Component {
       const newStyle = {
         top: 100 - unreadPercent * 100 + '%',
         height: unreadPercent * 100 + '%',
-        opacity: unreadPercent ? 1 : 0,
+        opacity: unreadPercent > 0 ? 1 : 0,
       };
 
       if (vnode.state.oldStyle) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3838**

**Changes proposed in this pull request:**
- Only set opacity of `Scrubber-unread` to `1` if `unreadPercent` is greater then `0`.

**Reviewers should focus on:**
As discovered in #3838 and verified just now, `unreadPercent` evaluates to a negative value when composing a new post.  This is because `this.stream.index` returns unexpected values.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
