### PR TITLE
[2.x] feat(core): allow to disable slidable on `DiscussionListItem`

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -29,6 +29,7 @@ export interface IDiscussionListItemAttrs extends ComponentAttrs {
   params: DiscussionListParams;
   jumpTo?: number;
   author?: User;
+  slidable?: boolean;
 }
 
 /**
@@ -62,7 +63,7 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
       className: classList('DiscussionListItem', this.attrs.className, {
         active: this.active(),
         'DiscussionListItem--hidden': this.attrs.discussion.isHidden(),
-        Slidable: 'ontouchstart' in window,
+        Slidable: this.isSlidableEnabled(),
       }),
     };
   }
@@ -212,13 +213,21 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     return jumpTo;
   }
 
+  protected isSlidableEnabled(): boolean {
+    if (this.attrs.slidable === false) {
+      return false;
+    }
+
+    return 'ontouchstart' in window;
+  }
+
   oncreate(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
     super.oncreate(vnode);
 
     // If we're on a touch device, set up the discussion row to be slidable.
     // This allows the user to drag the row to either side of the screen to
     // reveal controls.
-    if ('ontouchstart' in window) {
+    if (this.isSlidableEnabled()) {
       const slidableInstance = slidable(this.element);
 
       this.$('.DiscussionListItem-controls').on('hidden.bs.dropdown', () => slidableInstance.reset());


### PR DESCRIPTION
`2.x` equivalent to https://github.com/flarum/framework/pull/4302

**Fixes #0000**
No straight forward way to disable the Slidable Underneath Functionality on the DiscussionListItem

**Changes proposed in this pull request:**
Add new `slidable` attribute to the `DiscussionListItem` which allows to cleanly disable the slidable underneath functionality on the DiscussionListItem

**Reviewers should focus on:**
This PR is the most surgical change to preserve backwards compatibility as much as possible.

Here is how extensions can consume those new extensibility improvements:

```tsx
override(DiscussionListItem.prototype, 'isSlidableEnabled', function () {
    return false;
  });
  ```
  
  or
  
  ```tsx
  <DiscussionListItem discussion={discussion} params={params} slidable={false} />
  ```
  
This attribute is fully optional and doesn't have or need a default value of true.

**Screenshot**
_n.a._

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
