### PR TITLE
[1.x] (core) feat: better support 3rd party extensions setting canonical urls

### DIFF
--- a/framework/core/src/Forum/Content/Discussion.php
+++ b/framework/core/src/Forum/Content/Discussion.php
@@ -100,7 +100,12 @@ class Discussion
         $document->content = $this->view->make('flarum.forum::frontend.content.discussion', compact('apiDocument', 'page', 'hasPrevPage', 'hasNextPage', 'getResource', 'posts', 'url'));
         $document->payload['apiDocument'] = $apiDocument;
 
-        $document->canonicalUrl = $url([]);
+        // Only apply the canonical URL if it's empty. It could have been set by another extension already,
+        // if so, we'll leave it alone.
+        if (empty($document->canonicalUrl)) {
+            $document->canonicalUrl = $url([]);
+        }
+
         $document->page = $page;
         $document->hasNextPage = $hasNextPage;
 

--- a/framework/core/src/Forum/Content/Index.php
+++ b/framework/core/src/Forum/Content/Index.php
@@ -89,7 +89,12 @@ class Index
         $document->content = $this->view->make('flarum.forum::frontend.content.index', compact('apiDocument', 'page'));
         $document->payload['apiDocument'] = $apiDocument;
 
-        $document->canonicalUrl = $this->url->to('forum')->base().($defaultRoute === '/all' ? '' : $request->getUri()->getPath());
+        // Only apply the canonical URL if it's empty. It could have been set by another extension already,
+        // if so, we'll leave it alone.
+        if (empty($document->canonicalUrl)) {
+            $document->canonicalUrl = $this->url->to('forum')->base().($defaultRoute === '/all' ? '' : $request->getUri()->getPath());
+        }
+
         $document->page = $page;
         $document->hasNextPage = isset($apiDocument->links->next);
 

--- a/framework/core/src/Forum/Content/User.php
+++ b/framework/core/src/Forum/Content/User.php
@@ -47,7 +47,13 @@ class User
         $user = $apiDocument->data->attributes;
 
         $document->title = $user->displayName;
-        $document->canonicalUrl = $this->url->to('forum')->route('user', ['username' => $user->slug]);
+
+        // Only apply the canonical URL if it's empty. It could have been set by another extension already,
+        // if so, we'll leave it alone.
+        if (empty($document->canonicalUrl)) {
+            $document->canonicalUrl = $this->url->to('forum')->route('user', ['username' => $user->slug]);
+        }
+
         $document->payload['apiDocument'] = $apiDocument;
 
         return $document;


### PR DESCRIPTION
We currently assume that we will always be the source of truth for canonical URL setting. If a 3rd party extension needed to set a different canonical URL for any reason, this would then be overwritten. This change aims to accept pre-setting the canonical.

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
