### PR TITLE
fix: code split fails with common module

### DIFF
--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -140,12 +140,12 @@ class RegisterAsyncChunksPlugin {
 
                     if (
                       !chunkModuleMemory[sourceChunkId].includes(urlPath) &&
-                      !RegisterAsyncChunksPlugin.registry[`${chunkId}:${moduleId}:${namespace}`]?.includes(urlPath)
+                      !RegisterAsyncChunksPlugin.registry[`${sourceChunkId}:${chunkId}:${moduleId}:${namespace}`]?.includes(urlPath)
                     ) {
                       reg.push(`flarum.reg.addChunkModule('${chunkId}', '${moduleId}', '${namespace}', '${urlPath}');`);
                       chunkModuleMemory[sourceChunkId].push(urlPath);
-                      RegisterAsyncChunksPlugin.registry[`${chunkId}:${moduleId}:${namespace}`] ||= [];
-                      RegisterAsyncChunksPlugin.registry[`${chunkId}:${moduleId}:${namespace}`].push(urlPath);
+                      RegisterAsyncChunksPlugin.registry[`${sourceChunkId}:${chunkId}:${moduleId}:${namespace}`] ||= [];
+                      RegisterAsyncChunksPlugin.registry[`${sourceChunkId}:${chunkId}:${moduleId}:${namespace}`].push(urlPath);
                     }
                   });
 


### PR DESCRIPTION
**Fixes #4144**

**Changes proposed in this pull request:**
This only happens when the common module is lazy loaded from both forum and admin frontends.
