### PR TITLE
feat: actions dropdown in admin user list

### DIFF
--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -4,6 +4,7 @@ import app from '../../admin/app';
 
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Button from '../../common/components/Button';
+import Dropdown from '../../common/components/Dropdown';
 
 import listItems from '../../common/helpers/listItems';
 
@@ -363,23 +364,41 @@ export default class UserListPage extends AdminPage {
     );
 
     columns.add(
-      'editUser',
+      'userActions',
       {
-        name: app.translator.trans('core.admin.users.grid.columns.edit_user.title'),
+        name: app.translator.trans('core.admin.users.grid.columns.user_actions.title'),
         content: (user: User) => (
-          <Button
-            className="Button UserList-editModalBtn"
-            title={app.translator.trans('core.admin.users.grid.columns.edit_user.tooltip', { username: user.username() })}
-            onclick={() => app.modal.show(() => import('../../common/components/EditUserModal'), { user })}
+          <Dropdown
+            className="User-controls"
+            buttonClassName="Button Button--icon Button--flat"
+            menuClassName="Dropdown-menu--right"
+            icon="fas fa-ellipsis-h"
           >
-            {app.translator.trans('core.admin.users.grid.columns.edit_user.button')}
-          </Button>
+            {this.userActionItems(user).toArray()}
+          </Dropdown>
         ),
       },
       -90
     );
 
     return columns;
+  }
+
+  userActionItems(user: User): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'editUser',
+      <Button
+        icon="fas fa-pencil-alt"
+        title={app.translator.trans('core.admin.users.grid.columns.user_actions.edit_user.tooltip', { username: user.displayName() })}
+        onclick={() => app.modal.show(() => import('../../common/components/EditUserModal'), { user })}
+      >
+        {app.translator.trans('core.admin.users.grid.columns.user_actions.edit_user.button')}
+      </Button>
+    );
+
+    return items;
   }
 
   headerInfo() {

--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -391,7 +391,7 @@ export default class UserListPage extends AdminPage {
       'editUser',
       <Button
         icon="fas fa-pencil-alt"
-        title={app.translator.trans('core.admin.users.grid.columns.user_actions.edit_user.tooltip', { username: user.displayName() })}
+        title={app.translator.trans('core.admin.users.grid.columns.user_actions.edit_user.tooltip', { username: user.displayName() }, true)}
         onclick={() => app.modal.show(() => import('../../common/components/EditUserModal'), { user })}
       >
         {app.translator.trans('core.admin.users.grid.columns.user_actions.edit_user.button')}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -359,11 +359,6 @@ core:
           display_name:
             title: Display name
 
-          edit_user:
-            button: => core.ref.edit
-            title: => core.ref.edit_user
-            tooltip: Edit {username}
-
           email:
             title: => core.ref.email
             visibility_hide: Hide email address
@@ -375,6 +370,12 @@ core:
 
           join_time:
             title: Joined
+
+          user_actions:
+            title: Actions
+            edit_user:
+              button: => core.ref.edit
+              tooltip: Edit {username}
 
           user_id:
             title: ID


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
2.x port of https://github.com/flarum/framework/pull/4054 with some minor differences

**Progresses #4060**

**Changes proposed in this pull request:**
* Provide reusable actions dropdown
* Use `displayName` instead of `username` in button title
* Slightly adjust translation structure 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
