### PR TITLE
chore: add color-scheme property to root.less

### DIFF
--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -74,6 +74,8 @@
   .Button--color-vars(@@control-danger-color, @@control-danger-bg, 'control-danger');
   .Button--color-vars(@@muted-more-color, fade(@@muted-more-color, 30%), 'muted-more');
   .Button--color-vars(@@control-color, @@body-bg, 'button-inverted');
+
+  color-scheme:                    @mode;
 }
 
 // ---------------------------------


### PR DESCRIPTION
This property helps browser to understand which color scheme we're using, and it can make adjustments to the user interface, such as scrollbars and form controls(checkbox). We're able to change most of things, but there're actually some things controlled by browser, which can't be controlled by us. Besides, if a user is using Chrome's [Auto Dark Theme](https://developer.chrome.com/blog/auto-dark-theme/#per-element-opt-out), set this property can turn off color overrides in this case. Chrome's Auto Dark Theme sometimes inverts avatars' color.

**Changes proposed in this pull request:**
The whole UI.

**Reviewers should focus on:**
Scrollbar, checkbox in dark mode, etc.

**Screenshot**
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
