### PR TITLE
[1.x] fix: userOnline can render as null, causing the page to break

### DIFF
--- a/framework/core/js/src/forum/components/PostUser.js
+++ b/framework/core/js/src/forum/components/PostUser.js
@@ -69,7 +69,7 @@ export default class PostUser extends Component {
     items.add('avatar', avatar(user, { className: 'PostUser-avatar' }), 100);
 
     const onlineIndicator = userOnline(user);
-    if (onlineIndicator) {
+    if (onlineIndicator !== null) {
       items.add('userOnline', onlineIndicator, 90);
     }
 

--- a/framework/core/js/src/forum/components/PostUser.js
+++ b/framework/core/js/src/forum/components/PostUser.js
@@ -68,7 +68,10 @@ export default class PostUser extends Component {
 
     items.add('avatar', avatar(user, { className: 'PostUser-avatar' }), 100);
 
-    items.add('userOnline', userOnline(user), 90);
+    const onlineIndicator = userOnline(user);
+    if (onlineIndicator) {
+      items.add('userOnline', onlineIndicator, 90);
+    }
 
     items.add('username', username(user), 80);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Fixes a regression introduced during 1.8.11 development that caused the `userOnline` helper to render `null` in the dom

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
