### PR TITLE
[2.x] Add option to reuse default request error handler to handle extension toggles

### DIFF
--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -294,7 +294,6 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
         method: 'PATCH',
         body: { enabled: !enabled },
         errorHandler: this.onerror.bind(this),
-        fallbackToDefaultErrorHandler: true,
       })
       .then(() => {
         if (!enabled) localStorage.setItem('enabledExtension', this.extension.id);
@@ -309,14 +308,14 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
     return isExtensionEnabled(this.extension.id);
   }
 
-  onerror(e: RequestError) {
+  onerror(e: RequestError): void | false {
     app.modal.close();
 
     this.changingState = false;
 
-    // If it's not a conflict error, rethrow it to be handled by the default handler.
+    // If it's not a conflict error, use the default request error handler.
     if (e.status !== 409) {
-      throw e;
+      return false;
     }
 
     const error = e.response?.errors?.[0];

--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -294,11 +294,13 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
         method: 'PATCH',
         body: { enabled: !enabled },
         errorHandler: this.onerror.bind(this),
+        fallbackToDefaultErrorHandler: true,
       })
       .then(() => {
         if (!enabled) localStorage.setItem('enabledExtension', this.extension.id);
         window.location.reload();
-      });
+      })
+      .catch(() => {});
 
     app.modal.show(LoadingModal);
   }
@@ -308,15 +310,11 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
   }
 
   onerror(e: RequestError) {
-    // We need to give the modal animation time to start; if we close the modal too early,
-    // it breaks the bootstrap modal library.
-    // TODO: This workaround should be removed when we move away from bootstrap JS for modals.
-    setTimeout(() => {
-      app.modal.close();
-    }, 300); // Bootstrap's Modal.TRANSITION_DURATION is 300 ms.
+    app.modal.close();
 
     this.changingState = false;
 
+    // If it's not a conflict error, rethrow it to be handled by the default handler.
     if (e.status !== 409) {
       throw e;
     }
@@ -328,7 +326,7 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
         { type: 'error' },
         app.translator.trans(`core.lib.error.${error.code}_message`, {
           extension: error.extension,
-          extensions: (error.extensions as string[]).join(', '),
+          extensions: (error.extensions as string[])?.join(', '),
         })
       );
     }

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -47,6 +47,13 @@ export type FlarumGenericRoute = RouteItem<any, any, any>;
 
 export interface FlarumRequestOptions<ResponseType> extends Omit<Mithril.RequestOptions<ResponseType>, 'extract'> {
   errorHandler?: (error: RequestError) => void;
+  /**
+   * If a custom errorHandler is provided, this determines whether the default error handler
+   * should be called if the error is re-thrown inside the custom error handler.
+   *
+   * Defaults to false.
+   */
+  fallbackToDefaultErrorHandler?: boolean;
   url: string;
   /**
    * Manipulate the response text before it is parsed into JSON.
@@ -611,13 +618,17 @@ export default class Application {
 
     if (this.requestErrorAlert) this.alerts.dismiss(this.requestErrorAlert);
 
-    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler));
+    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler, !!originalOptions.fallbackToDefaultErrorHandler));
   }
 
   /**
    * By default, show an error alert, and log the error to the console.
    */
-  protected requestErrorCatch<ResponseType>(error: RequestError, customErrorHandler: FlarumRequestOptions<ResponseType>['errorHandler']) {
+  protected requestErrorCatch<ResponseType>(
+    error: RequestError,
+    customErrorHandler: FlarumRequestOptions<ResponseType>['errorHandler'],
+    fallbackToDefaultErrorHandler: boolean = false
+  ): Promise<never> {
     // the details property is decoded to transform escaped characters such as '\n'
     const formattedErrors = error.response?.errors?.map((e) => decodeURI(e.detail ?? '')) ?? [];
 
@@ -672,9 +683,20 @@ export default class Application {
       ],
     };
 
+    // Use the default error handler if no custom one was provided OR if we're handling a re-thrown error.
+    let useDefaultHandler = !customErrorHandler;
+
     if (customErrorHandler) {
-      customErrorHandler(error);
-    } else {
+      try {
+        customErrorHandler(error);
+      } catch {
+        if (fallbackToDefaultErrorHandler) {
+          useDefaultHandler = true;
+        }
+      }
+    }
+
+    if (useDefaultHandler) {
       this.requestErrorDefaultHandler(error, isDebug, formattedErrors);
     }
 

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -46,14 +46,17 @@ export type FlarumScreens = 'phone' | 'tablet' | 'desktop' | 'desktop-hd';
 export type FlarumGenericRoute = RouteItem<any, any, any>;
 
 export interface FlarumRequestOptions<ResponseType> extends Omit<Mithril.RequestOptions<ResponseType>, 'extract'> {
-  errorHandler?: (error: RequestError) => void;
   /**
-   * If a custom errorHandler is provided, this determines whether the default error handler
-   * should be called if the error is re-thrown inside the custom error handler.
+   * Custom error handler for failed requests. Overrides the default error handler.
    *
-   * Defaults to false.
+   * Return `false` (sync or promise) to fall back to the default error handler.
+   * Useful for handling specific errors without displaying error alerts to the user.
+   * To always show alerts, catch the error rejected by `app.request` instead.
+   *
+   * @param error
+   * @return  `false` (sync or promise) to fall back to the default error handler.
    */
-  fallbackToDefaultErrorHandler?: boolean;
+  errorHandler?: (error: RequestError) => void | false | Promise<void | false>;
   url: string;
   /**
    * Manipulate the response text before it is parsed into JSON.
@@ -618,16 +621,15 @@ export default class Application {
 
     if (this.requestErrorAlert) this.alerts.dismiss(this.requestErrorAlert);
 
-    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler, !!originalOptions.fallbackToDefaultErrorHandler));
+    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler));
   }
 
   /**
    * By default, show an error alert, and log the error to the console.
    */
-  protected requestErrorCatch<ResponseType>(
+  protected async requestErrorCatch<ResponseType>(
     error: RequestError,
-    customErrorHandler: FlarumRequestOptions<ResponseType>['errorHandler'],
-    fallbackToDefaultErrorHandler: boolean = false
+    customErrorHandler: FlarumRequestOptions<ResponseType>['errorHandler']
   ): Promise<never> {
     // the details property is decoded to transform escaped characters such as '\n'
     const formattedErrors = error.response?.errors?.map((e) => decodeURI(e.detail ?? '')) ?? [];
@@ -683,17 +685,14 @@ export default class Application {
       ],
     };
 
-    // Use the default error handler if no custom one was provided OR if we're handling a re-thrown error.
+    // Use the default error handler if no custom one was provided OR if we're handling falling back to the default.
     let useDefaultHandler = !customErrorHandler;
 
     if (customErrorHandler) {
-      try {
-        customErrorHandler(error);
-      } catch {
-        if (fallbackToDefaultErrorHandler) {
-          useDefaultHandler = true;
-        }
-      }
+      const output = await customErrorHandler(error);
+
+      // If the custom handler returned false, we should fall back to the default handler.
+      useDefaultHandler = output === false;
     }
 
     if (useDefaultHandler) {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4332**

**Changes proposed in this pull request:**
- Add option to fallback to default error handler if custom one re-throws the request error
  - If a non-RequestError is thrown, it will just be re-thrown by the default error handler so nothing happens
- Update error handling in ExtensionPage 

**Reviewers should focus on:**
Should this be an option at all? Should it be true by default? I didn't dive deep into what the previous functionality was -- not sure what would be best to have either. I'd say more error handling is better than less though, but it could have sideffects elsewhere.

**Screenshot**
https://github.com/user-attachments/assets/e598272f-a943-42eb-a2cf-13a4caeb9414


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
