### PR TITLE
fix: lazy module import always returns default module

### DIFF
--- a/framework/core/js/src/common/ExportRegistry.ts
+++ b/framework/core/js/src/common/ExportRegistry.ts
@@ -211,7 +211,16 @@ export default class ExportRegistry implements IExportRegistry, IChunkRegistry {
     // @ts-ignore
     const wr = this._webpack_runtimes[namespace] ?? __webpack_require__;
 
-    return await wr.e(module.chunkId).then(wr.bind(wr, module.moduleId));
+    return await wr
+      .e(module.chunkId)
+      .then(wr.bind(wr, module.moduleId))
+      .then(() => {
+        const m = this.get(namespace, id);
+
+        m.default ??= m;
+
+        return m;
+      });
   }
 
   public clear(): void {


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
A recent change before the beta.1 tag which fixed another code splitting issue, introduced an issue where if importing a module that belongs to a split chunk, it would always return the split chunk's default module instead.

Example: importing ReplyPlaceholder, would return PostStream