### PR TITLE
[2.x] feat: conditional setting extender

### DIFF
--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -72,6 +72,7 @@ class Conditional implements ExtenderInterface
     {
         return $this->when(function (SettingsRepositoryInterface $settings) use ($key, $expected, $strict) {
             $value = $settings->get($key);
+
             return $strict ? $value === $expected : $value == $expected;
         }, $extenders);
     }

--- a/framework/core/src/Extend/Conditional.php
+++ b/framework/core/src/Extend/Conditional.php
@@ -11,6 +11,7 @@ namespace Flarum\Extend;
 
 use Flarum\Extension\Extension;
 use Flarum\Extension\ExtensionManager;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 
 /**
@@ -56,6 +57,22 @@ class Conditional implements ExtenderInterface
     {
         return $this->when(function (ExtensionManager $extensions) use ($extensionId) {
             return ! $extensions->isEnabled($extensionId);
+        }, $extenders);
+    }
+
+    /**
+     * Apply extenders only if a setting matches an expected value.
+     *
+     * @param string $key The settings key.
+     * @param mixed $expected The expected value.
+     * @param callable|string $extenders A callable returning an array of extenders, or an invokable class string.
+     * @param bool $strict Whether to use strict comparison (===). Defaults to false (loose comparison ==).
+     */
+    public function whenSetting(string $key, mixed $expected, callable|string $extenders, bool $strict = false): self
+    {
+        return $this->when(function (SettingsRepositoryInterface $settings) use ($key, $expected, $strict) {
+            $value = $settings->get($key);
+            return $strict ? $value === $expected : $value == $expected;
         }, $extenders);
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Usage example:

```php
// Loose comparison (default) - '1' == 1 returns true
(new Extend\Conditional())
    ->whenSetting('some_setting', 1, fn () => [...])

// Strict comparison - '1' === 1 returns false
(new Extend\Conditional())
    ->whenSetting('some_setting', 1, fn () => [...], strict: true)
```

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
