### PR TITLE
feat: separate mariadb driver

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -94,7 +94,7 @@ jobs:
             driver: mysql
           - service: mariadb
             db: MariaDB
-            driver: mysql
+            driver: mariadb
           - service: 'mysql:8.1.0'
             db: MySQL 8.1
             driver: mysql

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -115,7 +115,7 @@ jobs:
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: mariadb
             db: MariaDB
-            driver: mysql
+            driver: mariadb
             prefix: flarum_
             prefixStr: (prefix)
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
@@ -154,14 +154,15 @@ jobs:
 
     services:
       mysql:
-        image: ${{ matrix.driver == 'mysql' && matrix.service || '' }}
+        image: ${{ (matrix.driver == 'mysql' && matrix.service) || ((matrix.driver == 'mariadb' && matrix.service) || '') }}
         env:
           MYSQL_DATABASE: ${{ env.DB_DATABASE }}
           MYSQL_USER: ${{ env.DB_USERNAME }}
           MYSQL_PASSWORD: ${{ env.DB_PASSWORD }}
-          MYSQL_ROOT_PASSWORD: ${{ env.DB_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: root
         ports:
-          - 13306:3306
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
       postgres:
         image: ${{ matrix.driver == 'pgsql' && matrix.service || '' }}
         env:
@@ -183,7 +184,10 @@ jobs:
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -194,11 +198,9 @@ jobs:
           tools: phpunit, composer:v2
           ini-values: ${{ matrix.php_ini_values }}
 
-      - name: Create MySQL Database
-        if: ${{ matrix.driver == 'mysql' }}
-        run: |
-          sudo systemctl start mysql
-          mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 13306
+      - name: Create ${{ matrix.db }} Database
+        if: ${{ matrix.driver == 'mysql' || matrix.driver == 'mariadb' }}
+        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -proot -e 'CREATE DATABASE flarum_test;'
 
       - name: Install Composer dependencies
         run: composer install
@@ -222,7 +224,7 @@ jobs:
           fi
         working-directory: ${{ inputs.backend_directory }}
         env:
-          DB_PORT: ${{ matrix.driver == 'mysql' && 13306 || 15432 }}
+          DB_PORT: ${{ matrix.driver == 'mysql' && 3306 || (matrix.driver == 'mariadb' && 3306 || 15432) }}
           DB_PREFIX: ${{ matrix.prefix }}
           DB_DRIVER: ${{ matrix.driver }}
           COMPOSER_PROCESS_TIMEOUT: 600
@@ -238,7 +240,7 @@ jobs:
       mysql:
         image: mysql:8.0.30
         ports:
-          - 33306:3306
+          - 3306
 
     name: 'PHPStan PHP ${{ matrix.php }}'
 
@@ -263,14 +265,12 @@ jobs:
         working-directory: ${{ inputs.backend_directory }}
 
       - name: Create MySQL Database
-        run: |
-          sudo systemctl start mysql
-          mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 33306
+        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -proot -e 'CREATE DATABASE flarum_test;'
 
       - name: Run PHPStan
         run: composer analyse:phpstan
         env:
-          DB_PORT: 33306
+          DB_PORT: 3306
           DB_PASSWORD: root
           COMPOSER_PROCESS_TIMEOUT: 600
           FLARUM_TEST_TMP_DIR_LOCAL: ./tmp

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -69,8 +69,8 @@ env:
   FLARUM_TEST_TMP_DIR_LOCAL: tests/integration/tmp
   COMPOSER_AUTH: ${{ secrets.composer_auth }}
   DB_DATABASE: flarum_test
-  DB_USERNAME: root
-  DB_PASSWORD: root
+  DB_USERNAME: flarum
+  DB_PASSWORD: password
 
 jobs:
   test:
@@ -154,7 +154,7 @@ jobs:
 
     services:
       mysql:
-        image: ${{ (matrix.driver == 'mysql' && matrix.service) || ((matrix.driver == 'mariadb' && matrix.service) || '') }}
+        image: ${{ matrix.driver == 'mysql' && matrix.service || '' }}
         env:
           MYSQL_DATABASE: ${{ env.DB_DATABASE }}
           MYSQL_USER: ${{ env.DB_USERNAME }}
@@ -163,6 +163,16 @@ jobs:
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
+      mariadb:
+        image: ${{ matrix.driver == 'mariadb' && matrix.service || '' }}
+        env:
+          MARIADB_DATABASE: ${{ env.DB_DATABASE }}
+          MARIADB_USER: ${{ env.DB_USERNAME }}
+          MARIADB_PASSWORD: ${{ env.DB_PASSWORD }}
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
         image: ${{ matrix.driver == 'pgsql' && matrix.service || '' }}
         env:
@@ -170,7 +180,7 @@ jobs:
           POSTGRES_USER: ${{ env.DB_USERNAME }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
         ports:
-          - 15432:5432
+          - 5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -198,10 +208,6 @@ jobs:
           tools: phpunit, composer:v2
           ini-values: ${{ matrix.php_ini_values }}
 
-      - name: Create ${{ matrix.db }} Database
-        if: ${{ matrix.driver == 'mysql' || matrix.driver == 'mariadb' }}
-        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -proot -e 'CREATE DATABASE flarum_test;'
-
       - name: Install Composer dependencies
         run: composer install
         working-directory: ${{ inputs.backend_directory }}
@@ -224,7 +230,8 @@ jobs:
           fi
         working-directory: ${{ inputs.backend_directory }}
         env:
-          DB_PORT: ${{ matrix.driver == 'mysql' && 3306 || (matrix.driver == 'mariadb' && 3306 || 15432) }}
+          DB_HOST: 127.0.0.1
+          DB_PORT: ${{ (matrix.driver == 'mysql' && job.services.mysql.ports['3306']) || (matrix.driver == 'mariadb' && job.services.mariadb.ports['3306']) || (matrix.driver == 'pgsql' && job.services.postgres.ports['5432']) }}
           DB_PREFIX: ${{ matrix.prefix }}
           DB_DRIVER: ${{ matrix.driver }}
           COMPOSER_PROCESS_TIMEOUT: 600
@@ -234,13 +241,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ${{ fromJSON(inputs.php_versions) }}
-
-    services:
-      mysql:
-        image: mysql:8.0.30
-        ports:
-          - 3306
+        php: ${{ fromJson(inputs.php_versions) }}
 
     name: 'PHPStan PHP ${{ matrix.php }}'
 
@@ -265,11 +266,14 @@ jobs:
         working-directory: ${{ inputs.backend_directory }}
 
       - name: Create MySQL Database
-        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -proot -e 'CREATE DATABASE flarum_test;'
+        run: |
+          sudo systemctl start mysql
+          mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 3306
 
       - name: Run PHPStan
         run: composer analyse:phpstan
         env:
+          DB_USERNAME: root
           DB_PORT: 3306
           DB_PASSWORD: root
           COMPOSER_PROCESS_TIMEOUT: 600

--- a/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
+++ b/extensions/statistics/src/Api/Controller/ShowStatisticsData.php
@@ -142,7 +142,7 @@ class ShowStatisticsData implements RequestHandlerInterface
         $dbFormattedDatetime = match ($query->getConnection()->getDriverName()) {
             'sqlite' => "strftime($format, $column)",
             'pgsql' => "TO_CHAR($column, $format)",
-            'mysql' => "DATE_FORMAT($column, $format)",
+            'mysql', 'mariadb' => "DATE_FORMAT($column, $format)",
             default => throw new Exception('Unsupported database driver'),
         };
 

--- a/framework/core/migrations/2018_01_11_120604_change_posts_table_to_innodb.php
+++ b/framework/core/migrations/2018_01_11_120604_change_posts_table_to_innodb.php
@@ -7,13 +7,14 @@
  * LICENSE file that was distributed with this source code.
  */
 
+use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
         $connection = $schema->getConnection();
 
-        if ($connection->getDriverName() === 'mysql') {
+        if ($connection->getDriverName() instanceof MySqlConnection) {
             $prefix = $connection->getTablePrefix();
             $connection->statement('ALTER TABLE '.$prefix.'posts ENGINE = InnoDB');
         }
@@ -22,7 +23,7 @@ return [
     'down' => function (Builder $schema) {
         $connection = $schema->getConnection();
 
-        if ($connection->getDriverName() === 'mysql') {
+        if ($connection->getDriverName() instanceof MySqlConnection) {
             $prefix = $connection->getTablePrefix();
             $connection->statement('ALTER TABLE '.$prefix.'posts ENGINE = MyISAM');
         }

--- a/framework/core/migrations/2024_05_05_000001_convert_preferences_to_json_in_users.php
+++ b/framework/core/migrations/2024_05_05_000001_convert_preferences_to_json_in_users.php
@@ -8,6 +8,7 @@
  */
 
 use Illuminate\Database\MariaDbConnection;
+use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -26,14 +27,16 @@ return [
                 $table->json('preferences_json')->nullable();
             });
 
-            if ($connection instanceof MariaDbConnection) {
-                $connection->table('users')->update([
-                    'preferences_json' => $connection->raw("IF(JSON_VALID(CONVERT($preferences USING utf8mb4)), CONVERT($preferences USING utf8mb4), NULL)"),
-                ]);
-            } elseif ($driver === 'mysql') {
-                $connection->table('users')->update([
-                    'preferences_json' => $connection->raw("CAST(CONVERT($preferences USING utf8mb4) AS JSON)"),
-                ]);
+            if ($connection instanceof MySqlConnection) {
+                if ($connection->isMaria()) {
+                    $connection->table('users')->update([
+                        'preferences_json' => $connection->raw("IF(JSON_VALID(CONVERT($preferences USING utf8mb4)), CONVERT($preferences USING utf8mb4), NULL)"),
+                    ]);
+                } else {
+                    $connection->table('users')->update([
+                        'preferences_json' => $connection->raw("CAST(CONVERT($preferences USING utf8mb4) AS JSON)"),
+                    ]);
+                }
             }
 
             $schema->table('users', function (Blueprint $table) {
@@ -60,7 +63,7 @@ return [
                 $table->binary('preferences_binary')->nullable();
             });
 
-            if ($driver === 'mysql') {
+            if ($connection instanceof MySqlConnection) {
                 $connection->table('users')->update([
                     'preferences_binary' => $connection->raw($preferences),
                 ]);

--- a/framework/core/migrations/2024_05_05_000001_convert_preferences_to_json_in_users.php
+++ b/framework/core/migrations/2024_05_05_000001_convert_preferences_to_json_in_users.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-use Illuminate\Database\MariaDbConnection;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;

--- a/framework/core/migrations/2024_05_07_000001_convert_data_to_json_in_notifications.php
+++ b/framework/core/migrations/2024_05_07_000001_convert_data_to_json_in_notifications.php
@@ -8,6 +8,7 @@
  */
 
 use Illuminate\Database\MariaDbConnection;
+use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
@@ -25,14 +26,16 @@ return [
                 $table->json('data_json')->nullable();
             });
 
-            if ($connection instanceof MariaDbConnection) {
-                $connection->table('notifications')->update([
-                    'data_json' => $connection->raw('IF(JSON_VALID(CONVERT(data USING utf8mb4)), CONVERT(data USING utf8mb4), NULL)'),
-                ]);
-            } elseif ($driver === 'mysql') {
-                $connection->table('notifications')->update([
-                    'data_json' => $connection->raw('CAST(CONVERT(data USING utf8mb4) AS JSON)'),
-                ]);
+            if ($connection instanceof MySqlConnection) {
+                if ($connection->isMaria()) {
+                    $connection->table('notifications')->update([
+                        'data_json' => $connection->raw('IF(JSON_VALID(CONVERT(data USING utf8mb4)), CONVERT(data USING utf8mb4), NULL)'),
+                    ]);
+                } else {
+                    $connection->table('notifications')->update([
+                        'data_json' => $connection->raw('CAST(CONVERT(data USING utf8mb4) AS JSON)'),
+                    ]);
+                }
             }
 
             $schema->table('notifications', function (Blueprint $table) {
@@ -58,7 +61,7 @@ return [
                 $table->binary('data_binary')->nullable();
             });
 
-            if ($driver === 'mysql') {
+            if ($connection instanceof MySqlConnection) {
                 $connection->table('notifications')->update([
                     'data_binary' => $connection->raw('data'),
                 ]);

--- a/framework/core/migrations/2024_05_07_000001_convert_data_to_json_in_notifications.php
+++ b/framework/core/migrations/2024_05_07_000001_convert_data_to_json_in_notifications.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-use Illuminate\Database\MariaDbConnection;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;

--- a/framework/core/migrations/mariadb-install.dump
+++ b/framework/core/migrations/mariadb-install.dump
@@ -1,0 +1,367 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `db_prefix_access_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_access_tokens` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `token` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `last_activity_at` datetime NOT NULL,
+  `created_at` datetime NOT NULL,
+  `type` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `title` varchar(150) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_ip_address` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_user_agent` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `db_prefix_access_tokens_token_unique` (`token`),
+  KEY `db_prefix_access_tokens_user_id_foreign` (`user_id`),
+  KEY `db_prefix_access_tokens_type_index` (`type`),
+  CONSTRAINT `db_prefix_access_tokens_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_api_keys`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_api_keys` (
+  `key` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `allowed_ips` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_id` int(10) unsigned DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `last_activity_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `db_prefix_api_keys_key_unique` (`key`),
+  KEY `db_prefix_api_keys_user_id_foreign` (`user_id`),
+  CONSTRAINT `db_prefix_api_keys_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_discussion_user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_discussion_user` (
+  `user_id` int(10) unsigned NOT NULL,
+  `discussion_id` int(10) unsigned NOT NULL,
+  `last_read_at` datetime DEFAULT NULL,
+  `last_read_post_number` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`discussion_id`),
+  KEY `db_prefix_discussion_user_discussion_id_foreign` (`discussion_id`),
+  CONSTRAINT `db_prefix_discussion_user_discussion_id_foreign` FOREIGN KEY (`discussion_id`) REFERENCES `db_prefix_discussions` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `db_prefix_discussion_user_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_discussions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_discussions` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comment_count` int(11) NOT NULL DEFAULT 1,
+  `participant_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_number_index` int(10) unsigned NOT NULL DEFAULT 0,
+  `created_at` datetime NOT NULL,
+  `user_id` int(10) unsigned DEFAULT NULL,
+  `first_post_id` int(10) unsigned DEFAULT NULL,
+  `last_posted_at` datetime DEFAULT NULL,
+  `last_posted_user_id` int(10) unsigned DEFAULT NULL,
+  `last_post_id` int(10) unsigned DEFAULT NULL,
+  `last_post_number` int(10) unsigned DEFAULT NULL,
+  `hidden_at` datetime DEFAULT NULL,
+  `hidden_user_id` int(10) unsigned DEFAULT NULL,
+  `slug` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `is_private` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `db_prefix_discussions_hidden_user_id_foreign` (`hidden_user_id`),
+  KEY `db_prefix_discussions_first_post_id_foreign` (`first_post_id`),
+  KEY `db_prefix_discussions_last_post_id_foreign` (`last_post_id`),
+  KEY `db_prefix_discussions_last_posted_at_index` (`last_posted_at`),
+  KEY `db_prefix_discussions_last_posted_user_id_index` (`last_posted_user_id`),
+  KEY `db_prefix_discussions_created_at_index` (`created_at`),
+  KEY `db_prefix_discussions_user_id_index` (`user_id`),
+  KEY `db_prefix_discussions_comment_count_index` (`comment_count`),
+  KEY `db_prefix_discussions_participant_count_index` (`participant_count`),
+  KEY `db_prefix_discussions_hidden_at_index` (`hidden_at`),
+  FULLTEXT KEY `title` (`title`),
+  CONSTRAINT `db_prefix_discussions_first_post_id_foreign` FOREIGN KEY (`first_post_id`) REFERENCES `db_prefix_posts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_discussions_hidden_user_id_foreign` FOREIGN KEY (`hidden_user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_discussions_last_post_id_foreign` FOREIGN KEY (`last_post_id`) REFERENCES `db_prefix_posts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_discussions_last_posted_user_id_foreign` FOREIGN KEY (`last_posted_user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_discussions_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_email_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_email_tokens` (
+  `token` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`token`),
+  KEY `db_prefix_email_tokens_user_id_foreign` (`user_id`),
+  CONSTRAINT `db_prefix_email_tokens_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_group_permission`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_group_permission` (
+  `group_id` int(10) unsigned NOT NULL,
+  `permission` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`group_id`,`permission`),
+  CONSTRAINT `db_prefix_group_permission_group_id_foreign` FOREIGN KEY (`group_id`) REFERENCES `db_prefix_groups` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_group_user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_group_user` (
+  `user_id` int(10) unsigned NOT NULL,
+  `group_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`user_id`,`group_id`),
+  KEY `db_prefix_group_user_group_id_foreign` (`group_id`),
+  CONSTRAINT `db_prefix_group_user_group_id_foreign` FOREIGN KEY (`group_id`) REFERENCES `db_prefix_groups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `db_prefix_group_user_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_groups`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_groups` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name_singular` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name_plural` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `color` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `icon` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `is_hidden` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_login_providers`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_login_providers` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL,
+  `provider` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identifier` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `last_login_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `db_prefix_login_providers_provider_identifier_unique` (`provider`,`identifier`),
+  KEY `db_prefix_login_providers_user_id_foreign` (`user_id`),
+  CONSTRAINT `db_prefix_login_providers_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_migrations` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `migration` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extension` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_notifications`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_notifications` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL,
+  `from_user_id` int(10) unsigned DEFAULT NULL,
+  `type` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_id` int(10) unsigned DEFAULT NULL,
+  `data` blob DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `is_deleted` tinyint(1) NOT NULL DEFAULT 0,
+  `read_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `db_prefix_notifications_from_user_id_foreign` (`from_user_id`),
+  KEY `db_prefix_notifications_user_id_index` (`user_id`),
+  CONSTRAINT `db_prefix_notifications_from_user_id_foreign` FOREIGN KEY (`from_user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_notifications_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_password_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_password_tokens` (
+  `token` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`token`),
+  KEY `db_prefix_password_tokens_user_id_foreign` (`user_id`),
+  CONSTRAINT `db_prefix_password_tokens_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_post_user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_post_user` (
+  `post_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `db_prefix_post_user_user_id_foreign` (`user_id`),
+  CONSTRAINT `db_prefix_post_user_post_id_foreign` FOREIGN KEY (`post_id`) REFERENCES `db_prefix_posts` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `db_prefix_post_user_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_posts` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `discussion_id` int(10) unsigned NOT NULL,
+  `number` int(10) unsigned DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `user_id` int(10) unsigned DEFAULT NULL,
+  `type` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT ' ',
+  `edited_at` datetime DEFAULT NULL,
+  `edited_user_id` int(10) unsigned DEFAULT NULL,
+  `hidden_at` datetime DEFAULT NULL,
+  `hidden_user_id` int(10) unsigned DEFAULT NULL,
+  `ip_address` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `is_private` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `db_prefix_posts_discussion_id_number_unique` (`discussion_id`,`number`),
+  KEY `db_prefix_posts_edited_user_id_foreign` (`edited_user_id`),
+  KEY `db_prefix_posts_hidden_user_id_foreign` (`hidden_user_id`),
+  KEY `db_prefix_posts_discussion_id_number_index` (`discussion_id`,`number`),
+  KEY `db_prefix_posts_discussion_id_created_at_index` (`discussion_id`,`created_at`),
+  KEY `db_prefix_posts_user_id_created_at_index` (`user_id`,`created_at`),
+  FULLTEXT KEY `content` (`content`),
+  CONSTRAINT `db_prefix_posts_discussion_id_foreign` FOREIGN KEY (`discussion_id`) REFERENCES `db_prefix_discussions` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `db_prefix_posts_edited_user_id_foreign` FOREIGN KEY (`edited_user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_posts_hidden_user_id_foreign` FOREIGN KEY (`hidden_user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `db_prefix_posts_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `db_prefix_users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_registration_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_registration_tokens` (
+  `token` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `provider` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_attributes` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_settings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_settings` (
+  `key` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `db_prefix_users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `db_prefix_users` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `is_email_confirmed` tinyint(1) NOT NULL DEFAULT 0,
+  `password` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `avatar_url` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `preferences` blob DEFAULT NULL,
+  `joined_at` datetime DEFAULT NULL,
+  `last_seen_at` datetime DEFAULT NULL,
+  `marked_all_as_read_at` datetime DEFAULT NULL,
+  `read_notifications_at` datetime DEFAULT NULL,
+  `discussion_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `comment_count` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `db_prefix_users_username_unique` (`username`),
+  UNIQUE KEY `db_prefix_users_email_unique` (`email`),
+  KEY `db_prefix_users_joined_at_index` (`joined_at`),
+  KEY `db_prefix_users_last_seen_at_index` (`last_seen_at`),
+  KEY `db_prefix_users_discussion_count_index` (`discussion_count`),
+  KEY `db_prefix_users_comment_count_index` (`comment_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+INSERT INTO `db_prefix_migrations` VALUES (1,'2015_02_24_000000_create_access_tokens_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (2,'2015_02_24_000000_create_api_keys_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (3,'2015_02_24_000000_create_config_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (4,'2015_02_24_000000_create_discussions_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (5,'2015_02_24_000000_create_email_tokens_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (6,'2015_02_24_000000_create_groups_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (7,'2015_02_24_000000_create_notifications_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (8,'2015_02_24_000000_create_password_tokens_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (9,'2015_02_24_000000_create_permissions_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (10,'2015_02_24_000000_create_posts_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (11,'2015_02_24_000000_create_users_discussions_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (12,'2015_02_24_000000_create_users_groups_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (13,'2015_02_24_000000_create_users_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (14,'2015_09_15_000000_create_auth_tokens_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (15,'2015_09_20_224327_add_hide_to_discussions',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (16,'2015_09_22_030432_rename_notification_read_time',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (17,'2015_10_07_130531_rename_config_to_settings',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (18,'2015_10_24_194000_add_ip_address_to_posts',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (19,'2015_12_05_042721_change_access_tokens_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (20,'2015_12_17_194247_change_settings_value_column_to_text',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (21,'2016_02_04_095452_add_slug_to_discussions',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (22,'2017_04_07_114138_add_is_private_to_discussions',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (23,'2017_04_07_114138_add_is_private_to_posts',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (24,'2018_01_11_093900_change_access_tokens_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (25,'2018_01_11_094000_change_access_tokens_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (26,'2018_01_11_095000_change_api_keys_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (27,'2018_01_11_101800_rename_auth_tokens_to_registration_tokens',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (28,'2018_01_11_102000_change_registration_tokens_rename_id_to_token',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (29,'2018_01_11_102100_change_registration_tokens_created_at_to_datetime',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (30,'2018_01_11_120604_change_posts_table_to_innodb',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (31,'2018_01_11_155200_change_discussions_rename_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (32,'2018_01_11_155300_change_discussions_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (33,'2018_01_15_071700_rename_users_discussions_to_discussion_user',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (34,'2018_01_15_071800_change_discussion_user_rename_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (35,'2018_01_15_071900_change_discussion_user_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (36,'2018_01_15_072600_change_email_tokens_rename_id_to_token',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (37,'2018_01_15_072700_change_email_tokens_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (38,'2018_01_15_072800_change_email_tokens_created_at_to_datetime',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (39,'2018_01_18_130400_rename_permissions_to_group_permission',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (40,'2018_01_18_130500_change_group_permission_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (41,'2018_01_18_130600_rename_users_groups_to_group_user',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (42,'2018_01_18_130700_change_group_user_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (43,'2018_01_18_133000_change_notifications_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (44,'2018_01_18_133100_change_notifications_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (45,'2018_01_18_134400_change_password_tokens_rename_id_to_token',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (46,'2018_01_18_134500_change_password_tokens_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (47,'2018_01_18_134600_change_password_tokens_created_at_to_datetime',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (48,'2018_01_18_135000_change_posts_rename_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (49,'2018_01_18_135100_change_posts_add_foreign_keys',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (50,'2018_01_30_112238_add_fulltext_index_to_discussions_title',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (51,'2018_01_30_220100_create_post_user_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (52,'2018_01_30_222900_change_users_rename_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (55,'2018_09_15_041340_add_users_indicies',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (56,'2018_09_15_041828_add_discussions_indicies',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (57,'2018_09_15_043337_add_notifications_indices',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (58,'2018_09_15_043621_add_posts_indices',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (59,'2018_09_22_004100_change_registration_tokens_columns',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (60,'2018_09_22_004200_create_login_providers_table',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (61,'2018_10_08_144700_add_shim_prefix_to_group_icons',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (62,'2019_10_12_195349_change_posts_add_discussion_foreign_key',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (63,'2020_03_19_134512_change_discussions_default_comment_count',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (64,'2020_04_21_130500_change_permission_groups_add_is_hidden',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (65,'2021_03_02_040000_change_access_tokens_add_type',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (66,'2021_03_02_040500_change_access_tokens_add_id',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (67,'2021_03_02_041000_change_access_tokens_add_title_ip_agent',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (68,'2021_04_18_040500_change_migrations_add_id_primary_key',NULL);
+INSERT INTO `db_prefix_migrations` VALUES (69,'2021_04_18_145100_change_posts_content_column_to_mediumtext',NULL);

--- a/framework/core/src/Database/DatabaseServiceProvider.php
+++ b/framework/core/src/Database/DatabaseServiceProvider.php
@@ -37,7 +37,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
 
             $config = $container['flarum']->config('database');
 
-            if ($config['driver'] === 'mysql') {
+            if (in_array($config['driver'], ['mysql', 'mariadb'])) {
                 $config['engine'] = 'InnoDB';
             } elseif ($config['driver'] === 'sqlite' && ! file_exists($config['database'])) {
                 $config['database'] = $container->make(Paths::class)->base.'/'.$config['database'];
@@ -85,6 +85,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
     {
         $drivers = [
             'mysql' => 'MySql',
+            'mariadb' => 'MariaDb',
             'pgsql' => 'PgSql',
             'sqlite' => 'Sqlite',
         ];

--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -33,7 +33,7 @@ class FulltextFilter extends AbstractFulltextFilter
     public function search(SearchState $state, string $value): void
     {
         match ($state->getQuery()->getConnection()->getDriverName()) {
-            'mysql' => $this->mysql($state, $value),
+            'mysql', 'mariadb' => $this->mysql($state, $value),
             'pgsql' => $this->pgsql($state, $value),
             'sqlite' => $this->sqlite($state, $value),
             default => throw new RuntimeException('Unsupported database driver: '.$state->getQuery()->getConnection()->getDriverName()),

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -71,7 +71,7 @@ class ApplicationInfoProvider
     public function identifyDatabaseVersion(): string
     {
         return match ($this->config['database.driver']) {
-            'mysql', 'pgsql' => $this->db->selectOne('select version() as version')->version,
+            'mysql', 'mariadb', 'pgsql' => $this->db->selectOne('select version() as version')->version,
             'sqlite' => $this->db->selectOne('select sqlite_version() as version')->version,
             default => 'Unknown',
         };
@@ -81,6 +81,7 @@ class ApplicationInfoProvider
     {
         return match ($this->config['database.driver']) {
             'mysql' => 'MySQL',
+            'mariadb' => 'MariaDB',
             'pgsql' => 'PostgreSQL',
             'sqlite' => 'SQLite',
             default => $this->config['database.driver'],

--- a/framework/core/src/Install/Console/UserDataProvider.php
+++ b/framework/core/src/Install/Console/UserDataProvider.php
@@ -43,14 +43,14 @@ class UserDataProvider implements DataProviderInterface
 
     private function getDatabaseConfiguration(): DatabaseConfig
     {
-        $driver = $this->ask('Database driver (mysql, sqlite, pgsql) (Default: mysql):', 'mysql');
+        $driver = $this->ask('Database driver (mysql, mariadb, sqlite, pgsql) (Default: mysql):', 'mysql');
         $port = match ($driver) {
-            'mysql' => 3306,
+            'mysql', 'mariadb' => 3306,
             'pgsql' => 5432,
             default => 0,
         };
 
-        if (in_array($driver, ['mysql', 'pgsql'])) {
+        if (in_array($driver, ['mysql', 'mariadb', 'pgsql'])) {
             $host = $this->ask('Database host (required):', required: true);
 
             if (Str::contains($host, ':')) {

--- a/framework/core/src/Install/Controller/InstallController.php
+++ b/framework/core/src/Install/Controller/InstallController.php
@@ -79,7 +79,7 @@ class InstallController implements RequestHandlerInterface
         $driver = Arr::get($input, 'dbDriver');
         $host = Arr::get($input, 'dbHost');
         $port = match ($driver) {
-            'mysql' => 3306,
+            'mysql', 'mariadb' => 3306,
             'pgsql' => 5432,
             default => 0,
         };

--- a/framework/core/src/Install/DatabaseConfig.php
+++ b/framework/core/src/Install/DatabaseConfig.php
@@ -42,15 +42,15 @@ class DatabaseConfig implements Arrayable
             throw new ValidationFailed('Please specify a database driver.');
         }
 
-        if (! in_array($this->driver, ['mysql', 'sqlite', 'pgsql'])) {
-            throw new ValidationFailed('Currently, only MySQL/MariaDB and SQLite are supported.');
+        if (! in_array($this->driver, ['mysql', 'mariadb', 'sqlite', 'pgsql'])) {
+            throw new ValidationFailed('Currently, only MySQL, MariaDB, SQLite and PostgreSQL are supported.');
         }
 
-        if (in_array($this->driver, ['mysql', 'pgsql']) && empty($this->host)) {
+        if (in_array($this->driver, ['mysql', 'mariadb', 'pgsql']) && empty($this->host)) {
             throw new ValidationFailed('Please specify the hostname of your database server.');
         }
 
-        if (in_array($this->driver, ['mysql', 'pgsql']) && ($this->port < 1 || $this->port > 65535)) {
+        if (in_array($this->driver, ['mysql', 'mariadb', 'pgsql']) && ($this->port < 1 || $this->port > 65535)) {
             throw new ValidationFailed('Please provide a valid port number between 1 and 65535.');
         }
 
@@ -58,7 +58,7 @@ class DatabaseConfig implements Arrayable
             throw new ValidationFailed('Please specify the database name.');
         }
 
-        if (in_array($this->driver, ['mysql', 'pgsql']) && empty($this->username)) {
+        if (in_array($this->driver, ['mysql', 'mariadb', 'pgsql']) && empty($this->username)) {
             throw new ValidationFailed('Please specify the username for accessing the database.');
         }
 
@@ -84,7 +84,7 @@ class DatabaseConfig implements Arrayable
     private function driverOptions(): array
     {
         return match ($this->driver) {
-            'mysql' => [
+            'mysql', 'mariadb' => [
                 'host' => $this->host,
                 'port' => $this->port,
                 'username' => $this->username,

--- a/framework/core/src/Post/Filter/FulltextFilter.php
+++ b/framework/core/src/Post/Filter/FulltextFilter.php
@@ -29,7 +29,7 @@ class FulltextFilter extends AbstractFulltextFilter
     public function search(SearchState $state, string $value): void
     {
         match ($state->getQuery()->getConnection()->getDriverName()) {
-            'mysql' => $this->mysql($state, $value),
+            'mysql', 'mariadb' => $this->mysql($state, $value),
             'pgsql' => $this->pgsql($state, $value),
             'sqlite' => $this->sqlite($state, $value),
             default => throw new RuntimeException('Unsupported database driver: '.$state->getQuery()->getConnection()->getDriverName()),

--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -25,6 +25,7 @@
       <label>Database Driver</label>
       <select class="FormControl" name="dbDriver">
         <option value="mysql">MySQL</option>
+        <option value="mariadb">MariaDB</option>
         <option value="pgsql">PostgreSQL</option>
         <option value="sqlite">SQLite</option>
       </select>
@@ -35,7 +36,7 @@
       <input class="FormControl" name="dbName" value="flarum">
     </div>
 
-    <div data-group="mysql,pgsql">
+    <div data-group="mysql,mariadb,pgsql">
       <div class="FormField">
         <label>Host</label>
         <input class="FormControl" name="dbHost" value="localhost">

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -41,7 +41,7 @@ class SetupScript
         $this->driver = getenv('DB_DRIVER') ?: 'mysql';
         $this->host = getenv('DB_HOST') ?: 'localhost';
         $this->port = intval(getenv('DB_PORT') ?: match ($this->driver) {
-            'mysql' => 3306,
+            'mysql', 'mariadb' => 3306,
             'pgsql' => 5432,
             default => 0,
         });


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
* Fixes checking of MariaDB in the migrations to using `->isMaria()`
* Adds `mariadb` as a separate database driver, laravel 11 has [done the same](https://github.com/laravel/framework/pull/50146) in order to more easily handle the growing differences between mysql and mariadb.
* This will not break things for instances using mariadb under the mysql driver. But we need to document switching to mariadb driver nonetheless.

**Screenshot**
![image](https://github.com/user-attachments/assets/9b41b341-21a2-4bb3-b05f-e34d6745cb8e)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
