### PR TITLE
[2.x] chore(core): open confirm box before deleting permission scope

### DIFF
--- a/framework/core/js/src/admin/components/PermissionGrid.tsx
+++ b/framework/core/js/src/admin/components/PermissionGrid.tsx
@@ -6,6 +6,7 @@ import Button from '../../common/components/Button';
 import ItemList from '../../common/utils/ItemList';
 import type Mithril from 'mithril';
 import Icon from '../../common/components/Icon';
+import extractText from '../../common/utils/extractText';
 
 export interface PermissionConfig {
   permission?: string;
@@ -63,7 +64,13 @@ export default class PermissionGrid<CustomAttrs extends IPermissionGridAttrs = I
                     icon="fas fa-times"
                     className="Button Button--text PermissionGrid-removeScope"
                     aria-label={app.translator.trans('core.admin.permissions.remove_scope_label', { scope: scope.label })}
-                    onclick={scope.onremove}
+                    onclick={() => {
+                      const message = extractText(app.translator.trans('core.admin.permissions.remove_scope_confirmation', { scope: scope.label }));
+
+                      if (confirm(message)) {
+                        scope.onremove?.();
+                      }
+                    }}
                   />
                 )}
               </th>

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -340,6 +340,7 @@ core:
       post_without_throttle_label: Reply multiple times without waiting
       read_heading: Read
       remove_scope_label: Remove scope of {scope}
+      remove_scope_confirmation: Are you sure you want to remove the {scope} scope?
       rename_discussions_label: Rename discussions
       reply_to_discussions_label: Reply to discussions
       search_users_label: => core.ref.search_users


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Accidentally hitting the delete button for removing a scope  

**Changes proposed in this pull request:**
Minor Quality of Life Improvement for Community Managers / Admins. Opens a Confirmation Box before a permission scope is deleted.

From past experiences "deleting" that scope doesn't actually irreversibly delete the configured permissions — unclear if this is intended behaviour or a bug. But erring on the side of caution I still choose a terminology which still somewhat suggests that the action is destructive

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="456" height="150" alt="Screenshot 2025-11-09 at 00 07 57" src="https://github.com/user-attachments/assets/fbd8087b-e27f-4f0d-80e0-b446ff871efe" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
