### PR TITLE
[2.x] fix: prevent avatar editor overlay stretching

### DIFF
--- a/framework/core/less/forum/AvatarEditor.less
+++ b/framework/core/less/forum/AvatarEditor.less
@@ -1,6 +1,10 @@
 .AvatarEditor {
   position: relative;
 
+  // prevent flex stretching and make the box the same size as the img
+  display: inline-block;
+  align-self: flex-start;
+
   .Dropdown-toggle {
     margin: 4px;
     font-size: 26px;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
When extensions add additional content to `UserCard`, the overlay becomes stretched based on the overall height.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before:
<img width="878" height="426" alt="image" src="https://github.com/user-attachments/assets/c07dc165-29be-49e3-90b0-e54165f5b122" />


After:

<img width="876" height="376" alt="image" src="https://github.com/user-attachments/assets/984aab6b-06e7-4e9d-a271-40ab49d59aae" />

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
