### PR TITLE
fixes issue with smtp non-tls connections

### DIFF
--- a/framework/core/src/Mail/SmtpDriver.php
+++ b/framework/core/src/Mail/SmtpDriver.php
@@ -53,7 +53,7 @@ class SmtpDriver implements DriverInterface
     public function buildTransport(SettingsRepositoryInterface $settings): TransportInterface
     {
         return $this->factory->create(new Dsn(
-            $settings->get('mail_encryption') === 'tls' ? 'smtps' : '',
+            $settings->get('mail_encryption') === 'tls' ? 'smtps' : 'smtp',
             $settings->get('mail_host'),
             $settings->get('mail_username'),
             $settings->get('mail_password'),


### PR DESCRIPTION
Seems the esmtp factory needs a dns with a proper scheme, we are now using smtp with ssl and smtps with tls.


```
[2025-02-23T16:07:36.975804+00:00] flarum.ERROR: Symfony\Component\Mailer\Exception\UnsupportedSchemeException: The "" scheme is not supported; supported schemes for mailer "smtp" are: "smtp", "smtps". in /home/luceos/code/flarum-v2/vendor/symfony/mailer/Transport/Smtp/EsmtpTransportFactory.php:28
Stack trace:
#0 /home/luceos/code/flarum-v2/vendor/flarum/framework/framework/core/src/Mail/SmtpDriver.php(55): Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory->create()
#1 /home/luceos/code/flarum-v2/vendor/flarum/framework/framework/core/src/Mail/MailServiceProvider.php(60): Flarum\Mail\SmtpDriver->buildTransport()
#2 /home/luceos/code/flarum-v2/vendor/illuminate/container/Container.php(952): Flarum\Mail\MailServiceProvider->{closure:Flarum\Mail\MailServiceProvider::register():59}()
#3 /home/luceos/code/flarum-v2/vendor/illuminate/container/Container.php(832): Illuminate\Container\Container->build()
#4 /home/luceos/code/flarum-v2/vendor/illuminate/container/Container.php(763): Illuminate\Container\Container->resolve()
#5 /home/luceos/code/flarum-v2/vendor/illuminate/container/Container.php(1580): Illuminate\Container\Container->make()
#6 /home/luceos/code/flarum-v2/vendor/flarum/framework/framework/core/src/Mail/MailServiceProvider.php(71): Illuminate\Container\Container->offsetGet()
```
