### PR TITLE
[1.x] refactor(core): improve extensibility of `NotificationList`

### DIFF
--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -14,19 +14,27 @@ import Tooltip from '../../common/components/Tooltip';
  */
 export default class NotificationList extends Component {
   view() {
+    return <div className="NotificationList">{this.viewItems().toArray()}</div>;
+  }
+
+  viewItems() {
     const state = this.attrs.state;
+    const items = new ItemList();
 
-    return (
-      <div className="NotificationList">
-        <div className="NotificationList-header">
-          <h4 className="App-titleControl App-titleControl--text">{app.translator.trans('core.forum.notifications.title')}</h4>
+    items.add('header', <div className="NotificationList-header">{this.headerItems().toArray()}</div>, 100);
 
-          <div className="App-primaryControl">{this.controlItems().toArray()}</div>
-        </div>
+    items.add('content', <div className="NotificationList-content">{this.content(state)}</div>, 90);
 
-        <div className="NotificationList-content">{this.content(state)}</div>
-      </div>
-    );
+    return items;
+  }
+
+  headerItems() {
+    const items = new ItemList();
+
+    items.add('title', <h4 className="App-titleControl App-titleControl--text">{app.translator.trans('core.forum.notifications.title')}</h4>, 100);
+    items.add('controls', <div className="App-primaryControl">{this.controlItems().toArray()}</div>, 90);
+
+    return items;
   }
 
   controlItems() {

--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -112,7 +112,7 @@ export default class NotificationList extends Component {
                   <span>{group.discussion.title()}</span>
                 </Link>
               ) : (
-                <div className="NotificationGroup-header">{app.forum.attribute('title')}</div>
+                <div className="NotificationGroup-header">{this.groupTitle(group)}</div>
               )}
 
               <ul className="NotificationGroup-content">
@@ -134,6 +134,10 @@ export default class NotificationList extends Component {
     }
 
     return <div className="NotificationList-empty">{app.translator.trans('core.forum.notifications.empty_text')}</div>;
+  }
+
+  groupTitle(group) {
+    return app.forum.attribute('title');
   }
 
   oncreate(vnode) {

--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -81,67 +81,67 @@ export default class NotificationList extends Component {
       return <LoadingIndicator className="LoadingIndicator--block" />;
     }
 
-    if (state.hasItems()) {
-      return state.getPages().map((page) => {
-        const groups = [];
-        const discussions = {};
-
-        page.items.forEach((notification) => {
-          const subject = notification.subject();
-
-          if (typeof subject === 'undefined') return;
-
-          // Get the discussion that this notification is related to. If it's not
-          // directly related to a discussion, it may be related to a post or
-          // other entity which is related to a discussion.
-          let discussion = null;
-          if (subject instanceof Discussion) discussion = subject;
-          else if (subject && subject.discussion) discussion = subject.discussion();
-
-          // If the notification is not related to a discussion directly or
-          // indirectly, then we will assign it to a neutral group.
-          const key = discussion ? discussion.id() : 0;
-          discussions[key] = discussions[key] || { discussion: discussion, notifications: [] };
-          discussions[key].notifications.push(notification);
-
-          if (groups.indexOf(discussions[key]) === -1) {
-            groups.push(discussions[key]);
-          }
-        });
-
-        return groups.map((group) => {
-          const badges = group.discussion && group.discussion.badges().toArray();
-
-          return (
-            <div className="NotificationGroup">
-              {group.discussion ? (
-                <Link className="NotificationGroup-header" href={app.route.discussion(group.discussion)}>
-                  {badges && !!badges.length && <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul>}
-                  <span>{group.discussion.title()}</span>
-                </Link>
-              ) : (
-                <div className="NotificationGroup-header">{this.groupTitle(group)}</div>
-              )}
-
-              <ul className="NotificationGroup-content">
-                {group.notifications.map((notification) => {
-                  const NotificationComponent = app.notificationComponents[notification.contentType()];
-                  return (
-                    !!NotificationComponent && (
-                      <li>
-                        <NotificationComponent notification={notification} />
-                      </li>
-                    )
-                  );
-                })}
-              </ul>
-            </div>
-          );
-        });
-      });
+    if (!state.hasItems()) {
+      return <div className="NotificationList-empty">{app.translator.trans('core.forum.notifications.empty_text')}</div>;
     }
 
-    return <div className="NotificationList-empty">{app.translator.trans('core.forum.notifications.empty_text')}</div>;
+    return state.getPages().map((page) => {
+      const groups = [];
+      const discussions = {};
+
+      page.items.forEach((notification) => {
+        const subject = notification.subject();
+
+        if (typeof subject === 'undefined') return;
+
+        // Get the discussion that this notification is related to. If it's not
+        // directly related to a discussion, it may be related to a post or
+        // other entity which is related to a discussion.
+        let discussion = null;
+        if (subject instanceof Discussion) discussion = subject;
+        else if (subject && subject.discussion) discussion = subject.discussion();
+
+        // If the notification is not related to a discussion directly or
+        // indirectly, then we will assign it to a neutral group.
+        const key = discussion ? discussion.id() : 0;
+        discussions[key] = discussions[key] || { discussion: discussion, notifications: [] };
+        discussions[key].notifications.push(notification);
+
+        if (groups.indexOf(discussions[key]) === -1) {
+          groups.push(discussions[key]);
+        }
+      });
+
+      return groups.map((group) => {
+        const badges = group.discussion && group.discussion.badges().toArray();
+
+        return (
+          <div className="NotificationGroup">
+            {group.discussion ? (
+              <Link className="NotificationGroup-header" href={app.route.discussion(group.discussion)}>
+                {badges && !!badges.length && <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul>}
+                <span>{group.discussion.title()}</span>
+              </Link>
+            ) : (
+              <div className="NotificationGroup-header">{this.groupTitle(group)}</div>
+            )}
+
+            <ul className="NotificationGroup-content">
+              {group.notifications.map((notification) => {
+                const NotificationComponent = app.notificationComponents[notification.contentType()];
+                return (
+                  !!NotificationComponent && (
+                    <li>
+                      <NotificationComponent notification={notification} />
+                    </li>
+                  )
+                );
+              })}
+            </ul>
+          </div>
+        );
+      });
+    });
   }
 
   groupTitle(group) {

--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -85,63 +85,112 @@ export default class NotificationList extends Component {
       return <div className="NotificationList-empty">{app.translator.trans('core.forum.notifications.empty_text')}</div>;
     }
 
-    return state.getPages().map((page) => {
-      const groups = [];
-      const discussions = {};
+    return state.getPages().flatMap((page) => this.pageItems(page).toArray());
+  }
 
-      page.items.forEach((notification) => {
-        const subject = notification.subject();
+  pageItems(page) {
+    const items = new ItemList();
 
-        if (typeof subject === 'undefined') return;
+    const groups = this.buildGroups(page);
 
-        // Get the discussion that this notification is related to. If it's not
-        // directly related to a discussion, it may be related to a post or
-        // other entity which is related to a discussion.
-        let discussion = null;
-        if (subject instanceof Discussion) discussion = subject;
-        else if (subject && subject.discussion) discussion = subject.discussion();
-
-        // If the notification is not related to a discussion directly or
-        // indirectly, then we will assign it to a neutral group.
-        const key = discussion ? discussion.id() : 0;
-        discussions[key] = discussions[key] || { discussion: discussion, notifications: [] };
-        discussions[key].notifications.push(notification);
-
-        if (groups.indexOf(discussions[key]) === -1) {
-          groups.push(discussions[key]);
-        }
-      });
-
-      return groups.map((group) => {
-        const badges = group.discussion && group.discussion.badges().toArray();
-
-        return (
-          <div className="NotificationGroup">
-            {group.discussion ? (
-              <Link className="NotificationGroup-header" href={app.route.discussion(group.discussion)}>
-                {badges && !!badges.length && <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul>}
-                <span>{group.discussion.title()}</span>
-              </Link>
-            ) : (
-              <div className="NotificationGroup-header">{this.groupTitle(group)}</div>
-            )}
-
-            <ul className="NotificationGroup-content">
-              {group.notifications.map((notification) => {
-                const NotificationComponent = app.notificationComponents[notification.contentType()];
-                return (
-                  !!NotificationComponent && (
-                    <li>
-                      <NotificationComponent notification={notification} />
-                    </li>
-                  )
-                );
-              })}
-            </ul>
-          </div>
-        );
-      });
+    groups.forEach((group, index) => {
+      items.add(`group-${index}`, this.groupView(group), -index);
     });
+
+    return items;
+  }
+
+  buildGroups(page) {
+    const groups = [];
+    const discussions = {};
+
+    page.items.forEach((notification) => {
+      const subject = notification.subject();
+      if (typeof subject === 'undefined') return;
+
+      // Get the discussion that this notification is related to. If it's not
+      // directly related to a discussion, it may be related to a post or
+      // other entity which is related to a discussion.
+      let discussion = null;
+      if (subject instanceof Discussion) discussion = subject;
+      else if (subject && subject.discussion) discussion = subject.discussion();
+
+      // If the notification is not related to a discussion directly or
+      // indirectly, then we will assign it to a neutral group.
+      const key = discussion ? discussion.id() : 0;
+      discussions[key] = discussions[key] || { discussion, notifications: [] };
+      discussions[key].notifications.push(notification);
+
+      if (groups.indexOf(discussions[key]) === -1) {
+        groups.push(discussions[key]);
+      }
+    });
+
+    return groups;
+  }
+
+  groupKey(group, fallbackIndex) {
+    return group.discussion ? group.discussion.id() : `neutral-${fallbackIndex}`;
+  }
+
+  groupView(group) {
+    const badges = group.discussion && group.discussion.badges().toArray();
+
+    const items = this.groupItems(group, badges).toArray();
+
+    return <div className="NotificationGroup">{items}</div>;
+  }
+
+  groupItems(group, badges) {
+    const items = new ItemList();
+
+    items.add('header', this.groupHeaderItems(group, badges).toArray()[0], 100);
+
+    items.add('body', this.groupBodyItems(group).toArray()[0], 90);
+
+    return items;
+  }
+
+  groupHeaderItems(group, badges) {
+    const items = new ItemList();
+
+    if (group.discussion) {
+      items.add(
+        'discussion',
+        <Link className="NotificationGroup-header" href={app.route.discussion(group.discussion)}>
+          {badges && !!badges.length && <ul className="NotificationGroup-badges badges">{listItems(badges)}</ul>}
+          <span>{group.discussion.title()}</span>
+        </Link>,
+        100
+      );
+    } else {
+      items.add('neutral', <div className="NotificationGroup-header">{this.groupTitle(group)}</div>, 0);
+    }
+
+    return items;
+  }
+
+  groupBodyItems(group) {
+    const items = new ItemList();
+
+    items.add(
+      'list',
+      <ul className="NotificationGroup-content">{group.notifications.map((n, i) => this.notificationItem(n, i)).filter(Boolean)}</ul>,
+      100
+    );
+
+    return items;
+  }
+
+  notificationItem(notification) {
+    const NotificationComponent = app.notificationComponents[notification.contentType()];
+    if (!NotificationComponent) return null;
+
+    return (
+      <li>
+        <NotificationComponent notification={notification} />
+      </li>
+    );
   }
 
   groupTitle(group) {


### PR DESCRIPTION

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This PR drastically improves the extensibility of the NotificationList component

While the group parameter is unused in this implementation, it allows third party extensions to differentiate between notification types and then customize this value only when needed

**Reviewers should focus on:**
* This change must obviously be 100% backwards compatible, existing appearance  / behaviour must be the same

Example of how this group title _can_ be customized:

```jsx
extend(NotificationList.prototype, 'groupHeaderItems', (items, group) => {
    if (group.discussion) return;

    const hasNotificationType = (group.notifications || []).some((notification) => notification.contentType?.() === 'extensionDisabled');

    if (!hasNotificationType) return;

    items.setContent('neutral', <div className="NotificationGroup-header">Custom Title</div>);
  });
```

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
