### PR TITLE
fix(regression): improve discussion list item styling extensibility

### DIFF
--- a/framework/core/less/forum/DiscussionListItem.less
+++ b/framework/core/less/forum/DiscussionListItem.less
@@ -15,15 +15,24 @@
 .DiscussionListItem-content {
   position: relative;
   color: var(--muted-color);
-  display: grid;
-  grid-template-columns: auto minmax(50%, 1fr) auto;
+  display: flex;
   gap: 16px;
   padding: 12px 26px 12px 0;
+
+  > * {
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
 }
 .DiscussionListItem-main {
   color: inherit;
   text-decoration: none;
   display: block;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.DiscussionListItem-author {
+  position: relative;
 }
 .DiscussionListItem-author-avatar {
   display: block;
@@ -35,7 +44,7 @@
   pointer-events: none;
 
   position: absolute;
-  top: 0;
+  top: -14px;
   left: -2px;
 }
 .DiscussionListItem-title {
@@ -167,9 +176,9 @@
     }
   }
   .DiscussionListItem-badges {
-    width: 38px;
-    left: 19px;
-    top: -4px;
+    width: 48px;
+    left: -4px;
+    top: -15px;
 
     .badge {
       .Badge--size(20px);

--- a/framework/core/less/forum/DiscussionListPane.less
+++ b/framework/core/less/forum/DiscussionListPane.less
@@ -48,9 +48,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .DiscussionListItem-badges {
-      left: 12px;
-    }
   }
 }
 


### PR DESCRIPTION
Improves extensibility of the discussion list item's design.

In 2.0 we refactored it to using CSS grid. but that turns out to be a pain to deal with when adding for example gamification voting actions.

This PR switches it to using the simpler flexbox.