### PR TITLE
fix: fixed side nav missing top spacing

### DIFF
--- a/framework/core/less/common/sideNav.less
+++ b/framework/core/less/common/sideNav.less
@@ -64,6 +64,7 @@
     > ul {
       &.affix {
         top: var(--header-height);
+        margin-top: 30px;
       }
       > li {
         margin-bottom: 10px;


### PR DESCRIPTION
**Fixes #4122**

**Changes proposed in this pull request:**
The top margin was moved into a parent element, but still needed when the nav is fixed in position.

**Screenshot**
![image](https://github.com/user-attachments/assets/8e02d38e-07f2-4137-a177-e53a308290f1)
