### PR TITLE
fix: prevent <button>'s from becoming form submit when they shouldn't

### DIFF
--- a/extensions/emoji/js/src/forum/addComposerAutocomplete.js
+++ b/extensions/emoji/js/src/forum/addComposerAutocomplete.js
@@ -70,6 +70,7 @@ export default function addComposerAutocomplete() {
           return (
             <Tooltip text={name}>
               <button
+                type="button"
                 key={emoji}
                 onclick={() => applySuggestion(emoji)}
                 onmouseenter={function () {

--- a/extensions/mentions/js/src/forum/components/MentionsDropdownItem.tsx
+++ b/extensions/mentions/js/src/forum/components/MentionsDropdownItem.tsx
@@ -17,7 +17,7 @@ export default class MentionsDropdownItem<CustomAttrs extends IMentionsDropdownI
     const className = classList('MentionsDropdownItem', 'PostPreview', `MentionsDropdown-${mentionable.type()}`);
 
     return (
-      <button className={className} {...attrs}>
+      <button className={className} type="button" {...attrs}>
         <span className="PostPreview-content">{vnode.children}</span>
       </button>
     );

--- a/extensions/mentions/js/src/forum/fragments/PostQuoteButton.js
+++ b/extensions/mentions/js/src/forum/fragments/PostQuoteButton.js
@@ -15,6 +15,7 @@ export default class PostQuoteButton extends Fragment {
     return (
       <button
         className="Button PostQuoteButton"
+        type="button"
         onclick={() => {
           reply(this.post, this.content);
         }}

--- a/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
+++ b/extensions/statistics/js/src/admin/components/StatisticsWidget.tsx
@@ -279,6 +279,7 @@ export default class StatisticsWidget extends DashboardWidget {
             return (
               <button
                 className={classList('Button--ua-reset StatisticsWidget-entity', { active: this.selectedEntity === entity })}
+                type="button"
                 onclick={this.changeEntity.bind(this, entity)}
               >
                 <h3 className="StatisticsWidget-heading">{app.translator.trans('flarum-statistics.admin.statistics.' + entity + '_heading')}</h3>

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -67,7 +67,13 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
    */
   submitButton(): Mithril.Children {
     return (
-      <Button type="submit" onclick={this.saveSettings.bind(this)} className="Button Button--primary" loading={this.loading} disabled={!this.isChanged()}>
+      <Button
+        type="submit"
+        onclick={this.saveSettings.bind(this)}
+        className="Button Button--primary"
+        loading={this.loading}
+        disabled={!this.isChanged()}
+      >
         {app.translator.trans('core.admin.settings.submit_button')}
       </Button>
     );

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -67,7 +67,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
    */
   submitButton(): Mithril.Children {
     return (
-      <Button onclick={this.saveSettings.bind(this)} className="Button Button--primary" loading={this.loading} disabled={!this.isChanged()}>
+      <Button type="submit" onclick={this.saveSettings.bind(this)} className="Button Button--primary" loading={this.loading} disabled={!this.isChanged()}>
         {app.translator.trans('core.admin.settings.submit_button')}
       </Button>
     );

--- a/framework/core/js/src/admin/components/PermissionsPage.tsx
+++ b/framework/core/js/src/admin/components/PermissionsPage.tsx
@@ -25,12 +25,12 @@ export default class PermissionsPage extends AdminPage {
             .all<Group>('groups')
             .filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1)
             .map((group) => (
-              <button className="Button Group" onclick={() => app.modal.show(EditGroupModal, { group })}>
+              <button className="Button Group" type="button" onclick={() => app.modal.show(EditGroupModal, { group })}>
                 <GroupBadge group={group} className="Group-icon" label={null} />
                 <span className="Group-name">{group.namePlural()}</span>
               </button>
             ))}
-          <button className="Button Group Group--add" onclick={() => app.modal.show(EditGroupModal)}>
+          <button className="Button Group Group--add" type="button" onclick={() => app.modal.show(EditGroupModal)}>
             <Icon name="fas fa-plus" className="Group-icon" />
             <span className="Group-name">{app.translator.trans('core.admin.permissions.new_group_button')}</span>
           </button>

--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -352,6 +352,7 @@ export default class UserListPage extends AdminPage {
               <button
                 onclick={toggleEmailVisibility}
                 className="Button Button--text UserList-emailIconBtn"
+                type="button"
                 title={app.translator.trans('core.admin.users.grid.columns.email.visibility_show')}
               >
                 <Icon name="far fa-eye-slash fa-fw" className="icon" />

--- a/framework/core/js/src/common/components/DetailedDropdownItem.tsx
+++ b/framework/core/js/src/common/components/DetailedDropdownItem.tsx
@@ -21,7 +21,7 @@ export default class DetailedDropdownItem<
 > extends Component<CustomAttrs> {
   view() {
     return (
-      <button className="DetailedDropdownItem hasIcon" onclick={this.attrs.onclick}>
+      <button type="button" className="DetailedDropdownItem hasIcon" onclick={this.attrs.onclick}>
         <Icon name={this.attrs.active ? 'fas fa-check' : 'fas'} className="Button-icon" />
         <span className="DetailedDropdownItem-content">
           <Icon name={this.attrs.icon} className="Button-icon" />

--- a/framework/core/js/src/common/components/Dropdown.tsx
+++ b/framework/core/js/src/common/components/Dropdown.tsx
@@ -139,6 +139,7 @@ export default class Dropdown<CustomAttrs extends IDropdownAttrs = IDropdownAttr
   getButton(children: Mithril.ChildArray): Mithril.Vnode<any, any> {
     let button = (
       <button
+        type="button"
         className={'Dropdown-toggle ' + this.attrs.buttonClassName}
         aria-haspopup="menu"
         aria-label={this.attrs.accessibleToggleLabel}

--- a/framework/core/js/src/common/components/SplitDropdown.tsx
+++ b/framework/core/js/src/common/components/SplitDropdown.tsx
@@ -45,6 +45,7 @@ export default class SplitDropdown<CustomAttrs extends ISplitDropdownAttrs = ISp
       <>
         {button}
         <button
+          type="button"
           className={'Dropdown-toggle Button Button--icon ' + this.attrs.buttonClassName}
           aria-haspopup="menu"
           aria-label={this.attrs.accessibleToggleLabel}

--- a/framework/core/js/src/forum/components/AvatarEditor.js
+++ b/framework/core/js/src/forum/components/AvatarEditor.js
@@ -43,6 +43,7 @@ export default class AvatarEditor extends Component {
       <div className={classList(['AvatarEditor', 'Dropdown', this.attrs.className, this.loading && 'loading', this.isDraggedOver && 'dragover'])}>
         <Avatar user={user} loading="eager" />
         <button
+          type="button"
           className={user.avatarUrl() ? 'Dropdown-toggle' : 'Dropdown-toggle AvatarEditor--noAvatar'}
           title={app.translator.trans('core.forum.user.avatar_upload_tooltip')}
           ariaLabel={app.translator.trans('core.forum.user.avatar_upload_tooltip')}

--- a/framework/core/js/src/forum/components/PostMeta.tsx
+++ b/framework/core/js/src/forum/components/PostMeta.tsx
@@ -40,6 +40,7 @@ export default class PostMeta<CustomAttrs extends IPostMetaAttrs = IPostMetaAttr
     items.add(
       'time',
       <button
+        type="button"
         className={classList({
           'Button Button--text': true,
           'Dropdown-toggle Button--link': !!permalink,

--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -58,7 +58,7 @@ export default class PostStreamScrubber extends Component {
 
     return (
       <div className={classNames.join(' ')}>
-        <button className="Button Dropdown-toggle" data-toggle="dropdown">
+        <button type="button" className="Button Dropdown-toggle" data-toggle="dropdown">
           {viewing} <Icon name={'fas fa-sort'} />
         </button>
 

--- a/framework/core/js/src/forum/components/ReplyPlaceholder.tsx
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.tsx
@@ -54,7 +54,7 @@ export default class ReplyPlaceholder<CustomAttrs extends IReplyPlaceholderAttrs
       });
 
     return (
-      <button className="Post ReplyPlaceholder" onclick={reply}>
+      <button type="button" className="Post ReplyPlaceholder" onclick={reply}>
         <div className="Post-container">
           <div className="Post-side">
             <Avatar user={app.session.user} className="Post-avatar" />


### PR DESCRIPTION
**Changes proposed in this pull request:**
Adds `type=button` to most `<button>` usage (except the `AdminPage#submitButton`). The first button of type `submit` (which is the default in HTML if undeclared) becomes what the enter keybind presses in a form. This makes the behavior with these components make more sense.

I found this behavior while trying to make an extension page use a <form>, and enter kept opening a dropdown way down the page. Even though I could've rectified this by implementing `onsubmit`, the submit behavior was already declared in the button (using `AdminPage#submitButton`) so there was no reason to if I could stop the dropdown from becoming the form's submit button.

**Reviewers should focus on:**
I believe all the buttons that were missing a `type` declaration (except the one in AdminPage, which I added just for clarity)  should all be regular buttons. They can still be clicked by pressing enter when focused, but they won't override the submit button of a `<form>` if they're the first submit button anymore.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
  - Did not test extensions, but just adding `type="submit"` and having the code compile should be fine.
- ~~Backend changes: tests are green (run `composer test`).~~
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
