### PR TITLE
[1.x] fix: remove redefinition of github token

### DIFF
--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -124,7 +124,6 @@ jobs:
     name: Checks & Build
     runs-on: ${{ inputs.runner_type }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_ACTOR_TOKEN: ${{ secrets.git_actor_token }}
 
     if: >-


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Fixes a regression introduced in https://github.com/flarum/framework/pull/4078 in relation to composer auth not working anymore.

It appears as if explicitly defining it in the job interferes with how actions such as shivammathur/setup-php@v2 authenticate with composer.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
