### PR TITLE
[1.x] fix: Reset password, email confirm, activation not locale aware

### DIFF
--- a/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
+++ b/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
@@ -12,6 +12,7 @@ namespace Flarum\Mail;
 use Flarum\Locale\Translator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
+use Symfony\Component\CssSelector\XPath\TranslatorInterface;
 
 trait SetTranslatorLocaleForEmailTrait
 {
@@ -20,7 +21,7 @@ trait SetTranslatorLocaleForEmailTrait
      * Falls back to forum default if user not found or has no preference.
      */
     protected function setTranslatorLocaleForEmail(
-        Translator $translator,
+        TranslatorInterface&Translator $translator,
         SettingsRepositoryInterface $settings,
         string $email
     ): void {

--- a/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
+++ b/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Locale\Translator;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\UserRepository;
+
+trait SetTranslatorLocaleForEmailTrait
+{
+    /**
+     * Set the translator locale based on the user's preference for the given email.
+     * Falls back to forum default if user not found or has no preference.
+     */
+    protected function setTranslatorLocaleForEmail(
+        Translator $translator,
+        SettingsRepositoryInterface $settings,
+        string $email
+    ): void {
+        $users = resolve(UserRepository::class);
+        $user = $users->findByEmail($email);
+        
+        $locale = $user 
+            ? ($user->getPreference('locale') ?? $settings->get('default_locale'))
+            : $settings->get('default_locale');
+            
+        $translator->setLocale($locale);
+    }
+}

--- a/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
+++ b/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
@@ -21,7 +21,7 @@ trait SetTranslatorLocaleForEmailTrait
      * Falls back to forum default if user not found or has no preference.
      */
     protected function setTranslatorLocaleForEmail(
-        TranslatorInterface&Translator $translator,
+        TranslatorInterface $translator,
         SettingsRepositoryInterface $settings,
         string $email
     ): void {
@@ -31,7 +31,8 @@ trait SetTranslatorLocaleForEmailTrait
         $locale = $user 
             ? ($user->getPreference('locale') ?? $settings->get('default_locale'))
             : $settings->get('default_locale');
-            
+
+        /** @var TranslatorInterface&Translator $translator */
         $translator->setLocale($locale);
     }
 }

--- a/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
+++ b/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
@@ -12,7 +12,7 @@ namespace Flarum\Mail;
 use Flarum\Locale\Translator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
-use Symfony\Component\CssSelector\XPath\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 trait SetTranslatorLocaleForEmailTrait
 {

--- a/framework/core/src/User/AccountActivationMailer.php
+++ b/framework/core/src/User/AccountActivationMailer.php
@@ -10,6 +10,7 @@
 namespace Flarum\User;
 
 use Flarum\Http\UrlGenerator;
+use Flarum\Mail\SetTranslatorLocaleForEmailTrait;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Event\Registered;
 use Illuminate\Contracts\Queue\Queue;
@@ -18,6 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class AccountActivationMailer
 {
     use AccountActivationMailerTrait;
+    use SetTranslatorLocaleForEmailTrait;
 
     /**
      * @var SettingsRepositoryInterface
@@ -60,6 +62,8 @@ class AccountActivationMailer
         if ($user->is_email_confirmed) {
             return;
         }
+
+        $this->setTranslatorLocaleForEmail($this->translator, $this->settings, $user->email);
 
         $token = $this->generateToken($user, $user->email);
         $data = $this->getEmailData($user, $token);

--- a/framework/core/src/User/EmailConfirmationMailer.php
+++ b/framework/core/src/User/EmailConfirmationMailer.php
@@ -11,6 +11,7 @@ namespace Flarum\User;
 
 use Flarum\Http\UrlGenerator;
 use Flarum\Mail\Job\SendRawEmailJob;
+use Flarum\Mail\SetTranslatorLocaleForEmailTrait;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Event\EmailChangeRequested;
 use Illuminate\Contracts\Queue\Queue;
@@ -18,6 +19,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EmailConfirmationMailer
 {
+    use SetTranslatorLocaleForEmailTrait;
+
     /**
      * @var SettingsRepositoryInterface
      */
@@ -49,6 +52,9 @@ class EmailConfirmationMailer
     public function handle(EmailChangeRequested $event)
     {
         $email = $event->email;
+
+        $this->setTranslatorLocaleForEmail($this->translator, $this->settings, $email);
+
         $data = $this->getEmailData($event->user, $email);
 
         $body = $this->translator->trans('core.email.confirm_email.body', $data);

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -39,11 +39,11 @@ class RequestPasswordResetJob extends AbstractJob
         SettingsRepositoryInterface $settings,
         UrlGenerator $url,
         TranslatorInterface $translator,
+        UserRepository $users,
         Queue $queue
     ) {
         $this->setTranslatorLocaleForEmail($translator, $settings, $this->email);
 
-        $users = resolve(UserRepository::class);
         $user = $users->findByEmail($this->email);
 
         if (! $user) {

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -11,6 +11,7 @@ namespace Flarum\User\Job;
 
 use Flarum\Http\UrlGenerator;
 use Flarum\Mail\Job\SendRawEmailJob;
+use Flarum\Mail\SetTranslatorLocaleForEmailTrait;
 use Flarum\Queue\AbstractJob;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\PasswordToken;
@@ -20,6 +21,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RequestPasswordResetJob extends AbstractJob
 {
+    use SetTranslatorLocaleForEmailTrait;
+
     /**
      * @var string
      */
@@ -36,9 +39,11 @@ class RequestPasswordResetJob extends AbstractJob
         SettingsRepositoryInterface $settings,
         UrlGenerator $url,
         TranslatorInterface $translator,
-        UserRepository $users,
         Queue $queue
     ) {
+        $this->setTranslatorLocaleForEmail($translator, $settings, $this->email);
+
+        $users = resolve(UserRepository::class);
         $user = $users->findByEmail($this->email);
 
         if (! $user) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Ensures that the locale matches the user's preference when sending emails such as
- Password reset
- Account activation
- Confirm email

These are all handled via `SendRawEmailJob`, which only deals with plain strings, so a new trait has been added for use by classes that send email in this way.

For `2.x` I'd propose we look at refactoring and making the job locale aware, but that cannot be done within the confines of `1.8.x` due to the braking changes it would introduce. I'll work on a `2.x` solution soon...

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
