### PR TITLE
fix(webpack): chunk module path checking fails with dotted directories

### DIFF
--- a/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
+++ b/js-packages/webpack-config/src/RegisterAsyncChunksPlugin.cjs
@@ -81,10 +81,13 @@ class RegisterAsyncChunksPlugin {
                   const chunkModules = (c) => Array.from(compilation.chunkGraph.getChunkModulesIterable(c));
 
                   const relevantChunk = chunks.find((chunk) =>
-                    chunkModules(chunk)?.find(
-                      (module) =>
-                        module.resource?.split('.')[0] === importPathResolved || module.rootModule?.resource?.split('.')[0] === importPathResolved
-                    )
+                    chunkModules(chunk)?.find((module) => {
+                      const resourceWithoutExt = module.resource ? module.resource.replace(path.extname(module.resource), '') : '';
+                      const rootResourceWithoutExt = module.rootModule?.resource
+                        ? module.rootModule.resource.replace(path.extname(module.rootModule.resource), '')
+                        : '';
+                      return resourceWithoutExt === importPathResolved || rootResourceWithoutExt === importPathResolved;
+                    })
                   );
 
                   if (!relevantChunk) {
@@ -94,7 +97,11 @@ class RegisterAsyncChunksPlugin {
 
                   const relevantChunkModules = chunkModules(relevantChunk);
                   const mainModule = relevantChunkModules.filter((m) => {
-                    return m.resource?.split('.')[0] === importPathResolved || m.rootModule?.resource?.split('.')[0] === importPathResolved;
+                    const resourceWithoutExt = m.resource ? m.resource.replace(path.extname(m.resource), '') : '';
+                    const rootResourceWithoutExt = m.rootModule?.resource
+                      ? m.rootModule.resource.replace(path.extname(m.rootModule.resource), '')
+                      : '';
+                    return resourceWithoutExt === importPathResolved || rootResourceWithoutExt === importPathResolved;
                   })[0];
                   const otherRelevantChunkModules = relevantChunkModules.filter((m) => m !== mainModule);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Resolves issues when the path contains unexpected dots. Also see https://discuss.flarum.org/d/36971-issues-developing-2x-locally



**Changes proposed in this pull request:**
Change algorithm for resolving chunks for code splitting in dev mode. GPT'd my way through resolving this issue... No idea if those changes introduced here are actually good or not / also work on other operating systems etc. 

Feel free to close this PR and create a new one if this can be done better

**Reviewers should focus on:**
Leaving this PR as draft because I'm not too confident about this, but in theory, it would be ready for review

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
