### PR TITLE
[2.x] [realtime] fix: dont use raw db query when bound to external settings cache

### DIFF
--- a/extensions/realtime/src/Websocket/Console/ServeCommand.php
+++ b/extensions/realtime/src/Websocket/Console/ServeCommand.php
@@ -14,6 +14,7 @@ use Flarum\Realtime\Websocket\Logger\HttpLogger;
 use Flarum\Realtime\Websocket\Logger\WebsocketLogger;
 use Flarum\Realtime\Websocket\Server\HttpServer;
 use Flarum\Realtime\Websocket\Settings;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Database\ConnectionInterface;
@@ -142,12 +143,21 @@ class ServeCommand extends Command
         $enabled = null;
 
         $loop->addPeriodicTimer(10, function (TimerInterface $timer) use ($loop, &$enabled) {
-            /** @var ConnectionInterface $connection */
-            $connection = $this->getLaravel()->make(ConnectionInterface::class);
+            $app = $this->getLaravel();
 
-            $newState = $connection->table('settings')
-                ->where('key', 'extensions_enabled')
-                ->value('value');
+            // If a Redis-backed settings cache is bound (e.g. fof/redis), use the settings
+            // repository which will read from Redis. Otherwise fall back to a direct DB query,
+            // because the default MemoryCacheSettingsRepository is a per-process in-memory cache
+            // that never reflects external changes in a long-running process.
+            if ($app->bound('cache.settings')) {
+                $newState = $app->make(SettingsRepositoryInterface::class)->get('extensions_enabled');
+            } else {
+                /** @var ConnectionInterface $connection */
+                $connection = $app->make(ConnectionInterface::class);
+                $newState = $connection->table('settings')
+                    ->where('key', 'extensions_enabled')
+                    ->value('value');
+            }
 
             if ($enabled === null || $newState === $enabled) {
                 $enabled = $newState;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
