### PR TITLE
[1.x] fix(tags): sanitize page param in `Tag`

### DIFF
--- a/extensions/tags/src/Content/Tag.php
+++ b/extensions/tags/src/Content/Tag.php
@@ -69,7 +69,7 @@ class Tag
         $slug = Arr::pull($queryParams, 'slug');
         $sort = Arr::pull($queryParams, 'sort');
         $q = Arr::pull($queryParams, 'q', '');
-        $page = Arr::pull($queryParams, 'page', 1);
+        $page = max(1, intval(Arr::pull($queryParams, 'page')));
         $filters = Arr::pull($queryParams, 'filter', []);
 
         $sortMap = $this->getSortMap();


### PR DESCRIPTION
Fix errors for requests like `https://discuss.flarum.org/t/sandbox?page=%27nvOpzp;%20AND%201=1%20OR%20(%3C%27%22%3EiKO))`

```
PHP Warning:  A non-numeric value encountered in vendor/flarum/tags/src/Content/Tag.php on line 84
```

Uses the same solution as in:
https://github.com/flarum/framework/blob/1d27f62c15b569f4cd74a24fc38a636d34933f9f/framework/core/src/Forum/Content/Index.php#L70