### PR TITLE
[2.x] [likes] fix: likes not loaded on firstPost when loaded via XHR

### DIFF
--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -50,6 +50,14 @@ return [
             }
         ),
 
+    (new Extend\ApiResource(Resource\DiscussionResource::class))
+        ->endpoint(
+            [Endpoint\Show::class, Endpoint\Index::class, Endpoint\Create::class],
+            function (Endpoint\Show|Endpoint\Index|Endpoint\Create $endpoint): Endpoint\Endpoint {
+                return $endpoint->addDefaultInclude(['firstPost.likes', 'lastPost.likes']);
+            }
+        ),
+
     (new Extend\Event())
         ->listen(PostWasLiked::class, Listener\SendNotificationWhenPostIsLiked::class)
         ->listen(PostWasUnliked::class, Listener\SendNotificationWhenPostIsUnliked::class)

--- a/extensions/likes/tests/integration/api/ListPostsTest.php
+++ b/extensions/likes/tests/integration/api/ListPostsTest.php
@@ -211,4 +211,72 @@ class ListPostsTest extends TestCase
             [null],
         ];
     }
+
+    #[Test]
+    #[DataProvider('likesIncludeProvider')]
+    public function likes_relation_included_when_loading_posts_by_id(?string $include)
+    {
+        // This simulates the frontend's loadRange() behavior when scrolling
+        // Posts are loaded by ID using filter[id]=101
+        $response = $this->send(
+            $this->request('GET', '/api/posts', [
+                'authenticatedAs' => 2,
+            ])->withQueryParams(array_filter([
+                'filter' => ['id' => '101'],
+                'include' => $include,
+            ]))
+        );
+
+        $body = $response->getBody()->getContents();
+
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $data = json_decode($body, true)['data'];
+
+        $likes = $data[0]['relationships']['likes']['data'] ?? null;
+
+        // Only displays a limited amount of likes
+        $this->assertNotNull($likes, 'Likes relationship should be included. Body: '.$body);
+        $this->assertCount(PostResourceFields::$maxLikes, $likes);
+        // Displays the correct count of likes
+        $this->assertEquals(11, $data[0]['attributes']['likesCount'], $body);
+        // Of the limited amount of likes, the actor always appears
+        $this->assertEquals([2, 102, 104, 105], Arr::pluck($likes, 'id'), $body);
+    }
+
+    #[Test]
+    public function first_post_likes_included_when_loading_discussion()
+    {
+        // This simulates loading a discussion which includes firstPost
+        // The firstPost should have its likes relationship included
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/100', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $included = json_decode($body, true)['included'] ?? [];
+
+        // Find the first post in the included resources
+        $firstPost = collect($included)
+            ->where('type', 'posts')
+            ->where('id', '101')
+            ->first();
+
+        $this->assertNotNull($firstPost, 'First post should be included. Body: '.$body);
+
+        $likes = $firstPost['relationships']['likes']['data'] ?? null;
+
+        // Only displays a limited amount of likes
+        $this->assertNotNull($likes, 'Likes relationship should be included on firstPost. Body: '.$body);
+        $this->assertCount(PostResourceFields::$maxLikes, $likes);
+        // Displays the correct count of likes
+        $this->assertEquals(11, $firstPost['attributes']['likesCount'], $body);
+        // Of the limited amount of likes, the actor always appears
+        $this->assertEquals([2, 102, 104, 105], Arr::pluck($likes, 'id'), $body);
+    }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
