### PR TITLE
[2.x] perf: store scheduler timestamp in cache

### DIFF
--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -91,7 +91,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
             $cache = $container->make(CacheRepository::class);
 
             if ($command === ScheduleRunCommand::getDefaultName()) {
-                $cache->put('schedule:last_run', Carbon::now(), 3600);
+                $cache->forever('flarum:schedule:last_run', Carbon::now());
             }
         });
     }

--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -19,7 +19,6 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Console\AssetsPublishCommand;
 use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\CacheSchedulingMutex;
@@ -28,6 +27,7 @@ use Illuminate\Console\Scheduling\Schedule as LaravelSchedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Events\Dispatcher;
 
@@ -88,10 +88,10 @@ class ConsoleServiceProvider extends AbstractServiceProvider
 
         $events->listen(CommandFinished::class, function (CommandFinished $event) use ($container) {
             $command = $event->command;
-            $settings = $container->make(SettingsRepositoryInterface::class);
+            $cache = $container->make(CacheRepository::class);
 
             if ($command === ScheduleRunCommand::getDefaultName()) {
-                $settings->set('schedule.last_run', Carbon::now());
+                $cache->set('schedule:last_run', Carbon::now(), 3600);
             }
         });
     }

--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -91,7 +91,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
             $cache = $container->make(CacheRepository::class);
 
             if ($command === ScheduleRunCommand::getDefaultName()) {
-                $cache->set('schedule:last_run', Carbon::now(), 3600);
+                $cache->put('schedule:last_run', Carbon::now(), 3600);
             }
         });
     }

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -42,7 +42,7 @@ class ApplicationInfoProvider
 
     public function getSchedulerStatus(): string
     {
-        $status = $this->cache->get('schedule:last_run');
+        $status = $this->cache->get('flarum:schedule:last_run');
 
         if (! $status) {
             return $this->translator->trans('core.admin.dashboard.status.scheduler.never-run');

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -11,9 +11,9 @@ namespace Flarum\Foundation;
 
 use Carbon\Carbon;
 use Flarum\Locale\Translator;
-use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\SessionManager;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
@@ -24,7 +24,7 @@ use SessionHandlerInterface;
 class ApplicationInfoProvider
 {
     public function __construct(
-        protected SettingsRepositoryInterface $settings,
+        protected CacheRepository $cache,
         protected Translator $translator,
         protected Schedule $schedule,
         protected ConnectionInterface $db,
@@ -42,7 +42,7 @@ class ApplicationInfoProvider
 
     public function getSchedulerStatus(): string
     {
-        $status = $this->settings->get('schedule.last_run');
+        $status = $this->cache->get('schedule:last_run');
 
         if (! $status) {
             return $this->translator->trans('core.admin.dashboard.status.scheduler.never-run');


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
`2.x` equivalent of #4363 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
