### PR TITLE
fix: custom styles from 1.x can crash the app

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ trim_trailing_whitespace = false
 [*.{php,xml,json}]
 indent_size = 4
 
-[{tsconfig.json,prettierrc.json}]
+[{tsconfig.json,prettierrc.json,package.json}]
 indent_size = 2
 
 [*.neon]

--- a/framework/core/js/src/admin/components/EditCustomCssModal.tsx
+++ b/framework/core/js/src/admin/components/EditCustomCssModal.tsx
@@ -1,7 +1,21 @@
 import app from '../../admin/app';
-import SettingsModal from './SettingsModal';
+import SettingsModal, { type ISettingsModalAttrs } from './SettingsModal';
+import Mithril from 'mithril';
 
 export default class EditCustomCssModal extends SettingsModal {
+  oninit(vnode: Mithril.Vnode<ISettingsModalAttrs, this>) {
+    super.oninit(vnode);
+
+    console.log(this.settings);
+
+    if (this.setting('custom_less_error')()) {
+      this.alertAttrs = {
+        type: 'error',
+        content: this.setting('custom_less_error')(),
+      };
+    }
+  }
+
   className() {
     return 'EditCustomCssModal TextareaCodeModal Modal--large';
   }

--- a/framework/core/js/src/admin/components/EditCustomCssModal.tsx
+++ b/framework/core/js/src/admin/components/EditCustomCssModal.tsx
@@ -6,8 +6,6 @@ export default class EditCustomCssModal extends SettingsModal {
   oninit(vnode: Mithril.Vnode<ISettingsModalAttrs, this>) {
     super.oninit(vnode);
 
-    console.log(this.settings);
-
     if (this.setting('custom_less_error')()) {
       this.alertAttrs = {
         type: 'error',

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -195,8 +195,8 @@ class ForumServiceProvider extends AbstractServiceProvider
                     $container->make('flarum.assets.forum'),
                     $container->make('flarum.locales'),
                     $container,
-                    $container->make('flarum.less.config'),
                     $container->make(SettingsRepositoryInterface::class),
+                    $container->make('flarum.less.config'),
                 );
                 $validator->whenSettingsSaved($event);
             }
@@ -209,8 +209,8 @@ class ForumServiceProvider extends AbstractServiceProvider
                     $container->make('flarum.assets.forum'),
                     $container->make('flarum.locales'),
                     $container,
-                    $container->make('flarum.less.config'),
                     $container->make(SettingsRepositoryInterface::class),
+                    $container->make('flarum.less.config'),
                 );
                 $validator->whenSettingsSaving($event);
             }

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -133,7 +133,7 @@ class ForumServiceProvider extends AbstractServiceProvider
                 $sources->addFile(__DIR__.'/../../less/forum.less');
                 $sources->addString(function () use ($container) {
                     return $container->make(SettingsRepositoryInterface::class)->get('custom_less', '');
-                });
+                }, 'custom_less');
             });
 
             $container->make(AddTranslations::class)->forFrontend('forum')->to($assets);
@@ -195,7 +195,8 @@ class ForumServiceProvider extends AbstractServiceProvider
                     $container->make('flarum.assets.forum'),
                     $container->make('flarum.locales'),
                     $container,
-                    $container->make('flarum.less.config')
+                    $container->make('flarum.less.config'),
+                    $container->make(SettingsRepositoryInterface::class),
                 );
                 $validator->whenSettingsSaved($event);
             }
@@ -208,7 +209,8 @@ class ForumServiceProvider extends AbstractServiceProvider
                     $container->make('flarum.assets.forum'),
                     $container->make('flarum.locales'),
                     $container,
-                    $container->make('flarum.less.config')
+                    $container->make('flarum.less.config'),
+                    $container->make(SettingsRepositoryInterface::class),
                 );
                 $validator->whenSettingsSaving($event);
             }

--- a/framework/core/src/Forum/ValidateCustomLess.php
+++ b/framework/core/src/Forum/ValidateCustomLess.php
@@ -32,7 +32,8 @@ class ValidateCustomLess
         protected Assets $assets,
         protected LocaleManager $locales,
         protected Container $container,
-        protected array $customLessSettings = []
+        protected array $customLessSettings = [],
+        protected SettingsRepositoryInterface $settings,
     ) {
     }
 
@@ -72,6 +73,8 @@ class ValidateCustomLess
         $adapter = new InMemoryFilesystemAdapter();
         $this->assets->setAssetsDir(new FilesystemAdapter(new Filesystem($adapter), $adapter));
 
+        $this->settings->delete('custom_less_error');
+
         try {
             $this->assets->makeCss()->commit();
 
@@ -80,6 +83,10 @@ class ValidateCustomLess
             }
         } catch (Less_Exception_Parser $e) {
             throw new ValidationException(['custom_less' => $e->getMessage()]);
+        }
+
+        if (! empty($this->settings->get('custom_less_error'))) {
+            throw new ValidationException(['custom_less' => $this->settings->get('custom_less_error')]);
         }
 
         $this->assets->setAssetsDir($assetsDir);

--- a/framework/core/src/Forum/ValidateCustomLess.php
+++ b/framework/core/src/Forum/ValidateCustomLess.php
@@ -32,8 +32,8 @@ class ValidateCustomLess
         protected Assets $assets,
         protected LocaleManager $locales,
         protected Container $container,
-        protected array $customLessSettings = [],
         protected SettingsRepositoryInterface $settings,
+        protected array $customLessSettings = [],
     ) {
     }
 

--- a/framework/core/src/Frontend/Compiler/RevisionCompiler.php
+++ b/framework/core/src/Frontend/Compiler/RevisionCompiler.php
@@ -13,6 +13,7 @@ use Flarum\Frontend\Compiler\Concerns\HasSources;
 use Flarum\Frontend\Compiler\Source\FileSource;
 use Flarum\Frontend\Compiler\Source\SourceInterface;
 use Flarum\Frontend\Compiler\Source\StringSource;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Filesystem\Cloud;
 
 /**
@@ -29,6 +30,7 @@ class RevisionCompiler implements CompilerInterface
     public function __construct(
         protected Cloud $assetsDir,
         protected string $filename,
+        protected SettingsRepositoryInterface $settings
     ) {
         $this->versioner = new FileVersioner($assetsDir);
     }

--- a/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
+++ b/framework/core/src/Frontend/Compiler/Source/SourceCollector.php
@@ -35,11 +35,17 @@ class SourceCollector
         return $this;
     }
 
-    public function addString(Closure $callback): static
+    public function addString(Closure $callback, ?string $key = null): static
     {
-        $this->sources[] = $this->validateSourceType(
+        $source = $this->validateSourceType(
             new StringSource($callback)
         );
+
+        if (! empty($key)) {
+            $this->sources[$key] = $source;
+        } else {
+            $this->sources[] = $source;
+        }
 
         return $this;
     }


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**
When upgrading from 1.x to 2.x, some instances will have custom less code that is no longer valid in 2.x, when that happens the upgraded instance will immediately crash.

This PR adds a safe guard to prevent crashes from invalid custom less code. It saves the error messages then displays it on the custom styles edit modal. Once the custom less is changed and saved, the new value is validated again and the error forgotten if valid.

![image](https://github.com/user-attachments/assets/43de8e1b-ad72-41ff-b993-758a45c5b11a)