### PR TITLE
[1.x] fix(em): prevent major updater for pre-releases

### DIFF
--- a/extensions/package-manager/js/src/admin/components/Updater.tsx
+++ b/extensions/package-manager/js/src/admin/components/Updater.tsx
@@ -7,6 +7,7 @@ import MajorUpdater from './MajorUpdater';
 import ExtensionItem from './ExtensionItem';
 import { Extension } from 'flarum/admin/AdminApplication';
 import ItemList from 'flarum/common/utils/ItemList';
+import { isProductionReady } from '../utils/versions';
 
 export interface IUpdaterAttrs extends ComponentAttrs {}
 
@@ -24,7 +25,7 @@ export default class Updater extends Component<IUpdaterAttrs> {
         <div className="ExtensionManager-updaterControls">{this.controlItems().toArray()}</div>
         {this.availableUpdatesView()}
       </div>,
-      core && core.package['latest-major'] ? (
+      core && core.package['latest-major'] && isProductionReady(core.package['latest-major']) ? (
         <MajorUpdater coreUpdate={core.package} updateState={app.extensionManager.control.lastUpdateRun.major} />
       ) : null,
     ];

--- a/extensions/package-manager/js/src/admin/utils/versions.ts
+++ b/extensions/package-manager/js/src/admin/utils/versions.ts
@@ -1,0 +1,32 @@
+export enum VersionStability {
+  Stable = 'stable',
+  Alpha = 'alpha',
+  Beta = 'beta',
+  RC = 'rc',
+  Dev = 'dev',
+}
+
+export function isProductionReady(version: string): boolean {
+  return [VersionStability.Stable].includes(stability(version));
+}
+
+export function stability(version: string): VersionStability {
+  const split = version.split('-');
+
+  if (split.length === 1) {
+    return VersionStability.Stable;
+  }
+
+  const stab = split[1].split('.')[0].toLowerCase();
+
+  switch (stab) {
+    case 'alpha':
+      return VersionStability.Alpha;
+    case 'beta':
+      return VersionStability.Beta;
+    case 'rc':
+      return VersionStability.RC;
+    default:
+      return VersionStability.Dev;
+  }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Prevents the major updater in the extension manager from showing up to people for non-stable major releases (like 2.0.0-beta and such).

**Before**
![image](https://github.com/user-attachments/assets/73925982-57b1-45dd-a02c-95380bce475f)

**After**
![image](https://github.com/user-attachments/assets/b0971813-46c0-48fe-9633-da1e81cb4c64)
