### PR TITLE
fix: discussion posts not always properly loaded

### DIFF
--- a/framework/core/src/Api/Resource/PostResource.php
+++ b/framework/core/src/Api/Resource/PostResource.php
@@ -123,8 +123,9 @@ class PostResource extends AbstractDatabaseResource
             Endpoint\Index::make()
                 ->extractOffset(function (Context $context, array $defaultExtracts): int {
                     $queryParams = $context->request->getQueryParams();
+                    $near = intval(Arr::get($queryParams, 'page.near'));
 
-                    if (($near = Arr::get($queryParams, 'page.near')) > 1) {
+                    if ($near > 1) {
                         $sort = $defaultExtracts['sort'];
                         $filter = $defaultExtracts['filter'];
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4137**

**Changes proposed in this pull request:**
Since https://github.com/flarum/framework/pull/4067 we no longer expect the discussion show endpoint to return the page of posts. The frontend code was not adapted to that change.
