### PR TITLE
[2.x] fix: reversed logic in notification template for body content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - sidebar width by @imorland [#4312]
 - minor styling fixes by @imorland [#4315]
 - FA icon shift when using Kit by @imorland [#4304]
+- email notification and information templates not rendering named slot content by @imorland [#4317]
 
 ### Changed
 

--- a/framework/core/views/email/html/information.blade.php
+++ b/framework/core/views/email/html/information.blade.php
@@ -4,10 +4,10 @@
     </x-slot:header>
 
     <x-slot:content>
-        {{ $slot ?? $body ?? '' }}
+        {!! $body ?? $slot ?? '' !!}
         @if (isset($preview))
             <div class="content-preview">
-                {{ $preview }}
+                {!! $preview !!}
             </div>
         @endif
     </x-slot:content>

--- a/framework/core/views/email/html/notification.blade.php
+++ b/framework/core/views/email/html/notification.blade.php
@@ -4,10 +4,10 @@
     </x-slot:header>
 
     <x-slot:content>
-        {{ $slot ?? $body ?? '' }}
+        {!! $body ?? $slot ?? '' !!}
         @if (isset($preview))
             <div class="content-preview">
-                {{ $preview }}
+                {!! $preview !!}
             </div>
         @endif
     </x-slot:content>

--- a/framework/core/views/email/plain/information.blade.php
+++ b/framework/core/views/email/plain/information.blade.php
@@ -4,7 +4,7 @@
 </x-slot:header>
 
 <x-slot:content>
-{{ $slot ?? $body ?? '' }}
+{!! $body ?? $slot ?? '' !!}
 </x-slot:content>
 
 <x-slot:footer>

--- a/framework/core/views/email/plain/notification.blade.php
+++ b/framework/core/views/email/plain/notification.blade.php
@@ -4,7 +4,7 @@
 </x-slot:header>
 
 <x-slot:content>
-{{ $slot ?? $body ?? '' }}
+{!! $body ?? $slot ?? '' !!}
 </x-slot:content>
 
 <x-slot:footer>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4296 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
