### PR TITLE
fix(core, tags): resolve `a11y` warnings in Admin Frontend

### DIFF
--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -19,7 +19,12 @@ function tagItem(tag) {
       <div className="TagListItem-info">
         {tagIcon(tag)}
         <span className="TagListItem-name">{tag.name()}</span>
-        <Button className="Button Button--link" icon="fas fa-pencil-alt" onclick={() => app.modal.show(EditTagModal, { model: tag })} />
+        <Button
+          className="Button Button--link"
+          icon="fas fa-pencil-alt"
+          aria-label={app.translator.trans('flarum-tags.admin.tags.edit_tag_label', { tag: tag.name() })}
+          onclick={() => app.modal.show(EditTagModal, { model: tag })}
+        />
       </div>
       {!tag.isChild() && tag.position() !== null && (
         <ol className="TagListItem-children TagList">

--- a/extensions/tags/locale/en.yml
+++ b/extensions/tags/locale/en.yml
@@ -56,6 +56,7 @@ flarum-tags:
       about_tags_text: "Tags are used to categorize discussions. Primary tags are like traditional forum categories: they can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization."
       create_primary_tag_button: Create Primary Tag
       create_secondary_tag_button: Create Secondary Tag
+      edit_tag_label: Edit Tag {tag}
       primary_heading: Primary Tags
       secondary_heading: Secondary Tags
       settings_heading: Settings

--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -59,7 +59,12 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
               <th>
                 {scope.label}{' '}
                 {!!scope.onremove && (
-                  <Button icon="fas fa-times" className="Button Button--text PermissionGrid-removeScope" onclick={scope.onremove} />
+                  <Button
+                    icon="fas fa-times"
+                    className="Button Button--text PermissionGrid-removeScope"
+                    aria-label={app.translator.trans('core.admin.permissions.remove_scope_label', { scope: scope.label })}
+                    onclick={scope.onremove}
+                  />
                 )}
               </th>
             ))}

--- a/framework/core/js/src/common/components/Pagination.tsx
+++ b/framework/core/js/src/common/components/Pagination.tsx
@@ -23,6 +23,7 @@ export default class Pagination<CustomAttrs extends IPaginationInterface = IPagi
         <Button
           disabled={currentPage === 1}
           title={app.translator.trans('core.lib.pagination.first_button')}
+          aria-label={app.translator.trans('core.lib.pagination.first_button')}
           onclick={() => onChange(1)}
           icon="fas fa-step-backward"
           className="Button Button--icon Pagination-first"
@@ -30,6 +31,7 @@ export default class Pagination<CustomAttrs extends IPaginationInterface = IPagi
         <Button
           disabled={currentPage === 1}
           title={app.translator.trans('core.lib.pagination.back_button')}
+          aria-label={app.translator.trans('core.lib.pagination.back_button')}
           onclick={() => onChange(currentPage - 1)}
           icon="fas fa-chevron-left"
           className="Button Button--icon Pagination-back"
@@ -77,6 +79,7 @@ export default class Pagination<CustomAttrs extends IPaginationInterface = IPagi
         <Button
           disabled={!moreData}
           title={app.translator.trans('core.lib.pagination.next_button')}
+          aria-label={app.translator.trans('core.lib.pagination.next_button')}
           onclick={() => onChange(currentPage + 1)}
           icon="fas fa-chevron-right"
           className="Button Button--icon Pagination-next"
@@ -84,6 +87,7 @@ export default class Pagination<CustomAttrs extends IPaginationInterface = IPagi
         <Button
           disabled={!moreData}
           title={app.translator.trans('core.lib.pagination.last_button')}
+          aria-label={app.translator.trans('core.lib.pagination.last_button')}
           onclick={() => onChange(totalPageCount)}
           icon="fas fa-step-forward"
           className="Button Button--icon Pagination-last"

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -310,6 +310,7 @@ core:
       participate_heading: Participate
       post_without_throttle_label: Reply multiple times without waiting
       read_heading: Read
+      remove_scope_label: Remove scope of {scope}
       rename_discussions_label: Rename discussions
       reply_to_discussions_label: Reply to discussions
       search_users_label: => core.ref.search_users


### PR DESCRIPTION
2.x port of https://github.com/flarum/framework/pull/4114. 

**Progresses #4060**

**Changes proposed in this pull request:**
Fixes `a11y` warnings in admin frontend as done on 1.x, also adds aria labels for new Pagination Buttons

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
