### PR TITLE
[2.x] [messages] fix: delete conversation when no messages are left

### DIFF
--- a/extensions/messages/js/src/common/models/Dialog.ts
+++ b/extensions/messages/js/src/common/models/Dialog.ts
@@ -30,6 +30,9 @@ export default class Dialog extends Model {
   unreadCount() {
     return Model.attribute<number>('unreadCount').call(this);
   }
+  lastMessageId() {
+    return Model.attribute<number>('lastMessageId').call(this);
+  }
   lastReadMessageId() {
     return Model.attribute<number>('lastReadMessageId').call(this);
   }

--- a/extensions/messages/js/src/forum/utils/MessageControls.tsx
+++ b/extensions/messages/js/src/forum/utils/MessageControls.tsx
@@ -59,6 +59,22 @@ const MessageControls = {
 
     return message.delete().then(() => {
       context.attrs.state.remove(message);
+
+      const noMessagesLeft =
+        context.attrs.state.getAllItems().filter((m) => {
+          const mDialog = m.dialog();
+          const messageDialog = message.dialog();
+
+          if (!mDialog || !messageDialog) return false;
+
+          return mDialog?.id() === messageDialog!.id();
+        }).length === 0;
+
+      if (noMessagesLeft && message.dialog()) {
+        app.dialogs.remove(message.dialog()!);
+        m.route.set(app.route('messages'));
+      }
+
       m.redraw();
     });
   },

--- a/extensions/messages/js/src/forum/utils/MessageControls.tsx
+++ b/extensions/messages/js/src/forum/utils/MessageControls.tsx
@@ -60,19 +60,53 @@ const MessageControls = {
     return message.delete().then(() => {
       context.attrs.state.remove(message);
 
-      const noMessagesLeft =
-        context.attrs.state.getAllItems().filter((m) => {
-          const mDialog = m.dialog();
-          const messageDialog = message.dialog();
+      const dialog = message.dialog();
 
-          if (!mDialog || !messageDialog) return false;
+      if (dialog) {
+        const noMessagesLeft =
+          context.attrs.state.getAllItems().filter((m) => {
+            const mDialog = m.dialog();
 
-          return mDialog?.id() === messageDialog!.id();
-        }).length === 0;
+            if (!mDialog) return false;
 
-      if (noMessagesLeft && message.dialog()) {
-        app.dialogs.remove(message.dialog()!);
-        m.route.set(app.route('messages'));
+            return mDialog?.id() === dialog!.id();
+          }).length === 0;
+
+        if (noMessagesLeft) {
+          app.dialogs.remove(dialog!);
+          m.route.set(app.route('messages'));
+        }
+
+        if (parseInt(message.id()!) === dialog.lastMessageId()) {
+          const lastMessage = context.attrs.state
+            .getAllItems()
+            .filter((m) => {
+              const mDialog = m.dialog();
+
+              if (!mDialog) return false;
+
+              return mDialog.id() === dialog?.id();
+            })
+            .sort((a, b) => parseInt(a.id()!) - parseInt(b.id()!))
+            .pop();
+
+          if (lastMessage) {
+            dialog!.pushData({
+              relationships: {
+                ...dialog!.data.relationships,
+                lastMessage: {
+                  data: {
+                    type: 'dialog-messages',
+                    id: lastMessage.id()!,
+                  },
+                },
+              },
+            });
+            dialog.pushAttributes({
+              lastMessageId: parseInt(lastMessage.id()!),
+            });
+          }
+        }
       }
 
       m.redraw();

--- a/extensions/messages/src/Api/Resource/DialogResource.php
+++ b/extensions/messages/src/Api/Resource/DialogResource.php
@@ -68,9 +68,6 @@ class DialogResource extends Resource\AbstractDatabaseResource
                     $connection = UserDialogState::query()->getConnection();
                     $grammar = UserDialogState::query()->getGrammar();
 
-                    $table = $grammar->wrapTable('dialogs');
-                    $column = $grammar->wrap('last_message_id');
-
                     UserDialogState::query()
                         ->where('dialog_user.user_id', $context->getActor()->id)
                         ->update([
@@ -121,6 +118,7 @@ class DialogResource extends Resource\AbstractDatabaseResource
                 ->get(function (Dialog $dialog) {
                     return $dialog->state->last_read_at;
                 }),
+            Schema\Integer::make('lastMessageId'),
             Schema\Integer::make('lastReadMessageId')
                 ->visible(fn (Dialog $dialog) => $dialog->state !== null)
                 ->get(function (Dialog $dialog) {

--- a/extensions/messages/src/DialogMessage.php
+++ b/extensions/messages/src/DialogMessage.php
@@ -70,6 +70,18 @@ class DialogMessage extends AbstractModel implements Formattable
                     ->toSql()
                 .')');
         });
+
+        static::deleted(function (self $message) {
+            if ($message->dialog) {
+                if ($message->dialog->messages()->count() === 0) {
+                    $message->dialog->delete();
+                } elseif ($message->dialog->first_message_id === $message->id) {
+                    $message->dialog->setFirstMessage(
+                        $message->dialog->messages()->oldest('id')->first()
+                    );
+                }
+            }
+        });
     }
 
     public function dialog(): BelongsTo

--- a/extensions/messages/src/DialogMessage.php
+++ b/extensions/messages/src/DialogMessage.php
@@ -31,7 +31,7 @@ use Illuminate\Database\Query\Expression;
  * @property int|Expression $number
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
- * @property-read Dialog $dialog
+ * @property-read Dialog|null $dialog
  * @property-read User|null $user
  * @property-read Collection<int, User> $mentionsUsers
  * @property-read Collection<int, Post> $mentionsPosts

--- a/extensions/messages/src/DialogMessage.php
+++ b/extensions/messages/src/DialogMessage.php
@@ -79,6 +79,12 @@ class DialogMessage extends AbstractModel implements Formattable
                     $message->dialog->setFirstMessage(
                         $message->dialog->messages()->oldest('id')->first()
                     );
+                    $message->dialog->save();
+                } elseif ($message->dialog->last_message_id === $message->id) {
+                    $message->dialog->setLastMessage(
+                        $message->dialog->messages()->latest('id')->first()
+                    );
+                    $message->dialog->save();
                 }
             }
         });


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4233**

**Changes proposed in this pull request:**
* Handles the effects of deleted messages appropriately.
* Updates the last/first messages if the first/last message is deleted
* Deletes the conversation if the only message is deleted.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
