### PR TITLE
fix: prevent users from seeing their own flags

### DIFF
--- a/extensions/flags/src/Access/ScopeFlagVisibility.php
+++ b/extensions/flags/src/Access/ScopeFlagVisibility.php
@@ -37,10 +37,8 @@ class ScopeFlagVisibility
                     if ($actor->hasPermission('discussion.viewFlags')) {
                         $query->orWhereDoesntHave('post.discussion.tags');
                     }
-                }
-
-                if (! $actor->hasPermission('discussion.viewFlags')) {
-                    $query->orWhere('flags.user_id', $actor->id);
+                } elseif (! $actor->hasPermission('discussion.viewFlags')) {
+                    $query->whereRaw('1 = 0');
                 }
             });
     }

--- a/extensions/flags/tests/integration/api/flags/ListTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListTest.php
@@ -96,7 +96,7 @@ class ListTest extends TestCase
     }
 
     #[Test]
-    public function regular_user_sees_own_flags_of_visible_posts()
+    public function regular_user_does_not_see_own_flags_of_visible_posts()
     {
         $response = $this->send(
             $this->request('GET', '/api/flags', [
@@ -109,7 +109,7 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
 
         $ids = Arr::pluck($data, 'id');
-        $this->assertEqualsCanonicalizing(['2', '4'], $ids);
+        $this->assertEqualsCanonicalizing([], $ids);
     }
 
     #[Test]

--- a/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
+++ b/extensions/flags/tests/integration/api/flags/ListWithTagsTest.php
@@ -122,7 +122,7 @@ class ListWithTagsTest extends TestCase
     }
 
     #[Test]
-    public function regular_user_sees_own_flags()
+    public function regular_user_does_not_see_own_flags()
     {
         $response = $this->send(
             $this->request('GET', '/api/flags', [
@@ -135,7 +135,7 @@ class ListWithTagsTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
 
         $ids = Arr::pluck($data, 'id');
-        $this->assertEqualsCanonicalizing(['2', '4'], $ids);
+        $this->assertEqualsCanonicalizing([], $ids);
     }
 
     #[Test]

--- a/extensions/flags/tests/integration/api/posts/IncludeFlagsVisibilityTest.php
+++ b/extensions/flags/tests/integration/api/posts/IncludeFlagsVisibilityTest.php
@@ -144,7 +144,7 @@ class IncludeFlagsVisibilityTest extends TestCase
             'user_with_general_permission_sees_where_unrestricted_tag' => [2, [6, 7, 8]],
             'user_with_tag1_permission_sees_tag1_flags' => [3, [1, 2, 3, 4, 5]],
             'normal_user_sees_none' => [4, []],
-            'normal_user_sees_own' => [5, [2, 7, 4, 8]],
+            'normal_user_does_not_see_own' => [5, []],
         ];
     }
 }


### PR DESCRIPTION
**Fixes #4163**

**Changes proposed in this pull request:**
In 1.x you could not see your own flag, changes made in 2.x have unintentionally made it so that you can. That is because while 1.x allows seeing one's own flags in the API, it explicitly hides them in the UI.

Looking at the git history, the additional "see own flags" query scope seems to have been a mistake addition. Flags were never shown to the flag creator prior to that.