### PR TITLE
[1.x] fix(a11y): missing default alt text for avatar

### DIFF
--- a/framework/core/js/src/common/helpers/avatar.tsx
+++ b/framework/core/js/src/common/helpers/avatar.tsx
@@ -22,12 +22,6 @@ export default function avatar(user: User | null, attrs: ComponentAttrs = {}): M
   const hasTitle: boolean | string = attrs.title === 'undefined' || attrs.title;
   if (!hasTitle) delete attrs.title;
 
-  // If the `alt` attribute is set to null or false, we don't want to give the
-  // avatar an alt description. If it hasn't been set, we can default it later
-  // to the user's display name for accessibility.
-  const hasAlt: boolean | string = attrs.alt === 'undefined' || attrs.alt;
-  if (!hasAlt) delete attrs.alt;
-
   // If a user has been passed, then we will set up an avatar using their
   // uploaded image, or the first letter of their username if they haven't
   // uploaded one.
@@ -37,25 +31,27 @@ export default function avatar(user: User | null, attrs: ComponentAttrs = {}): M
 
     if (hasTitle) attrs.title = attrs.title || username;
 
-    // If alt has not been explicitly set, default it to the username
-    // so screen readers have meaningful context.
-    if (attrs.alt === undefined) {
-      attrs.alt = username;
-    }
+    // Alt text logic:
+    // If the `alt` attribute is set to null or false, we don't want to give the
+    // avatar an alt description. If it hasn't been provided, we'll default it to
+    // the user's display name *when rendering an <img>* so screen readers have context.
+    const hasAlt: boolean | string = attrs.alt === 'undefined' || attrs.alt;
+    if (!hasAlt) delete attrs.alt;
 
     if (avatarUrl) {
+      // Default alt to username unless explicitly overridden.
+      if (attrs.alt === undefined) {
+        attrs.alt = username;
+      }
+
       return <img {...attrs} src={avatarUrl} />;
     }
 
     content = username.charAt(0).toUpperCase();
     attrs.style = { '--avatar-bg': user.color() };
-  } else {
-    // If there is no user, and no alt provided, set alt to an empty string
-    // so the avatar is treated as decorative.
-    if (attrs.alt === undefined) {
-      attrs.alt = '';
-    }
   }
 
+  // Note: We intentionally do NOT set `alt` when rendering the fallback <span>,
+  // as `alt` is only valid for certain elements (e.g., <img>, <area>, <input type="image">).
   return <span {...attrs}>{content}</span>;
 }

--- a/framework/core/js/src/common/helpers/avatar.tsx
+++ b/framework/core/js/src/common/helpers/avatar.tsx
@@ -22,6 +22,12 @@ export default function avatar(user: User | null, attrs: ComponentAttrs = {}): M
   const hasTitle: boolean | string = attrs.title === 'undefined' || attrs.title;
   if (!hasTitle) delete attrs.title;
 
+  // If the `alt` attribute is set to null or false, we don't want to give the
+  // avatar an alt description. If it hasn't been set, we can default it later
+  // to the user's display name for accessibility.
+  const hasAlt: boolean | string = attrs.alt === 'undefined' || attrs.alt;
+  if (!hasAlt) delete attrs.alt;
+
   // If a user has been passed, then we will set up an avatar using their
   // uploaded image, or the first letter of their username if they haven't
   // uploaded one.
@@ -31,12 +37,24 @@ export default function avatar(user: User | null, attrs: ComponentAttrs = {}): M
 
     if (hasTitle) attrs.title = attrs.title || username;
 
+    // If alt has not been explicitly set, default it to the username
+    // so screen readers have meaningful context.
+    if (attrs.alt === undefined) {
+      attrs.alt = username;
+    }
+
     if (avatarUrl) {
-      return <img {...attrs} src={avatarUrl} alt="" />;
+      return <img {...attrs} src={avatarUrl} />;
     }
 
     content = username.charAt(0).toUpperCase();
     attrs.style = { '--avatar-bg': user.color() };
+  } else {
+    // If there is no user, and no alt provided, set alt to an empty string
+    // so the avatar is treated as decorative.
+    if (attrs.alt === undefined) {
+      attrs.alt = '';
+    }
   }
 
   return <span {...attrs}>{content}</span>;


### PR DESCRIPTION
This PR improves accessibility of the avatar helper by ensuring that <img> avatars include meaningful alt text by default.
	•	If a user is present and no alt attribute is provided, it falls back to the user’s display name.
	•	If explicitly set to null/false, the alt attribute is omitted (treated as decorative).
	•	For cases where no user is passed, the alt defaults to an empty string.

This change aligns avatars with [WCAG guidelines](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) by providing screen readers with descriptive text, while still allowing developers to override or suppress alt when needed.

A follow-up PR for `2.x` will also be made

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
