### PR TITLE
[2.x] fix: cannot moderate security page of other users

### DIFF
--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -123,7 +123,7 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn ($model, Context $context) => $context->getActor()->can('searchUsers')),
             Schema\Boolean::make('canCreateAccessToken')
                 ->get(fn ($model, Context $context) => $context->getActor()->can('createAccessToken')),
-            Schema\Boolean::make('moderateAccessTokens')
+            Schema\Boolean::make('canModerateAccessTokens')
                 ->get(fn ($model, Context $context) => $context->getActor()->can('moderateAccessTokens')),
             Schema\Boolean::make('canEditUserCredentials')
                 ->get(fn ($model, Context $context) => $context->getActor()->hasPermission('user.editCredentials')),

--- a/framework/core/tests/integration/api/access_tokens/PermissionTest.php
+++ b/framework/core/tests/integration/api/access_tokens/PermissionTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Tests\integration\api\access_tokens;
 
 use Flarum\Group\Group;
@@ -41,7 +48,7 @@ class PermissionTest extends TestCase
     {
         $response = $this->send(
             $this->request('GET', '/api', compact('authenticatedAs'))
-            );
+        );
 
         $this->assertEquals(200, $response->getStatusCode());
 
@@ -59,7 +66,7 @@ class PermissionTest extends TestCase
     {
         $response = $this->send(
             $this->request('GET', '/api', compact('authenticatedAs'))
-            );
+        );
 
         $this->assertEquals(200, $response->getStatusCode());
 

--- a/framework/core/tests/integration/api/access_tokens/PermissionTest.php
+++ b/framework/core/tests/integration/api/access_tokens/PermissionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Flarum\Tests\integration\api\access_tokens;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class PermissionTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator1', 'email' => 'moderator1@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'test', 'name_plural' => 'test']
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 100]
+            ],
+            'group_permission' => [
+                ['group_id' => 100, 'permission' => 'moderateAccessTokens']
+            ]
+        ]);
+    }
+
+    #[Test]
+    #[DataProvider('usersWithPermissionDataProvider')]
+    public function user_with_permission_has_access(int $authenticatedAs): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api', compact('authenticatedAs'))
+            );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        $canModerateAccessTokens = Arr::get($body, 'data.attributes.canModerateAccessTokens');
+
+        $this->assertNotNull($canModerateAccessTokens);
+        $this->assertTrue($canModerateAccessTokens);
+    }
+
+    #[Test]
+    #[DataProvider('usersWithoutPermissionDataProvider')]
+    public function user_without_permission_has_no_access(?int $authenticatedAs): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api', compact('authenticatedAs'))
+            );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        $canModerateAccessTokens = Arr::get($body, 'data.attributes.canModerateAccessTokens');
+
+        $this->assertNotNull($canModerateAccessTokens);
+        $this->assertFalse($canModerateAccessTokens);
+    }
+
+    public static function usersWithPermissionDataProvider(): array
+    {
+        return [
+            [1],
+            [3]
+        ];
+    }
+
+    public static function usersWithoutPermissionDataProvider(): array
+    {
+        return [
+            [2],
+            [null]
+        ];
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4324 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
