### PR TITLE
[1.x] fix(em): skip incompatible extension updates

### DIFF
--- a/extensions/package-manager/src/Command/CheckForUpdatesHandler.php
+++ b/extensions/package-manager/src/Command/CheckForUpdatesHandler.php
@@ -9,12 +9,15 @@
 
 namespace Flarum\ExtensionManager\Command;
 
+use Composer\Semver\Semver;
 use Flarum\Extension\ExtensionManager;
 use Flarum\ExtensionManager\Composer\ComposerAdapter;
 use Flarum\ExtensionManager\Composer\ComposerJson;
 use Flarum\ExtensionManager\Exception\ComposerCommandFailedException;
 use Flarum\ExtensionManager\Settings\LastUpdateCheck;
 use Flarum\ExtensionManager\Support\Util;
+use Flarum\Foundation\Application;
+use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\ArrayInput;
 
@@ -40,12 +43,20 @@ class CheckForUpdatesHandler
      */
     protected $composerJson;
 
-    public function __construct(ComposerAdapter $composer, LastUpdateCheck $lastUpdateCheck, ExtensionManager $extensions, ComposerJson $composerJson)
+    /**
+     * @var Client
+     */
+    protected $http;
+
+    protected $meta = [];
+
+    public function __construct(ComposerAdapter $composer, LastUpdateCheck $lastUpdateCheck, ExtensionManager $extensions, ComposerJson $composerJson, Client $http)
     {
         $this->composer = $composer;
         $this->lastUpdateCheck = $lastUpdateCheck;
         $this->extensions = $extensions;
         $this->composerJson = $composerJson;
+        $this->http = $http;
     }
 
     /**
@@ -116,6 +127,10 @@ class CheckForUpdatesHandler
 
             $mainPackageUpdate['required-as'] = $composerJson['require'][$mainPackageUpdate['name']] ?? null;
 
+            if (! $this->compatibleWithCurrentFlarumVersion($mainPackageUpdate)) {
+                continue;
+            }
+
             $updates->push($mainPackageUpdate);
         }
 
@@ -154,5 +169,50 @@ class CheckForUpdatesHandler
         }
 
         return $output->getContents();
+    }
+
+    private function compatibleWithCurrentFlarumVersion(array $mainPackageUpdate): bool
+    {
+        if (empty($mainPackageUpdate['latest-major']) || str_contains($mainPackageUpdate['latest-major'], 'dev-')) {
+            return true;
+        }
+
+        if (! empty($this->meta[$mainPackageUpdate['name']])) {
+            $json = $this->meta[$mainPackageUpdate['name']];
+        } else {
+            $response = $this->http->get("https://repo.packagist.org/p2/{$mainPackageUpdate['name']}.json");
+
+            $body = $response->getBody()->getContents();
+
+            if ($response->getStatusCode() > 299 || $response->getStatusCode() < 200) {
+                return true;
+            }
+
+            $json = json_decode($body, true);
+
+            $this->meta[$mainPackageUpdate['name']] = $json;
+        }
+
+        $packages = Collection::make($json['packages'][$mainPackageUpdate['name']] ?? []);
+
+        if ($packages->isEmpty()) {
+            return true;
+        }
+
+        $package = $packages->firstWhere('version', $mainPackageUpdate['latest-major']);
+
+        if (! $package) {
+            return true;
+        }
+
+        $flarumVersion = Application::VERSION;
+
+        $require = $package['require']['flarum/core'] ?? null;
+
+        if (! $require || str_contains($require, 'dev-')) {
+            return true;
+        }
+
+        return Semver::satisfies($flarumVersion, $require);
     }
 }

--- a/extensions/package-manager/src/Support/Util.php
+++ b/extensions/package-manager/src/Support/Util.php
@@ -29,6 +29,9 @@ class Util
         if (str_starts_with($currentVersion, 'v')) {
             $currentVersion = substr($currentVersion, 1);
         }
+        if (str_starts_with($latestVersion, 'v')) {
+            $latestVersion = substr($latestVersion, 1);
+        }
 
         $currentVersion = explode('.', $currentVersion);
         $latestVersion = explode('.', $latestVersion);


### PR DESCRIPTION
**https://discuss.flarum.org/d/36867-issue-extension-manager-v106-update-not-installable**

As extensions get updated for 2.0, the package manager is currently showing 2.0-compatible extension versions as updates available, even though they are not compatible with 1.x, this creates a lot of confusion and questions about why they can't update when trying to.

This PR adds an additional check, comparing the current app version with the extension's flarum/core requirement.