### PR TITLE
fix(mentions): use relative path for mention links to support multiple domains setup

### DIFF
--- a/extensions/mentions/src/ConfigureMentions.php
+++ b/extensions/mentions/src/ConfigureMentions.php
@@ -59,7 +59,7 @@ class ConfigureMentions
 
     private function configureUserMentions(Configurator $config): void
     {
-        $config->rendering->parameters['PROFILE_URL'] = $this->url->to('forum')->route('user', ['username' => '']);
+        $config->rendering->parameters['PROFILE_URL_PATH'] = parse_url($this->url->to('forum')->route('user', ['username' => '']), PHP_URL_PATH);
 
         $tagName = 'USERMENTION';
 
@@ -70,7 +70,7 @@ class ConfigureMentions
         $tag->template = '
             <xsl:choose>
                 <xsl:when test="@deleted != 1">
-                    <a href="{$PROFILE_URL}{@slug}" class="UserMention">@<xsl:value-of select="@displayname"/></a>
+                    <a href="{$PROFILE_URL_PATH}{@slug}" class="UserMention">@<xsl:value-of select="@displayname"/></a>
                 </xsl:when>
                 <xsl:otherwise>
                     <span class="UserMention UserMention--deleted">@<xsl:value-of select="@displayname"/></span>
@@ -115,7 +115,7 @@ class ConfigureMentions
 
     private function configurePostMentions(Configurator $config): void
     {
-        $config->rendering->parameters['DISCUSSION_URL'] = $this->url->to('forum')->route('discussion', ['id' => '']);
+        $config->rendering->parameters['DISCUSSION_URL_PATH'] = parse_url($this->url->to('forum')->route('discussion', ['id' => '']), PHP_URL_PATH);
 
         $tagName = 'POSTMENTION';
 
@@ -129,7 +129,7 @@ class ConfigureMentions
         $tag->template = '
             <xsl:choose>
                 <xsl:when test="@deleted != 1">
-                    <a href="{$DISCUSSION_URL}{@discussionid}/{@number}" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>
+                    <a href="{$DISCUSSION_URL_PATH}{@discussionid}/{@number}" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>
                 </xsl:when>
                 <xsl:otherwise>
                     <span class="PostMention PostMention--deleted" data-id="{@id}"><xsl:value-of select="@displayname"/></span>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4226**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Use relative path instead of abusolute url for mentions
For user mentions use /u/admin instead of https://my.domain/u/admin
For discussion mentions, use /d/1234/1 instead of https://my.domain/d/1234/1

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Not sure if there are any other extension that relies on the abusolute url for mentions

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://github.com/user-attachments/assets/bd48788c-41c0-490e-af59-cd3fd7af1dc3)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
