### PR TITLE
fix: php warnings in restricted environments

### DIFF
--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -192,7 +192,7 @@ class InfoCommand extends AbstractCommand
         ];
 
         foreach ($possiblePhpBinaries as $phpBinary) {
-            if (file_exists($phpBinary) && is_executable($phpBinary)) {
+            if (@file_exists($phpBinary) && @is_executable($phpBinary)) {
                 $output = [];
                 $status = null;
                 exec("$phpBinary -v 2>&1 | head -n 1", $output, $status);
@@ -234,16 +234,16 @@ class InfoCommand extends AbstractCommand
         ];
 
         foreach ($possiblePaths as $path) {
-            if (file_exists($path) && is_readable($path)) {
-                $content = file_get_contents($path);
+            if (@file_exists($path) && @is_readable($path)) {
+                $content = @file_get_contents($path);
 
                 // Look for memory_limit setting
-                if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                if ($content && preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
                     return trim($matches[1]);
                 }
 
                 // For FPM pool configs, also check php_admin_value
-                if (preg_match('/^\s*php_admin_value\[memory_limit\]\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                if ($content && preg_match('/^\s*php_admin_value\[memory_limit\]\s*=\s*(.+?)\s*$/m', $content, $matches)) {
                     return trim($matches[1]);
                 }
             }
@@ -251,13 +251,13 @@ class InfoCommand extends AbstractCommand
 
         // Also scan /usr/local/etc/php/conf.d/ directory for any INI files with memory_limit
         $confDir = '/usr/local/etc/php/conf.d';
-        if (is_dir($confDir) && is_readable($confDir)) {
-            $iniFiles = glob($confDir . '/*.ini');
+        if (@is_dir($confDir) && @is_readable($confDir)) {
+            $iniFiles = @glob($confDir . '/*.ini');
             if ($iniFiles) {
                 foreach ($iniFiles as $iniFile) {
-                    if (is_readable($iniFile)) {
-                        $content = file_get_contents($iniFile);
-                        if (preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
+                    if (@is_readable($iniFile)) {
+                        $content = @file_get_contents($iniFile);
+                        if ($content && preg_match('/^\s*memory_limit\s*=\s*(.+?)\s*$/m', $content, $matches)) {
                             return trim($matches[1]);
                         }
                     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
