### PR TITLE
[2.x] feat(core, mentions): implement ability to order groups

### DIFF
--- a/extensions/mentions/js/src/forum/mentionables/GroupMention.tsx
+++ b/extensions/mentions/js/src/forum/mentionables/GroupMention.tsx
@@ -5,6 +5,7 @@ import type Mithril from 'mithril';
 import Badge from 'flarum/common/components/Badge';
 import highlight from 'flarum/common/helpers/highlight';
 import type AtMentionFormat from './formats/AtMentionFormat';
+import sortGroups from 'flarum/common/utils/sortGroups';
 
 export default class GroupMention extends MentionableModel<Group, AtMentionFormat> {
   type(): string {
@@ -13,9 +14,11 @@ export default class GroupMention extends MentionableModel<Group, AtMentionForma
 
   initialResults(): Group[] {
     return Array.from(
-      app.store.all<Group>('groups').filter((g: Group) => {
-        return g.id() !== Group.GUEST_ID && g.id() !== Group.MEMBER_ID;
-      })
+      sortGroups(
+        app.store.all<Group>('groups').filter((g: Group) => {
+          return g.id() !== Group.GUEST_ID && g.id() !== Group.MEMBER_ID;
+        })
+      )
     );
   }
 

--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -17,7 +17,7 @@
         "mithril": "^2.2",
         "nanoid": "^3.1.30",
         "punycode": "^2.1.1",
-        "sortablejs": "^1.15.6",
+        "sortablejs": "^1.14.0",
         "textarea-caret": "^3.1.0",
         "throttle-debounce": "^3.0.1"
     },

--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -27,6 +27,7 @@
         "@types/jquery": "^3.5.10",
         "@types/mithril": "^2.0.8",
         "@types/punycode": "^2.1.0",
+        "@types/sortablejs": "^1.15.9",
         "@types/textarea-caret": "^3.0.1",
         "@types/ua-parser-js": "^0.7.36",
         "bundlewatch": "^0.3.2",

--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -17,6 +17,7 @@
         "mithril": "^2.2",
         "nanoid": "^3.1.30",
         "punycode": "^2.1.1",
+        "sortablejs": "^1.15.6",
         "textarea-caret": "^3.1.0",
         "throttle-debounce": "^3.0.1"
     },

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -14,7 +14,7 @@ export interface IGroupBarAttrs extends ComponentAttrs {
   groups: Group[];
 }
 
-export default abstract class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
+export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
   groups: Group[] = [];
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -14,6 +14,21 @@ export interface IGroupBarAttrs extends ComponentAttrs {
   groups: Group[];
 }
 
+/**
+ * A reusable component for displaying a list of groups in the admin interface,
+ * with the ability to edit and reorder them.
+ *
+ * @property {Group[]} groups Required. Groups to display.
+ *
+ * @example
+ * ```ts
+ * const availableGroups = app.store
+ *   .all<Group>('groups')
+ *   .filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1);
+ *
+ * <GroupBar groups={availableGroups} />
+ * ```
+ */
 export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
   groups: Group[] = [];
 

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -1,0 +1,80 @@
+import sortable from 'sortablejs';
+
+import app from '../../admin/app';
+import Component, { ComponentAttrs } from '../../common/Component';
+import GroupBadge from '../../common/components/GroupBadge';
+import Icon from '../../common/components/Icon';
+import EditGroupModal from './EditGroupModal';
+import sortGroups from '../../common/utils/sortGroups';
+
+import type Group from '../../common/models/Group';
+import type Mithril from 'mithril';
+
+export interface IGroupBarAttrs extends ComponentAttrs {
+  groups: Group[];
+}
+
+export default abstract class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
+  groups: Group[] = [];
+
+  oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
+    super.oninit(vnode);
+
+    this.groups = sortGroups(this.attrs.groups);
+  }
+
+  view(): JSX.Element {
+    return (
+      <div className="GroupBar" oncreate={this.onGroupBarCreate.bind(this)}>
+        {this.groups.map((group) => (
+          <button className="Button Group" type="button" data-id={group.id()} onclick={() => app.modal.show(EditGroupModal, { group })}>
+            <GroupBadge group={group} className="Group-icon" label={null} />
+            <span className="Group-name">{group.namePlural()}</span>
+          </button>
+        ))}
+        <button className="Button Group Group--add" type="button" onclick={() => app.modal.show(EditGroupModal)}>
+          <Icon name="fas fa-plus" className="Group-icon" />
+          <span className="Group-name">{app.translator.trans('core.admin.permissions.new_group_button')}</span>
+        </button>
+      </div>
+    );
+  }
+
+  onGroupBarCreate(vnode: Mithril.VnodeDOM) {
+    sortable.create(vnode.dom as HTMLElement, {
+      group: 'groups',
+      delay: 50,
+      delayOnTouchOnly: true,
+      touchStartThreshold: 5,
+      animation: 150,
+      swapThreshold: 0.65,
+      dragClass: 'Group-Sortable-Dragging',
+      ghostClass: 'Group-Sortable-Placeholder',
+
+      filter: '.Group--add',
+      onMove: (evt) => !evt.related.classList.contains('Group--add'),
+
+      onSort: (e) => this.onSortUpdate(),
+    });
+  }
+
+  onSortUpdate() {
+    const order = this.$('.Group:not(.Group--add)')
+      .map(function () {
+        return $(this).data('id');
+      })
+      .get();
+
+    order.forEach((id, i) => {
+      app.store.getById<Group>('groups', id)?.pushData({
+        attributes: { position: i },
+      });
+    });
+
+    app.request({
+      url: app.forum.attribute('apiUrl') + '/groups/order',
+      method: 'POST',
+      body: { order },
+    });
+  }
+}

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -38,6 +38,11 @@ export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttr
     this.groups = sortGroups(this.attrs.groups);
   }
 
+  onupdate(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
+    super.onupdate(vnode);
+    this.groups = sortGroups(this.attrs.groups);
+  }
+
   view(): JSX.Element {
     return (
       <div className="GroupBar" oncreate={this.onGroupBarCreate.bind(this)}>

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -69,7 +69,7 @@ export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttr
       filter: '.Group--add',
       onMove: (evt) => !evt.related.classList.contains('Group--add'),
 
-      onSort: (e) => this.onSortUpdate(),
+      onSort: () => this.onSortUpdate(),
     });
   }
 

--- a/framework/core/js/src/admin/components/PermissionDropdown.tsx
+++ b/framework/core/js/src/admin/components/PermissionDropdown.tsx
@@ -5,6 +5,7 @@ import Separator from '../../common/components/Separator';
 import Group from '../../common/models/Group';
 import Badge from '../../common/components/Badge';
 import GroupBadge from '../../common/components/GroupBadge';
+import sortGroups from '../../common/utils/sortGroups';
 import Mithril from 'mithril';
 
 function badgeForId(id: string) {
@@ -95,21 +96,20 @@ export default class PermissionDropdown<CustomAttrs extends IPermissionDropdownA
       // These groups are defined above, appearing first in the list.
       const excludedGroups = [Group.ADMINISTRATOR_ID, Group.GUEST_ID, Group.MEMBER_ID];
 
-      const groupButtons = app.store
-        .all<Group>('groups')
-        .filter((group) => !excludedGroups.includes(group.id()!))
-        .map((group) => (
-          <Button
-            icon={groupIds.includes(group.id()!) ? 'fas fa-check' : true}
-            onclick={(e: MouseEvent) => {
-              if (e.shiftKey) e.stopPropagation();
-              this.toggle(group.id()!);
-            }}
-            disabled={this.isGroupDisabled(group.id()!) && this.isGroupDisabled(Group.MEMBER_ID) && this.isGroupDisabled(Group.GUEST_ID)}
-          >
-            {badgeForId(group.id()!)} {group.namePlural()}
-          </Button>
-        ));
+      const availableGroups = sortGroups(app.store.all<Group>('groups').filter((group) => !excludedGroups.includes(group.id()!)));
+
+      const groupButtons = availableGroups.map((group) => (
+        <Button
+          icon={groupIds.includes(group.id()!) ? 'fas fa-check' : true}
+          onclick={(e: MouseEvent) => {
+            if (e.shiftKey) e.stopPropagation();
+            this.toggle(group.id()!);
+          }}
+          disabled={this.isGroupDisabled(group.id()!) && this.isGroupDisabled(Group.MEMBER_ID) && this.isGroupDisabled(Group.GUEST_ID)}
+        >
+          {badgeForId(group.id()!)} {group.namePlural()}
+        </Button>
+      ));
 
       children.push(...groupButtons);
     }

--- a/framework/core/js/src/admin/components/PermissionsPage.tsx
+++ b/framework/core/js/src/admin/components/PermissionsPage.tsx
@@ -6,6 +6,7 @@ import PermissionGrid from './PermissionGrid';
 import AdminPage from './AdminPage';
 import Icon from '../../common/components/Icon';
 import SettingDropdown from './SettingDropdown';
+import sortGroups from '../../common/utils/sortGroups';
 
 export default class PermissionsPage extends AdminPage {
   headerInfo() {
@@ -18,18 +19,19 @@ export default class PermissionsPage extends AdminPage {
   }
 
   content() {
+    const availableGroups = sortGroups(
+      app.store.all<Group>('groups').filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1)
+    );
+
     return (
       <>
         <div className="PermissionsPage-groups">
-          {app.store
-            .all<Group>('groups')
-            .filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1)
-            .map((group) => (
-              <button className="Button Group" type="button" onclick={() => app.modal.show(EditGroupModal, { group })}>
-                <GroupBadge group={group} className="Group-icon" label={null} />
-                <span className="Group-name">{group.namePlural()}</span>
-              </button>
-            ))}
+          {availableGroups.map((group) => (
+            <button className="Button Group" type="button" onclick={() => app.modal.show(EditGroupModal, { group })}>
+              <GroupBadge group={group} className="Group-icon" label={null} />
+              <span className="Group-name">{group.namePlural()}</span>
+            </button>
+          ))}
           <button className="Button Group Group--add" type="button" onclick={() => app.modal.show(EditGroupModal)}>
             <Icon name="fas fa-plus" className="Group-icon" />
             <span className="Group-name">{app.translator.trans('core.admin.permissions.new_group_button')}</span>

--- a/framework/core/js/src/admin/components/PermissionsPage.tsx
+++ b/framework/core/js/src/admin/components/PermissionsPage.tsx
@@ -1,12 +1,9 @@
 import app from '../../admin/app';
-import GroupBadge from '../../common/components/GroupBadge';
-import EditGroupModal from './EditGroupModal';
+import GroupBar from './GroupBar';
 import Group from '../../common/models/Group';
 import PermissionGrid from './PermissionGrid';
 import AdminPage from './AdminPage';
-import Icon from '../../common/components/Icon';
 import SettingDropdown from './SettingDropdown';
-import sortGroups from '../../common/utils/sortGroups';
 
 export default class PermissionsPage extends AdminPage {
   headerInfo() {
@@ -19,23 +16,12 @@ export default class PermissionsPage extends AdminPage {
   }
 
   content() {
-    const availableGroups = sortGroups(
-      app.store.all<Group>('groups').filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1)
-    );
+    const availableGroups = app.store.all<Group>('groups').filter((group) => [Group.GUEST_ID, Group.MEMBER_ID].indexOf(group.id()!) === -1);
 
     return (
       <>
         <div className="PermissionsPage-groups">
-          {availableGroups.map((group) => (
-            <button className="Button Group" type="button" onclick={() => app.modal.show(EditGroupModal, { group })}>
-              <GroupBadge group={group} className="Group-icon" label={null} />
-              <span className="Group-name">{group.namePlural()}</span>
-            </button>
-          ))}
-          <button className="Button Group Group--add" type="button" onclick={() => app.modal.show(EditGroupModal)}>
-            <Icon name="fas fa-plus" className="Group-icon" />
-            <span className="Group-name">{app.translator.trans('core.admin.permissions.new_group_button')}</span>
-          </button>
+          <GroupBar groups={availableGroups} />
         </div>
 
         <div className="PermissionsPage-permissions">

--- a/framework/core/js/src/common/common.ts
+++ b/framework/core/js/src/common/common.ts
@@ -20,6 +20,7 @@ import './utils/abbreviateNumber';
 import './utils/escapeRegExp';
 import './utils/string';
 import './utils/throttleDebounce';
+import './utils/sortGroups';
 import './utils/Stream';
 import './utils/SubtreeRetainer';
 import './utils/setRouteWithForcedRefresh';

--- a/framework/core/js/src/common/components/EditUserModal.tsx
+++ b/framework/core/js/src/common/components/EditUserModal.tsx
@@ -3,6 +3,7 @@ import FormModal, { IFormModalAttrs } from '../../common/components/FormModal';
 import Button from './Button';
 import GroupBadge from './GroupBadge';
 import Group from '../models/Group';
+import sortGroups from '../utils/sortGroups';
 import extractText from '../utils/extractText';
 import ItemList from '../utils/ItemList';
 import Stream from '../utils/Stream';
@@ -22,6 +23,7 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
   protected setPassword!: Stream<boolean>;
   protected password!: Stream<string>;
   protected groups: Record<string, Stream<boolean>> = {};
+  protected availableGroups: Group[] = [];
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
@@ -36,10 +38,11 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
 
     const userGroups = user.groups() || [];
 
-    app.store
-      .all<Group>('groups')
-      .filter((group) => ![Group.GUEST_ID, Group.MEMBER_ID].includes(group.id()!))
-      .forEach((group) => (this.groups[group.id()!] = Stream(userGroups.includes(group))));
+    this.availableGroups = sortGroups(app.store.all<Group>('groups').filter((group) => ![Group.GUEST_ID, Group.MEMBER_ID].includes(group.id()!)));
+
+    this.availableGroups.forEach((group) => {
+      this.groups[group.id()!] = Stream(userGroups.includes(group));
+    });
   }
 
   className() {
@@ -139,25 +142,16 @@ export default class EditUserModal<CustomAttrs extends IEditUserModalAttrs = IEd
         <div className="Form-group EditUserModal-groups">
           <label>{app.translator.trans('core.lib.edit_user.groups_heading')}</label>
           <div>
-            {Object.keys(this.groups)
-              .map((id) => app.store.getById<Group>('groups', id))
-              .filter(Boolean)
-              .map(
-                (group) =>
-                  // Necessary because filter(Boolean) doesn't narrow out falsy values.
-                  group && (
-                    <label className="checkbox">
-                      <input
-                        type="checkbox"
-                        bidi={this.groups[group.id()!]}
-                        disabled={
-                          group.id() === Group.ADMINISTRATOR_ID && (this.attrs.user === app.session.user || !this.userIsAdmin(app.session.user))
-                        }
-                      />
-                      <GroupBadge group={group} label={null} /> {group.nameSingular()}
-                    </label>
-                  )
-              )}
+            {this.availableGroups.map((group) => (
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  bidi={this.groups[group.id()!]}
+                  disabled={group.id() === Group.ADMINISTRATOR_ID && (this.attrs.user === app.session.user || !this.userIsAdmin(app.session.user))}
+                />
+                <GroupBadge group={group} label={null} /> {group.nameSingular()}
+              </label>
+            ))}
           </div>
         </div>,
         10

--- a/framework/core/js/src/common/models/Group.ts
+++ b/framework/core/js/src/common/models/Group.ts
@@ -22,4 +22,8 @@ export default class Group extends Model {
   isHidden() {
     return Model.attribute<boolean>('isHidden').call(this);
   }
+
+  position() {
+    return Model.attribute<number>('position').call(this);
+  }
 }

--- a/framework/core/js/src/common/utils/sortGroups.ts
+++ b/framework/core/js/src/common/utils/sortGroups.ts
@@ -1,5 +1,14 @@
 import type Group from '../models/Group';
 
 export default function sortGroups(groups: Group[]) {
-  return groups.slice().sort((a, b) => a.position() - b.position());
+  return groups.slice().sort((a, b) => {
+    const aPos = a.position();
+    const bPos = b.position();
+
+    if (aPos === null && bPos === null) return 0;
+    if (aPos === null) return 1;
+    if (bPos === null) return -1;
+
+    return aPos - bPos;
+  });
 }

--- a/framework/core/js/src/common/utils/sortGroups.ts
+++ b/framework/core/js/src/common/utils/sortGroups.ts
@@ -1,0 +1,5 @@
+import type Group from '../models/Group';
+
+export default function sortGroups(groups: Group[]) {
+  return groups.slice().sort((a, b) => a.position() - b.position());
+}

--- a/framework/core/js/webpack.config.cjs
+++ b/framework/core/js/webpack.config.cjs
@@ -5,4 +5,9 @@ module.exports = merge(config(), {
   output: {
     library: 'flarum.core',
   },
+  resolve: {
+    alias: {
+      sortablejs: require.resolve('sortablejs/Sortable.js'),
+    },
+  },
 });

--- a/framework/core/less/admin/PermissionsPage.less
+++ b/framework/core/less/admin/PermissionsPage.less
@@ -1,10 +1,15 @@
-.PermissionsPage-groups {
+.GroupBar {
   background: var(--control-bg);
-  border-radius: var(--border-radius);
-  display: block;
-  overflow-x: auto;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
   padding: 10px;
+  border-radius: var(--border-radius);
 }
+.Group-Sortable-Placeholder {
+    outline: 2px dashed var(--body-bg);
+    border-radius: var(--border-radius);
+  }
 .Group {
   width: 90px;
   display: inline-block;

--- a/framework/core/less/admin/PermissionsPage.less
+++ b/framework/core/less/admin/PermissionsPage.less
@@ -7,8 +7,8 @@
   border-radius: var(--border-radius);
 }
 .Group-Sortable-Placeholder {
-    outline: 2px dashed var(--body-bg);
-    border-radius: var(--border-radius);
+  outline: 2px dashed var(--body-bg);
+  border-radius: var(--border-radius);
   }
 .Group {
   width: 90px;

--- a/framework/core/migrations/2026_01_24_000000_add_position_to_groups_table.php
+++ b/framework/core/migrations/2026_01_24_000000_add_position_to_groups_table.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('groups', function (Blueprint $table) {
+            $table->integer('position')->after('is_hidden')->nullable();
+        });
+
+        $db = $schema->getConnection();
+
+        $ids = $db->table('groups')
+            ->orderBy('id')
+            ->pluck('id');
+
+        $position = 0;
+        foreach ($ids as $id) {
+            $db->table('groups')
+                ->where('id', $id)
+                ->update(['position' => $position]);
+
+            $position++;
+        }
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('groups', function (Blueprint $table) {
+            $table->dropColumn('position');
+        });
+    }
+];

--- a/framework/core/src/Api/Controller/OrderGroupsController.php
+++ b/framework/core/src/Api/Controller/OrderGroupsController.php
@@ -25,7 +25,7 @@ class OrderGroupsController implements RequestHandlerInterface
 
         $order = Arr::get($request->getParsedBody(), 'order');
 
-        if ($order === null || !is_array($order)) {
+        if ($order === null || ! is_array($order)) {
             return new EmptyResponse(422);
         }
 

--- a/framework/core/src/Api/Controller/OrderGroupsController.php
+++ b/framework/core/src/Api/Controller/OrderGroupsController.php
@@ -25,7 +25,7 @@ class OrderGroupsController implements RequestHandlerInterface
 
         $order = Arr::get($request->getParsedBody(), 'order');
 
-        if ($order === null) {
+        if ($order === null || !is_array($order)) {
             return new EmptyResponse(422);
         }
 

--- a/framework/core/src/Api/Controller/OrderGroupsController.php
+++ b/framework/core/src/Api/Controller/OrderGroupsController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Group\Group;
+use Flarum\Http\RequestUtil;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class OrderGroupsController implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $order = Arr::get($request->getParsedBody(), 'order');
+
+        if ($order === null) {
+            return new EmptyResponse(422);
+        }
+
+        Group::query()->update(['position' => null]);
+
+        foreach ($order as $position => $id) {
+            Group::where('id', $id)->update(['position' => $position]);
+        }
+
+        return new EmptyResponse(204);
+    }
+}

--- a/framework/core/src/Api/Resource/GroupResource.php
+++ b/framework/core/src/Api/Resource/GroupResource.php
@@ -94,6 +94,7 @@ class GroupResource extends AbstractDatabaseResource
             Schema\Boolean::make('isHidden')
                 ->writable(),
             Schema\Integer::make('position')
+                ->nullable(),
         ];
     }
 

--- a/framework/core/src/Api/Resource/GroupResource.php
+++ b/framework/core/src/Api/Resource/GroupResource.php
@@ -93,6 +93,7 @@ class GroupResource extends AbstractDatabaseResource
                 ->writable(),
             Schema\Boolean::make('isHidden')
                 ->writable(),
+            Schema\Integer::make('position')
         ];
     }
 

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -55,6 +55,19 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
 
     /*
     |--------------------------------------------------------------------------
+    | Groups
+    |--------------------------------------------------------------------------
+    */
+
+    // Change order of groups
+    $map->post(
+        '/groups/order',
+        'groups.order',
+        $route->toController(Controller\OrderGroupsController::class)
+    );
+
+    /*
+    |--------------------------------------------------------------------------
     | Notifications
     |--------------------------------------------------------------------------
     */

--- a/framework/core/src/Group/Group.php
+++ b/framework/core/src/Group/Group.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|null $color
  * @property string|null $icon
  * @property bool $is_hidden
+ * @property int $position
  * @property-read \Illuminate\Database\Eloquent\Collection $users
  * @property-read \Illuminate\Database\Eloquent\Collection $permissions
  */

--- a/framework/core/src/Group/Group.php
+++ b/framework/core/src/Group/Group.php
@@ -27,7 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|null $color
  * @property string|null $icon
  * @property bool $is_hidden
- * @property int $position
+ * @property int|null $position
  * @property-read \Illuminate\Database\Eloquent\Collection $users
  * @property-read \Illuminate\Database\Eloquent\Collection $permissions
  */

--- a/framework/core/src/Group/GroupFactory.php
+++ b/framework/core/src/Group/GroupFactory.php
@@ -21,7 +21,7 @@ class GroupFactory extends Factory
             'color' => $this->faker->hexColor,
             'icon' => null,
             'is_hidden' => false,
-            'position' => 0,
+            'position' => null,
         ];
     }
 }

--- a/framework/core/src/Group/GroupFactory.php
+++ b/framework/core/src/Group/GroupFactory.php
@@ -21,6 +21,7 @@ class GroupFactory extends Factory
             'color' => $this->faker->hexColor,
             'icon' => null,
             'is_hidden' => false,
+            'position' => 0,
         ];
     }
 }

--- a/framework/core/tests/integration/api/groups/OrderTest.php
+++ b/framework/core/tests/integration/api/groups/OrderTest.php
@@ -27,7 +27,7 @@ class OrderTest extends TestCase
         parent::setUp();
 
         $this->prepareDatabase([
-             User::class => [
+            User::class => [
                 $this->normalUser(),
             ],
             Group::class => [
@@ -58,7 +58,7 @@ class OrderTest extends TestCase
         $this->assertNull(Group::findOrFail(7)->position, 'Group 7 should have null position when not included');
     }
 
-     #[Test]
+    #[Test]
     public function non_admin_cannot_reorder_groups()
     {
         $response = $this->send(

--- a/framework/core/tests/integration/api/groups/OrderTest.php
+++ b/framework/core/tests/integration/api/groups/OrderTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\groups;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class OrderTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+             User::class => [
+                $this->normalUser(),
+            ],
+            Group::class => [
+                ['id' => 5, 'name_singular' => 'Developer',  'name_plural' => 'Developers',  'is_hidden' => false, 'position' => 5],
+                ['id' => 6, 'name_singular' => 'Subscriber', 'name_plural' => 'Subscribers', 'is_hidden' => false, 'position' => 6],
+                ['id' => 7, 'name_singular' => 'VIP',        'name_plural' => 'VIPs',        'is_hidden' => false, 'position' => 7],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function admin_can_reorder_groups()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/groups/order', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'order' => [6, 5],
+                ],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertSame(1, Group::findOrFail(5)->position, 'Group 5 should be moved to position 1');
+        $this->assertSame(0, Group::findOrFail(6)->position, 'Group 6 should be moved to position 0');
+
+        $this->assertNull(Group::findOrFail(7)->position, 'Group 7 should have null position when not included');
+    }
+
+     #[Test]
+    public function non_admin_cannot_reorder_groups()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/groups/order', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'order' => [6, 5],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertSame(5, Group::findOrFail(5)->position);
+        $this->assertSame(6, Group::findOrFail(6)->position);
+        $this->assertSame(7, Group::findOrFail(7)->position);
+    }
+
+    #[Test]
+    public function rejects_missing_order_payload()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/groups/order', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    // empty payload
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertSame(5, Group::findOrFail(5)->position);
+        $this->assertSame(6, Group::findOrFail(6)->position);
+        $this->assertSame(7, Group::findOrFail(7)->position);
+    }
+
+    #[Test]
+    public function rejects_null_order()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/groups/order', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'order' => null,
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertSame(5, Group::findOrFail(5)->position);
+        $this->assertSame(6, Group::findOrFail(6)->position);
+        $this->assertSame(7, Group::findOrFail(7)->position);
+    }
+}

--- a/framework/core/tests/integration/api/groups/OrderTest.php
+++ b/framework/core/tests/integration/api/groups/OrderTest.php
@@ -114,4 +114,23 @@ class OrderTest extends TestCase
         $this->assertSame(6, Group::findOrFail(6)->position);
         $this->assertSame(7, Group::findOrFail(7)->position);
     }
+
+    #[Test]
+    public function rejects_malformed_order()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/groups/order', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'order' => 'not-an-array',
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertSame(5, Group::findOrFail(5)->position);
+        $this->assertSame(6, Group::findOrFail(6)->position);
+        $this->assertSame(7, Group::findOrFail(7)->position);
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,6 +1587,11 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
   integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
 
+"@types/sortablejs@^1.15.9":
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/@types/sortablejs/-/sortablejs-1.15.9.tgz#82d2337f54d4db827914d80dee5cf65539ae3c8b"
+  integrity sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,11 +4969,6 @@ sortablejs@^1.14.0:
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.3.tgz#033668db5ebfb11167d1249ab88e748f27959e29"
   integrity sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==
 
-sortablejs@^1.15.6:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.6.tgz#ff93699493f5b8ab8d828f933227b4988df1d393"
-  integrity sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==
-
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,6 +4969,11 @@ sortablejs@^1.14.0:
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.3.tgz#033668db5ebfb11167d1249ab88e748f27959e29"
   integrity sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==
 
+sortablejs@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.6.tgz#ff93699493f5b8ab8d828f933227b4988df1d393"
+  integrity sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==
+
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
* Implement ability to change ordering of Groups, similar to how it works for `flarum/tags`
* Implement reusable `GroupBar` component which contains the `sortablejs` integration. Extensions like https://github.com/imorland/flarum-ext-twofactor/blob/2.x/js/src/admin/components/ExtractedGroupBar.tsx could consume this new component

**Reviewers should focus on:**
* Backend, how to handle the Guest and Member Group here? The DB migration does set a position, but the first time the order is changed in the frontend those groups' position would be set back to null. From a usability point of view it doesn't matter, but it could be argued it's a quirk we don't wanna have
* Also the changes in the webpack config.. it appears like that the current minification step from Terser fails to parse the esm build of sortable js due to unsupported syntax. The alias I added forces webpack to use sortables UDM build which appears to fix the issues. Really unsure how we should address this issue and if maybe changes in flarums webpack config itself are needed.

This was the error message (reproducible both in CI and when running `yarn build` locally):
```
ERROR in admin.js
  admin.js from Terser plugin
  Unexpected token: punc ({) [webpack://../node_modules/sortablejs/modular/sortable.esm.js:1212,31][admin.js:22591,37]
      at js_error (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:536:11)
      at croak (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1264:9)
      at token_error (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1272:9)
      at unexpected (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1278:9)
      at semicolon (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1316:56)
      at simple_statement (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1577:73)
      at statement (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1390:19)
      at _embed_tokens_wrapper (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:1329:26)
      at block_ (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:2168:20)
      at _function_body (/home/runner/work/framework/framework/node_modules/terser/dist/bundle.min.js:2080:21)
```
**Screenshot**
https://github.com/user-attachments/assets/8dcb047b-bd52-435e-a5b1-a5da46673664

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
