### PR TITLE
fix: discussion page renders before loading is finished

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -84,6 +84,10 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
   }
 
   view() {
+    if (this.loading || !this.discussion) {
+      return <LoadingIndicator />;
+    }
+
     return (
       <PageStructure
         className="DiscussionPage"


### PR DESCRIPTION
**Fixes #0000**

Since the PostStream component is now lazy loaded, the first discussion page access might error out as there is more time needed to actually start rendering the page. This PR adds a loading indicator to prevent early rendering.
