### PR TITLE
[1.x] perf: store scheduler timestamp in cache

### DIFF
--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -14,6 +14,7 @@ use Flarum\Locale\Translator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\SessionManager;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
@@ -64,6 +65,11 @@ class ApplicationInfoProvider
     protected $queue;
 
     /**
+     * @var CacheRepository
+     */
+    protected $cache;
+
+    /**
      * @param SettingsRepositoryInterface $settings
      * @param Translator $translator
      * @param Schedule $schedule
@@ -72,6 +78,7 @@ class ApplicationInfoProvider
      * @param SessionManager $session
      * @param SessionHandlerInterface $sessionHandler
      * @param Queue $queue
+     * @param CacheRepository $cache
      */
     public function __construct(
         SettingsRepositoryInterface $settings,
@@ -81,7 +88,8 @@ class ApplicationInfoProvider
         Config $config,
         SessionManager $session,
         SessionHandlerInterface $sessionHandler,
-        Queue $queue
+        Queue $queue,
+        CacheRepository $cache
     ) {
         $this->settings = $settings;
         $this->translator = $translator;
@@ -91,6 +99,7 @@ class ApplicationInfoProvider
         $this->session = $session;
         $this->sessionHandler = $sessionHandler;
         $this->queue = $queue;
+        $this->cache = $cache;
     }
 
     /**
@@ -110,7 +119,8 @@ class ApplicationInfoProvider
      */
     public function getSchedulerStatus(): string
     {
-        $status = $this->settings->get('schedule.last_run');
+        // Read from cache instead of persistent settings
+        $status = $this->cache->get('schedule:last_run');
 
         if (! $status) {
             return $this->translator->trans('core.admin.dashboard.status.scheduler.never-run');

--- a/framework/core/src/Foundation/Console/ScheduleRunCommand.php
+++ b/framework/core/src/Foundation/Console/ScheduleRunCommand.php
@@ -9,26 +9,26 @@
 
 namespace Flarum\Foundation\Console;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class ScheduleRunCommand extends \Illuminate\Console\Scheduling\ScheduleRunCommand
 {
     /**
-     * @var SettingsRepositoryInterface
+     * @var CacheRepository
      */
-    protected $settings;
+    protected $cache;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(SettingsRepositoryInterface $settings)
+    public function __construct(CacheRepository $cache)
     {
         parent::__construct();
 
-        $this->settings = $settings;
+        $this->cache = $cache;
     }
 
     /**
@@ -38,6 +38,7 @@ class ScheduleRunCommand extends \Illuminate\Console\Scheduling\ScheduleRunComma
     {
         parent::handle($schedule, $dispatcher, $handler);
 
-        $this->settings->set('schedule.last_run', $this->startedAt);
+        // Store in cache instead of persistent settings (1 hour TTL)
+        $this->cache->put('schedule:last_run', $this->startedAt, 3600);
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Currently when the scheduler is run, it stores the last run timestamp in the DB (settings). This PR changes that to store in the cache, which is faster, and decreases the load on the DB

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
