### PR TITLE
[2.x] feat: highlight abandoned packages, expose php flarum info to admin UI

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -45,6 +45,7 @@ export interface Extension {
     };
   };
   require?: Record<string, string>;
+  abandoned?: boolean | string;
 }
 
 export enum DatabaseDriver {

--- a/framework/core/js/src/admin/components/AdminNav.js
+++ b/framework/core/js/src/admin/components/AdminNav.js
@@ -156,6 +156,8 @@ export default class AdminNav extends Component {
         const query = this.query().toUpperCase();
         const title = extension.extra['flarum-extension'].title || '';
         const description = extension.description || '';
+        const isAbandoned = extension.abandoned;
+        const hasReplacement = typeof isAbandoned === 'string';
 
         if (!query || title.toUpperCase().includes(query) || description.toUpperCase().includes(query)) {
           items.add(
@@ -167,6 +169,7 @@ export default class AdminNav extends Component {
               title={description}
             >
               {title}
+              {isAbandoned && <span className={`Badge Badge--${hasReplacement ? 'danger' : 'warning'}`}>!</span>}
             </ExtensionLinkButton>,
             categories[category]
           );

--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -61,9 +61,23 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
   view(vnode: Mithril.VnodeDOM<Attrs, this>) {
     if (!this.extension) return null;
 
+    const isAbandoned = this.extension.abandoned;
+    const hasReplacement = typeof isAbandoned === 'string';
+
     return (
       <div className={'ExtensionPage ' + this.className()}>
         {this.header()}
+        {isAbandoned && (
+          <div className="container">
+            <div className={`Alert Alert--${hasReplacement ? 'danger' : 'warning'}`}>
+              <span className="Alert-body">
+                {hasReplacement
+                  ? app.translator.trans('core.admin.extension.abandoned_with_replacement', { replacement: isAbandoned })
+                  : app.translator.trans('core.admin.extension.abandoned_no_replacement')}
+              </span>
+            </div>
+          </div>
+        )}
         {app.data.maintenanceMode === MaintenanceMode.SAFE_MODE && !app.data.safeModeExtensions?.includes(this.extension.id) ? (
           <div className="container">
             <div className="ExtensionPage-body">

--- a/framework/core/js/src/admin/components/ExtensionsWidget.js
+++ b/framework/core/js/src/admin/components/ExtensionsWidget.js
@@ -37,13 +37,23 @@ export default class ExtensionsWidget extends DashboardWidget {
   }
 
   extensionWidget(extension) {
+    const isAbandoned = extension.abandoned;
+    const hasReplacement = typeof isAbandoned === 'string';
+
     return (
-      <li className={classList('ExtensionListItem', { disabled: !isExtensionEnabled(extension.id) })}>
+      <li className={classList('ExtensionListItem', { disabled: !isExtensionEnabled(extension.id), abandoned: isAbandoned })}>
         <Link href={app.route('extension', { id: extension.id })}>
           <div className="ExtensionListItem-content">
-            <span className="ExtensionListItem-icon ExtensionIcon" style={extension.icon}>
-              {!!extension.icon && <Icon name={extension.icon.name} />}
-            </span>
+            <div className="ExtensionListItem-icon-wrapper">
+              <span className="ExtensionListItem-icon ExtensionIcon" style={extension.icon}>
+                {!!extension.icon && <Icon name={extension.icon.name} />}
+              </span>
+              {isAbandoned && (
+                <span className={classList('ExtensionListItem-badge Badge', hasReplacement ? 'Badge--danger' : 'Badge--warning')}>
+                  <Icon name="fas fa-exclamation-triangle" />
+                </span>
+              )}
+            </div>
             <span className="ExtensionListItem-title">{extension.extra['flarum-extension'].title}</span>
           </div>
         </Link>

--- a/framework/core/js/src/admin/components/InfoModal.tsx
+++ b/framework/core/js/src/admin/components/InfoModal.tsx
@@ -1,0 +1,75 @@
+import app from '../../admin/app';
+import Modal, { IInternalModalAttrs } from '../../common/components/Modal';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Button from '../../common/components/Button';
+import type Mithril from 'mithril';
+
+export default class InfoModal extends Modal<IInternalModalAttrs> {
+  protected info: string = '';
+
+  oninit(vnode: Mithril.Vnode<IInternalModalAttrs, this>) {
+    super.oninit(vnode);
+
+    this.loading = true;
+
+    this.loadInfo();
+  }
+
+  className() {
+    return 'InfoModal Modal--large';
+  }
+
+  title() {
+    return app.translator.trans('core.admin.dashboard.info_modal.title');
+  }
+
+  content() {
+    return (
+      <div className="Modal-body">
+        {this.loading ? (
+          <div className="InfoModal-loading">
+            <LoadingIndicator />
+          </div>
+        ) : (
+          <div>
+            <div className="InfoModal-actions">
+              <Button className="Button Button--primary" onclick={this.copyToClipboard.bind(this)}>
+                {app.translator.trans('core.admin.dashboard.info_modal.copy_button')}
+              </Button>
+            </div>
+            <pre className="InfoModal-content">
+              <code>{this.info}</code>
+            </pre>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  copyToClipboard() {
+    navigator.clipboard.writeText(this.info).then(
+      () => {
+        app.alerts.show({ type: 'success' }, app.translator.trans('core.admin.dashboard.info_modal.copy_success'));
+      },
+      () => {
+        app.alerts.show({ type: 'error' }, app.translator.trans('core.admin.dashboard.info_modal.copy_error'));
+      }
+    );
+  }
+
+  async loadInfo() {
+    try {
+      const response = await app.request<any>({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/system-info/system',
+      });
+
+      this.info = response.data?.attributes?.content || 'No info available';
+    } catch (error) {
+      this.info = 'Error loading info: ' + (error as Error).message;
+    }
+
+    this.loading = false;
+    m.redraw();
+  }
+}

--- a/framework/core/js/src/admin/components/StatusWidget.js
+++ b/framework/core/js/src/admin/components/StatusWidget.js
@@ -8,6 +8,7 @@ import LoadingModal from './LoadingModal';
 import LinkButton from '../../common/components/LinkButton';
 import saveSettings from '../utils/saveSettings';
 import StatusWidgetItem from './StatusWidgetItem';
+import InfoModal from './InfoModal';
 
 export default class StatusWidget extends DashboardWidget {
   className() {
@@ -82,8 +83,11 @@ export default class StatusWidget extends DashboardWidget {
 
     items.add(
       'clearCache',
-      <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>
+      <Button onclick={this.handleClearCache.bind(this)}>{app.translator.trans('core.admin.dashboard.clear_cache_button')}</Button>,
+      10
     );
+
+    items.add('info', <Button onclick={this.handleShowInfo.bind(this)}>{app.translator.trans('core.admin.dashboard.info_button')}</Button>, 0);
 
     items.add(
       'toggleAdvancedPage',
@@ -122,5 +126,9 @@ export default class StatusWidget extends DashboardWidget {
 
         app.modal.close();
       });
+  }
+
+  handleShowInfo() {
+    app.modal.show(InfoModal);
   }
 }

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -13,6 +13,7 @@
 @import "admin/EditGroupModal";
 @import "admin/ExtensionPage";
 @import "admin/ExtensionWidget";
+@import "admin/InfoModal";
 @import "admin/AppearancePage";
 @import "admin/MailPage";
 @import "admin/NoJs";

--- a/framework/core/less/admin/AdminNav.less
+++ b/framework/core/less/admin/AdminNav.less
@@ -208,3 +208,22 @@
   border: 2px solid var(--disabled-color);
   box-sizing: border-box;
 }
+
+.ExtensionNavButton {
+  .Badge {
+    margin-left: 5px;
+    .Badge--size(16px);
+    font-size: 10px;
+    font-weight: bold;
+
+    &.Badge--danger {
+      --badge-bg: @error-color;
+      --contrast-color: var(--text-on-dark);
+    }
+
+    &.Badge--warning {
+      --badge-bg: @alert-color;
+      --contrast-color: var(--text-on-dark);
+    }
+  }
+}

--- a/framework/core/less/admin/ExtensionWidget.less
+++ b/framework/core/less/admin/ExtensionWidget.less
@@ -90,3 +90,25 @@
   justify-content: center;
   vertical-align: middle;
 }
+
+.ExtensionListItem-icon-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.ExtensionListItem-badge {
+  position: absolute;
+  bottom: -5px;
+  right: -5px;
+  .Badge--size(24px);
+
+  &.Badge--danger {
+    --badge-bg: @error-color;
+    --contrast-color: var(--text-on-dark);
+  }
+
+  &.Badge--warning {
+    --badge-bg: @alert-color;
+    --contrast-color: var(--text-on-dark);
+  }
+}

--- a/framework/core/less/admin/InfoModal.less
+++ b/framework/core/less/admin/InfoModal.less
@@ -1,0 +1,22 @@
+.InfoModal {
+  .InfoModal-loading {
+    padding: 50px;
+    text-align: center;
+  }
+
+  .InfoModal-actions {
+    margin-bottom: 15px;
+    text-align: right;
+  }
+
+  .InfoModal-content {
+    background: var(--code-bg);
+    color: var(--code-color);
+    padding: 15px;
+    border-radius: var(--border-radius);
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.5;
+    word-wrap: break-word;
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -161,6 +161,12 @@ core:
     dashboard:
       clear_cache_button: Clear Cache
       description: Your forum at a glance.
+      info_button: System Info
+      info_modal:
+        title: System Information
+        copy_button: Copy to Clipboard
+        copy_success: System information copied to clipboard
+        copy_error: Failed to copy to clipboard
       io_error_message: "Could not write to filesystem. Check your filesystem permissions and try again. Or try running from the command line."
       status:
         headers:
@@ -251,9 +257,12 @@ core:
 
     # These translations are used on default extension pages.
     extension:
+      abandoned_no_replacement: This extension is no longer maintained by its author and may not receive updates.
+      abandoned_with_replacement: "This extension has been replaced by {replacement}. Consider migrating to the replacement package."
       configure_scopes: Configure Scopes
       confirm_purge: Purging will remove all database entries and assets related to the extension. It will not uninstall the extension; that must be done via Composer. Are you sure you want to continue?
       database_driver_mismatch: This extension does not support your configured database driver.
+      deprecated: Deprecated
       disabled: Disabled
       enable_to_see: Enable the extension to view and change settings.
       enabled: Enabled
@@ -273,6 +282,7 @@ core:
         button_label: README
         no_readme: This extension does not appear to have a README file
         title: "{extName} documentation"
+      replaced: Replaced
       safe_mode_warning: Safe mode is currently enabled. Extensions are not booted and their settings are therefore inaccessible.
 
     # These translations are used in the secondary header.

--- a/framework/core/src/Api/ApiServiceProvider.php
+++ b/framework/core/src/Api/ApiServiceProvider.php
@@ -42,6 +42,7 @@ class ApiServiceProvider extends AbstractServiceProvider
                 Resource\AccessTokenResource::class,
                 Resource\MailSettingResource::class,
                 Resource\ExtensionReadmeResource::class,
+                Resource\SystemInfoResource::class,
             ];
         });
 

--- a/framework/core/src/Api/Resource/SystemInfoResource.php
+++ b/framework/core/src/Api/Resource/SystemInfoResource.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Resource;
+
+use Flarum\Api\Endpoint;
+use Flarum\Api\Resource\Contracts\Findable;
+use Flarum\Api\Schema;
+use Flarum\Foundation\Console\InfoCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tobyz\JsonApiServer\Context;
+
+/**
+ * @extends AbstractResource<object>
+ */
+class SystemInfoResource extends AbstractResource implements Findable
+{
+    public function __construct(
+        protected InfoCommand $infoCommand
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'system-info';
+    }
+
+    public function getId(object $model, Context $context): string
+    {
+        return 'system';
+    }
+
+    public function id(Context $context): ?string
+    {
+        return 'system';
+    }
+
+    public function find(string $id, Context $context): ?object
+    {
+        return (object) [];
+    }
+
+    public function endpoints(): array
+    {
+        return [
+            Endpoint\Show::make()
+                ->admin(),
+        ];
+    }
+
+    public function fields(): array
+    {
+        return [
+            Schema\Str::make('content')
+                ->get(function () {
+                    $output = new BufferedOutput();
+
+                    $this->infoCommand->run(
+                        new ArrayInput([]),
+                        $output
+                    );
+
+                    return $output->fetch();
+                }),
+        ];
+    }
+}

--- a/framework/core/src/Extension/Extension.php
+++ b/framework/core/src/Extension/Extension.php
@@ -77,6 +77,14 @@ class Extension implements Arrayable
     protected bool $installed = true;
     protected string $version;
 
+    /**
+     * Whether the composer package is marked as abandoned.
+     * If true, it may contain the name of a replacement package.
+     *
+     * @var bool|string
+     */
+    protected bool|string $abandoned = false;
+
     public function __construct(
         protected string $path,
         protected array $composerJson
@@ -160,6 +168,18 @@ class Extension implements Arrayable
     }
 
     /**
+     * @param bool|string $abandoned
+     *
+     * @internal
+     */
+    public function setAbandoned(bool|string $abandoned): static
+    {
+        $this->abandoned = $abandoned;
+
+        return $this;
+    }
+
+    /**
      * Get the list of flarum extensions that this extension depends on.
      *
      * @param array<string, mixed> $extensionSet: An associative array where keys are the composer package names
@@ -189,6 +209,27 @@ class Extension implements Arrayable
     public function getVersion(): ?string
     {
         return $this->version;
+    }
+
+    /**
+     * Check if the composer package is marked as abandoned.
+     *
+     * @return bool
+     */
+    public function isAbandoned(): bool
+    {
+        return (bool) $this->abandoned;
+    }
+
+    /**
+     * Get the abandoned status.
+     * Returns false if not abandoned, or a string with the replacement package name if abandoned.
+     *
+     * @return bool|string
+     */
+    public function getAbandoned(): bool|string
+    {
+        return $this->abandoned;
     }
 
     public function getIcon(): ?array
@@ -435,7 +476,7 @@ class Extension implements Arrayable
      */
     public function toArray(): array
     {
-        return array_merge([
+        return array_merge($this->composerJson, [
             'id' => $this->getId(),
             'version' => $this->getVersion(),
             'path' => $this->getPath(),
@@ -445,7 +486,8 @@ class Extension implements Arrayable
             'extensionDependencyIds' => $this->getExtensionDependencyIds(),
             'optionalDependencyIds' => $this->getOptionalDependencyIds(),
             'links' => $this->getLinks(),
-        ], $this->composerJson);
+            'abandoned' => $this->getAbandoned(),
+        ]);
     }
 
     /**

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -491,6 +491,24 @@ class ExtensionManager
         $extension->setInstalled(true);
         $extension->setVersion(Arr::get($package, 'version', '0.0'));
 
+        // Set abandoned status if the package is marked as abandoned in composer
+        // The abandoned field can be either true (no replacement) or a string (replacement package name)
+        $abandoned = Arr::get($package, 'abandoned');
+        if (is_string($abandoned) && !empty($abandoned)) {
+            // Always set abandoned status if a replacement package is specified
+            $extension->setAbandoned($abandoned);
+        } elseif ($abandoned === true) {
+            // If abandoned is just true (no replacement), check the package source
+            // Packages from flarum.org/composer may have unreliable abandoned flags
+            $distUrl = Arr::get($package, 'dist.url', '');
+            $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
+
+            // Only set abandoned if NOT from flarum.org/composer
+            if (!$isFromFlarumComposer) {
+                $extension->setAbandoned($abandoned);
+            }
+        }
+
         return $extension;
     }
 

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -494,7 +494,7 @@ class ExtensionManager
         // Set abandoned status if the package is marked as abandoned in composer
         // The abandoned field can be either true (no replacement) or a string (replacement package name)
         $abandoned = Arr::get($package, 'abandoned');
-        if (is_string($abandoned) && !empty($abandoned)) {
+        if (is_string($abandoned) && ! empty($abandoned)) {
             // Always set abandoned status if a replacement package is specified
             $extension->setAbandoned($abandoned);
         } elseif ($abandoned === true) {
@@ -504,7 +504,7 @@ class ExtensionManager
             $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
 
             // Only set abandoned if NOT from flarum.org/composer
-            if (!$isFromFlarumComposer) {
+            if (! $isFromFlarumComposer) {
                 $extension->setAbandoned($abandoned);
             }
         }

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -177,8 +177,8 @@ class InfoCommand extends AbstractCommand
     {
         // Try common PHP binary paths for web servers
         $possiblePhpBinaries = [
-            '/usr/bin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-            '/usr/sbin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            '/usr/bin/php-fpm'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
+            '/usr/sbin/php-fpm'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             '/usr/local/bin/php',
             '/usr/bin/php',
         ];
@@ -189,7 +189,7 @@ class InfoCommand extends AbstractCommand
                 $status = null;
                 exec("$phpBinary -v 2>&1 | head -n 1", $output, $status);
 
-                if ($status === 0 && !empty($output[0])) {
+                if ($status === 0 && ! empty($output[0])) {
                     // Extract version from output like "PHP 8.3.1 (fpm-fcgi) ..."
                     if (preg_match('/PHP\s+([\d.]+)/', $output[0], $matches)) {
                         return $matches[1];
@@ -208,21 +208,21 @@ class InfoCommand extends AbstractCommand
     private function detectWebServerMemoryLimit(): ?string
     {
         // Try to detect PHP-FPM pool configuration
-        $phpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+        $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
 
         $possiblePaths = [
             // Docker PHP paths (most common for containerized setups)
-            "/usr/local/etc/php/php.ini",
-            "/usr/local/etc/php/conf.d/memory.ini",
+            '/usr/local/etc/php/php.ini',
+            '/usr/local/etc/php/conf.d/memory.ini',
             // Common PHP-FPM pool paths
             "/etc/php/{$phpVersion}/fpm/pool.d/www.conf",
             "/etc/php{$phpVersion}/fpm/pool.d/www.conf",
-            "/etc/php-fpm.d/www.conf",
-            "/usr/local/etc/php-fpm.d/www.conf",
+            '/etc/php-fpm.d/www.conf',
+            '/usr/local/etc/php-fpm.d/www.conf',
             // Common php.ini paths for web
             "/etc/php/{$phpVersion}/fpm/php.ini",
             "/etc/php{$phpVersion}/fpm/php.ini",
-            "/etc/php.ini",
+            '/etc/php.ini',
         ];
 
         foreach ($possiblePaths as $path) {
@@ -244,7 +244,7 @@ class InfoCommand extends AbstractCommand
         // Also scan /usr/local/etc/php/conf.d/ directory for any INI files with memory_limit
         $confDir = '/usr/local/etc/php/conf.d';
         if (is_dir($confDir) && is_readable($confDir)) {
-            $iniFiles = glob($confDir . '/*.ini');
+            $iniFiles = glob($confDir.'/*.ini');
             if ($iniFiles) {
                 foreach ($iniFiles as $iniFile) {
                     if (is_readable($iniFile)) {

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -44,7 +44,28 @@ class InfoCommand extends AbstractCommand
         $coreVersion = $this->findPackageVersion(__DIR__.'/../../../', Application::VERSION);
         $this->output->writeln("<info>Flarum core:</info> $coreVersion");
 
-        $this->output->writeln('<info>PHP version:</info> '.$this->appInfo->identifyPHPVersion());
+        $cliPhpVersion = $this->appInfo->identifyPHPVersion();
+        $webPhpVersion = $this->detectWebServerPhpVersion();
+
+        if ($webPhpVersion) {
+            if ($webPhpVersion !== $cliPhpVersion) {
+                $this->output->writeln("<info>PHP version:</info> <error>CLI: {$cliPhpVersion}, Web: {$webPhpVersion} (MISMATCH - versions should match!)</error>");
+            } else {
+                $this->output->writeln("<info>PHP version:</info> CLI: {$cliPhpVersion}, Web: {$webPhpVersion}");
+            }
+        } else {
+            $this->output->writeln("<info>PHP version:</info> CLI: {$cliPhpVersion}, Web: unable to detect");
+        }
+
+        $cliMemoryLimit = ini_get('memory_limit');
+        $webMemoryLimit = $this->detectWebServerMemoryLimit();
+
+        if ($webMemoryLimit) {
+            $this->output->writeln("<info>PHP memory limit:</info> CLI: {$cliMemoryLimit}, Web: {$webMemoryLimit}");
+        } else {
+            $this->output->writeln("<info>PHP memory limit:</info> CLI: {$cliMemoryLimit}, Web: unable to detect");
+        }
+
         $this->output->writeln('<info>'.$this->appInfo->identifyDatabaseDriver().' version:</info> '.$this->appInfo->identifyDatabaseVersion());
 
         $phpExtensions = implode(', ', get_loaded_extensions());
@@ -79,17 +100,44 @@ class InfoCommand extends AbstractCommand
         $table = (new Table($this->output))
             ->setHeaders([
                 ['Flarum Extensions'],
-                ['ID', 'Version', 'Commit']
+                ['ID', 'Version', 'Commit', 'Notes']
             ])->setStyle(
                 (new TableStyle)->setCellHeaderFormat('<info>%s</info>')
             );
 
         foreach ($this->extensions->getEnabledExtensions() as $extension) {
-            $table->addRow([
-                $extension->getId(),
-                $extension->getVersion(),
-                $this->findPackageVersion($extension->getPath())
-            ]);
+            $abandoned = $extension->getAbandoned();
+            $notesText = '';
+
+            if ($abandoned) {
+                // Package is abandoned, show replacement info or deprecation notice
+                if (is_string($abandoned)) {
+                    // Replacement exists - highlight in red (more urgent)
+                    $notesText = "Replaced by {$abandoned}";
+                    $table->addRow([
+                        "<error>{$extension->getId()}</error>",
+                        "<error>{$extension->getVersion()}</error>",
+                        "<error>{$this->findPackageVersion($extension->getPath())}</error>",
+                        "<error>{$notesText}</error>"
+                    ]);
+                } else {
+                    // Just deprecated - highlight in yellow (warning)
+                    $notesText = 'Deprecated';
+                    $table->addRow([
+                        "<comment>{$extension->getId()}</comment>",
+                        "<comment>{$extension->getVersion()}</comment>",
+                        "<comment>{$this->findPackageVersion($extension->getPath())}</comment>",
+                        "<comment>{$notesText}</comment>"
+                    ]);
+                }
+            } else {
+                $table->addRow([
+                    $extension->getId(),
+                    $extension->getVersion(),
+                    $this->findPackageVersion($extension->getPath()),
+                    $notesText
+                ]);
+            }
         }
 
         return $table;
@@ -119,5 +167,96 @@ class InfoCommand extends AbstractCommand
         }
 
         return $fallback;
+    }
+
+    /**
+     * Try to detect the web server's PHP version.
+     * This is a best-effort attempt and may not work in all environments.
+     */
+    private function detectWebServerPhpVersion(): ?string
+    {
+        // Try common PHP binary paths for web servers
+        $possiblePhpBinaries = [
+            '/usr/bin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            '/usr/sbin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            '/usr/local/bin/php',
+            '/usr/bin/php',
+        ];
+
+        foreach ($possiblePhpBinaries as $phpBinary) {
+            if (file_exists($phpBinary) && is_executable($phpBinary)) {
+                $output = [];
+                $status = null;
+                exec("$phpBinary -v 2>&1 | head -n 1", $output, $status);
+
+                if ($status === 0 && !empty($output[0])) {
+                    // Extract version from output like "PHP 8.3.1 (fpm-fcgi) ..."
+                    if (preg_match('/PHP\s+([\d.]+)/', $output[0], $matches)) {
+                        return $matches[1];
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to detect the web server's PHP memory limit.
+     * This is a best-effort attempt and may not work in all environments.
+     */
+    private function detectWebServerMemoryLimit(): ?string
+    {
+        // Try to detect PHP-FPM pool configuration
+        $phpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+
+        $possiblePaths = [
+            // Docker PHP paths (most common for containerized setups)
+            "/usr/local/etc/php/php.ini",
+            "/usr/local/etc/php/conf.d/memory.ini",
+            // Common PHP-FPM pool paths
+            "/etc/php/{$phpVersion}/fpm/pool.d/www.conf",
+            "/etc/php{$phpVersion}/fpm/pool.d/www.conf",
+            "/etc/php-fpm.d/www.conf",
+            "/usr/local/etc/php-fpm.d/www.conf",
+            // Common php.ini paths for web
+            "/etc/php/{$phpVersion}/fpm/php.ini",
+            "/etc/php{$phpVersion}/fpm/php.ini",
+            "/etc/php.ini",
+        ];
+
+        foreach ($possiblePaths as $path) {
+            if (file_exists($path) && is_readable($path)) {
+                $content = file_get_contents($path);
+
+                // Look for memory_limit setting
+                if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                    return trim($matches[1]);
+                }
+
+                // For FPM pool configs, also check php_admin_value
+                if (preg_match('/^\s*php_admin_value\[memory_limit\]\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                    return trim($matches[1]);
+                }
+            }
+        }
+
+        // Also scan /usr/local/etc/php/conf.d/ directory for any INI files with memory_limit
+        $confDir = '/usr/local/etc/php/conf.d';
+        if (is_dir($confDir) && is_readable($confDir)) {
+            $iniFiles = glob($confDir . '/*.ini');
+            if ($iniFiles) {
+                foreach ($iniFiles as $iniFile) {
+                    if (is_readable($iniFile)) {
+                        $content = file_get_contents($iniFile);
+                        if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                            return trim($matches[1]);
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/framework/core/tests/integration/api/info/ShowTest.php
+++ b/framework/core/tests/integration/api/info/ShowTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\info;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\Test;
+
+class ShowTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ]
+        ]);
+    }
+
+    #[Test]
+    public function guest_cannot_access_system_info(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/system-info/system')
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normal_user_cannot_access_system_info(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/system-info/system', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_access_system_info(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/system-info/system', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        // Check that we have the expected structure
+        $this->assertEquals('system-info', Arr::get($json, 'data.type'));
+        $this->assertEquals('system', Arr::get($json, 'data.id'));
+        $this->assertArrayHasKey('content', Arr::get($json, 'data.attributes'));
+
+        // Check that content is a non-empty string
+        $content = Arr::get($json, 'data.attributes.content');
+        $this->assertIsString($content);
+        $this->assertNotEmpty($content);
+
+        // Check that the content contains expected information
+        $this->assertStringContainsString('Flarum core:', $content);
+        $this->assertStringContainsString('PHP version:', $content);
+    }
+}

--- a/framework/core/tests/integration/api/info/ShowTest.php
+++ b/framework/core/tests/integration/api/info/ShowTest.php
@@ -11,7 +11,6 @@ namespace Flarum\Tests\integration\api\info;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
-use Flarum\User\User;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Attributes\Test;
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
`2.x` equivalent of #4322 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
