### PR TITLE
perf: optimize querying post index

### DIFF
--- a/framework/core/src/Api/Resource/PostResource.php
+++ b/framework/core/src/Api/Resource/PostResource.php
@@ -129,16 +129,16 @@ class PostResource extends AbstractDatabaseResource
                         $sort = $defaultExtracts['sort'];
                         $filter = $defaultExtracts['filter'];
 
-                        if (count($filter) > 1 || ! isset($filter['discussion']) || $sort) {
+                        if (count($filter) > 1 || ! isset($filter['discussion']) || ($sort && $sort !== ['number' => 'asc'])) {
                             throw new BadRequestException(
                                 'You can only use page[near] with filter[discussion] and the default sort order'
                             );
                         }
 
                         $limit = $defaultExtracts['limit'];
-                        $offset = $this->posts->getIndexForNumber((int) $filter['discussion'], $near, $context->getActor());
+                        $index = $this->posts->getIndexForNumber((int) $filter['discussion'], $near, $context->getActor());
 
-                        return max(0, $offset - $limit / 2);
+                        return max(0, $index - $limit / 2);
                     }
 
                     return $defaultExtracts['offset'];
@@ -150,6 +150,7 @@ class PostResource extends AbstractDatabaseResource
                     'hiddenUser',
                     'discussion'
                 ])
+                ->defaultSort('number')
                 ->paginate(static::$defaultLimit),
         ];
     }

--- a/framework/core/src/Post/PostRepository.php
+++ b/framework/core/src/Post/PostRepository.php
@@ -85,23 +85,15 @@ class PostRepository
      */
     public function getIndexForNumber(int $discussionId, int $number, ?User $actor = null): int
     {
+        /** @var Discussion $discussion */
         if (! ($discussion = Discussion::find($discussionId))) {
             return 0;
         }
 
         $query = $discussion->posts()
             ->whereVisibleTo($actor)
-            ->where('created_at', '<', function ($query) use ($discussionId, $number) {
-                $query->select('created_at')
-                    ->from('posts')
-                    ->where('discussion_id', $discussionId)
-                    ->whereNotNull('number')
-                    ->take(1)
-
-                    // We don't add $number as a binding because for some
-                    // reason doing so makes the bindings go out of order.
-                    ->orderByRaw('ABS(CAST(number AS SIGNED) - '.(int) $number.')');
-            });
+            ->where('number', '<=', $number)
+            ->orderBy('number');
 
         return $query->count();
     }

--- a/framework/core/src/Post/PostRepository.php
+++ b/framework/core/src/Post/PostRepository.php
@@ -85,8 +85,7 @@ class PostRepository
      */
     public function getIndexForNumber(int $discussionId, int $number, ?User $actor = null): int
     {
-        /** @var Discussion $discussion */
-        if (! ($discussion = Discussion::find($discussionId))) {
+        if (! ($discussion = Discussion::query()->find($discussionId))) {
             return 0;
         }
 


### PR DESCRIPTION
**Fixes #3895**

This PR changes the query responsible for getting the **index** of a post in the database.

**Changes proposed in this pull request:**
When the original query was first written, the ordering of posts in a discussion was by creation time (`created_at`) which explains why the query is structured the way it was.

We have however since changed to exclusively sorting by post number to simplify things: https://github.com/flarum/framework/pull/3282

We can safely change the mentioned query to a simpler version that only relies on the post number, which is a lot more simple and light for the database to handle.

For context, we just count the amount of posts that exist before the post number in question, which gives us the database index of the row.

Found out about this while making https://github.com/flarum/framework/pull/4175