### PR TITLE
[1.x] [workflows] fix: peg composer at 2.8.x to avoid security blocking, etc in 2.9

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -143,7 +143,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:v2
+          tools: phpunit, composer:2.8
           ini-values: ${{ matrix.php_ini_values }}
 
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
@@ -197,7 +197,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:v2
+          tools: phpunit, composer:2.8
           ini-values: ${{ matrix.php_ini_values }}
 
       - name: Install Composer dependencies

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           php-version: '8.2'
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
-          tools: composer:v2
+          tools: composer:2.8
 
       # Needed since tsconfig draws typings from vendor folder.
       - name: Install Composer dependencies


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Composer now automatically blocks updates to packages with known security advisories. This is a problem for some of `1.x`'s deps, especially laminas.

To prevent CI failures, this pegs composer to `2.8.x` (ie before these changes were introduced).

The other option is to add `audit.block-insecure: false` in `composer.json`, but this would not be helpful for currently released Flarum versions.

The changes here are not needed for `2.x`

More information: https://blog.packagist.com/composer-2-9/

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
