### PR TITLE
[1.x] Fix running phpstan with newer PHP versions (e.g. 8.4)

### DIFF
--- a/php-packages/phpstan/composer.json
+++ b/php-packages/phpstan/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "dev",
     "license": "MIT",
     "require": {
-        "phpstan/phpstan": ">=1.8.11 < 1.9.0",
+        "phpstan/phpstan": "^1.9",
         "nunomaduro/larastan": "^1.0"
     },
     "autoload": {

--- a/php-packages/phpstan/phpstan-baseline.neon
+++ b/php-packages/phpstan/phpstan-baseline.neon
@@ -9,12 +9,12 @@ parameters:
 		  reportUnmatched: false
 
 		#	We ignore this because resolve can either take a class name as the generic return type or just a binding name.
-		- message: "#Template type T of function resolve[()]{2} is not referenced in a parameter.#"
+		- message: '#Template type T of function resolve\(\) is not referenced in a parameter.#'
 		  reportUnmatched: false
 
 		#	We ignore new static errors because we want extensibility.
 		#	@TODO: needs discussion.
-		- message: "#^Unsafe usage of new static[()]{2}.$#"
+		- message: '#^Unsafe usage of new static\(\).$#'
 		  reportUnmatched: false
 
 		# ConnectionInterface lacks methods that exist in the implementation,


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**

phpstan 1.8 cannot run properly with PHP 8.4, but newer versions in the 1.x branch do, thus we change the requirement to phpstan ^1.9, to allow version up to 2.0 (excluding).

Newer phpstan versions now detect common errors in regexes:

    Ignored error #Template type T of function resolve[()]{2} is not referenced in a parameter.# has an unescaped '()' which leads to ignoring all errors. Use '\(\)' instead.
    Ignored error #^Unsafe usage of new static[()]{2}.$# has an unescaped '()' which leads to ignoring all errors. Use '\(\)' instead.

So these regexes are also fixed by using [non-evaluated string literals](https://doc.nette.org/en/neon/format#toc-strings) and escaping the parenthesis as recommended instead of using a weird trick with the brackets.

<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
???

**Screenshot**

Before:
<!-- include an image of the most relevant user-facing change, if any -->
<img width="1080" height="639" alt="2026-01-11-170241_1080x639_scrot" src="https://github.com/user-attachments/assets/c796259b-36ca-41ef-82f5-8ecbafb79c4e" />

After:
<img width="1081" height="610" alt="2026-01-11-165928_1081x610_scrot" src="https://github.com/user-attachments/assets/c0290ace-e3a6-46a4-a181-cc5ac4fdae32" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
