### PR TITLE
fix(core): change condition when `unread` label is shown in Scrubber

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -42,7 +42,7 @@ export default class PostStreamScrubber extends Component {
       const newStyle = {
         top: 100 - unreadPercent * 100 + '%',
         height: unreadPercent * 100 + '%',
-        opacity: unreadPercent ? 1 : 0,
+        opacity: unreadPercent > 0 ? 1 : 0,
       };
 
       if (vnode.state.oldStyle) {


### PR DESCRIPTION
2.x port of https://github.com/flarum/framework/pull/4116

**Progresses #4060**

**Changes proposed in this pull request:**
Change condition when `unread` label is shown in Scrubber, prevents `0 UNREAD` being shown. 

**Reviewers should focus on:**
See https://github.com/flarum/framework/pull/4116 and https://github.com/flarum/framework/issues/3838 for more details

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
