### PR TITLE
[1.x] fix(tags): defer policy if min primary & secondary tags 0

### DIFF
--- a/extensions/tags/composer.json
+++ b/extensions/tags/composer.json
@@ -79,7 +79,8 @@
     },
     "require-dev": {
         "flarum/core": "*@dev",
-        "flarum/testing": "^1.0.0"
+        "flarum/testing": "^1.0.0",
+        "flarum/suspend": "*@dev"
     },
     "repositories": [
         {

--- a/extensions/tags/src/Access/GlobalPolicy.php
+++ b/extensions/tags/src/Access/GlobalPolicy.php
@@ -47,7 +47,7 @@ class GlobalPolicy extends AbstractPolicy
             $minSecondaryTags = (int) $this->settings->get('flarum-tags.min_secondary_tags');
 
             if (($minPrimaryTags === 0 && $minSecondaryTags === 0)) {
-                return;
+                return null;
             }
         }
 

--- a/extensions/tags/src/Access/GlobalPolicy.php
+++ b/extensions/tags/src/Access/GlobalPolicy.php
@@ -46,7 +46,7 @@ class GlobalPolicy extends AbstractPolicy
             $minPrimaryTags = (int) $this->settings->get('flarum-tags.min_primary_tags');
             $minSecondaryTags = (int) $this->settings->get('flarum-tags.min_secondary_tags');
 
-            if (($minPrimaryTags === 0 && $minSecondaryTags === 0)) {
+            if ($minPrimaryTags === 0 && $minSecondaryTags === 0) {
                 return null;
             }
         }

--- a/extensions/tags/src/Access/GlobalPolicy.php
+++ b/extensions/tags/src/Access/GlobalPolicy.php
@@ -47,7 +47,7 @@ class GlobalPolicy extends AbstractPolicy
             $minSecondaryTags = (int) $this->settings->get('flarum-tags.min_secondary_tags');
 
             if ($minPrimaryTags === 0 && $minSecondaryTags === 0) {
-                return null;
+                return;
             }
         }
 

--- a/extensions/tags/src/Access/GlobalPolicy.php
+++ b/extensions/tags/src/Access/GlobalPolicy.php
@@ -42,6 +42,15 @@ class GlobalPolicy extends AbstractPolicy
             return $this->allow();
         }
 
+        if ($ability === 'startDiscussion') {
+            $minPrimaryTags = (int) $this->settings->get('flarum-tags.min_primary_tags');
+            $minSecondaryTags = (int) $this->settings->get('flarum-tags.min_secondary_tags');
+
+            if (($minPrimaryTags === 0 && $minSecondaryTags === 0)) {
+                return;
+            }
+        }
+
         if (in_array($ability, ['viewForum', 'startDiscussion'])) {
             if (! isset($enoughPrimary[$actor->id][$ability])) {
                 $primaryTagsWhereNeedsPermission = $this->settings->get('flarum-tags.min_primary_tags');

--- a/extensions/tags/tests/integration/forum/ForumAttributeTest.php
+++ b/extensions/tags/tests/integration/forum/ForumAttributeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\api\forum;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Support\Arr;
+
+class ForumAttributeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use RetrievesRepresentativeTags;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+        $this->extension('flarum-suspend');
+
+        $this->prepareDatabase([
+            'tags' => $this->tags(),
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'suspended-user', 'email' => 'suspended-user@machine.local', 'suspended_until' => '2043-11-17 22:05:23', 'is_email_confirmed' => 1],
+            ]
+        ]);
+    }
+
+    public function canStartDiscussionProvider()
+    {
+        return [
+            'admin user, min 0/0' => ['authenticatedAs' => 1, 'minPrimary' => 0, 'minSecondary' => 0, 'expected' => true],
+            'normal user, min 0/0' => ['authenticatedAs' => 2, 'minPrimary' => 0, 'minSecondary' => 0, 'expected' => true],
+            'suspended user, min 0/0' => ['authenticatedAs' => 3, 'minPrimary' => 0, 'minSecondary' => 0, 'expected' => false],
+            'guest user, min 0/0' => ['authenticatedAs' => null, 'minPrimary' => 0, 'minSecondary' => 0, 'expected' => false],
+
+            'admin user, min 1/0' => ['authenticatedAs' => 1, 'minPrimary' => 1, 'minSecondary' => 0, 'expected' => true],
+            'normal user, min 1/0' => ['authenticatedAs' => 2, 'minPrimary' => 1, 'minSecondary' => 0, 'expected' => true],
+            'suspended user, min 1/0' => ['authenticatedAs' => 3, 'minPrimary' => 1, 'minSecondary' => 0, 'expected' => false],
+            'guest user, min 1/0' => ['authenticatedAs' => null, 'minPrimary' => 1, 'minSecondary' => 0, 'expected' => false],
+
+            'admin user, min 0/1' => ['authenticatedAs' => 1, 'minPrimary' => 0, 'minSecondary' => 1, 'expected' => true],
+            'normal user, min 0/1' => ['authenticatedAs' => 2, 'minPrimary' => 0, 'minSecondary' => 1, 'expected' => true],
+            'suspended user, min 0/1' => ['authenticatedAs' => 3, 'minPrimary' => 0, 'minSecondary' => 1, 'expected' => false],
+            'guest user, min 0/1' => ['authenticatedAs' => null, 'minPrimary' => 0, 'minSecondary' => 1, 'expected' => false],
+
+            'admin user, min 1/1' => ['authenticatedAs' => 1, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => true],
+            'normal user, min 1/1' => ['authenticatedAs' => 2, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => true],
+            'suspended user, min 1/1' => ['authenticatedAs' => 3, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => false],
+            'guest user, min 1/1' => ['authenticatedAs' => null, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => false],
+        ];
+}
+
+    /**
+     * @test
+     *
+     * @dataProvider canStartDiscussionProvider
+     */
+    public function it_returns_the_expected_can_start_discussion_attribute(
+        ?int $authenticatedAs,
+        int $minPrimary,
+        int $minSecondary,
+        bool $expected
+    )
+    {
+        $this->setting('flarum-tags.min_primary_tags', $minPrimary);
+        $this->setting('flarum-tags.min_secondary_tags', $minSecondary);
+
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => $authenticatedAs,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals($expected, Arr::get($json, 'data.attributes.canStartDiscussion'));
+    }
+}

--- a/extensions/tags/tests/integration/forum/ForumAttributeTest.php
+++ b/extensions/tags/tests/integration/forum/ForumAttributeTest.php
@@ -61,7 +61,7 @@ class ForumAttributeTest extends TestCase
             'suspended user, min 1/1' => ['authenticatedAs' => 3, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => false],
             'guest user, min 1/1' => ['authenticatedAs' => null, 'minPrimary' => 1, 'minSecondary' => 1, 'expected' => false],
         ];
-}
+    }
 
     /**
      * @test

--- a/extensions/tags/tests/integration/forum/ForumAttributeTest.php
+++ b/extensions/tags/tests/integration/forum/ForumAttributeTest.php
@@ -9,8 +9,8 @@
 
 namespace Flarum\Tags\Tests\integration\api\forum;
 
-use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Illuminate\Support\Arr;
 
@@ -73,8 +73,7 @@ class ForumAttributeTest extends TestCase
         int $minPrimary,
         int $minSecondary,
         bool $expected
-    )
-    {
+    ) {
         $this->setting('flarum-tags.min_primary_tags', $minPrimary);
         $this->setting('flarum-tags.min_secondary_tags', $minSecondary);
 


### PR DESCRIPTION
`1.x` equivalent to #4279 

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4276**

**Changes proposed in this pull request:**
Early return if minimum number of primary and secondary tags is 0.  Deferring it rather then force allowing in that case allows other policies to take action

**Reviewers should focus on:**
 Consider this more of a POC. Unsure yet if this PR causes regression in other parts

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
