### PR TITLE
[2.x] fix: randomized username fails validation

### DIFF
--- a/extensions/nicknames/extend.php
+++ b/extensions/nicknames/extend.php
@@ -38,6 +38,7 @@ return [
 
     (new Extend\Settings())
         ->default('flarum-nicknames.set_on_registration', true)
+        ->default('flarum-nicknames.random_username', false)
         ->default('flarum-nicknames.min', 1)
         ->default('flarum-nicknames.max', 150)
         ->default('display_name_driver', 'username')

--- a/extensions/nicknames/js/src/forum/index.js
+++ b/extensions/nicknames/js/src/forum/index.js
@@ -99,10 +99,10 @@ app.initializers.add('flarum-nicknames', () => {
 
     if (app.forum.attribute('setNicknameOnRegistration')) {
       data.nickname = this.nickname();
+
+      // Don't send username when randomization is enabled - backend will generate it
       if (app.forum.attribute('randomizeUsernameOnRegistration')) {
-        const arr = new Uint32Array(2);
-        crypto.getRandomValues(arr);
-        data.username = arr.join('');
+        delete data.username;
       }
     }
   });

--- a/extensions/nicknames/src/Api/UserResourceFields.php
+++ b/extensions/nicknames/src/Api/UserResourceFields.php
@@ -12,6 +12,7 @@ namespace Flarum\Nicknames\Api;
 use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Locale\TranslatorInterface;
+use Flarum\Nicknames\RandomUsernameGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 
@@ -56,6 +57,36 @@ class UserResourceFields
 
     public static function username(Schema\Str $field): Schema\Str
     {
-        return $field->unique('users', 'nickname', true, (bool) resolve(SettingsRepositoryInterface::class)->get('flarum-nicknames.unique'));
+        $settings = resolve(SettingsRepositoryInterface::class);
+
+        $field = $field->unique('users', 'nickname', true, (bool) $settings->get('flarum-nicknames.unique'));
+
+        // When randomization is enabled, username is not required if nickname is provided
+        $randomEnabled = (bool) $settings->get('flarum-nicknames.random_username');
+        if ($randomEnabled) {
+            $field = $field->requiredOnCreateWithout(['token', 'nickname']);
+        }
+
+        // Use default() to provide a value when username is not sent
+        $field = $field->default(function (Context $context) use ($randomEnabled) {
+            // Only generate default for new users when randomization is enabled
+            if ($context->creating() && $randomEnabled) {
+                $generator = resolve(RandomUsernameGenerator::class);
+                return $generator->generate();
+            }
+
+            return null;
+        });
+
+        // Override the set() callback for custom model assignment logic
+        $field = $field->set(function (User $user, string $value) {
+            if ($user->exists) {
+                $user->rename($value);
+            } else {
+                $user->username = $value;
+            }
+        });
+
+        return $field;
     }
 }

--- a/extensions/nicknames/src/Api/UserResourceFields.php
+++ b/extensions/nicknames/src/Api/UserResourceFields.php
@@ -72,6 +72,7 @@ class UserResourceFields
             // Only generate default for new users when randomization is enabled
             if ($context->creating() && $randomEnabled) {
                 $generator = resolve(RandomUsernameGenerator::class);
+
                 return $generator->generate();
             }
 

--- a/extensions/nicknames/src/RandomUsernameGenerator.php
+++ b/extensions/nicknames/src/RandomUsernameGenerator.php
@@ -47,7 +47,7 @@ class RandomUsernameGenerator
         } while ($attempts < self::MAX_ATTEMPTS);
 
         throw new \RuntimeException(
-            'Unable to generate a unique random username after ' . self::MAX_ATTEMPTS . ' attempts'
+            'Unable to generate a unique random username after '.self::MAX_ATTEMPTS.' attempts'
         );
     }
 
@@ -62,6 +62,6 @@ class RandomUsernameGenerator
         // This provides 4.3 billion possible combinations
         $randomHex = bin2hex(random_bytes(4));
 
-        return 'user_' . $randomHex;
+        return 'user_'.$randomHex;
     }
 }

--- a/extensions/nicknames/src/RandomUsernameGenerator.php
+++ b/extensions/nicknames/src/RandomUsernameGenerator.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Nicknames;
+
+use Flarum\User\User;
+
+class RandomUsernameGenerator
+{
+    /**
+     * Maximum number of attempts to generate a unique username.
+     */
+    protected const MAX_ATTEMPTS = 10;
+
+    /**
+     * Generate a random username that satisfies Flarum's username validation.
+     *
+     * Flarum requires usernames to match: /^(?![0-9]*$)[a-z0-9_-]+$/i
+     * - At least one letter (ensured by 'user_' prefix)
+     * - Only letters, numbers, dashes, and underscores
+     * - Between 3-30 characters
+     *
+     * Format: user_{8 random hex characters}
+     * Example: user_a3f7b2c9
+     *
+     * @return string A unique random username
+     * @throws \RuntimeException If unable to generate a unique username after MAX_ATTEMPTS
+     */
+    public function generate(): string
+    {
+        $attempts = 0;
+
+        do {
+            $username = $this->generateCandidate();
+            $attempts++;
+
+            // Check if username is unique
+            if (! User::where('username', $username)->exists()) {
+                return $username;
+            }
+        } while ($attempts < self::MAX_ATTEMPTS);
+
+        throw new \RuntimeException(
+            'Unable to generate a unique random username after ' . self::MAX_ATTEMPTS . ' attempts'
+        );
+    }
+
+    /**
+     * Generate a single random username candidate.
+     *
+     * @return string A random username in format: user_{hex}
+     */
+    protected function generateCandidate(): string
+    {
+        // Generate 4 random bytes = 8 hex characters
+        // This provides 4.3 billion possible combinations
+        $randomHex = bin2hex(random_bytes(4));
+
+        return 'user_' . $randomHex;
+    }
+}

--- a/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
@@ -59,9 +59,7 @@ class RegisterWithRandomUsernameTest extends TestCase
         );
 
         $body = $response->getBody()->getContents();
-        if ($response->getStatusCode() !== 201) {
-            var_dump($body);
-        }
+
         $this->assertEquals(201, $response->getStatusCode());
 
         $data = json_decode($body, true)['data'];

--- a/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Nicknames\Tests\Integration\Api;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class RegisterWithRandomUsernameTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-nicknames');
+
+        $this->extend(
+            (new Extend\Csrf)->exemptRoute('users.create')
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser()
+            ],
+        ]);
+
+        $this->setting('display_name_driver', 'nickname');
+        $this->setting('flarum-nicknames.set_on_registration', true);
+        $this->setting('flarum-nicknames.random_username', true);
+    }
+
+    #[Test]
+    public function can_register_with_nickname_and_random_username()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            // No username sent - backend will generate it automatically
+                            'nickname' => 'John Doe',
+                            'email' => 'john@example.com',
+                            'password' => 'secure_password_123',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+        if ($response->getStatusCode() !== 201) {
+            var_dump($body);
+        }
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $data = json_decode($body, true)['data'];
+        $user = User::find($data['id']);
+
+        // Verify username was auto-generated
+        $this->assertMatchesRegularExpression('/^user_[a-f0-9]{8}$/', $user->username);
+        $this->assertEquals('John Doe', $user->nickname);
+    }
+
+    #[Test]
+    public function can_provide_manual_username_when_randomization_enabled()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'username' => 'johndoe',
+                            'nickname' => 'John Doe',
+                            'email' => 'john@example.com',
+                            'password' => 'secure_password_123',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $user = User::find(json_decode($response->getBody()->getContents(), true)['data']['id']);
+
+        // Should use provided username
+        $this->assertEquals('johndoe', $user->username);
+    }
+
+    #[Test]
+    public function generated_usernames_are_unique()
+    {
+        $usernames = [];
+
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->send(
+                $this->request('POST', '/api/users', [
+                    'json' => [
+                        'data' => [
+                            'attributes' => [
+                                // No username sent
+                                'nickname' => "User $i",
+                                'email' => "user$i@example.com",
+                                'password' => 'secure_password_123',
+                            ],
+                        ],
+                    ],
+                ])
+            );
+
+            $user = User::find(json_decode($response->getBody()->getContents(), true)['data']['id']);
+            $usernames[] = $user->username;
+        }
+
+        $this->assertEquals(5, count(array_unique($usernames)));
+    }
+
+    #[Test]
+    public function username_validation_still_works_when_randomization_enabled()
+    {
+        // Try to register with an invalid username (too short)
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'username' => 'ab', // Too short (min is 3)
+                            'nickname' => 'Test User',
+                            'email' => 'test@example.com',
+                            'password' => 'secure_password_123',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+}
+

--- a/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterWithRandomUsernameTest.php
@@ -148,4 +148,3 @@ class RegisterWithRandomUsernameTest extends TestCase
         $this->assertEquals(422, $response->getStatusCode());
     }
 }
-

--- a/extensions/nicknames/tests/integration/api/RegisterWithoutRandomUsernameTest.php
+++ b/extensions/nicknames/tests/integration/api/RegisterWithoutRandomUsernameTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Nicknames\Tests\Integration\Api;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class RegisterWithoutRandomUsernameTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-nicknames');
+
+        $this->extend(
+            (new Extend\Csrf)->exemptRoute('users.create')
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser()
+            ],
+        ]);
+
+        $this->setting('display_name_driver', 'nickname');
+        $this->setting('flarum-nicknames.set_on_registration', true);
+        // Explicitly disable random usernames (this is the default)
+        $this->setting('flarum-nicknames.random_username', false);
+    }
+
+    #[Test]
+    public function username_required_when_randomization_disabled()
+    {
+        // Try to register without username when randomization is disabled
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            // No username sent
+                            'nickname' => 'John Doe',
+                            'email' => 'john@example.com',
+                            'password' => 'secure_password_123',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        // Should fail because username is required
+        $this->assertEquals(422, $response->getStatusCode());
+        $body = $response->getBody()->getContents();
+        $this->assertStringContainsString('username', $body);
+    }
+
+    #[Test]
+    public function normal_registration_still_works()
+    {
+        // Normal registration with username and nickname
+        $response = $this->send(
+            $this->request('POST', '/api/users', [
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'username' => 'johndoe',
+                            'nickname' => 'John Doe',
+                            'email' => 'john@example.com',
+                            'password' => 'secure_password_123',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $user = User::find(json_decode($response->getBody()->getContents(), true)['data']['id']);
+
+        // Should use the provided username
+        $this->assertEquals('johndoe', $user->username);
+        $this->assertEquals('John Doe', $user->nickname);
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4282 **

**Changes proposed in this pull request:**
Moves the random username generation to the backend, complies with the username validator

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
