### PR TITLE
[1.x] perf: eliminate redundant DB writes in auth middleware and cache notification counts

### DIFF
--- a/framework/core/src/Api/Controller/ListNotificationsController.php
+++ b/framework/core/src/Api/Controller/ListNotificationsController.php
@@ -64,6 +64,9 @@ class ListNotificationsController extends AbstractListController
 
         $actor->markNotificationsAsRead()->save();
 
+        // Invalidate new notification count cache since read_notifications_at changed
+        resolve('cache.store')->forget("user.{$actor->id}.new_notification_count");
+
         $limit = $this->extractLimit($request);
         $offset = $this->extractOffset($request);
         $include = $this->extractInclude($request);

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -158,7 +158,10 @@ class ApplicationInfoProvider
      */
     public function identifyDatabaseVersion(): string
     {
-        return $this->db->selectOne('select version() as version')->version;
+        // Cache for 24 hours since database version rarely changes
+        return $this->cache->remember('flarum:db_version', 86400, function () {
+            return $this->db->selectOne('select version() as version')->version;
+        });
     }
 
     /**

--- a/framework/core/src/Http/AccessToken.php
+++ b/framework/core/src/Http/AccessToken.php
@@ -111,12 +111,20 @@ class AccessToken extends AbstractModel
         }
 
         if ($request) {
-            $this->last_ip_address = $request->getAttribute('ipAddress');
+            $newIp = $request->getAttribute('ipAddress');
             // We truncate user agent so it fits in the database column
             // The length is hard-coded as the column length
             // It seems like MySQL or Laravel already truncates values, but we'll play safe and do it ourselves
             $agent = Arr::get($request->getServerParams(), 'HTTP_USER_AGENT');
-            $this->last_user_agent = substr($agent ?? '', 0, 255);
+            $newUserAgent = substr($agent ?? '', 0, 255);
+
+            // Only update if values have changed
+            if ($this->last_ip_address !== $newIp) {
+                $this->last_ip_address = $newIp;
+            }
+            if ($this->last_user_agent !== $newUserAgent) {
+                $this->last_user_agent = $newUserAgent;
+            }
         } else {
             // If no request is provided, we set the values back to null
             // That way the values always match with the date logged in last_activity
@@ -124,7 +132,12 @@ class AccessToken extends AbstractModel
             $this->last_user_agent = null;
         }
 
-        return $this->save();
+        // Only save if model has changes (throttles unnecessary DB writes)
+        if ($this->isDirty()) {
+            return $this->save();
+        }
+
+        return true;
     }
 
     /**

--- a/framework/core/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/framework/core/src/Http/Middleware/AuthenticateWithHeader.php
@@ -47,7 +47,12 @@ class AuthenticateWithHeader implements Middleware
             }
 
             if (isset($actor)) {
-                $actor->updateLastSeen()->save();
+                $actor->updateLastSeen();
+
+                // Only save if last_seen_at was actually updated (throttled to 180 seconds)
+                if ($actor->isDirty()) {
+                    $actor->save();
+                }
 
                 $request = RequestUtil::withActor($request, $actor);
                 $request = $request->withAttribute('bypassCsrfToken', true);

--- a/framework/core/src/Http/Middleware/AuthenticateWithSession.php
+++ b/framework/core/src/Http/Middleware/AuthenticateWithSession.php
@@ -38,7 +38,12 @@ class AuthenticateWithSession implements Middleware
 
             if ($token) {
                 $actor = $token->user;
-                $actor->updateLastSeen()->save();
+                $actor->updateLastSeen();
+
+                // Only save if last_seen_at was actually updated (throttled to 180 seconds)
+                if ($actor->isDirty()) {
+                    $actor->save();
+                }
 
                 $token->touch($request);
 

--- a/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -48,6 +48,9 @@ class ReadAllNotificationsHandler
 
         $this->notifications->markAllAsRead($actor);
 
+        // Invalidate notification count cache
+        resolve('cache.store')->forget("user.{$actor->id}.unread_notification_count");
+
         $this->events->dispatch(new ReadAll($actor, Carbon::now()));
     }
 }

--- a/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -48,8 +48,10 @@ class ReadAllNotificationsHandler
 
         $this->notifications->markAllAsRead($actor);
 
-        // Invalidate notification count cache
-        resolve('cache.store')->forget("user.{$actor->id}.unread_notification_count");
+        // Invalidate notification count caches
+        $cache = resolve('cache.store');
+        $cache->forget("user.{$actor->id}.unread_notification_count");
+        $cache->forget("user.{$actor->id}.new_notification_count");
 
         $this->events->dispatch(new ReadAll($actor, Carbon::now()));
     }

--- a/framework/core/src/Notification/Command/ReadNotificationHandler.php
+++ b/framework/core/src/Notification/Command/ReadNotificationHandler.php
@@ -51,6 +51,9 @@ class ReadNotificationHandler
 
         $notification->read_at = Carbon::now();
 
+        // Invalidate notification count cache
+        resolve('cache.store')->forget("user.{$actor->id}.unread_notification_count");
+
         $this->events->dispatch(new Read($actor, $notification, Carbon::now()));
 
         return $notification;

--- a/framework/core/src/Notification/Command/ReadNotificationHandler.php
+++ b/framework/core/src/Notification/Command/ReadNotificationHandler.php
@@ -51,8 +51,10 @@ class ReadNotificationHandler
 
         $notification->read_at = Carbon::now();
 
-        // Invalidate notification count cache
-        resolve('cache.store')->forget("user.{$actor->id}.unread_notification_count");
+        // Invalidate notification count caches
+        $cache = resolve('cache.store');
+        $cache->forget("user.{$actor->id}.unread_notification_count");
+        $cache->forget("user.{$actor->id}.new_notification_count");
 
         $this->events->dispatch(new Read($actor, $notification, Carbon::now()));
 

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -234,10 +234,11 @@ class Notification extends AbstractModel
             }, $recipients)
         );
 
-        // Invalidate notification count cache for all recipients
+        // Invalidate notification count caches for all recipients
         $cache = resolve('cache.store');
         foreach ($recipients as $user) {
             $cache->forget("user.{$user->id}.unread_notification_count");
+            $cache->forget("user.{$user->id}.new_notification_count");
         }
     }
 

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -233,6 +233,12 @@ class Notification extends AbstractModel
                 ];
             }, $recipients)
         );
+
+        // Invalidate notification count cache for all recipients
+        $cache = resolve('cache.store');
+        foreach ($recipients as $user) {
+            $cache->forget("user.{$user->id}.unread_notification_count");
+        }
     }
 
     /**

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -472,9 +472,15 @@ class User extends AbstractModel
      */
     public function getNewNotificationCount()
     {
-        return $this->unreadNotifications()
-            ->where('created_at', '>', $this->read_notifications_at ?? 0)
-            ->count();
+        // Cache notification count for 5 minutes to avoid expensive query on every page load
+        // Cache is actively invalidated when notifications change or user views notifications
+        $cacheKey = "user.{$this->id}.new_notification_count";
+
+        return resolve('cache.store')->remember($cacheKey, 300, function () {
+            return $this->unreadNotifications()
+                ->where('created_at', '>', $this->read_notifications_at ?? 0)
+                ->count();
+        });
     }
 
     /**

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -431,7 +431,14 @@ class User extends AbstractModel
      */
     public function getUnreadNotificationCount()
     {
-        return $this->unreadNotifications()->count();
+        // Cache notification count for 5 minutes to avoid expensive query on every page load
+        // Cache is actively invalidated when notifications are marked as read or created,
+        // so the TTL is mainly a safety net for edge cases (e.g., direct DB updates)
+        $cacheKey = "user.{$this->id}.unread_notification_count";
+
+        return resolve('cache.store')->remember($cacheKey, 300, function () {
+            return $this->unreadNotifications()->count();
+        });
     }
 
     /**


### PR DESCRIPTION
## Changes

### `AccessToken::touch()`
Only update `last_ip_address` / `last_user_agent` when the values have actually changed, and only call `save()` when the model is dirty. On high-traffic sites this eliminates a DB write on every token touch when `last_activity_at` has not yet elapsed the update threshold.

### `AuthenticateWithHeader` / `AuthenticateWithSession`
Guard `$actor->save()` with `isDirty()` after `updateLastSeen()`. Since `updateLastSeen()` is throttled to 180 seconds, requests within that window were previously triggering an unconditional DB write even when nothing changed.

### Notification count caching
Cache `getUnreadNotificationCount()` and `getNewNotificationCount()` for 5 minutes with active invalidation on all write paths. The TTL is a safety net; the cache is eagerly invalidated whenever:
- `Notification::notify()` creates new notifications for recipients
- `ReadNotificationHandler` marks a notification read
- `ReadAllNotificationsHandler` marks all notifications read
- `ListNotificationsController` updates `read_notifications_at` via `markNotificationsAsRead()`

### `ApplicationInfoProvider::identifyDatabaseVersion()`
Cache the DB version query for 24 hours. `$this->cache` (`CacheRepository`) is already injected into the class.

---

The 2.x port of this PR is #4380.