### PR TITLE
feat: allow extending `PostPreview` content

### DIFF
--- a/framework/core/js/src/forum/components/PostPreview.js
+++ b/framework/core/js/src/forum/components/PostPreview.js
@@ -17,16 +17,28 @@ export default class PostPreview extends Component {
   view() {
     const post = this.attrs.post;
     const user = post.user();
-    const content = post.contentType() === 'comment' && post.contentPlain();
-    const excerpt = content ? highlight(content, this.attrs.highlight, 300) : '';
 
     return (
       <Link className="PostPreview" href={app.route.post(post)} onclick={this.attrs.onclick}>
         <span className="PostPreview-content">
           <Avatar user={user} />
-          {username(user)} <span className="PostPreview-excerpt">{excerpt}</span>
+          {username(user)} <span className="PostPreview-excerpt">{this.excerpt()}</span>
         </span>
       </Link>
     );
+  }
+
+  /**
+   * @returns {string|undefined|null}
+   */
+  content() {
+    return this.attrs.post.contentType() === 'comment' && this.attrs.post.contentPlain();
+  }
+
+  /**
+   * @returns {string}
+   */
+  excerpt() {
+    return this.content() ? highlight(this.content(), this.attrs.highlight, 300) : '';
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
2.x port of #4043

**Progresses #4060**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
