### PR TITLE
[2.x] feat: `DatabaseQueue` support, queue settings in advanced page

### DIFF
--- a/framework/core/js/src/admin/components/AdvancedPage.tsx
+++ b/framework/core/js/src/admin/components/AdvancedPage.tsx
@@ -70,6 +70,8 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
 
     items.add('maintenance', this.maintenance(), 90);
 
+    items.add('queue', this.queue(), 70);
+
     if (app.data.dbDriver === DatabaseDriver.PostgreSQL) {
       items.add(DatabaseDriver.PostgreSQL, this.pgsqlSettings(), 80);
     }
@@ -194,6 +196,115 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
     );
   }
 
+  queue() {
+    return <FormSection label={app.translator.trans('core.admin.advanced.queue.section_label')}>{this.queueItems().toArray()}</FormSection>;
+  }
+
+  queueItems() {
+    const items = new ItemList<Mithril.Children>();
+    const driver = app.data.queueDriver || 'sync';
+
+    // Extensions can remove this and add their own by key
+    if (driver === 'sync') {
+      items.add('content', this.queueSyncContent(), 100);
+    } else if (driver === 'database') {
+      items.add('content', this.queueDatabaseContent(), 100);
+    } else {
+      items.add('content', this.queueCustomContent(), 100);
+    }
+
+    return items;
+  }
+
+  queueSyncContent() {
+    return (
+      <InfoTile icon="fas fa-bolt" className="InfoTile--muted">
+        <p>{app.translator.trans('core.admin.advanced.queue.sync_info')}</p>
+        <p className="helpText">{app.translator.trans('core.admin.advanced.queue.sync_help')}</p>
+      </InfoTile>
+    );
+  }
+
+  queueDatabaseContent() {
+    return <Form>{this.queueDatabaseSettings().toArray()}</Form>;
+  }
+
+  queueDatabaseSettings() {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'retries',
+      this.buildSettingComponent({
+        type: 'number',
+        setting: 'database-queue.retries',
+        label: app.translator.trans('core.admin.advanced.queue.retries_label'),
+        help: app.translator.trans('core.admin.advanced.queue.retries_help'),
+        placeholder: '1',
+        min: 1,
+      }),
+      100
+    );
+
+    items.add(
+      'memory',
+      this.buildSettingComponent({
+        type: 'number',
+        setting: 'database-queue.memory',
+        label: app.translator.trans('core.admin.advanced.queue.memory_label'),
+        help: app.translator.trans('core.admin.advanced.queue.memory_help'),
+        placeholder: '128',
+        min: 32,
+      }),
+      90
+    );
+
+    items.add(
+      'timeout',
+      this.buildSettingComponent({
+        type: 'number',
+        setting: 'database-queue.timeout',
+        label: app.translator.trans('core.admin.advanced.queue.timeout_label'),
+        help: app.translator.trans('core.admin.advanced.queue.timeout_help'),
+        placeholder: '60',
+        min: 1,
+      }),
+      80
+    );
+
+    items.add(
+      'rest',
+      this.buildSettingComponent({
+        type: 'number',
+        setting: 'database-queue.rest',
+        label: app.translator.trans('core.admin.advanced.queue.rest_label'),
+        help: app.translator.trans('core.admin.advanced.queue.rest_help'),
+        placeholder: '0',
+        min: 0,
+      }),
+      70
+    );
+
+    items.add(
+      'backoff',
+      this.buildSettingComponent({
+        type: 'number',
+        setting: 'database-queue.backoff',
+        label: app.translator.trans('core.admin.advanced.queue.backoff_label'),
+        help: app.translator.trans('core.admin.advanced.queue.backoff_help'),
+        placeholder: '0',
+        min: 0,
+      }),
+      60
+    );
+
+    return items;
+  }
+
+  queueCustomContent() {
+    const driver = app.data.queueDriver;
+    return <InfoTile icon="fas fa-server">{app.translator.trans('core.admin.advanced.queue.custom_driver', { driver })}</InfoTile>;
+  }
+
   pgsqlSettings() {
     return (
       <FormSection label={DatabaseDriver.PostgreSQL}>
@@ -233,6 +344,36 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
         id: 'extension_bisect',
         label: app.translator.trans('core.admin.advanced.maintenance.bisect.label', {}, true),
         help: app.translator.trans('core.admin.advanced.maintenance.bisect.help', {}, true),
+      },
+      {
+        id: 'database-queue.retries',
+        label: app.translator.trans('core.admin.advanced.queue.retries_label', {}, true),
+        help: app.translator.trans('core.admin.advanced.queue.retries_help', {}, true),
+        visible: () => (app.data.queueDriver || 'sync') === 'database',
+      },
+      {
+        id: 'database-queue.memory',
+        label: app.translator.trans('core.admin.advanced.queue.memory_label', {}, true),
+        help: app.translator.trans('core.admin.advanced.queue.memory_help', {}, true),
+        visible: () => (app.data.queueDriver || 'sync') === 'database',
+      },
+      {
+        id: 'database-queue.timeout',
+        label: app.translator.trans('core.admin.advanced.queue.timeout_label', {}, true),
+        help: app.translator.trans('core.admin.advanced.queue.timeout_help', {}, true),
+        visible: () => (app.data.queueDriver || 'sync') === 'database',
+      },
+      {
+        id: 'database-queue.rest',
+        label: app.translator.trans('core.admin.advanced.queue.rest_label', {}, true),
+        help: app.translator.trans('core.admin.advanced.queue.rest_help', {}, true),
+        visible: () => (app.data.queueDriver || 'sync') === 'database',
+      },
+      {
+        id: 'database-queue.backoff',
+        label: app.translator.trans('core.admin.advanced.queue.backoff_label', {}, true),
+        help: app.translator.trans('core.admin.advanced.queue.backoff_help', {}, true),
+        visible: () => (app.data.queueDriver || 'sync') === 'database',
       },
     ]);
   }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -47,6 +47,21 @@ core:
         section_label: Maintenance
       pgsql:
         search_configuration: Search configuration to use
+      queue:
+        section_label: Queue
+        sync_info: Your forum is using the synchronous queue driver. Jobs are processed immediately in the main process thread.
+        sync_help: For better performance and user experience, consider using the database queue driver. Learn more in the documentation.
+        custom_driver: "Your forum is using the '{driver}' queue driver, which is provided by an extension."
+        retries_label: Job Retries
+        retries_help: Maximum number of times to attempt a job before marking it as failed. Default is 1.
+        memory_label: Memory Limit (MB)
+        memory_help: Maximum memory the queue worker can use before restarting. Default is 128 MB.
+        timeout_label: Job Timeout (seconds)
+        timeout_help: Maximum time a single job can run before timing out. Default is 60 seconds.
+        rest_label: Rest Time (seconds)
+        rest_help: Time to wait between processing jobs. Default is 0 seconds.
+        backoff_label: Backoff (seconds)
+        backoff_help: Time to wait before retrying a failed job. Default is 0 seconds.
       search:
         section_label: Search Drivers
         driver_heading: "Search Driver: {model}"

--- a/framework/core/migrations/2025_10_11_000000_create_queue_jobs.php
+++ b/framework/core/migrations/2025_10_11_000000_create_queue_jobs.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/framework/core/migrations/2025_10_11_000000_create_queue_jobs.php
+++ b/framework/core/migrations/2025_10_11_000000_create_queue_jobs.php
@@ -1,0 +1,17 @@
+<?php
+
+use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return Migration::createTableIfNotExists(
+    'queue_jobs',
+    function (Blueprint $table) {
+        $table->bigIncrements('id');
+        $table->string('queue')->index();
+        $table->longText('payload');
+        $table->unsignedTinyInteger('attempts');
+        $table->unsignedInteger('reserved_at')->nullable();
+        $table->unsignedInteger('available_at');
+        $table->unsignedInteger('created_at');
+    }
+);

--- a/framework/core/migrations/2025_10_11_000001_create_queue_failed_jobs.php
+++ b/framework/core/migrations/2025_10_11_000001_create_queue_failed_jobs.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/framework/core/migrations/2025_10_11_000001_create_queue_failed_jobs.php
+++ b/framework/core/migrations/2025_10_11_000001_create_queue_failed_jobs.php
@@ -1,0 +1,17 @@
+<?php
+
+use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return Migration::createTableIfNotExists(
+    'queue_failed_jobs',
+    function (Blueprint $table) {
+        $table->id();
+        $table->string('uuid')->unique();
+        $table->text('connection')->nullable();
+        $table->text('queue');
+        $table->longText('payload');
+        $table->longText('exception');
+        $table->timestamp('failed_at')->useCurrent();
+    }
+);

--- a/framework/core/src/Foundation/Config.php
+++ b/framework/core/src/Foundation/Config.php
@@ -34,6 +34,11 @@ readonly class Config implements ArrayAccess
         return $this->data['debug'] ?? false;
     }
 
+    public function queueDriver(): ?string
+    {
+        return $this->data['queue']['driver'] ?? null;
+    }
+
     public function inMaintenanceMode(): bool
     {
         return $this->inHighMaintenanceMode() || $this->inLowMaintenanceMode() || $this->inSafeMode();

--- a/framework/core/src/Install/Steps/StoreConfig.php
+++ b/framework/core/src/Install/Steps/StoreConfig.php
@@ -51,6 +51,9 @@ readonly class StoreConfig implements ReversibleStep
             'headers' => [
                 'poweredByHeader' => true,
                 'referrerPolicy' => 'same-origin',
+            ],
+            'queue' => [
+                'driver' => 'sync'
             ]
         ];
     }

--- a/framework/core/src/Queue/Console/DatabaseWorkerArgs.php
+++ b/framework/core/src/Queue/Console/DatabaseWorkerArgs.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Queue\Console;
 
 use Flarum\Settings\SettingsRepositoryInterface;

--- a/framework/core/src/Queue/Console/DatabaseWorkerArgs.php
+++ b/framework/core/src/Queue/Console/DatabaseWorkerArgs.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Flarum\Queue\Console;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class DatabaseWorkerArgs
+{
+    public function __construct(protected SettingsRepositoryInterface $settings)
+    {
+    }
+
+    public function args(): array
+    {
+        $args = [
+            '--stop-when-empty',
+        ];
+
+        if ($retries = $this->settings->get('database-queue.retries')) {
+            $args['--tries'] = $retries;
+        }
+
+        if ($memory = $this->settings->get('database-queue.memory')) {
+            $args['--memory'] = $memory;
+        }
+
+        if ($timeout = $this->settings->get('database-queue.timeout')) {
+            $args['--timeout'] = $timeout;
+        }
+
+        if ($rest = $this->settings->get('database-queue.rest')) {
+            $args['--rest'] = $rest;
+        }
+
+        if ($backoff = $this->settings->get('database-queue.backoff')) {
+            $args['--backoff'] = $backoff;
+        }
+
+        return $args;
+    }
+}

--- a/framework/core/src/Queue/Console/WorkCommand.php
+++ b/framework/core/src/Queue/Console/WorkCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Flarum\Queue\Console;
+
+use Carbon\Carbon;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Worker;
+
+class WorkCommand extends \Illuminate\Queue\Console\WorkCommand
+{
+    public function __construct(Worker $worker, Cache $cache, protected SettingsRepositoryInterface $settings)
+    {
+        parent::__construct($worker, $cache);
+    }
+
+    public function handle()
+    {
+        $this->settings->set('database_queue.working', Carbon::now()->toIso8601String());
+
+        try {
+            parent::handle();
+        } catch (\Exception $e) {
+            $this->settings->delete('database_queue.working');
+
+            throw $e;
+        }
+    }
+}

--- a/framework/core/src/Queue/Console/WorkCommand.php
+++ b/framework/core/src/Queue/Console/WorkCommand.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Queue\Console;
 
 use Carbon\Carbon;

--- a/framework/core/src/Queue/DatabaseUuidFailedJobProvider.php
+++ b/framework/core/src/Queue/DatabaseUuidFailedJobProvider.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Queue;
 
 use Illuminate\Database\ConnectionInterface;

--- a/framework/core/src/Queue/DatabaseUuidFailedJobProvider.php
+++ b/framework/core/src/Queue/DatabaseUuidFailedJobProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Flarum\Queue;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\ConnectionResolverInterface;
+
+class DatabaseUuidFailedJobProvider extends \Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider
+{
+    public function __construct(ConnectionResolverInterface $resolver, $database, $table, protected ConnectionInterface $connection)
+    {
+        parent::__construct($resolver, $database, $table);
+    }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function getTable()
+    {
+        return $this->connection->table($this->table);
+    }
+}

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -27,6 +27,7 @@ use Illuminate\Queue\Console as Commands;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\Listener as QueueListener;
+use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\SyncQueue;
 use Illuminate\Queue\Worker;
 
@@ -39,7 +40,7 @@ class QueueServiceProvider extends AbstractServiceProvider
         Commands\ListFailedCommand::class,
         Commands\RestartCommand::class,
         Commands\RetryCommand::class,
-        Commands\WorkCommand::class,
+        Console\WorkCommand::class,
     ];
 
     public function register(): void
@@ -55,7 +56,21 @@ class QueueServiceProvider extends AbstractServiceProvider
         // Extensions can override this binding if they want to make Flarum use
         // a different queuing backend.
         $this->container->singleton('flarum.queue.connection', function (ContainerImplementation $container) {
-            $queue = new SyncQueue;
+            /** @var Config $config */
+            $config = $container->make(Config::class);
+            $driver = $config->queueDriver() ?? 'sync';
+
+            if ($driver === 'database') {
+                $queue = new DatabaseQueue(
+                    $container->make('db.connection'),
+                    'queue_jobs',
+                    'default',
+                    60
+                );
+            } else {
+                $queue = new SyncQueue;
+            }
+
             $queue->setContainer($container);
 
             return $queue;
@@ -116,7 +131,20 @@ class QueueServiceProvider extends AbstractServiceProvider
             };
         });
 
-        $this->container->singleton('queue.failer', function () {
+        $this->container->singleton('queue.failer', function (Container $container) {
+            $queue = $container->make('flarum.queue.connection');
+
+            if ($queue instanceof DatabaseQueue) {
+                /** @var Config $config */
+                $config = $container->make(Config::class);
+                return new DatabaseUuidFailedJobProvider(
+                    $container->make('db'),
+                    $config['database']['database'],
+                    'queue_failed_jobs',
+                    $container->make('db.connection')
+                );
+            }
+
             return new NullFailedJobProvider();
         });
 
@@ -128,6 +156,7 @@ class QueueServiceProvider extends AbstractServiceProvider
         $this->container->alias(Listener::class, 'queue.listener');
 
         $this->registerCommands();
+        $this->registerSchedule();
     }
 
     protected function registerCommands(): void
@@ -143,6 +172,27 @@ class QueueServiceProvider extends AbstractServiceProvider
             // Otherwise add our commands, while allowing them to be overridden by those
             // already added through the container.
             return array_merge($this->commands, $commands);
+        });
+    }
+
+    protected function registerSchedule(): void
+    {
+        $this->container->extend('flarum.console.scheduled', function ($scheduled, Container $container) {
+            $queue = $container->make(Queue::class);
+
+            // Only schedule the queue worker for the database driver specifically.
+            // Other queue drivers (like Redis/Horizon) should handle their own scheduling.
+            if ($queue instanceof DatabaseQueue) {
+                $scheduled[] = [
+                    'command' => Console\WorkCommand::class,
+                    'args' => $container->make(Console\DatabaseWorkerArgs::class)->args(),
+                    'callback' => function ($event) {
+                        $event->everyMinute();
+                    },
+                ];
+            }
+
+            return $scheduled;
         });
     }
 

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -24,10 +24,10 @@ use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Illuminate\Queue\Console as Commands;
+use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\Listener as QueueListener;
-use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\SyncQueue;
 use Illuminate\Queue\Worker;
 
@@ -137,6 +137,7 @@ class QueueServiceProvider extends AbstractServiceProvider
             if ($queue instanceof DatabaseQueue) {
                 /** @var Config $config */
                 $config = $container->make(Config::class);
+
                 return new DatabaseUuidFailedJobProvider(
                     $container->make('db'),
                     $config['database']['database'],

--- a/framework/core/tests/integration/queue/QueueCommandTest.php
+++ b/framework/core/tests/integration/queue/QueueCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\queue;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+class QueueCommandTest extends ConsoleTestCase
+{
+    #[Test]
+    public function queue_commands_dont_exist_with_sync_driver()
+    {
+        $this->app();
+
+        $this->expectException(CommandNotFoundException::class);
+        $this->runCommand(['command' => 'queue:work']);
+    }
+
+    #[Test]
+    public function queue_work_command_exists_with_database_driver()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        // Just test that the command is registered (it will fail without actual jobs, but won't throw CommandNotFoundException)
+        try {
+            $output = $this->runCommand([
+                'command' => 'queue:work',
+                '--stop-when-empty' => true,
+            ]);
+            // If we get here, command exists and ran (even if empty queue)
+            $this->assertTrue(true);
+        } catch (CommandNotFoundException $e) {
+            $this->fail('queue:work command should be registered with database driver');
+        }
+    }
+
+    #[Test]
+    public function queue_restart_command_exists_with_database_driver()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $output = $this->runCommand(['command' => 'queue:restart']);
+
+        $this->assertStringContainsString('Broadcasting queue restart signal', $output);
+    }
+
+    #[Test]
+    public function queue_list_failed_command_exists_with_database_driver()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        // This command should run without error even with no failed jobs
+        $output = $this->runCommand(['command' => 'queue:failed']);
+
+        // Should not throw an exception
+        $this->assertTrue(true);
+    }
+}

--- a/framework/core/tests/integration/queue/QueueScheduleTest.php
+++ b/framework/core/tests/integration/queue/QueueScheduleTest.php
@@ -34,7 +34,8 @@ class QueueScheduleTest extends ConsoleTestCase
         $output = $this->runCommand(['command' => 'schedule:list']);
 
         $this->assertStringContainsString('queue:work', $output);
-        $this->assertStringContainsString('Every minute', $output);
+        // The schedule output shows the cron expression instead of "Every minute"
+        $this->assertStringContainsString('* * * * *', $output);
     }
 
     #[Test]

--- a/framework/core/tests/integration/queue/QueueScheduleTest.php
+++ b/framework/core/tests/integration/queue/QueueScheduleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\queue;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class QueueScheduleTest extends ConsoleTestCase
+{
+    #[Test]
+    public function it_does_not_schedule_queue_worker_for_sync_driver()
+    {
+        $this->app();
+
+        $output = $this->runCommand(['command' => 'schedule:list']);
+
+        $this->assertStringNotContainsString('queue:work', $output);
+    }
+
+    #[Test]
+    public function it_schedules_queue_worker_for_database_driver()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $output = $this->runCommand(['command' => 'schedule:list']);
+
+        $this->assertStringContainsString('queue:work', $output);
+        $this->assertStringContainsString('Every minute', $output);
+    }
+
+    #[Test]
+    public function it_includes_worker_args_in_scheduled_command()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        // Set some queue settings
+        $settings = $this->app()->getContainer()->make('flarum.settings');
+        $settings->set('database-queue.retries', '5');
+        $settings->set('database-queue.memory', '256');
+
+        $output = $this->runCommand(['command' => 'schedule:list']);
+
+        // The schedule:list command should show the command with its arguments
+        $this->assertStringContainsString('queue:work', $output);
+    }
+}

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -45,16 +45,7 @@ class QueueServiceProviderTest extends TestCase
     {
         $this->extend(
             (new Extend\ServiceProvider())
-                ->register(function ($container) {
-                    $container->extend('flarum.queue.connection', function () use ($container) {
-                        $queue = new class extends SyncQueue {
-                            // Custom queue implementation for testing
-                        };
-                        $queue->setContainer($container);
-
-                        return $queue;
-                    });
-                })
+                ->register(CustomQueueServiceProvider::class)
         );
 
         $this->app();
@@ -120,5 +111,19 @@ class QueueServiceProviderTest extends TestCase
         $failer = $this->app()->getContainer()->make('queue.failer');
 
         $this->assertInstanceOf(\Flarum\Queue\DatabaseUuidFailedJobProvider::class, $failer);
+    }
+}
+
+class CustomQueueServiceProvider extends \Flarum\Foundation\AbstractServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->extend('flarum.queue.connection', function ($queue, $container) {
+            $customQueue = new class extends SyncQueue {
+                // Custom queue implementation for testing
+            };
+            $customQueue->setContainer($container);
+            return $customQueue;
+        });
     }
 }

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\queue;
+
+use Flarum\Extend;
+use Flarum\Foundation\Config;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\DatabaseQueue;
+use Illuminate\Queue\SyncQueue;
+use PHPUnit\Framework\Attributes\Test;
+
+class QueueServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function it_uses_sync_queue_by_default()
+    {
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(Queue::class);
+
+        $this->assertInstanceOf(SyncQueue::class, $queue);
+    }
+
+    #[Test]
+    public function it_uses_database_queue_when_configured()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(Queue::class);
+
+        $this->assertInstanceOf(DatabaseQueue::class, $queue);
+    }
+
+    #[Test]
+    public function it_allows_extensions_to_override_queue()
+    {
+        $this->extend(
+            (new Extend\ServiceProvider())
+                ->register(function ($container) {
+                    $container->extend('flarum.queue.connection', function () use ($container) {
+                        $queue = new class extends SyncQueue {
+                            // Custom queue implementation for testing
+                        };
+                        $queue->setContainer($container);
+                        return $queue;
+                    });
+                })
+        );
+
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(Queue::class);
+
+        // Should be our custom sync queue, not the default
+        $this->assertNotEquals(SyncQueue::class, get_class($queue));
+        $this->assertInstanceOf(SyncQueue::class, $queue);
+    }
+
+    #[Test]
+    public function it_does_not_register_queue_commands_for_sync_driver()
+    {
+        $this->app();
+
+        $commands = $this->app()->getContainer()->make('flarum.console.commands');
+
+        $commandNames = array_map(function ($command) {
+            return is_string($command) ? $command : get_class($command);
+        }, $commands);
+
+        // Queue commands should not be registered for sync driver
+        $this->assertNotContains(\Flarum\Queue\Console\WorkCommand::class, $commandNames);
+    }
+
+    #[Test]
+    public function it_registers_queue_commands_for_database_driver()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $commands = $this->app()->getContainer()->make('flarum.console.commands');
+
+        $commandNames = array_map(function ($command) {
+            return is_string($command) ? $command : get_class($command);
+        }, $commands);
+
+        // Queue commands should be registered for database driver
+        $this->assertContains(\Flarum\Queue\Console\WorkCommand::class, $commandNames);
+        $this->assertContains(\Illuminate\Queue\Console\RestartCommand::class, $commandNames);
+        $this->assertContains(\Illuminate\Queue\Console\RetryCommand::class, $commandNames);
+    }
+
+    #[Test]
+    public function it_uses_null_failed_job_provider_for_sync_queue()
+    {
+        $this->app();
+
+        $failer = $this->app()->getContainer()->make('queue.failer');
+
+        $this->assertInstanceOf(\Illuminate\Queue\Failed\NullFailedJobProvider::class, $failer);
+    }
+
+    #[Test]
+    public function it_uses_database_failed_job_provider_for_database_queue()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $failer = $this->app()->getContainer()->make('queue.failer');
+
+        $this->assertInstanceOf(\Flarum\Queue\DatabaseUuidFailedJobProvider::class, $failer);
+    }
+}

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -123,6 +123,7 @@ class CustomQueueServiceProvider extends \Flarum\Foundation\AbstractServiceProvi
                 // Custom queue implementation for testing
             };
             $customQueue->setContainer($container);
+
             return $customQueue;
         });
     }

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -10,7 +10,6 @@
 namespace Flarum\Tests\integration\queue;
 
 use Flarum\Extend;
-use Flarum\Foundation\Config;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\DatabaseQueue;
@@ -52,6 +51,7 @@ class QueueServiceProviderTest extends TestCase
                             // Custom queue implementation for testing
                         };
                         $queue->setContainer($container);
+
                         return $queue;
                     });
                 })

--- a/framework/core/tests/unit/Foundation/ConfigTest.php
+++ b/framework/core/tests/unit/Foundation/ConfigTest.php
@@ -172,4 +172,38 @@ class ConfigTest extends TestCase
         // Ensure the value was not changed
         $this->assertEquals('b', $config['custom_a']);
     }
+
+    #[Test]
+    public function it_returns_queue_driver_from_config()
+    {
+        $config = new Config([
+            'url' => 'https://flarum.localhost',
+            'queue' => [
+                'driver' => 'database',
+            ],
+        ]);
+
+        $this->assertEquals('database', $config->queueDriver());
+    }
+
+    #[Test]
+    public function it_returns_null_for_missing_queue_driver()
+    {
+        $config = new Config([
+            'url' => 'https://flarum.localhost',
+        ]);
+
+        $this->assertNull($config->queueDriver());
+    }
+
+    #[Test]
+    public function it_returns_null_for_empty_queue_config()
+    {
+        $config = new Config([
+            'url' => 'https://flarum.localhost',
+            'queue' => [],
+        ]);
+
+        $this->assertNull($config->queueDriver());
+    }
 }

--- a/framework/core/tests/unit/Queue/DatabaseWorkerArgsTest.php
+++ b/framework/core/tests/unit/Queue/DatabaseWorkerArgsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Queue;
+
+use Flarum\Queue\Console\DatabaseWorkerArgs;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class DatabaseWorkerArgsTest extends TestCase
+{
+    private function mockSettings(array $settings): SettingsRepositoryInterface
+    {
+        $mock = $this->createMock(SettingsRepositoryInterface::class);
+        $mock->method('get')->willReturnCallback(function ($key) use ($settings) {
+            return $settings[$key] ?? null;
+        });
+
+        return $mock;
+    }
+
+    #[Test]
+    public function it_always_includes_stop_when_empty()
+    {
+        $settings = $this->mockSettings([]);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertContains('--stop-when-empty', $args);
+    }
+
+    #[Test]
+    public function it_adds_retries_when_setting_exists()
+    {
+        $settings = $this->mockSettings(['database-queue.retries' => '5']);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayHasKey('--tries', $args);
+        $this->assertEquals('5', $args['--tries']);
+    }
+
+    #[Test]
+    public function it_adds_memory_when_setting_exists()
+    {
+        $settings = $this->mockSettings(['database-queue.memory' => '256']);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayHasKey('--memory', $args);
+        $this->assertEquals('256', $args['--memory']);
+    }
+
+    #[Test]
+    public function it_adds_timeout_when_setting_exists()
+    {
+        $settings = $this->mockSettings(['database-queue.timeout' => '120']);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayHasKey('--timeout', $args);
+        $this->assertEquals('120', $args['--timeout']);
+    }
+
+    #[Test]
+    public function it_adds_rest_when_setting_exists()
+    {
+        $settings = $this->mockSettings(['database-queue.rest' => '5']);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayHasKey('--rest', $args);
+        $this->assertEquals('5', $args['--rest']);
+    }
+
+    #[Test]
+    public function it_adds_backoff_when_setting_exists()
+    {
+        $settings = $this->mockSettings(['database-queue.backoff' => '10']);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayHasKey('--backoff', $args);
+        $this->assertEquals('10', $args['--backoff']);
+    }
+
+    #[Test]
+    public function it_does_not_add_arguments_for_missing_settings()
+    {
+        $settings = $this->mockSettings([]);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertArrayNotHasKey('--tries', $args);
+        $this->assertArrayNotHasKey('--memory', $args);
+        $this->assertArrayNotHasKey('--timeout', $args);
+        $this->assertArrayNotHasKey('--rest', $args);
+        $this->assertArrayNotHasKey('--backoff', $args);
+    }
+
+    #[Test]
+    public function it_adds_all_arguments_when_all_settings_exist()
+    {
+        $settings = $this->mockSettings([
+            'database-queue.retries' => '3',
+            'database-queue.memory' => '512',
+            'database-queue.timeout' => '90',
+            'database-queue.rest' => '2',
+            'database-queue.backoff' => '5',
+        ]);
+        $workerArgs = new DatabaseWorkerArgs($settings);
+
+        $args = $workerArgs->args();
+
+        $this->assertContains('--stop-when-empty', $args);
+        $this->assertEquals('3', $args['--tries']);
+        $this->assertEquals('512', $args['--memory']);
+        $this->assertEquals('90', $args['--timeout']);
+        $this->assertEquals('2', $args['--rest']);
+        $this->assertEquals('5', $args['--backoff']);
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**

Docs: https://github.com/flarum/docs/pull/495

By default, Flarum continues to use the synchronous queue. No action needed.

// config.php - Default behavior (no queue config)
```php
<?php return [
    'url' => 'https://forum.example.com',
    'database' => [...],
    // Jobs execute synchronously (same as before)
];
```

For forum admins who wish to use the `DatabaseQueue`, this can be enabled:

// config.php - Specify `database` as the queue driver
```php
<?php return [
    'url' => 'https://forum.example.com',
    'database' => [...],
    
    'queue' => [
        'driver' => 'database',
    ],
];
```

Also allows for 3rd party extensions to provide/bind their own queue implementation as required

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
With `DatabaseQueue` active:
<img width="2630" height="1778" alt="image" src="https://github.com/user-attachments/assets/c4e8c663-b98e-45a9-a32f-d3be9a8f1aa6" />
<img width="1480" height="182" alt="image" src="https://github.com/user-attachments/assets/7452a7e4-f07a-4c9a-8c20-6a83d213c165" />

With default `SyncQueue` active:
<img width="2702" height="1060" alt="image" src="https://github.com/user-attachments/assets/6c0baba9-2bec-4e7d-8953-158bb8be33c4" />
<img width="1490" height="188" alt="image" src="https://github.com/user-attachments/assets/20c8f496-5fa7-483b-ae65-9b5e77ef9383" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
