### PR TITLE
feat: Add support for pgsql's search_path

### DIFF
--- a/framework/core/src/Database/Migrator.php
+++ b/framework/core/src/Database/Migrator.php
@@ -11,6 +11,7 @@ namespace Flarum\Database;
 
 use Flarum\Database\Exception\MigrationKeyMissing;
 use Flarum\Extension\Extension;
+use Flarum\Install\DatabaseConfig;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Filesystem\Filesystem;
@@ -224,8 +225,11 @@ class Migrator
      *
      * @param string $path to the directory containing the dump.
      */
-    public function installFromSchema(string $path, string $driver): bool
+    public function installFromSchema(string $path, DatabaseConfig $dbConfig): bool
     {
+        $driver = $dbConfig->toArray()['driver'];
+        $pgSearchPath = $dbConfig->toArray()['search_path'] ?? 'public';
+
         $schemaPath = "$path/$driver-install.dump";
 
         if (! file_exists($schemaPath)) {
@@ -252,11 +256,16 @@ class Migrator
                 $this->connection->getTablePrefix() ?? '',
                 $statement
             );
+
+            if ($driver === 'pgsql' && $pgSearchPath != 'public') {
+                $statement = preg_replace('/(public)([\s.;])/', "$pgSearchPath\$2", $statement);
+            }
+
             $this->connection->statement($statement);
         }
 
         if ($driver === 'pgsql') {
-            $this->connection->statement('SELECT pg_catalog.set_config(\'search_path\', \'public\', false)');
+            $this->connection->statement("SELECT pg_catalog.set_config('search_path', '$pgSearchPath', false)");
         }
 
         $this->connection->getSchemaBuilder()->enableForeignKeyConstraints();

--- a/framework/core/src/Install/Console/FileDataProvider.php
+++ b/framework/core/src/Install/Console/FileDataProvider.php
@@ -73,6 +73,7 @@ class FileDataProvider implements DataProviderInterface
             $this->databaseConfiguration['host'] ?? 'localhost',
             $this->databaseConfiguration['port'] ?? 3306,
             $this->databaseConfiguration['database'] ?? 'flarum',
+            $this->databaseConfiguration['search_path'] ?? 'public',
             $this->databaseConfiguration['username'] ?? 'root',
             $this->databaseConfiguration['password'] ?? '',
             $this->databaseConfiguration['prefix'] ?? ''

--- a/framework/core/src/Install/Console/UserDataProvider.php
+++ b/framework/core/src/Install/Console/UserDataProvider.php
@@ -56,19 +56,30 @@ class UserDataProvider implements DataProviderInterface
             if (Str::contains($host, ':')) {
                 [$host, $port] = explode(':', $host, 2);
             }
+        }
 
+        $database = $this->ask('Database name (required):', required: true);
+
+        if ($driver === 'pgsql') {
+            $schema = $this->ask('Schema (Default: public):', 'public');
+        }
+
+        if (in_array($driver, ['mysql', 'mariadb', 'pgsql'])) {
             $user = $this->ask('Database user (required):', required: true);
             $password = $this->secret('Database password:');
         }
+
+        $prefix = $this->ask('Prefix:');
 
         return new DatabaseConfig(
             $driver,
             $host ?? null,
             intval($port),
-            $this->ask('Database name (required):', required: true),
+            $database,
+            $schema ?? null,
             $user ?? null,
             $password ?? null,
-            $this->ask('Prefix:')
+            $prefix ?? null
         );
     }
 

--- a/framework/core/src/Install/Controller/InstallController.php
+++ b/framework/core/src/Install/Controller/InstallController.php
@@ -92,6 +92,7 @@ class InstallController implements RequestHandlerInterface
             $driver,
             $host,
             intval($port),
+            Arr::get($input, 'dbSchema'),
             Arr::get($input, 'dbName'),
             Arr::get($input, 'dbUsername'),
             Arr::get($input, 'dbPassword'),

--- a/framework/core/src/Install/Controller/InstallController.php
+++ b/framework/core/src/Install/Controller/InstallController.php
@@ -92,8 +92,8 @@ class InstallController implements RequestHandlerInterface
             $driver,
             $host,
             intval($port),
-            Arr::get($input, 'dbSchema'),
             Arr::get($input, 'dbName'),
+            Arr::get($input, 'dbSchema'),
             Arr::get($input, 'dbUsername'),
             Arr::get($input, 'dbPassword'),
             Arr::get($input, 'tablePrefix')

--- a/framework/core/src/Install/DatabaseConfig.php
+++ b/framework/core/src/Install/DatabaseConfig.php
@@ -18,8 +18,8 @@ class DatabaseConfig implements Arrayable
         private readonly string $driver,
         private readonly ?string $host,
         private readonly int $port,
-        private string $schema,
         private string $database,
+        private readonly ?string $schema,
         private readonly ?string $username,
         #[\SensitiveParameter] private readonly ?string $password,
         private readonly ?string $prefix
@@ -55,12 +55,12 @@ class DatabaseConfig implements Arrayable
             throw new ValidationFailed('Please provide a valid port number between 1 and 65535.');
         }
 
-        if (empty($this->schema) && $this->driver == 'pgsql') {
-            throw new ValidationFailed('Please specify the schema name.');
-        }
-
         if (empty($this->database)) {
             throw new ValidationFailed('Please specify the database name.');
+        }
+
+        if (empty($this->schema) && $this->driver == 'pgsql') {
+            throw new ValidationFailed('Please specify the schema name.');
         }
 
         if (empty($this->username) && in_array($this->driver, ['mysql', 'mariadb', 'pgsql'])) {

--- a/framework/core/src/Install/DatabaseConfig.php
+++ b/framework/core/src/Install/DatabaseConfig.php
@@ -18,6 +18,7 @@ class DatabaseConfig implements Arrayable
         private readonly string $driver,
         private readonly ?string $host,
         private readonly int $port,
+        private string $schema,
         private string $database,
         private readonly ?string $username,
         #[\SensitiveParameter] private readonly ?string $password,
@@ -52,6 +53,10 @@ class DatabaseConfig implements Arrayable
 
         if (($this->port < 1 || $this->port > 65535) && in_array($this->driver, ['mysql', 'mariadb', 'pgsql'])) {
             throw new ValidationFailed('Please provide a valid port number between 1 and 65535.');
+        }
+
+        if (empty($this->schema) && $this->driver == 'pgsql') {
+            throw new ValidationFailed('Please specify the schema name.');
         }
 
         if (empty($this->database)) {
@@ -100,7 +105,7 @@ class DatabaseConfig implements Arrayable
                 'username' => $this->username,
                 'password' => $this->password,
                 'charset' => 'utf8',
-                'search_path' => 'public',
+                'search_path' => $this->schema,
                 'sslmode' => 'prefer',
             ],
             'sqlite' => [

--- a/framework/core/src/Install/Installation.php
+++ b/framework/core/src/Install/Installation.php
@@ -138,7 +138,7 @@ class Installation
         });
 
         $pipeline->pipe(function () {
-            return new Steps\RunMigrations($this->db, $this->dbConfig->toArray()['driver'], $this->getMigrationPath());
+            return new Steps\RunMigrations($this->db, $this->dbConfig, $this->getMigrationPath());
         });
 
         $pipeline->pipe(function () {

--- a/framework/core/src/Install/Steps/RunMigrations.php
+++ b/framework/core/src/Install/Steps/RunMigrations.php
@@ -11,6 +11,7 @@ namespace Flarum\Install\Steps;
 
 use Flarum\Database\DatabaseMigrationRepository;
 use Flarum\Database\Migrator;
+use Flarum\Install\DatabaseConfig;
 use Flarum\Install\Step;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Filesystem\Filesystem;
@@ -19,7 +20,7 @@ readonly class RunMigrations implements Step
 {
     public function __construct(
         private ConnectionInterface $database,
-        private string $driver,
+        private DatabaseConfig $dbConfig,
         private string $path
     ) {
     }
@@ -33,7 +34,7 @@ readonly class RunMigrations implements Step
     {
         $migrator = $this->getMigrator();
 
-        if (! $migrator->repositoryExists() && ! $migrator->installFromSchema($this->path, $this->driver)) {
+        if (! $migrator->repositoryExists() && ! $migrator->installFromSchema($this->path, $this->dbConfig)) {
             $migrator->getRepository()->createRepository();
         }
 

--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -31,6 +31,13 @@
       </select>
     </div>
 
+    <div data-group="pgsql">
+      <div class="FormField">
+        <label>Schema</label>
+        <input class="FormControl" name="dbSchema" value="public">
+      </div>
+    </div>
+
     <div class="FormField">
       <label>Database</label>
       <input class="FormControl" name="dbName" value="flarum">
@@ -90,7 +97,9 @@
   document.addEventListener('DOMContentLoaded', function() {
     document.querySelector('form input').select();
 
-    document.querySelector('select[name="dbDriver"]').addEventListener('change', function() {
+    const dbDriver = document.querySelector('select[name="dbDriver"]');
+
+    dbDriver.addEventListener('change', function() {
       document.querySelectorAll('[data-group]').forEach(function(group) {
         group.style.display = 'none';
       });
@@ -101,6 +110,8 @@
         group.style.display = 'block';
       });
     });
+
+    dbDriver.dispatchEvent(new Event('change', { bubbles: true }));
 
     document.querySelector('form').addEventListener('submit', function(e) {
       e.preventDefault();

--- a/framework/core/views/install/install.php
+++ b/framework/core/views/install/install.php
@@ -31,16 +31,16 @@
       </select>
     </div>
 
+    <div class="FormField">
+      <label>Database</label>
+      <input class="FormControl" name="dbName" value="flarum">
+    </div>
+
     <div data-group="pgsql">
       <div class="FormField">
         <label>Schema</label>
         <input class="FormControl" name="dbSchema" value="public">
       </div>
-    </div>
-
-    <div class="FormField">
-      <label>Database</label>
-      <input class="FormControl" name="dbName" value="flarum">
     </div>
 
     <div data-group="mysql,mariadb,pgsql">

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -47,7 +47,7 @@ class SetupScript
             default => 0,
         });
         $this->name = getenv('DB_DATABASE') ?: 'flarum_test';
-        $this->name = getenv('DB_SCHEMA') ?: 'public';
+        $this->schema = getenv('DB_SCHEMA') ?: 'public';
         $this->user = getenv('DB_USERNAME') ?: 'root';
         $this->pass = getenv('DB_PASSWORD') ?? 'root';
         $this->pref = getenv('DB_PREFIX') ?: '';
@@ -59,7 +59,7 @@ class SetupScript
 
         if ($this->driver === 'sqlite') {
             echo "Connecting to SQLite database at $this->name.\n";
-        } else if ($this->driver === 'pgsql') {
+        } elseif ($this->driver === 'pgsql') {
             echo "Connecting to database $this->name, schema $this->schema at $this->host:$this->port.\n";
         } else {
             echo "Connecting to database $this->name at $this->host:$this->port.\n";

--- a/php-packages/testing/src/integration/Setup/SetupScript.php
+++ b/php-packages/testing/src/integration/Setup/SetupScript.php
@@ -25,6 +25,7 @@ class SetupScript
     protected string $host;
     protected int $port;
     protected string $name;
+    protected string $schema;
     protected string $user;
     protected string $pass;
     protected string $pref;
@@ -46,6 +47,7 @@ class SetupScript
             default => 0,
         });
         $this->name = getenv('DB_DATABASE') ?: 'flarum_test';
+        $this->name = getenv('DB_SCHEMA') ?: 'public';
         $this->user = getenv('DB_USERNAME') ?: 'root';
         $this->pass = getenv('DB_PASSWORD') ?? 'root';
         $this->pref = getenv('DB_PREFIX') ?: '';
@@ -57,6 +59,8 @@ class SetupScript
 
         if ($this->driver === 'sqlite') {
             echo "Connecting to SQLite database at $this->name.\n";
+        } else if ($this->driver === 'pgsql') {
+            echo "Connecting to database $this->name, schema $this->schema at $this->host:$this->port.\n";
         } else {
             echo "Connecting to database $this->name at $this->host:$this->port.\n";
         }
@@ -80,6 +84,7 @@ class SetupScript
             $this->host,
             $this->port,
             $this->name,
+            $this->schema,
             $this->user,
             $this->pass,
             $this->pref


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4240**

**Changes proposed in this pull request:**
Added support for specifying and using pgsql's search_path

**Reviewers should focus on:**
- Some changes to existing classes and method signatures.
- Some changes to UI:
    - Addition of a "Schema" field.
    - Triggering the update of the UI upon DOM loading, so that the field is only displayed for the relevant driver.

**Screenshot**

<img width="564" height="1124" alt="image" src="https://github.com/user-attachments/assets/24cc19bf-397e-457d-9197-90e431ede560" />

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
    - Not acceptable: Install in `"public"` schema, then move tables to other schema and finally change `config.php`.
- [x] For core PRs, does this need to be in core, or could it be in an extension?
    - Needs to be in core as the issue/limitation exists since install.
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
    - There is no such command on my `composer.json`s
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
