### PR TITLE
chore: graceful failure from extend/override errors

### DIFF
--- a/framework/core/js/src/common/helpers/fireApplicationError.ts
+++ b/framework/core/js/src/common/helpers/fireApplicationError.ts
@@ -3,9 +3,9 @@ import app from '../app';
 /**
  * Fire a Flarum error which is shown in the JS console for everyone and in an alert for the admin.
  *
- * @param userTitle: a user friendly title of the error, should be localized.
- * @param consoleTitle: an error title that goes in the console, doesn't have to be localized.
- * @param error: the error.
+ * @param userTitle a user friendly title of the error, should be localized.
+ * @param consoleTitle an error title that goes in the console, doesn't have to be localized.
+ * @param error the error.
  */
 export default function fireApplicationError(userTitle: string, consoleTitle: string, error: any) {
   console.group(`%c${consoleTitle}`, 'background-color: #d83e3e; color: #ffffff; font-weight: bold;');

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -722,6 +722,7 @@ core:
       db_error_message: "Database query failed. This may be caused by an incompatibility between an extension and your database driver."
       dependent_extensions_message: "Cannot disable {extension} until the following dependent extensions are disabled: {extensions}"
       extension_initialiation_failed_message: "{extension} failed to initialize, check the browser console for further information."
+      extension_runtime_failed_message: "{extension} encountered an error while running. Check the browser console for further information."
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       generic_cross_origin_message: "Oops! Something went wrong during a cross-origin request. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"


### PR DESCRIPTION
**Changes proposed in this pull request:**
Reduces forum crashes by gracefully failing from extension logic errors within `extend` and `override` callbacks.

**Before**
![Screenshot from 2024-12-07 16-21-06](https://github.com/user-attachments/assets/87abe557-5008-415c-b8be-f5e0c98e540b)

**After**
![Screenshot from 2024-12-07 16-21-22](https://github.com/user-attachments/assets/05095396-0187-426c-bb9c-19d1c43908a7)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
