### PR TITLE
[1.x] refactor(core): make search debounce time extensible

### DIFF
--- a/framework/core/js/src/forum/components/Search.tsx
+++ b/framework/core/js/src/forum/components/Search.tsx
@@ -60,6 +60,11 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
   protected static MIN_SEARCH_LEN = 3;
 
   /**
+   * Time to wait (in milliseconds) after the user stops typing before triggering a search.
+   */
+  protected static SEARCH_DEBOUNCE_TIME_MS = 250;
+
+  /**
    * The instance of `SearchState` for this component.
    */
   protected searchState!: SearchState;
@@ -258,7 +263,7 @@ export default class Search<T extends SearchAttrs = SearchAttrs> extends Compone
 
           state.cache(query);
           m.redraw();
-        }, 250);
+        }, (search.constructor as typeof Search).SEARCH_DEBOUNCE_TIME_MS);
       })
 
       .on('focus', function () {


### PR DESCRIPTION
`1.x` equivalent to https://github.com/flarum/framework/pull/4172

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Third-party extensions might want to adjust the search debounce time. Currently, it's very hard to customize this value.

**Changes proposed in this pull request:**
Create a new constant `SEARCH_DEBOUNCE_TIME_MS` for the search debounce timeout. Allows to third-party extensions to easily customize this value.

**Reviewers should focus on:**
Behaviour is the same as previously

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
