### PR TITLE
fix: suppress registry warnings for lazy-loaded chunk modules

### DIFF
--- a/framework/core/js/src/common/ExportRegistry.ts
+++ b/framework/core/js/src/common/ExportRegistry.ts
@@ -121,10 +121,13 @@ export default class ExportRegistry implements IExportRegistry, IChunkRegistry {
     const extensionEnabled = namespace in flarum.extensions || namespace === 'core';
     const error = `No module found for ${namespace}:${id}`;
 
+    // Check if the module is registered in a chunk (will be loaded lazily)
+    const isInChunk = this.chunkModules.has(`${namespace}:${id}`);
+
     // @ts-ignore
-    if (!module && extensionEnabled && flarum.debug) {
+    if (!module && extensionEnabled && !isInChunk && flarum.debug) {
       throw new Error(error);
-    } else if (!module && extensionEnabled) {
+    } else if (!module && extensionEnabled && !isInChunk) {
       console.warn(error);
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4330 **

**Changes proposed in this pull request:**
When using code splitting with dynamic imports, ExportRegistry.get() was
warning about missing modules even though they were properly registered
in chunks and would load successfully. This adds a check to verify if a
module exists in the chunkModules registry before issuing warnings.

The fix allows code splitting to work without spurious console errors
while still warning about genuinely missing modules that are not
registered anywhere.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
