### PR TITLE
[2.x] fix: tags page edit icon position, preload fa kit

### DIFF
--- a/extensions/tags/less/admin/TagsPage.less
+++ b/extensions/tags/less/admin/TagsPage.less
@@ -34,6 +34,14 @@
   .icon {
     margin-right: 10px;
   }
+
+  // FontAwesome Kit sets --fa-display variable which breaks layout
+  // Only target tag icons (not button icons), as Button-icon has its own fix
+  > li .icon {
+    --fa-display: inline-block;
+    display: inline-block !important;
+    line-height: inherit !important;
+  }
 }
 
 .TagListItem-info {

--- a/framework/core/less/common/Button.less
+++ b/framework/core/less/common/Button.less
@@ -268,6 +268,10 @@
 }
 .Button-icon {
   line-height: inherit;
+
+  // FontAwesome Kit overrides display to block, breaking button flex layout
+  // Force inline-block to work with button's inline-flex container
+  display: inline-block !important;
 }
 .Button-icon,
 .Button-caret {

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -109,12 +109,26 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     if ($fontAwesome->useCdn()) {
                         $cdnUrl = $fontAwesome->cdnUrl();
                         if (! empty($cdnUrl)) {
-                            $document->css[] = $cdnUrl;
+                            // Preload CDN CSS for better performance
+                            $document->preloads[] = [
+                                'href' => $cdnUrl,
+                                'as' => 'style',
+                                'crossorigin' => 'anonymous'
+                            ];
+                            // Add CDN CSS with crossorigin for better caching
+                            $document->head[] = '<link rel="stylesheet" href="'.e($cdnUrl).'" crossorigin="anonymous">';
                         }
                     } elseif ($fontAwesome->useKit()) {
                         $kitUrl = $fontAwesome->kitUrl();
                         if (! empty($kitUrl)) {
-                            $document->js[] = $kitUrl;
+                            // Preload Kit JS for better performance
+                            $document->preloads[] = [
+                                'href' => $kitUrl,
+                                'as' => 'script',
+                                'crossorigin' => 'anonymous'
+                            ];
+                            // Add Kit JS with crossorigin for better caching
+                            $document->head[] = '<script src="'.e($kitUrl).'" crossorigin="anonymous"></script>';
                         }
                     }
 

--- a/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
+++ b/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
@@ -66,10 +66,13 @@ class FontAwesomeLoadingTest extends TestCase
 
         $body = $response->getBody()->getContents();
 
-        // Should contain CDN CSS
-        $this->assertStringContainsString('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">', $body);
+        // Should contain CDN CSS with crossorigin attribute
+        $this->assertStringContainsString('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous">', $body);
 
-        // Should not contain font preloads
+        // Should contain preload for CDN CSS
+        $this->assertStringContainsString('<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" as="style" crossorigin="anonymous">', $body);
+
+        // Should not contain local font preloads
         $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
         $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
     }
@@ -86,10 +89,13 @@ class FontAwesomeLoadingTest extends TestCase
 
         $body = $response->getBody()->getContents();
 
-        // Should contain Kit JS
-        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/abc123xyz.js"></script>', $body);
+        // Should contain Kit JS with crossorigin attribute
+        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/abc123xyz.js" crossorigin="anonymous"></script>', $body);
 
-        // Should not contain font preloads
+        // Should contain preload for Kit JS
+        $this->assertStringContainsString('<link rel="preload" href="https://kit.fontawesome.com/abc123xyz.js" as="script" crossorigin="anonymous">', $body);
+
+        // Should not contain local font preloads
         $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
         $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
     }
@@ -158,8 +164,11 @@ class FontAwesomeLoadingTest extends TestCase
 
         $body = $response->getBody()->getContents();
 
-        // Should use config CDN URL, not local fonts
-        $this->assertStringContainsString('<link rel="stylesheet" href="https://config.example.com/fontawesome.css">', $body);
+        // Should use config CDN URL with crossorigin attribute, not local fonts
+        $this->assertStringContainsString('<link rel="stylesheet" href="https://config.example.com/fontawesome.css" crossorigin="anonymous">', $body);
+
+        // Should contain preload for config CDN CSS
+        $this->assertStringContainsString('<link rel="preload" href="https://config.example.com/fontawesome.css" as="style" crossorigin="anonymous">', $body);
 
         // Should not contain local font preloads
         $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
@@ -185,8 +194,11 @@ class FontAwesomeLoadingTest extends TestCase
 
         $body = $response->getBody()->getContents();
 
-        // Should use config Kit URL
-        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/config123.js"></script>', $body);
+        // Should use config Kit URL with crossorigin attribute
+        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/config123.js" crossorigin="anonymous"></script>', $body);
+
+        // Should contain preload for config Kit JS
+        $this->assertStringContainsString('<link rel="preload" href="https://kit.fontawesome.com/config123.js" as="script" crossorigin="anonymous">', $body);
 
         // Should not contain database CDN URL
         $this->assertStringNotContainsString('database.example.com', $body);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
