### PR TITLE
[1.x] fix: action dropdown inaccessible near bottom of the userlist

### DIFF
--- a/framework/core/less/admin/UsersListPage.less
+++ b/framework/core/less/admin/UsersListPage.less
@@ -1,6 +1,7 @@
 .UserListPage {
   // Pad bottom of page to make nav area look less squashed
   padding-bottom: 24px;
+  overflow-x: auto;
 
   &-header {
     margin-bottom: 16px;
@@ -52,7 +53,6 @@
     &--loaded,
     &--loadingPage {
       display: grid;
-      overflow-x: auto;
     }
 
     &-header {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1f1e90d0-8574-47b3-8364-32309a287076)

After:
![image](https://github.com/user-attachments/assets/6cfe1ebf-bb70-4c92-8407-270b7e8b4f43)
