### PR TITLE
fix: use correct human time format key

### DIFF
--- a/framework/core/js/src/common/utils/humanTime.ts
+++ b/framework/core/js/src/common/utils/humanTime.ts
@@ -24,7 +24,7 @@ export default function humanTime(time: dayjs.ConfigType): string {
     if (d.isSame(now, 'year')) {
       ago = app.translator.formatDateTime(d, 'core.lib.datetime_formats.humanTimeShort');
     } else {
-      ago = app.translator.formatDateTime(d, 'core.lib.datetime_formats.humanTimeFull');
+      ago = app.translator.formatDateTime(d, 'core.lib.datetime_formats.humanTimeLong');
     }
   } else {
     ago = d.fromNow();


### PR DESCRIPTION
**Before**
![image](https://github.com/user-attachments/assets/96a1ef02-6ee5-4393-ba83-6a0337691fe1)

**After**
![image](https://github.com/user-attachments/assets/f0bd9436-a7ab-4753-b3f8-eae1d29ef0f0)