### PR TITLE
refactor(core): make search debounce time extensible

### DIFF
--- a/framework/core/js/src/common/SearchManager.ts
+++ b/framework/core/js/src/common/SearchManager.ts
@@ -8,6 +8,11 @@ export default class SearchManager<State extends SearchState = SearchState> {
   public static MIN_SEARCH_LEN = 3;
 
   /**
+   * Time to wait (in milliseconds) after the user stops typing before triggering a search.
+   */
+  public static SEARCH_DEBOUNCE_TIME_MS = 250;
+
+  /**
    * An object which stores previously searched queries and provides convenient
    * tools for retrieving and managing search values.
    */

--- a/framework/core/js/src/common/components/SearchModal.tsx
+++ b/framework/core/js/src/common/components/SearchModal.tsx
@@ -324,7 +324,7 @@ export default class SearchModal<CustomAttrs extends ISearchModalAttrs = ISearch
 
       this.searchState.cache(query);
       m.redraw();
-    }, 250);
+    }, SearchManager.SEARCH_DEBOUNCE_TIME_MS);
   }
 
   /**


### PR DESCRIPTION
`2.x` equivalent to https://github.com/flarum/framework/pull/4171
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Third-party extensions might want to adjust the search debounce time. Currently, it's very hard to customize this value.

**Changes proposed in this pull request:**
Create a new constant `SEARCH_DEBOUNCE_TIME_MS` for the search debounce timeout. Allows to third-party extensions to easily customize this value.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
