### PR TITLE
[1.x] fix: validate mail settings for whitespace

### DIFF
--- a/framework/core/src/Mail/MailgunDriver.php
+++ b/framework/core/src/Mail/MailgunDriver.php
@@ -18,6 +18,8 @@ use Swift_Transport;
 
 class MailgunDriver implements DriverInterface
 {
+    use ValidatesMailSettings;
+    
     public function availableSettings(): array
     {
         return [
@@ -33,7 +35,7 @@ class MailgunDriver implements DriverInterface
     public function validate(SettingsRepositoryInterface $settings, Factory $validator): MessageBag
     {
         return $validator->make($settings->all(), [
-            'mail_mailgun_secret' => 'required',
+            'mail_mailgun_secret' => ['required', $this->noWhitespace()],
             'mail_mailgun_domain' => 'required|regex:/^(?!\-)(?:[a-zA-Z\d\-]{0,62}[a-zA-Z\d]\.){1,126}(?!\d+)[a-zA-Z\d]{1,63}$/',
             'mail_mailgun_region' => 'required|in:api.mailgun.net,api.eu.mailgun.net',
         ])->errors();

--- a/framework/core/src/Mail/SmtpDriver.php
+++ b/framework/core/src/Mail/SmtpDriver.php
@@ -17,6 +17,8 @@ use Swift_Transport;
 
 class SmtpDriver implements DriverInterface
 {
+    use ValidatesMailSettings;
+
     public function availableSettings(): array
     {
         return [
@@ -31,11 +33,11 @@ class SmtpDriver implements DriverInterface
     public function validate(SettingsRepositoryInterface $settings, Factory $validator): MessageBag
     {
         return $validator->make($settings->all(), [
-            'mail_host' => 'required',
-            'mail_port' => 'nullable|integer',
+            'mail_host' => ['required', $this->noWhitespace()],
+            'mail_port' => ['nullable', 'integer', $this->noWhitespace()],
             'mail_encryption' => 'nullable|in:tls,ssl,TLS,SSL',
-            'mail_username' => 'nullable|string',
-            'mail_password' => 'nullable|string',
+            'mail_username' => ['nullable', 'string', $this->noWhitespace()],
+            'mail_password' => ['nullable', 'string', $this->noWhitespace()],
         ])->errors();
     }
 

--- a/framework/core/src/Mail/ValidatesMailSettings.php
+++ b/framework/core/src/Mail/ValidatesMailSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+trait ValidatesMailSettings
+{
+    /**
+     * Returns a validation rule that checks for leading or trailing whitespace.
+     *
+     * @return callable
+     */
+    protected function noWhitespace(): callable
+    {
+        return function ($attribute, $value, $fail) {
+            if ($value !== trim($value)) {
+                $fail('The ' . str_replace('_', ' ', $attribute) . ' must not contain leading or trailing whitespace.');
+            }
+        };
+    }
+}

--- a/framework/core/tests/integration/api/settings/MailSettingsTest.php
+++ b/framework/core/tests/integration/api/settings/MailSettingsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\settings;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class MailSettingsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function smtpDriverWithWhitespaceIsInvalidated()
+    {
+        $this->setting('mail_driver', 'smtp');
+        $this->setting('mail_host', ' world');
+        $this->setting('mail_port', ' 587 ');
+        $this->setting('mail_encryption', 'tls');
+        $this->setting('mail_username', 'user ');
+        $this->setting('mail_password', ' password');
+
+        $mailSettingsResponse = $this->send(
+            $this->request('GET', '/api/mail/settings', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
+        
+        $data = json_decode((string) $mailSettingsResponse->getBody(), true);
+
+        $this->assertFalse($data['data']['attributes']['sending']);
+
+        $this->assertArrayHasKey('errors', $data['data']['attributes']);
+
+        $this->assertArrayHasKey('mail_host', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail host must not contain leading or trailing whitespace.', $data['data']['attributes']['errors']['mail_host'][0]);
+
+        $this->assertArrayHasKey('mail_port', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail port must not contain leading or trailing whitespace.', $data['data']['attributes']['errors']['mail_port'][0]);
+
+        $this->assertArrayHasKey('mail_username', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail username must not contain leading or trailing whitespace.', $data['data']['attributes']['errors']['mail_username'][0]);
+
+        $this->assertArrayHasKey('mail_password', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail password must not contain leading or trailing whitespace.', $data['data']['attributes']['errors']['mail_password'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function smtpDriverWithValidSettingsIsNotInvalidated()
+    {
+        $this->setting('mail_driver', 'smtp');
+        $this->setting('mail_host', 'mail.example.com');
+        $this->setting('mail_port', '587');
+        $this->setting('mail_encryption', 'tls');
+        $this->setting('mail_username', 'user');
+        $this->setting('mail_password', 'password');
+
+        $mailSettingsResponse = $this->send(
+            $this->request('GET', '/api/mail/settings', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
+        
+        $data = json_decode((string) $mailSettingsResponse->getBody(), true);
+
+        $this->assertEmpty($data['data']['attributes']['errors']);
+        $this->assertTrue($data['data']['attributes']['sending']);
+    }
+
+    /**
+     * @test
+     */
+    public function mailgunDriverWithWhitespaceIsInvalidated()
+    {
+        $this->setting('mail_driver', 'mailgun');
+        $this->setting('mail_mailgun_secret', 'key ');
+        $this->setting('mail_mailgun_domain', ' example.com');
+        $this->setting('mail_mailgun_region', 'api.mailgun.net');
+
+        $mailSettingsResponse = $this->send(
+            $this->request('GET', '/api/mail/settings', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
+
+        $data = json_decode((string) $mailSettingsResponse->getBody(), true);
+
+        $this->assertFalse($data['data']['attributes']['sending']);
+
+        $this->assertArrayHasKey('errors', $data['data']['attributes']);
+
+        $this->assertArrayHasKey('mail_mailgun_secret', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail mailgun secret must not contain leading or trailing whitespace.', $data['data']['attributes']['errors']['mail_mailgun_secret'][0]);
+
+        $this->assertArrayHasKey('mail_mailgun_domain', $data['data']['attributes']['errors']);
+        $this->assertEquals('The mail mailgun domain format is invalid.', $data['data']['attributes']['errors']['mail_mailgun_domain'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function mailgunDriverWithValidSettingsIsNotInvalidated()
+    {
+        $this->setting('mail_driver', 'mailgun');
+        $this->setting('mail_mailgun_secret', 'key');
+        $this->setting('mail_mailgun_domain', 'example.com');
+        $this->setting('mail_mailgun_region', 'api.mailgun.net');
+
+        $mailSettingsResponse = $this->send(
+            $this->request('GET', '/api/mail/settings', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
+
+        $data = json_decode((string) $mailSettingsResponse->getBody(), true);
+
+        $this->assertEmpty($data['data']['attributes']['errors']);
+        $this->assertTrue($data['data']['attributes']['sending']);
+    }
+}


### PR DESCRIPTION
**Fixes #4222 **

**Changes proposed in this pull request:**
Introduces a reusable trait `ValidatesMailSettings` which is used by default in `SmtpDriver` and `MailgunDriver` to ensure that leading or trailing whitespace throws a validation error, which is displayed in the mail settings UI.

I'll also create an accompanying PR to this for `2.x`

For `SmtpDriver`, we now check for whitespace on
- `mail_host`
- `mail_port`
- `mail_username` *
- `mail_password` *

`* still allows for empty string`

For `MailgunDriver`
- `mail_mailgun_secret`

`mail_mailgun_domain` is already covered by the regex rule in place

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="1218" height="580" alt="image" src="https://github.com/user-attachments/assets/7dffd60e-bc75-465b-81d1-7e1fb0fc812c" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
- [X] Core developer confirmed locally this works as intended.
- [X] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
