### PR TITLE
fix: include LabelValue in the default bundle (sync)

### DIFF
--- a/framework/core/js/src/common/common.ts
+++ b/framework/core/js/src/common/common.ts
@@ -63,6 +63,7 @@ import './components/FieldSet';
 import './components/Select';
 import './components/Navigation';
 import './components/Alert';
+import './components/LabelValue';
 import './components/Link';
 import './components/LinkButton';
 import './components/Checkbox';


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4219**

**Changes proposed in this pull request:**
* Makes the LabelValue component always available to import in sync mode. 

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
