### PR TITLE
[2.x] [realtime] Fixed an issue where tag-specified discussion pushing could not work

### DIFF
--- a/extensions/realtime/js/src/forum/extend/DiscussionList/NewActivity.js
+++ b/extensions/realtime/js/src/forum/extend/DiscussionList/NewActivity.js
@@ -67,7 +67,8 @@ export default function () {
         // When we're viewing a specific tag but the discussion has no such tags, ignore it.
         if (discussion && activeTag && discussion.tags?.()) {
           // Tag is not assigned to this discussion.
-          if (discussion.tags().indexOf(activeTag.id()) === -1) return;
+          const tagIds = discussion.tags().map(tag => tag.id());
+          if (tagIds.indexOf(activeTag.id()) === -1) return;
         }
 
         if (

--- a/extensions/realtime/js/src/forum/extend/DiscussionList/NewActivity.js
+++ b/extensions/realtime/js/src/forum/extend/DiscussionList/NewActivity.js
@@ -67,7 +67,7 @@ export default function () {
         // When we're viewing a specific tag but the discussion has no such tags, ignore it.
         if (discussion && activeTag && discussion.tags?.()) {
           // Tag is not assigned to this discussion.
-          const tagIds = discussion.tags().map(tag => tag.id());
+          const tagIds = discussion.tags().map((tag) => tag.id());
           if (tagIds.indexOf(activeTag.id()) === -1) return;
         }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
I have located this issue long ago, just publishing now because former `blomstra/realtime` is not open for PRs.

Fixed an issue where tag-specified discussion pushing could not work. The original code tried to index an `id` from an array of `tags` which is obviously wrong.

My fix has only been tested and proven work on my own `1.x` deployment, please tell me if anything has changed.
There could be something slug-related to reproduce the issue.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
See above.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
