### PR TITLE
[2.x] Admin `StatusWidgetItem`

### DIFF
--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -7,6 +7,7 @@ import Button from '../../common/components/Button';
 import LoadingModal from './LoadingModal';
 import LinkButton from '../../common/components/LinkButton';
 import saveSettings from '../utils/saveSettings';
+import StatusWidgetItem from './StatusWidgetItem';
 
 export default class StatusWidget extends DashboardWidget {
   className() {
@@ -32,32 +33,44 @@ export default class StatusWidget extends DashboardWidget {
       </Dropdown>
     );
 
-    items.add('version-flarum', [<strong>Flarum</strong>, <br />, app.forum.attribute('version')], 100);
-    items.add('version-php', [<strong>PHP</strong>, <br />, app.data.phpVersion], 90);
-    items.add('version-db', [<strong>{app.data.dbDriver}</strong>, <br />, app.data.dbVersion], 80);
-    if (app.data.schedulerStatus) {
-      items.add(
-        'schedule-status',
-        [
+    items.add('version-flarum', <StatusWidgetItem label="Flarum" value={app.forum.attribute('version')} icon="fas fa-comments" />, 100);
+
+    items.add('version-php', <StatusWidgetItem label="PHP" value={app.data.phpVersion} icon="fab fa-php" />, 90);
+
+    items.add('version-db', <StatusWidgetItem label={app.data.dbDriver} value={app.data.dbVersion} icon="fas fa-database" />, 80);
+
+    items.add(
+      'schedule-status',
+      <StatusWidgetItem
+        icon="fas fa-clock"
+        label={app.translator.trans('core.admin.dashboard.status.headers.scheduler-status')}
+        value={
           <span>
-            <strong>{app.translator.trans('core.admin.dashboard.status.headers.scheduler-status')}</strong>{' '}
+            {app.data.schedulerStatus}{' '}
             <LinkButton href="https://docs.flarum.org/scheduler" external={true} target="_blank" icon="fas fa-info-circle" />
-          </span>,
-          <br />,
-          app.data.schedulerStatus,
-        ],
-        70
-      );
-    }
+          </span>
+        }
+      />,
+      70
+    );
 
     items.add(
       'queue-driver',
-      [<strong>{app.translator.trans('core.admin.dashboard.status.headers.queue-driver')}</strong>, <br />, app.data.queueDriver],
+      <StatusWidgetItem
+        icon="fas fa-list-check"
+        label={app.translator.trans('core.admin.dashboard.status.headers.queue-driver')}
+        value={app.data.queueDriver}
+      />,
       60
     );
+
     items.add(
       'session-driver',
-      [<strong>{app.translator.trans('core.admin.dashboard.status.headers.session-driver')}</strong>, <br />, app.data.sessionDriver],
+      <StatusWidgetItem
+        icon="fas fa-user-lock"
+        label={app.translator.trans('core.admin.dashboard.status.headers.session-driver')}
+        value={app.data.sessionDriver}
+      />,
       50
     );
 

--- a/framework/core/js/src/admin/components/StatusWidgetItem.tsx
+++ b/framework/core/js/src/admin/components/StatusWidgetItem.tsx
@@ -2,6 +2,7 @@ import Component, { ComponentAttrs } from '../../common/Component';
 import type Mithril from 'mithril';
 import ItemList from '../../common/utils/ItemList';
 import classList from '../../common/utils/classList';
+import Icon from '../../common/components/Icon';
 
 export interface StatusWidgetItemAttrs extends ComponentAttrs {
   /**
@@ -63,9 +64,9 @@ export default class StatusWidgetItem<CustomAttrs extends StatusWidgetItemAttrs 
   iconView(): Mithril.Children {
     const { icon } = this.attrs;
 
-    if (!icon) return null;
+    if (!icon) return <></>;
 
-    return <i className={icon} />;
+    return <Icon name={icon} />;
   }
 
   /**

--- a/framework/core/js/src/admin/components/StatusWidgetItem.tsx
+++ b/framework/core/js/src/admin/components/StatusWidgetItem.tsx
@@ -1,0 +1,84 @@
+import Component, { ComponentAttrs } from '../../common/Component';
+import type Mithril from 'mithril';
+import ItemList from '../../common/utils/ItemList';
+import classList from '../../common/utils/classList';
+
+export interface StatusWidgetItemAttrs extends ComponentAttrs {
+  /**
+   * The label/header for this status item
+   */
+  label: Mithril.Children;
+
+  /**
+   * The value/content to display
+   */
+  value: Mithril.Children;
+
+  /**
+   * Optional icon to display next to the label
+   */
+  icon?: string;
+}
+
+export default class StatusWidgetItem<CustomAttrs extends StatusWidgetItemAttrs = StatusWidgetItemAttrs> extends Component<CustomAttrs> {
+  view() {
+    return <li className={classList('StatusWidgetItem', this.attrs.className)}>{this.content()}</li>;
+  }
+
+  /**
+   * Build the main content of the status item.
+   * Can be overridden to completely customize the layout.
+   */
+  content(): Mithril.Children {
+    const { icon } = this.attrs;
+
+    return (
+      <>
+        {icon && <i className={icon} />}
+        <div className="StatusWidgetItem-content">
+          {this.labelView()}
+          {this.valueView()}
+        </div>
+      </>
+    );
+  }
+
+  /**
+   * Build an ItemList of the status item's contents.
+   * Extensions can easily add, remove, or modify parts.
+   */
+  contentItems(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('icon', this.iconView(), 100);
+    items.add('label', this.labelView(), 90);
+    items.add('value', this.valueView(), 70);
+
+    return items;
+  }
+
+  /**
+   * Render the icon (if provided).
+   */
+  iconView(): Mithril.Children {
+    const { icon } = this.attrs;
+
+    if (!icon) return null;
+
+    return <i className={icon} />;
+  }
+
+  /**
+   * Render the label.
+   */
+  labelView(): Mithril.Children {
+    return <strong className="StatusWidgetItem-label">{this.attrs.label}</strong>;
+  }
+
+  /**
+   * Render the value.
+   */
+  valueView(): Mithril.Children {
+    return <span className="StatusWidgetItem-value">{this.attrs.value}</span>;
+  }
+}

--- a/framework/core/less/admin/DashboardPage.less
+++ b/framework/core/less/admin/DashboardPage.less
@@ -20,12 +20,12 @@
 .StatusWidget {
   color: var(--muted-color);
 
-  >ul {
+  > ul {
     margin: 0;
     padding: 0;
     list-style-type: none;
 
-    >li {
+    > li {
       display: inline-block;
       margin-right: 30px;
       vertical-align: middle;
@@ -40,6 +40,42 @@
       &.item-tools {
         float: right;
         margin-right: 0;
+      }
+    }
+  }
+}
+
+.StatusWidgetItem {
+  display: flex;
+  align-items: flex-start;
+  
+  > i {
+    margin-right: 8px;
+    margin-top: 2px;
+    opacity: 0.7;
+    flex-shrink: 0;
+  }
+
+  &-content {
+    flex: 1;
+  }
+
+  &-label {
+    display: block;
+    margin-bottom: 2px;
+  }
+
+  &-value {
+    display: block;
+    
+    .LinkButton {
+      margin-left: 4px;
+      opacity: 0.6;
+      text-decoration: none;
+      
+      &:hover {
+        opacity: 1;
+        text-decoration: none;
       }
     }
   }

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -63,10 +63,7 @@ class AdminPayload
         $document->payload['dbOptions'] = $this->appInfo->identifyDatabaseOptions();
         $document->payload['debugEnabled'] = Arr::get($this->config, 'debug');
 
-        if ($this->appInfo->scheduledTasksRegistered()) {
-            $document->payload['schedulerStatus'] = $this->appInfo->getSchedulerStatus();
-        }
-
+        $document->payload['schedulerStatus'] = $this->appInfo->getSchedulerStatus();
         $document->payload['queueDriver'] = $this->appInfo->identifyQueueDriver();
         $document->payload['sessionDriver'] = $this->appInfo->identifySessionDriver(true);
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Creates an extensible, reusable component for displaying data in the Status bar

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="1548" height="238" alt="image" src="https://github.com/user-attachments/assets/569f57d0-1587-4279-a3b0-0b754f8a9e49" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
