### PR TITLE
[1.x] chore: change private to protected, allowing extensibility

### DIFF
--- a/framework/core/src/Forum/Auth/ResponseFactory.php
+++ b/framework/core/src/Forum/Auth/ResponseFactory.php
@@ -62,7 +62,7 @@ class ResponseFactory
         ));
     }
 
-    private function makeResponse(array $payload): HtmlResponse
+    protected function makeResponse(array $payload): HtmlResponse
     {
         $content = sprintf(
             '<script>window.close(); window.opener.app.authenticationComplete(%s);</script>',
@@ -72,7 +72,7 @@ class ResponseFactory
         return new HtmlResponse($content);
     }
 
-    private function makeLoggedInResponse(User $user)
+    protected function makeLoggedInResponse(User $user)
     {
         $response = $this->makeResponse(['loggedIn' => true]);
 


### PR DESCRIPTION
Simply change `private` to `protected` so we can extend and replace `ResponseFactory` when required.

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
