### PR TITLE
fix(forum): prevent scroll jump when loading discussion to specific post (#4346)

### DIFF
--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -152,12 +152,14 @@ export default class PostStream extends Component {
     super.onupdate(vnode);
 
     this.triggerScroll();
+    this.observeNewPostItems();
   }
 
   oncreate(vnode) {
     super.oncreate(vnode);
 
     this.triggerScroll();
+    this.setupScrollAnchoring();
 
     // This is wrapped in setTimeout due to the following Mithril issue:
     // https://github.com/lhorie/mithril.js/issues/637
@@ -168,6 +170,7 @@ export default class PostStream extends Component {
     super.onremove(vnode);
 
     this.scrollListener.stop();
+    this.cleanupScrollAnchoring();
     clearTimeout(this.calculatePositionTimeout);
   }
 
@@ -197,6 +200,11 @@ export default class PostStream extends Component {
     this.updateScrubber(top);
 
     this.loadPostsIfNeeded(top);
+
+    // While the page is settling after a programmatic scroll, layout shifts
+    // are still happening (images loading, etc). Skip position/URL updates
+    // until settling completes -- endSettling() will call calculatePosition().
+    if (this.settling) return;
 
     // Throttle calculation of our position (start/end numbers of posts in the
     // viewport) to 100ms.
@@ -445,15 +453,160 @@ export default class PostStream extends Component {
         $(window).scrollTop(itemOffset.top - this.getMarginTop());
       }
 
+      // Enter "settling" mode. After the initial scroll, asynchronous content
+      // (images, embeds, etc.) may cause post elements to resize, shifting the
+      // target post out of view. During settling, a ResizeObserver watches for
+      // these layout shifts and re-scrolls to the target post synchronously
+      // (before the browser paints) so the user never sees the shift.
+      //
+      // Settling ends when: the user interacts (wheel/touch/key), no resizes
+      // occur for 3 seconds (stability), or a 30-second hard timeout elapses.
+      // At that point endSettling() calls calculatePosition() to update the URL
+      // and scrubber to match the final viewport state.
+      this.settling = true;
+      this.settlingTarget = this.stream.targetPost;
+      this.startSettlingListeners();
+      this.resetStabilityTimer();
+      this.settlingHardTimer = setTimeout(() => this.endSettling(), 30000);
+
       // We want to adjust this again after posts have been loaded in
       // and position adjusted so that the scrubber's height is accurate.
       updateScrubberHeight();
 
-      this.calculatePosition();
       this.stream.paused = false;
       // Check if we need to load more posts after scrolling.
       this.loadPostsIfNeeded();
     });
+  }
+
+  /**
+   * Set up a ResizeObserver that watches `.PostStream-item` elements for size
+   * changes. During the "settling" phase (after a programmatic scroll), any
+   * observed resize triggers an immediate re-scroll to the target post so the
+   * viewport stays locked on it while asynchronous content loads.
+   */
+  setupScrollAnchoring() {
+    this.settling = false;
+    this.settlingTarget = null;
+    this.settlingStabilityTimer = null;
+    this.settlingHardTimer = null;
+    this.observedElements = new Set();
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (!this.settling) return;
+
+      // Re-scroll synchronously. ResizeObserver callbacks run after layout
+      // but before paint, so correcting scrollTop here prevents the user
+      // from ever seeing the shifted (wrong) position.
+      this.reScrollToTarget();
+      this.resetStabilityTimer();
+    });
+
+    this.observeNewPostItems();
+  }
+
+  /**
+   * Re-scroll to the locked target post. Uses the same offset logic as
+   * scrollToItem's post-load adjustment. Called synchronously from the
+   * ResizeObserver callback so the correction is applied before the browser
+   * paints, preventing visible flicker.
+   */
+  reScrollToTarget() {
+    const target = this.settlingTarget;
+    if (!target) return;
+
+    let $item;
+    if ('number' in target) {
+      $item = this.$(`.PostStream-item[data-number=${target.number}]`);
+    } else if ('index' in target) {
+      $item = target.reply ? this.$('.PostStream-item:last-child') : this.$(`.PostStream-item[data-index=${target.index}]`);
+    }
+
+    if (!$item || !$item.length) return;
+
+    const desiredTop = $item.is(':first-child') ? 0 : $item.offset().top - this.getMarginTop();
+    $(window).scrollTop(desiredTop);
+  }
+
+  /**
+   * Register global event listeners that end settling when the user takes
+   * control (scrolling, touching, or pressing a key).
+   */
+  startSettlingListeners() {
+    this._onUserInteraction = () => this.endSettling();
+    window.addEventListener('wheel', this._onUserInteraction, { passive: true });
+    window.addEventListener('touchstart', this._onUserInteraction, { passive: true });
+    window.addEventListener('keydown', this._onUserInteraction, { passive: true });
+  }
+
+  /**
+   * Remove the user-interaction listeners registered by startSettlingListeners.
+   */
+  stopSettlingListeners() {
+    if (!this._onUserInteraction) return;
+    window.removeEventListener('wheel', this._onUserInteraction);
+    window.removeEventListener('touchstart', this._onUserInteraction);
+    window.removeEventListener('keydown', this._onUserInteraction);
+    this._onUserInteraction = null;
+  }
+
+  /**
+   * Reset (or start) the stability timer. If no ResizeObserver callback fires
+   * within 3 seconds, we consider the layout stable and exit settling.
+   */
+  resetStabilityTimer() {
+    clearTimeout(this.settlingStabilityTimer);
+    this.settlingStabilityTimer = setTimeout(() => this.endSettling(), 3000);
+  }
+
+  /**
+   * Exit settling mode: stop watching for layout shifts, remove listeners,
+   * clear timers, and update the URL/scrubber to match the final viewport.
+   */
+  endSettling() {
+    if (!this.settling) return;
+    this.settling = false;
+    this.settlingTarget = null;
+    this.stopSettlingListeners();
+    clearTimeout(this.settlingStabilityTimer);
+    clearTimeout(this.settlingHardTimer);
+    this.settlingStabilityTimer = null;
+    this.settlingHardTimer = null;
+    this.calculatePosition();
+  }
+
+  /**
+   * Observe any newly-rendered `.PostStream-item` elements that are not yet
+   * tracked. Called on every `onupdate` to pick up items added by infinite
+   * scroll or lazy loading.
+   */
+  observeNewPostItems() {
+    if (!this.resizeObserver) return;
+
+    const items = this.element.querySelectorAll('.PostStream-item');
+
+    for (const item of items) {
+      if (!this.observedElements.has(item)) {
+        this.observedElements.add(item);
+        this.resizeObserver.observe(item);
+      }
+    }
+  }
+
+  /**
+   * Disconnect the ResizeObserver, end settling mode, and release tracked data.
+   * Called from `onremove` to prevent memory leaks.
+   */
+  cleanupScrollAnchoring() {
+    this.endSettling();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    if (this.observedElements) {
+      this.observedElements.clear();
+      this.observedElements = null;
+    }
   }
 
   /**

--- a/framework/core/js/tests/integration/forum/components/PostStream.test.ts
+++ b/framework/core/js/tests/integration/forum/components/PostStream.test.ts
@@ -4,6 +4,20 @@ import PostStreamState from '../../../../src/forum/states/PostStreamState';
 import Discussion from '../../../../src/common/models/Discussion';
 import app from '../../../../src/forum/app';
 import mq from 'mithril-query';
+import { jest } from '@jest/globals';
+
+// Provide a minimal ResizeObserver stub for JSDOM environments where it
+// is not natively available, so that PostStream.oncreate can call
+// setupScrollAnchoring without throwing.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  // @ts-ignore
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    constructor(_cb: any) {}
+  };
+}
 
 beforeAll(() => bootstrapForum());
 
@@ -86,5 +100,186 @@ describe('PostStream component', () => {
     expect(postStream).toContainRaw('Bye');
     expect(postStream).toContainRaw('Hi again');
     expect(postStream).toContainRaw('Bye again');
+  });
+});
+
+describe('PostStream scroll anchoring (settling guard)', () => {
+  let mockObserveCallbacks: Function[];
+  let mockDisconnect: ReturnType<typeof jest.fn>;
+  let mockObserve: ReturnType<typeof jest.fn>;
+  let originalResizeObserver: typeof globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    mockObserveCallbacks = [];
+    mockDisconnect = jest.fn();
+    mockObserve = jest.fn();
+
+    originalResizeObserver = globalThis.ResizeObserver;
+
+    // @ts-ignore - mock ResizeObserver for JSDOM
+    globalThis.ResizeObserver = jest.fn((callback: Function) => {
+      mockObserveCallbacks.push(callback);
+      return {
+        observe: mockObserve,
+        unobserve: jest.fn(),
+        disconnect: mockDisconnect,
+      };
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('creates a ResizeObserver when setupScrollAnchoring is called', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    instance.setupScrollAnchoring();
+
+    expect(globalThis.ResizeObserver).toHaveBeenCalledTimes(1);
+    expect(instance.resizeObserver).toBeDefined();
+    expect(instance.observedElements).toBeInstanceOf(Set);
+  });
+
+  it('disconnects the ResizeObserver when cleanupScrollAnchoring is called', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    instance.setupScrollAnchoring();
+    instance.cleanupScrollAnchoring();
+
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    expect(instance.resizeObserver).toBeNull();
+    expect(instance.observedElements).toBeNull();
+  });
+
+  it('observes new PostStream-item elements added to the DOM', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.getMarginTop = () => 0;
+
+    const container = document.createElement('div');
+    const item1 = document.createElement('div');
+    item1.className = 'PostStream-item';
+    const item2 = document.createElement('div');
+    item2.className = 'PostStream-item';
+    container.appendChild(item1);
+    container.appendChild(item2);
+    instance.element = container;
+
+    instance.setupScrollAnchoring();
+
+    expect(mockObserve).toHaveBeenCalledTimes(2);
+    expect(instance.observedElements!.size).toBe(2);
+
+    const item3 = document.createElement('div');
+    item3.className = 'PostStream-item';
+    container.appendChild(item3);
+
+    instance.observeNewPostItems();
+
+    expect(mockObserve).toHaveBeenCalledTimes(3);
+    expect(instance.observedElements!.size).toBe(3);
+  });
+
+  it('re-scrolls to target post when ResizeObserver fires during settling', () => {
+    jest.useFakeTimers();
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.getMarginTop = () => 60;
+    instance.calculatePosition = jest.fn();
+    const container = document.createElement('div');
+    const item = document.createElement('div');
+    item.className = 'PostStream-item';
+    item.setAttribute('data-number', '5');
+    container.appendChild(item);
+    instance.element = container;
+
+    instance.setupScrollAnchoring();
+    instance.settling = true;
+    instance.settlingTarget = { number: 5 };
+    instance.$ = jest.fn((sel: string) => {
+      if (sel === '.PostStream-item[data-number=5]') {
+        return { length: 1, is: () => false, offset: () => ({ top: 1000 }), outerHeight: () => 100 };
+      }
+      return { length: 0 };
+    });
+
+    const callback = mockObserveCallbacks[0];
+    callback([]);
+
+    // Verify the target element was queried for offset calculation
+    expect(instance.$).toHaveBeenCalledWith('.PostStream-item[data-number=5]');
+
+    // Verify the stability timer was reset (endSettling will fire after 3s)
+    jest.advanceTimersByTime(3000);
+    expect(instance.settling).toBe(false);
+    expect(instance.calculatePosition).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it('does not re-scroll when ResizeObserver fires outside of settling', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.reScrollToTarget = jest.fn();
+
+    instance.setupScrollAnchoring();
+
+    // settling is false by default after setup
+    expect(instance.settling).toBe(false);
+
+    const callback = mockObserveCallbacks[0];
+    callback([]);
+
+    expect(instance.reScrollToTarget).not.toHaveBeenCalled();
+  });
+
+  it('exits settling mode on user interaction', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.calculatePosition = jest.fn();
+
+    instance.setupScrollAnchoring();
+    instance.settling = true;
+    instance.settlingTarget = { number: 1 };
+    instance.startSettlingListeners();
+
+    expect(instance.settling).toBe(true);
+    window.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+
+    expect(instance.settling).toBe(false);
+    expect(instance.settlingTarget).toBeNull();
+    expect(instance.calculatePosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits settling mode after stability timeout', () => {
+    jest.useFakeTimers();
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.calculatePosition = jest.fn();
+
+    instance.setupScrollAnchoring();
+    instance.settling = true;
+    instance.settlingTarget = { number: 1 };
+    instance.resetStabilityTimer();
+
+    expect(instance.settling).toBe(true);
+    jest.advanceTimersByTime(3000);
+
+    expect(instance.settling).toBe(false);
+    expect(instance.calculatePosition).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Description

Prevents the viewport from jumping when opening a discussion with a post number in the URL (e.g. `/d/9-slug/63`). Asynchronous content (images, embeds) loading above the viewport was shifting the target post out of view after the initial scroll.

## Solution

- **Settling guard**: After programmatic scroll to a target post, we enter a short "settling" phase. A `ResizeObserver` watches `.PostStream-item` elements; on any resize we re-scroll to the target post **synchronously** (in the same callback, before paint), so the user never sees the shifted layout.
- Settling ends when: the user interacts (wheel/touch/key), no resizes occur for 3 seconds, or a 30s hard timeout. We then call `calculatePosition()` to update the URL and scrubber.
- During settling, scroll events do not update the URL so we don't overwrite the intended post number with a wrong one.

## Changes

- **PostStream.js**: `setupScrollAnchoring()`, `reScrollToTarget()`, settling lifecycle (start/stop listeners, stability timer, `endSettling()`), `observeNewPostItems()`, `cleanupScrollAnchoring()`; `onscroll` skips position/URL updates while settling; `scrollToItem()` enters settling after the initial scroll and defers `calculatePosition()` until settling ends.
- **PostStream.test.ts**: ResizeObserver stub for JSDOM; tests for setup/cleanup, observing new items, re-scroll during settling, no re-scroll when not settling, user interaction and stability timeout ending settling.

## Testing

- Open a discussion with a post number in the URL (e.g. `/d/9-slug/63`). Reload multiple times: the viewport should stay on the target post as images load, without jump or flicker.
- Existing PostStream integration tests updated; new tests cover scroll-anchoring behaviour.

Closes #4346.