### PR TITLE
[2.x] feat: fire `ApplicationBooted` after all callbacks have completed

### DIFF
--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -175,7 +175,7 @@ class Application extends IlluminateContainer implements LaravelApplication
         // Finally, we will fire an event to indicate that the application has booted.
         // We explicitly do this after firing the "booted" callbacks so that any listener that
         // needs to do work after booting can use this event to know when it is truly done.
-        $this->container->make(Dispatcher::class)->dispatch(new ApplicationBooted());
+        resolve(Dispatcher::class)->dispatch(new ApplicationBooted());
     }
 
     protected function bootProvider(ServiceProvider $provider): mixed

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -10,7 +10,9 @@
 namespace Flarum\Foundation;
 
 use Flarum\Foundation\Concerns\InteractsWithLaravel;
+use Flarum\Foundation\Event\ApplicationBooted;
 use Illuminate\Container\Container as IlluminateContainer;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Support\Arr;
@@ -169,6 +171,11 @@ class Application extends IlluminateContainer implements LaravelApplication
         $this->booted = true;
 
         $this->fireAppCallbacks($this->bootedCallbacks);
+
+        // Finally, we will fire an event to indicate that the application has booted.
+        // We explicitly do this after firing the "booted" callbacks so that any listener that
+        // needs to do work after booting can use this event to know when it is truly done.
+        $this->container->make(Dispatcher::class)->dispatch(new ApplicationBooted());
     }
 
     protected function bootProvider(ServiceProvider $provider): mixed

--- a/framework/core/src/Foundation/Event/ApplicationBooted.php
+++ b/framework/core/src/Foundation/Event/ApplicationBooted.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Foundation\Event;
+
+/**
+ * The "application booted" event is fired after the application has finished booting and all extension boot callbacks have been run, but before any requests have been handled.
+ */
+class ApplicationBooted
+{
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
`2.x` equivalent of #4358 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
