### PR TITLE
[1.x] fix(core): change caching logic for validation attributes

### DIFF
--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -98,11 +98,7 @@ abstract class AbstractValidator
     {
         $cache = resolve(Cache::class);
 
-        $cacheKey = sprintf(
-            'core.validation.attributes.%s.%s',
-            $this->translator->getLocale(),
-            static::class
-        );
+        $cacheKey = 'core.validation.attributes.' . $this->translator->getLocale() . '.' . static::class;
 
         if ($cached = $cache->get($cacheKey)) {
             return $cached;

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -107,7 +107,7 @@ abstract class AbstractValidator
         $extId = $this->getClassExtensionId();
         $attributeNames = [];
 
-        foreach (array_keys($this->rules) as $attribute) {
+        foreach (array_keys($this->getRules()) as $attribute) {
             $key = $extId ? "$extId.validation.attributes.$attribute" : "validation.attributes.$attribute";
             $attributeNames[$attribute] = $this->translator->trans($key);
         }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -20,6 +20,8 @@ abstract class AbstractValidator
     use ExtensionIdTrait;
 
     /**
+     * @deprecated This constant is no longer used internally and will be removed in a future release.
+     *             Use dynamic cache keys based on class and locale instead.
      * @var string
      */
     public static $CORE_VALIDATION_CACHE_KEY = 'core.validation.extension_id_class_names';

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -96,8 +96,14 @@ abstract class AbstractValidator
     {
         $cache = resolve(Cache::class);
 
-        if ($cache->get(self::$CORE_VALIDATION_CACHE_KEY) !== null) {
-            return $cache->get(self::$CORE_VALIDATION_CACHE_KEY);
+        $cacheKey = sprintf(
+            'core.validation.attributes.%s.%s',
+            $this->translator->getLocale(),
+            static::class
+        );
+
+        if ($cached = $cache->get($cacheKey)) {
+            return $cached;
         }
 
         $extId = $this->getClassExtensionId();
@@ -108,7 +114,7 @@ abstract class AbstractValidator
             $attributeNames[$attribute] = $this->translator->trans($key);
         }
 
-        $cache->forever(self::$CORE_VALIDATION_CACHE_KEY, $attributeNames);
+        $cache->forever($cacheKey, $attributeNames);
 
         return $attributeNames;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
The caching logic of the previous solution to make validation attributes translatable was flawed. 

* `getAttributeNames()` always stored the first set of attribute names it built under the single key
core.validation.extension_id_class_names
* Every later validator – regardless of its own rules, extension ID or the current locale – hit that same key and therefore received the wrong map of attribute names

**Changes proposed in this pull request:**
* change caching logic for validation attributes
* deprecate now unused const 

A cache key might now look like this:

* `core.validation.attributes.de.Flarum\\Discussion\\DiscussionValidator`
* `core.validation.attributes.de.Flarum\\Post\\PostValidator`

**Reviewers should focus on:**
I tried to get a test running which covers this but had crazy difficulties changing the forum lang in the first place

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
