### PR TITLE
feat: advanced admin registry extenders

### DIFF
--- a/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
+++ b/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
@@ -32,7 +32,7 @@ use Tobyz\JsonApiServer\Schema\CustomFilter;
 
 class ExternalExtensionResource extends AbstractResource implements Listable, Paginatable, Countable
 {
-    protected int|null $totalResults = null;
+    protected ?int $totalResults = null;
 
     public function __construct(
         protected Repository $cache,

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -129,12 +129,14 @@ export default class AdminApplication extends Application {
     this.route = (Object.getPrototypeOf(Object.getPrototypeOf(this)) as Application).route.bind(this);
   }
 
-  protected beforeMount(): void {
+  protected runBeforeMount(): void {
     BasicsPage.register();
     AppearancePage.register();
     MailPage.register();
     AdvancedPage.register();
     PermissionsPage.register();
+
+    super.runBeforeMount();
   }
 
   /**

--- a/framework/core/js/src/admin/components/GeneralSearchSource.tsx
+++ b/framework/core/js/src/admin/components/GeneralSearchSource.tsx
@@ -9,7 +9,7 @@ import Icon from '../../common/components/Icon';
 import PermissionGrid from './PermissionGrid';
 import escapeRegExp from '../../common/utils/escapeRegExp';
 import { GeneralIndexData, GeneralIndexItem } from '../states/GeneralSearchIndex';
-import { ExtensionConfig, SettingConfigInternal } from '../utils/AdminRegistry';
+import { ExtensionConfig, SettingConfigInput } from '../utils/AdminRegistry';
 import ItemList from '../../common/utils/ItemList';
 
 export class GeneralSearchResult {
@@ -94,7 +94,7 @@ export default class GeneralSearchSource implements GlobalSearchSource {
     for (const extensionId in data) {
       // settings
       const settings = data[extensionId]!.settings;
-      let normalizedSettings: GeneralIndexItem[] | SettingConfigInternal[] = [];
+      let normalizedSettings: GeneralIndexItem[] | SettingConfigInput[] = [];
 
       if (settings instanceof ItemList) {
         normalizedSettings = settings?.toArray();
@@ -113,7 +113,7 @@ export default class GeneralSearchSource implements GlobalSearchSource {
         const group = app.generalIndex.getGroup(extensionId);
 
         if (this.itemHasQuery(label, query) || this.itemHasQuery(help, query)) {
-          const id = extensionId + '-' + ('setting' in setting ? setting : setting.id);
+          const id = extensionId + '-' + ('setting' in setting ? setting : 'id' in setting ? setting.id : '');
 
           results.push(
             new GeneralSearchResult(

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -286,6 +286,8 @@ export default class Application {
 
   private handledErrors: { extension: null | string; errorId: string; error: any }[] = [];
 
+  private beforeMounts: (() => void)[] = [];
+
   public load(payload: Application['data']) {
     this.data = payload;
     this.translator.setLocale(payload.locale);
@@ -326,7 +328,7 @@ export default class Application {
 
     this.session = new Session(this.store.getById<User>('users', String(this.data.session.userId)) ?? null, this.data.session.csrfToken);
 
-    this.beforeMount();
+    this.runBeforeMount();
 
     this.mount();
 
@@ -335,8 +337,13 @@ export default class Application {
     caughtInitializationErrors.forEach((handler) => handler());
   }
 
-  protected beforeMount(): void {
-    // ...
+  public beforeMount(callback: () => void) {
+    this.beforeMounts.push(callback);
+  }
+
+  protected runBeforeMount(): void {
+    this.beforeMounts.forEach((callback) => callback());
+    this.beforeMounts = [];
   }
 
   public bootExtensions(extensions: Record<string, { extend?: IExtender[] }>) {

--- a/framework/core/js/src/common/extenders/Admin.ts
+++ b/framework/core/js/src/common/extenders/Admin.ts
@@ -1,21 +1,61 @@
 import IExtender, { IExtensionModule } from './IExtender';
 import type AdminApplication from '../../admin/AdminApplication';
-import type { CustomExtensionPage, SettingConfigInternal } from '../../admin/utils/AdminRegistry';
+import type { CustomExtensionPage, SettingConfigInput } from '../../admin/utils/AdminRegistry';
 import type { PermissionConfig, PermissionType } from '../../admin/components/PermissionGrid';
 import type Mithril from 'mithril';
 import type { GeneralIndexItem } from '../../admin/states/GeneralSearchIndex';
 
 export default class Admin implements IExtender<AdminApplication> {
-  protected settings: { setting?: () => SettingConfigInternal | null; customSetting?: () => Mithril.Children; priority: number }[] = [];
+  protected context: string | null;
+
+  protected settings: { setting?: () => SettingConfigInput | null; customSetting?: () => Mithril.Children; priority: number }[] = [];
+  protected settingReplacements: { setting: string; replacement: (original: SettingConfigInput) => SettingConfigInput }[] = [];
+  protected settingPriorityChanges: { setting: string; priority: number }[] = [];
+  protected settingRemovals: string[] = [];
   protected permissions: { permission: () => PermissionConfig | null; type: PermissionType; priority: number }[] = [];
+  protected permissionsReplacements: { permission: string; type: PermissionType; replacement: (original: PermissionConfig) => PermissionConfig }[] =
+    [];
+  protected permissionsPriorityChanges: { permission: string; type: PermissionType; priority: number }[] = [];
+  protected permissionsRemovals: { permission: string; type: PermissionType }[] = [];
   protected customPage: CustomExtensionPage | null = null;
   protected generalIndexes: { settings?: () => GeneralIndexItem[]; permissions?: () => GeneralIndexItem[] } = {};
+
+  constructor(context: string | null = null) {
+    this.context = context;
+  }
 
   /**
    * Register a setting to be shown on the extension's settings page.
    */
-  setting(setting: () => SettingConfigInternal | null, priority = 0) {
+  setting(setting: () => SettingConfigInput | null, priority = 0) {
     this.settings.push({ setting, priority });
+
+    return this;
+  }
+
+  /**
+   * Replace an existing setting's configuration.
+   */
+  replaceSetting(setting: string, replacement: (original: SettingConfigInput) => SettingConfigInput) {
+    this.settingReplacements.push({ setting, replacement });
+
+    return this;
+  }
+
+  /**
+   * Change the priority of an existing setting.
+   */
+  setSettingPriority(setting: string, priority: number) {
+    this.settingPriorityChanges.push({ setting, priority });
+
+    return this;
+  }
+
+  /**
+   * Remove a setting from the extension's settings page.
+   */
+  removeSetting(setting: string) {
+    this.settingRemovals.push(setting);
 
     return this;
   }
@@ -39,6 +79,33 @@ export default class Admin implements IExtender<AdminApplication> {
   }
 
   /**
+   * Replace an existing permission's configuration.
+   */
+  replacePermission(permission: string, replacement: (original: PermissionConfig) => PermissionConfig, type: PermissionType) {
+    this.permissionsReplacements.push({ permission, type, replacement });
+
+    return this;
+  }
+
+  /**
+   * Change the priority of an existing permission.
+   */
+  setPermissionPriority(permission: string, type: PermissionType, priority: number) {
+    this.permissionsPriorityChanges.push({ permission, type, priority });
+
+    return this;
+  }
+
+  /**
+   * Remove a permission from the extension's permissions page.
+   */
+  removePermission(permission: string, type: PermissionType) {
+    this.permissionsRemovals.push({ permission, type });
+
+    return this;
+  }
+
+  /**
    * Register a custom page to be shown in the admin interface.
    */
   page(page: CustomExtensionPage) {
@@ -57,7 +124,7 @@ export default class Admin implements IExtender<AdminApplication> {
   }
 
   extend(app: AdminApplication, extension: IExtensionModule) {
-    app.registry.for(extension.name);
+    app.registry.for(this.context || extension.name);
 
     this.settings.forEach(({ setting, customSetting, priority }) => {
       const settingConfig = setting ? setting() : customSetting!;
@@ -67,12 +134,36 @@ export default class Admin implements IExtender<AdminApplication> {
       }
     });
 
+    this.settingReplacements.forEach(({ setting, replacement }) => {
+      app.registry.setSetting(setting, replacement);
+    });
+
+    this.settingPriorityChanges.forEach(({ setting, priority }) => {
+      app.registry.setSettingPriority(setting, priority);
+    });
+
+    this.settingRemovals.forEach((setting) => {
+      app.registry.removeSetting(setting);
+    });
+
     this.permissions.forEach(({ permission, type, priority }) => {
       const permissionConfig = permission();
 
       if (permissionConfig) {
         app.registry.registerPermission(permissionConfig, type, priority);
       }
+    });
+
+    this.permissionsReplacements.forEach(({ permission, type, replacement }) => {
+      app.registry.setPermission(permission, replacement, type);
+    });
+
+    this.permissionsPriorityChanges.forEach(({ permission, type, priority }) => {
+      app.registry.setPermissionPriority(permission, type, priority);
+    });
+
+    this.permissionsRemovals.forEach(({ permission, type }) => {
+      app.registry.removePermission(permission, type);
     });
 
     if (this.customPage) {

--- a/framework/core/js/src/common/extenders/Admin.ts
+++ b/framework/core/js/src/common/extenders/Admin.ts
@@ -124,62 +124,64 @@ export default class Admin implements IExtender<AdminApplication> {
   }
 
   extend(app: AdminApplication, extension: IExtensionModule) {
-    app.registry.for(this.context || extension.name);
+    app.beforeMount(() => {
+      app.registry.for(this.context || extension.name);
 
-    this.settings.forEach(({ setting, customSetting, priority }) => {
-      const settingConfig = setting ? setting() : customSetting!;
+      this.settings.forEach(({ setting, customSetting, priority }) => {
+        const settingConfig = setting ? setting() : customSetting!;
 
-      if (settingConfig) {
-        app.registry.registerSetting(settingConfig, priority);
+        if (settingConfig) {
+          app.registry.registerSetting(settingConfig, priority);
+        }
+      });
+
+      this.settingReplacements.forEach(({ setting, replacement }) => {
+        app.registry.setSetting(setting, replacement);
+      });
+
+      this.settingPriorityChanges.forEach(({ setting, priority }) => {
+        app.registry.setSettingPriority(setting, priority);
+      });
+
+      this.settingRemovals.forEach((setting) => {
+        app.registry.removeSetting(setting);
+      });
+
+      this.permissions.forEach(({ permission, type, priority }) => {
+        const permissionConfig = permission();
+
+        if (permissionConfig) {
+          app.registry.registerPermission(permissionConfig, type, priority);
+        }
+      });
+
+      this.permissionsReplacements.forEach(({ permission, type, replacement }) => {
+        app.registry.setPermission(permission, replacement, type);
+      });
+
+      this.permissionsPriorityChanges.forEach(({ permission, type, priority }) => {
+        app.registry.setPermissionPriority(permission, type, priority);
+      });
+
+      this.permissionsRemovals.forEach(({ permission, type }) => {
+        app.registry.removePermission(permission, type);
+      });
+
+      if (this.customPage) {
+        app.registry.registerPage(this.customPage);
       }
-    });
 
-    this.settingReplacements.forEach(({ setting, replacement }) => {
-      app.registry.setSetting(setting, replacement);
-    });
+      app.generalIndex.for(extension.name);
 
-    this.settingPriorityChanges.forEach(({ setting, priority }) => {
-      app.registry.setSettingPriority(setting, priority);
-    });
+      Object.keys(this.generalIndexes).forEach((key) => {
+        if (key !== 'settings' && key !== 'permissions') return;
 
-    this.settingRemovals.forEach((setting) => {
-      app.registry.removeSetting(setting);
-    });
+        const callback = this.generalIndexes[key];
 
-    this.permissions.forEach(({ permission, type, priority }) => {
-      const permissionConfig = permission();
-
-      if (permissionConfig) {
-        app.registry.registerPermission(permissionConfig, type, priority);
-      }
-    });
-
-    this.permissionsReplacements.forEach(({ permission, type, replacement }) => {
-      app.registry.setPermission(permission, replacement, type);
-    });
-
-    this.permissionsPriorityChanges.forEach(({ permission, type, priority }) => {
-      app.registry.setPermissionPriority(permission, type, priority);
-    });
-
-    this.permissionsRemovals.forEach(({ permission, type }) => {
-      app.registry.removePermission(permission, type);
-    });
-
-    if (this.customPage) {
-      app.registry.registerPage(this.customPage);
-    }
-
-    app.generalIndex.for(extension.name);
-
-    Object.keys(this.generalIndexes).forEach((key) => {
-      if (key !== 'settings' && key !== 'permissions') return;
-
-      const callback = this.generalIndexes[key];
-
-      if (callback) {
-        app.generalIndex.add(key, callback());
-      }
+        if (callback) {
+          app.generalIndex.add(key, callback());
+        }
+      });
     });
   }
 }

--- a/framework/core/src/Api/Context.php
+++ b/framework/core/src/Api/Context.php
@@ -108,27 +108,27 @@ class Context extends BaseContext
         return $this->parameters[$key] ?? $default;
     }
 
-    public function creating(string|null $resource = null): bool
+    public function creating(?string $resource = null): bool
     {
         return $this->endpoint instanceof Endpoint\Create && (! $resource || is_a($this->collection, $resource));
     }
 
-    public function updating(string|null $resource = null): bool
+    public function updating(?string $resource = null): bool
     {
         return $this->endpoint instanceof Endpoint\Update && (! $resource || is_a($this->collection, $resource));
     }
 
-    public function deleting(string|null $resource = null): bool
+    public function deleting(?string $resource = null): bool
     {
         return $this->endpoint instanceof Endpoint\Delete && (! $resource || is_a($this->collection, $resource));
     }
 
-    public function showing(string|null $resource = null): bool
+    public function showing(?string $resource = null): bool
     {
         return $this->endpoint instanceof Endpoint\Show && (! $resource || is_a($this->collection, $resource));
     }
 
-    public function listing(string|null $resource = null): bool
+    public function listing(?string $resource = null): bool
     {
         return $this->endpoint instanceof Endpoint\Index && (! $resource || is_a($this->collection, $resource));
     }

--- a/framework/core/src/Api/Endpoint/Concerns/HasAuthorization.php
+++ b/framework/core/src/Api/Endpoint/Concerns/HasAuthorization.php
@@ -60,7 +60,7 @@ trait HasAuthorization
             : ($this->authenticated)($context));
     }
 
-    public function getAuthorized(Context $context): string|null
+    public function getAuthorized(Context $context): ?string
     {
         if (! is_callable($this->ability)) {
             return $this->ability;

--- a/framework/core/src/Extend/Link.php
+++ b/framework/core/src/Extend/Link.php
@@ -19,8 +19,8 @@ use s9e\TextFormatter\Utils;
 
 class Link implements ExtenderInterface
 {
-    protected Closure|null $setRel = null;
-    protected Closure|null $setTarget = null;
+    protected ?Closure $setRel = null;
+    protected ?Closure $setTarget = null;
 
     public function setRel(Closure $callable): self
     {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Addresses https://github.com/flarum/framework/pull/4200#issuecomment-2669514856**

**Changes proposed in this pull request:**
* Allows changing an existing admin setting/permission.
* Allows changing the priority of an existing admin setting/permission.
* Allows removing an existing admin setting/priority.

The current caveat is that when extension A wants to do any of this to a setting/permission from extension B, it has to specify the extension ID in the constructor of the Admin extender, and it also has to be booted after extension B.

**Examples**
```ts
// current extension: nicknames

new Extend.Admin('flarum-sticky').replaceSetting('flarum-sticky.only_sticky_unread_discussions', (original) => ({
  ...original,
  label: 'test',
 })),

new Extend.Admin('flarum-sticky').setSettingPriority('flarum-sticky.only_sticky_unread_discussions', 500),

new Extend.Admin('flarum-sticky').removeSetting('flarum-sticky.only_sticky_unread_discussions'),

new Extend.Admin('flarum-sticky').replacePermission(
  'discussion.sticky',
  (original) => ({
    ...original,
    icon: 'fas fa-at',
  }),
  'moderate'
),

new Extend.Admin('flarum-sticky').setPermissionPriority('discussion.sticky', 'moderate', 500),

new Extend.Admin('flarum-sticky').removePermission('discussion.sticky', 'moderate'),
``` 

```ts
new Extend.Admin('core-basics').removeSetting('welcome_title'),
```