### PR TITLE
fix(forum): sync discussion URL immediately on programmatic scroll (#4346)

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -214,18 +214,28 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
   /**
    * When the posts that are visible in the post stream change (i.e. the user
    * scrolls up or down), then we update the URL and mark the posts as read.
+   *
+   * URL and history writes are skipped when startNumber hasn't changed from the
+   * last known position — this prevents double history churn from the immediate
+   * post-scroll emit and the subsequent settle-end reconciliation both resolving
+   * to the same post. Read-state saves are intentionally independent of this
+   * guard and use their own endNumber condition.
    */
   positionChanged(startNumber: number, endNumber: number): void {
     const discussion = this.discussion;
 
     if (!discussion) return;
 
-    // Construct a URL to this discussion with the updated position, then
-    // replace it into the window's history and our own history stack.
-    const url = app.route.discussion(discussion, (this.near = startNumber));
+    // Only write history when the visible start post actually changed.
+    if (startNumber !== this.near) {
+      // Construct a URL to this discussion with the updated position, then
+      // replace it into the window's history and our own history stack.
+      const url = app.route.discussion(discussion, startNumber);
+      this.near = startNumber;
 
-    window.history.replaceState(null, document.title, url);
-    app.history.push('discussion', discussion.title());
+      window.history.replaceState(null, document.title, url);
+      app.history.push('discussion', discussion.title());
+    }
 
     // If the user hasn't read past here before, then we'll update their read
     // state and redraw.

--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -194,7 +194,7 @@ export default class PostStream extends Component {
    *
    * @param {number} top
    */
-  onscroll(top = window.pageYOffset) {
+  onscroll(top = window.scrollY) {
     if (this.stream.paused || this.stream.pagesLoading) return;
 
     this.updateScrubber(top);
@@ -218,7 +218,7 @@ export default class PostStream extends Component {
    *
    * @param {number} top
    */
-  loadPostsIfNeeded(top = window.pageYOffset) {
+  loadPostsIfNeeded(top = window.scrollY) {
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
     const viewportTop = top + marginTop;
@@ -241,7 +241,7 @@ export default class PostStream extends Component {
     }
   }
 
-  updateScrubber(top = window.pageYOffset) {
+  updateScrubber(top = window.scrollY) {
     const marginTop = this.getMarginTop();
     const viewportHeight = $(window).height() - marginTop;
     const viewportTop = top + marginTop;
@@ -304,10 +304,13 @@ export default class PostStream extends Component {
   }
 
   /**
-   * Work out which posts (by number) are currently visible in the viewport, and
-   * fire an event with the information.
+   * Compute which post numbers are currently visible in the viewport, without
+   * emitting anything. Pure calculation.
+   *
+   * @param {number} top
+   * @returns {{ startNumber: number|undefined, endNumber: number|undefined }}
    */
-  calculatePosition(top = window.pageYOffset) {
+  computeVisiblePosition(top = window.scrollY) {
     const marginTop = this.getMarginTop();
     const $window = $(window);
     const viewportHeight = $window.height() - marginTop;
@@ -319,9 +322,9 @@ export default class PostStream extends Component {
 
     this.$('.PostStream-item').each(function () {
       const $item = $(this);
-      const top = $item.offset().top;
+      const itemTop = $item.offset().top;
       const height = $item.outerHeight(true);
-      const visibleTop = Math.max(0, viewportTop - top);
+      const visibleTop = Math.max(0, viewportTop - itemTop);
 
       const threeQuartersVisible = visibleTop / height < 0.75;
       const coversQuarterOfViewport = (height - visibleTop) / viewportHeight > 0.25;
@@ -329,8 +332,8 @@ export default class PostStream extends Component {
         startNumber = $item.data('number');
       }
 
-      if (top + height > scrollTop) {
-        if (top + height < scrollTop + viewportHeight) {
+      if (itemTop + height > scrollTop) {
+        if (itemTop + height < scrollTop + viewportHeight) {
           if ($item.data('number')) {
             endNumber = $item.data('number');
           }
@@ -338,8 +341,65 @@ export default class PostStream extends Component {
       }
     });
 
+    return { startNumber, endNumber };
+  }
+
+  /**
+   * Resolve a definitive post number from the current settling target, for use
+   * as an immediate-emit fallback when the DOM scan finds no loaded post.
+   *
+   * Returns undefined when no number can be determined (placeholder targets,
+   * reply targets) — callers should skip the emit in that case.
+   *
+   * @returns {number|undefined}
+   */
+  resolveTargetStartNumber() {
+    const target = this.settlingTarget;
+    if (!target) return undefined;
+
+    if ('number' in target) {
+      return target.number;
+    }
+
+    if ('index' in target && !target.reply) {
+      const num = this.$(`.PostStream-item[data-index=${target.index}]`).data('number');
+      return num || undefined;
+    }
+
+    // { reply: true } — no meaningful post number available
+    return undefined;
+  }
+
+  /**
+   * Emit a position update to the host page. Single path to call onPositionChange.
+   *
+   * @param {number} startNumber
+   * @param {number|undefined} endNumber
+   */
+  emitPosition(startNumber, endNumber) {
+    this.attrs.onPositionChange(startNumber, endNumber, startNumber);
+  }
+
+  /**
+   * Work out which posts (by number) are currently visible in the viewport, and
+   * fire an event with the information.
+   *
+   * @param {number} top
+   * @param {{ fallbackToTarget?: boolean }} options
+   *   When `fallbackToTarget` is true and the DOM scan finds no loaded post with
+   *   a `data-number`, the settling target's post number is used as the start.
+   *   This allows an immediate URL emit right after a programmatic scroll lands,
+   *   before async content has finished loading.
+   */
+  calculatePosition(top = window.scrollY, { fallbackToTarget = false } = {}) {
+    let { startNumber, endNumber } = this.computeVisiblePosition(top);
+
+    if (!startNumber && fallbackToTarget) {
+      startNumber = this.resolveTargetStartNumber();
+    }
+
     if (startNumber) {
-      this.attrs.onPositionChange(startNumber || 1, endNumber, startNumber);
+      this.emitPosition(startNumber, endNumber);
     }
   }
 
@@ -453,6 +513,13 @@ export default class PostStream extends Component {
         $(window).scrollTop(itemOffset.top - this.getMarginTop());
       }
 
+      // Emit the URL update immediately now that the scroll has landed and the
+      // DOM reflects the rendered posts. If all visible items are loading
+      // placeholders (no data-number), fallbackToTarget resolves the number
+      // directly from the target descriptor. Either way the user sees the
+      // correct URL without waiting for the stability timer.
+      this.calculatePosition(window.scrollY, { fallbackToTarget: true });
+
       // Enter "settling" mode. After the initial scroll, asynchronous content
       // (images, embeds, etc.) may cause post elements to resize, shifting the
       // target post out of view. During settling, a ResizeObserver watches for
@@ -463,11 +530,10 @@ export default class PostStream extends Component {
       // occur for 3 seconds (stability), or a 30-second hard timeout elapses.
       // At that point endSettling() calls calculatePosition() to update the URL
       // and scrubber to match the final viewport state.
-      this.settling = true;
-      this.settlingTarget = this.stream.targetPost;
-      this.startSettlingListeners();
-      this.resetStabilityTimer();
-      this.settlingHardTimer = setTimeout(() => this.endSettling(), 30000);
+      //
+      // beginSettling tears down any previous settling first, preventing event
+      // listener and timer leaks on consecutive programmatic jumps.
+      this.beginSettling(this.stream.targetPost);
 
       // We want to adjust this again after posts have been loaded in
       // and position adjusted so that the scrubber's height is accurate.
@@ -529,6 +595,28 @@ export default class PostStream extends Component {
   }
 
   /**
+   * Begin settling mode for the given target. Fully tears down any in-progress
+   * settling first to avoid listener and timer leaks on consecutive jumps, then
+   * arms fresh listeners and timers.
+   *
+   * @param {{ number: number }|{ index: number, reply?: boolean }} target
+   */
+  beginSettling(target) {
+    // Tear down any existing settling state without emitting a position update.
+    // This prevents orphaned wheel/touchstart/keydown listeners and hanging
+    // 30s hard timers when a second jump fires before the first settles.
+    this.stopSettlingListeners();
+    clearTimeout(this.settlingHardTimer);
+    clearTimeout(this.settlingStabilityTimer);
+
+    this.settling = true;
+    this.settlingTarget = target;
+    this.startSettlingListeners();
+    this.resetStabilityTimer();
+    this.settlingHardTimer = setTimeout(() => this.endSettling(), 30000);
+  }
+
+  /**
    * Register global event listeners that end settling when the user takes
    * control (scrolling, touching, or pressing a key).
    */
@@ -561,9 +649,14 @@ export default class PostStream extends Component {
 
   /**
    * Exit settling mode: stop watching for layout shifts, remove listeners,
-   * clear timers, and update the URL/scrubber to match the final viewport.
+   * clear timers, and optionally update the URL/scrubber to match the final viewport.
+   *
+   * @param {{ updatePosition?: boolean }} options
+   *   `updatePosition` defaults to `true` (normal end-of-settling reconciliation).
+   *   Pass `false` when called from the unmount path so no stale history entry is
+   *   written after the user has already navigated away.
    */
-  endSettling() {
+  endSettling({ updatePosition = true } = {}) {
     if (!this.settling) return;
     this.settling = false;
     this.settlingTarget = null;
@@ -572,7 +665,7 @@ export default class PostStream extends Component {
     clearTimeout(this.settlingHardTimer);
     this.settlingStabilityTimer = null;
     this.settlingHardTimer = null;
-    this.calculatePosition();
+    if (updatePosition) this.calculatePosition();
   }
 
   /**
@@ -596,9 +689,12 @@ export default class PostStream extends Component {
   /**
    * Disconnect the ResizeObserver, end settling mode, and release tracked data.
    * Called from `onremove` to prevent memory leaks.
+   *
+   * Passes `updatePosition: false` to endSettling so that no history entry is
+   * written after the user has already navigated away from this discussion.
    */
   cleanupScrollAnchoring() {
-    this.endSettling();
+    this.endSettling({ updatePosition: false });
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;

--- a/framework/core/js/tests/integration/forum/components/PostStream.test.ts
+++ b/framework/core/js/tests/integration/forum/components/PostStream.test.ts
@@ -283,3 +283,213 @@ describe('PostStream scroll anchoring (settling guard)', () => {
     jest.useRealTimers();
   });
 });
+
+describe('PostStream position sync (immediate emit + settling lifecycle)', () => {
+  let originalResizeObserver: typeof globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    originalResizeObserver = globalThis.ResizeObserver;
+    // @ts-ignore
+    globalThis.ResizeObserver = jest.fn(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('emits position on programmatic jump without waiting for the stability timer', () => {
+    jest.useFakeTimers();
+
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    const onPositionChange = jest.fn();
+    instance.attrs = { onPositionChange };
+
+    instance.computeVisiblePosition = jest.fn(() => ({ startNumber: 3, endNumber: 3 }));
+    instance.setupScrollAnchoring();
+
+    instance.calculatePosition(0, { fallbackToTarget: true });
+
+    expect(onPositionChange).toHaveBeenCalledTimes(1);
+    expect(onPositionChange).toHaveBeenCalledWith(3, 3, 3);
+
+    // Stability timer also triggers calculatePosition (reconciliation).
+    instance.calculatePosition = jest.fn();
+    instance.settling = true;
+    instance.settlingTarget = { number: 3 };
+    instance.resetStabilityTimer();
+    jest.advanceTimersByTime(3000);
+
+    expect(instance.calculatePosition).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  it('does not emit via onscroll while settling', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false, pagesLoading: 0 };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.updateScrubber = jest.fn();
+    instance.loadPostsIfNeeded = jest.fn();
+    instance.calculatePosition = jest.fn();
+
+    instance.settling = true;
+
+    instance.onscroll(0);
+
+    expect(instance.calculatePosition).not.toHaveBeenCalled();
+  });
+
+  it('endSettling calls calculatePosition for reconciliation', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.calculatePosition = jest.fn();
+
+    instance.setupScrollAnchoring();
+    instance.settling = true;
+    instance.settlingTarget = { number: 1 };
+    instance.startSettlingListeners();
+
+    instance.endSettling();
+
+    expect(instance.settling).toBe(false);
+    expect(instance.calculatePosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit position when cleanupScrollAnchoring is called while settling', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    const onPositionChange = jest.fn();
+    instance.attrs = { onPositionChange };
+
+    instance.setupScrollAnchoring();
+    instance.settling = true;
+    instance.settlingTarget = { number: 5 };
+    instance.startSettlingListeners();
+
+    instance.cleanupScrollAnchoring();
+
+    expect(onPositionChange).not.toHaveBeenCalled();
+    expect(instance.settling).toBe(false);
+  });
+
+  it('does not leak wheel listeners on consecutive beginSettling calls', () => {
+    jest.useFakeTimers();
+
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+    instance.calculatePosition = jest.fn();
+
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    instance.setupScrollAnchoring();
+
+    instance.beginSettling({ number: 1 });
+    const wheelAddsAfterFirst = addSpy.mock.calls.filter((c) => c[0] === 'wheel').length;
+
+    instance.beginSettling({ number: 2 });
+    const wheelAddsAfterSecond = addSpy.mock.calls.filter((c) => c[0] === 'wheel').length;
+    const wheelRemovesAfterSecond = removeSpy.mock.calls.filter((c) => c[0] === 'wheel').length;
+
+    expect(wheelAddsAfterSecond - wheelAddsAfterFirst).toBe(1);
+    expect(wheelRemovesAfterSecond).toBeGreaterThanOrEqual(1);
+
+    const netListeners = wheelAddsAfterSecond - wheelRemovesAfterSecond;
+    expect(netListeners).toBe(1);
+
+    instance.stopSettlingListeners();
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+
+    jest.useRealTimers();
+  });
+
+  it('falls back to settlingTarget.number when all visible items are loading placeholders', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    const onPositionChange = jest.fn();
+    instance.attrs = { onPositionChange };
+
+    instance.computeVisiblePosition = jest.fn(() => ({ startNumber: undefined, endNumber: undefined }));
+    instance.settlingTarget = { number: 7 };
+
+    instance.calculatePosition(0, { fallbackToTarget: true });
+
+    expect(onPositionChange).toHaveBeenCalledWith(7, undefined, 7);
+  });
+
+  it('skips emit for reply targets when no loaded post is visible', () => {
+    const instance = new (PostStream as any)();
+    instance.stream = { paused: false };
+    instance.element = document.createElement('div');
+    instance.getMarginTop = () => 0;
+
+    const onPositionChange = jest.fn();
+    instance.attrs = { onPositionChange };
+
+    instance.computeVisiblePosition = jest.fn(() => ({ startNumber: undefined, endNumber: undefined }));
+    instance.settlingTarget = { index: 99, reply: true };
+
+    instance.calculatePosition(0, { fallbackToTarget: true });
+
+    expect(onPositionChange).not.toHaveBeenCalled();
+  });
+
+  it('resolveTargetStartNumber returns the post number for number targets', () => {
+    const instance = new (PostStream as any)();
+    instance.settlingTarget = { number: 42 };
+    instance.$ = jest.fn();
+
+    expect(instance.resolveTargetStartNumber()).toBe(42);
+  });
+
+  it('resolveTargetStartNumber reads data-number from DOM for index targets', () => {
+    const instance = new (PostStream as any)();
+    instance.settlingTarget = { index: 5 };
+    instance.$ = jest.fn(() => ({ data: () => 10 }));
+
+    expect(instance.resolveTargetStartNumber()).toBe(10);
+  });
+
+  it('resolveTargetStartNumber returns undefined for index targets pointing to unloaded posts', () => {
+    const instance = new (PostStream as any)();
+    instance.settlingTarget = { index: 5 };
+    instance.$ = jest.fn(() => ({ data: () => undefined }));
+
+    expect(instance.resolveTargetStartNumber()).toBeUndefined();
+  });
+
+  it('resolveTargetStartNumber returns undefined for reply targets', () => {
+    const instance = new (PostStream as any)();
+    instance.settlingTarget = { index: 99, reply: true };
+    instance.$ = jest.fn();
+
+    expect(instance.resolveTargetStartNumber()).toBeUndefined();
+  });
+
+  it('resolveTargetStartNumber returns undefined when settlingTarget is null', () => {
+    const instance = new (PostStream as any)();
+    instance.settlingTarget = null;
+
+    expect(instance.resolveTargetStartNumber()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

Two bugs introduced by the scroll-anchoring settling guard (#4361):

1. Clicking or dragging the scrubber delayed the browser URL update by ~3s. The settling guard suppresses `calculatePosition()` during settling, so the URL was not updated until the stability timer fired.
2. If a user opened a discussion and navigated away within 3s, the browser URL would remain on the discussion URL. On unmount, the still-running settling guard called `calculatePosition()` → `positionChanged()` → `window.history.replaceState()`, overwriting the destination page's URL with the old discussion URL.

## Solution

- **Immediate URL emit**: `scrollToItem()` calls `calculatePosition({ fallbackToTarget: true })` right after the scroll lands and before entering settling. This updates the URL without waiting for the stability timer, while the scroll-anchoring behavior introduced in #4361 is fully preserved.
- **Unmount safety**: `cleanupScrollAnchoring()` now calls `endSettling({ updatePosition: false })`, so the settling teardown on unmount never writes to the browser history.
- **Duplicate write guard**: `positionChanged()` skips `replaceState` and `app.history.push` when `startNumber` hasn't changed, preventing a double write from the immediate emit and the settle-end reconciliation resolving to the same post.
- **Consecutive jump cleanup**: `beginSettling(target)` replaces the inline settling setup in `scrollToItem()` and fully tears down any in-progress settling (listeners, timers) before arming new ones, preventing event listener and timer leaks on rapid scrubber jumps.

## Changes

- **`PostStream.js`**: Extract `computeVisiblePosition(top)` (pure DOM scan), `resolveTargetStartNumber()` (target-based fallback when visible items are loading placeholders), `emitPosition()` (single call site for `onPositionChange`); refactor `calculatePosition()` to compose these with an optional `fallbackToTarget` param; add `beginSettling(target)`; add `updatePosition` param to `endSettling()`; update `cleanupScrollAnchoring()` to pass `updatePosition: false`; call `calculatePosition({ fallbackToTarget: true })` and `beginSettling()` in `scrollToItem()`; replace deprecated `window.pageYOffset` with `window.scrollY` throughout.
- **`DiscussionPage.tsx`**: Gate `replaceState` and `app.history.push` in `positionChanged()` on `startNumber !== this.near`; read-state save is unaffected.
- **`PostStream.test.ts`**: 12 new tests covering immediate emit, settling suppression via `onscroll`, `endSettling` reconciliation, unmount no-op, consecutive-jump listener leak, placeholder fallback, reply-target no-emit, and all `resolveTargetStartNumber` target shapes.

## Testing

- Scrubber click/drag: URL updates immediately, no ~3s wait.
- Open a discussion and navigate away within 3s: URL must follow the navigation, not remain on the discussion.
- Media-heavy discussion: scroll-anchoring (no viewport jump) must still work as in #4361.
- Existing PostStream integration tests pass; 12 new tests added.

Closes #4346.