### PR TITLE
fix(forum): show pop-in animation on first post when loading discussion (#4334)

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -175,7 +175,9 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
     this.stream = new PostStreamState(discussion);
     const rawNearParam = m.route.param('near');
     const nearParam = rawNearParam === 'reply' ? 'reply' : parseInt(rawNearParam);
-    this.stream.goToNumber(nearParam || 0, true).then(() => {
+    // Post numbers start at 1; use 1 when near is missing/invalid so the first post gets the pop-in
+    const targetPost = nearParam === 'reply' ? 'reply' : nearParam && !isNaN(nearParam) ? nearParam : 1;
+    this.stream.goToNumber(targetPost, true).then(() => {
       this.discussion = discussion;
 
       app.current.set('discussion', discussion);

--- a/framework/core/src/Locale/Translator.php
+++ b/framework/core/src/Locale/Translator.php
@@ -73,6 +73,9 @@ class Translator extends BaseTranslator implements TranslatorInterface
         return $translation;
     }
 
+    /**
+     * @param string $locale
+     */
     public function setLocale($locale): void
     {
         parent::setLocale($locale);


### PR DESCRIPTION
## Description

On page load, a discussion without replies (or with URL without a post number, e.g. `/d/slug`) did not show the pop-in animation on the first post. The animation worked for subsequent replies and when opening a specific post number.

## Root cause

In `DiscussionPage.show()`, when `near` was missing from the URL, `nearParam` became `NaN` and `nearParam || 0` yielded `0`. We called `goToNumber(0)`, but post numbers start at **1**, so no `.PostStream-item[data-number=0]` exists. `scrollToNumber(0)` and `flashItem` never ran for the first post.

## Solution

Use post number `1` when `near` is missing or invalid (e.g. `undefined`, `NaN`, or `0`). `reply` and valid numbers are unchanged.

## Changes

- **DiscussionPage.tsx**: In `show()`, compute `targetPost` as `reply` when `nearParam === 'reply'`, otherwise `nearParam && !isNaN(nearParam) ? nearParam : 1`, and call `goToNumber(targetPost, true)`.

## Testing

- Open a discussion with only the first post at `/d/{slug}` (no post number). Reload: first post shows the pop-in (flash) animation.
- `/d/{slug}/1` and `/d/{slug}/5` still behave as before.

Closes #4334.

Made with [Cursor](https://cursor.com)