### PR TITLE
refactor(core): allow labels of `PostStreamScrubber` to be customized

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -65,7 +65,7 @@ export default class PostStreamScrubber extends Component {
         <div className="Dropdown-menu dropdown-menu">
           <div className="Scrubber">
             <Button className="Scrubber-first Button Button--link" onclick={this.goToFirst.bind(this)} icon="fas fa-angle-double-up">
-              {app.translator.trans('core.forum.post_scrubber.original_post_link')}
+              {this.firstPostLabel()}
             </Button>
 
             <div className="Scrubber-scrollbar">
@@ -80,17 +80,29 @@ export default class PostStreamScrubber extends Component {
               <div className="Scrubber-after" />
 
               <div className="Scrubber-unread" oncreate={styleUnread} onupdate={styleUnread}>
-                {app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount })}
+                {this.unreadLabel(unreadCount)}
               </div>
             </div>
 
             <Button className="Scrubber-last Button Button--link" onclick={this.goToLast.bind(this)} icon="fas fa-angle-double-down">
-              {app.translator.trans('core.forum.post_scrubber.now_link')}
+              {this.lastPostLabel()}
             </Button>
           </div>
         </div>
       </div>
     );
+  }
+
+  firstPostLabel() {
+    return app.translator.trans('core.forum.post_scrubber.original_post_link');
+  }
+
+  unreadLabel(unreadCount) {
+    return app.translator.trans('core.forum.post_scrubber.unread_text', { count: unreadCount });
+  }
+
+  lastPostLabel() {
+    return app.translator.trans('core.forum.post_scrubber.now_link');
   }
 
   onupdate(vnode) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
2.x port for https://github.com/flarum/framework/pull/4049/

**Progresses #4060**

**Changes proposed in this pull request:**
Improve extensibility for customizing the Labels of the Scrubber. Use case here being that third party extensions might want to show different translations depending on the "type" of Discussion.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
