### PR TITLE
[2.x] fix: identify minified js reliably

### DIFF
--- a/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
+++ b/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
@@ -107,8 +107,14 @@ class JsDirectoryCompiler implements CompilerInterface
         $filesystem = $source->getFilesystem();
 
         foreach ($filesystem->allFiles() as $relativeFilePath) {
-            // Skip non-JS files.
-            if ($filesystem->mimeType($relativeFilePath) !== 'application/javascript') {
+            // Check both file extension and MIME type to identify JS files.
+            // We require at least one of these checks to pass, as MIME type detection
+            // can be unreliable for minified/bundled JS files.
+            $hasJsExtension = str_ends_with($relativeFilePath, '.js');
+            $mimeType = $filesystem->mimeType($relativeFilePath);
+            $hasJsMimeType = $mimeType === 'application/javascript' || $mimeType === 'text/javascript';
+
+            if (! $hasJsExtension && ! $hasJsMimeType) {
                 continue;
             }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4328 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
