### PR TITLE
[2.x] chore(core): improve `a11y` of avatar with no `avatarUrl`

### DIFF
--- a/framework/core/js/src/common/components/Avatar.tsx
+++ b/framework/core/js/src/common/components/Avatar.tsx
@@ -49,6 +49,10 @@ export default class Avatar<CustomAttrs extends IAvatarAttrs = IAvatarAttrs> ext
 
       content = username.charAt(0).toUpperCase();
       attrs.style = !window.testing && { '--avatar-bg': user.color() };
+
+      delete attrs.loading;
+      attrs.role = 'img';
+      attrs['aria-label'] = username;
     }
 
     // Note: We intentionally do NOT set `alt` when rendering the fallback <span>,


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->
`2.x` equivalent to https://github.com/flarum/framework/pull/4246

**Fixes #0000**

**Changes proposed in this pull request:**
* Removes the unnecessary `loading="lazy"` attribute for avatars with no `avatarUrl`
* Sets the aria role to `img` and adds an `aria-label`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before this Change:

```html
<span class="Avatar Post-avatar" loading="lazy" style="--avatar-bg: #afa0e5;">M</span>
```

After this change:

```html
<span class="Avatar Post-avatar" role="img" aria-label="moderator" style="--avatar-bg: #afa0e5;">M</span>
```

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
