### PR TITLE
feat: reusable component for showing IP address

### DIFF
--- a/framework/core/js/src/common/components/IPAddress.tsx
+++ b/framework/core/js/src/common/components/IPAddress.tsx
@@ -1,0 +1,38 @@
+import Component, { ComponentAttrs } from '../Component';
+import ItemList from '../utils/ItemList';
+import type Mithril from 'mithril';
+
+export interface IIPAddressAttrs extends ComponentAttrs {
+  ip: string | undefined | null;
+}
+
+/**
+ * A component to wrap an IP address for display.
+ * Designed to be customizable for different use cases.
+ *
+ * @example
+ * <IPAddress ip="127.0.0.1" />
+ * @example
+ * <IPAddress ip={post.data.attributes.ipAddress} />
+ */
+export default class IPAddress<CustomAttrs extends IIPAddressAttrs = IIPAddressAttrs> extends Component<CustomAttrs> {
+  ip!: string;
+
+  oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    super.oninit(vnode);
+
+    this.ip = this.attrs.ip || '';
+  }
+
+  view() {
+    return <span className="IPAddress">{this.viewItems().toArray()}</span>;
+  }
+
+  viewItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('ip', <>{this.ip}</>, 100);
+
+    return items;
+  }
+}

--- a/framework/core/js/src/forum/components/AccessTokensList.tsx
+++ b/framework/core/js/src/forum/components/AccessTokensList.tsx
@@ -1,6 +1,7 @@
 import app from '../app';
 import Component, { ComponentAttrs } from '../../common/Component';
 import Button from '../../common/components/Button';
+import IPAddress from '../../common/components/IPAddress';
 import humanTime from '../../common/helpers/humanTime';
 import ItemList from '../../common/utils/ItemList';
 import LabelValue from '../../common/components/LabelValue';
@@ -105,7 +106,12 @@ export default class AccessTokensList<CustomAttrs extends IAccessTokensListAttrs
             token.lastActivityAt() ? (
               <>
                 {humanTime(token.lastActivityAt())}
-                {token.lastIpAddress() && ` — ${token.lastIpAddress()}`}
+                {token.lastIpAddress() && (
+                  <span>
+                    {' '}
+                    — <IPAddress ip={token.lastIpAddress()} />
+                  </span>
+                )}
                 {this.attrs.type === 'developer_token' && token.device() && (
                   <>
                     {' '}

--- a/framework/core/js/src/forum/components/PostMeta.tsx
+++ b/framework/core/js/src/forum/components/PostMeta.tsx
@@ -2,6 +2,7 @@ import app from '../../forum/app';
 import Component, { type ComponentAttrs } from '../../common/Component';
 import humanTime from '../../common/helpers/humanTime';
 import fullTime from '../../common/helpers/fullTime';
+import IPAddress from '../../common/components/IPAddress';
 import Post from '../../common/models/Post';
 import type Model from '../../common/Model';
 import type User from '../../common/models/User';
@@ -51,7 +52,9 @@ export default class PostMeta<CustomAttrs extends IPostMetaAttrs = IPostMetaAttr
         {!!permalink && (
           <div className="Dropdown-menu dropdown-menu">
             <span className="PostMeta-number">{this.postIdentifier(post)}</span> <span className="PostMeta-time">{fullTime(time)}</span>{' '}
-            <span className="PostMeta-ip">{post.data.attributes!.ipAddress}</span>
+            <span className="PostMeta-ip">
+              <IPAddress ip={post.data.attributes?.ipAddress} />
+            </span>
             {touch ? (
               <a className="Button PostMeta-permalink" href={permalink}>
                 {permalink}


### PR DESCRIPTION
(mostly) a 2.x port of https://github.com/flarum/framework/pull/4042. Only difference being I removed an extra `<span>` in the `viewItems()` method in the new `IPAddress` class which is not needed IMO

**Progresses #4060**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
