### PR TITLE
[2.x] fix(admin): correct tree array construction in GeneralSearchSource

### DIFF
--- a/framework/core/js/src/admin/components/GeneralSearchSource.tsx
+++ b/framework/core/js/src/admin/components/GeneralSearchSource.tsx
@@ -122,7 +122,7 @@ export default class GeneralSearchSource implements GlobalSearchSource {
                 extensions[extensionId]?.extra['flarum-extension'].title ||
                 app.translator.trans('core.admin.' + corePage + '.title', {}, true),
               group?.icon || extensions[extensionId]?.icon || { name: 'fas fa-cog' },
-              'tree' in setting && setting.tree ? setting.tree.map(extractText).push(label) : [label],
+              'tree' in setting && setting.tree ? [...setting.tree.map(extractText), label] : [label],
               group?.link || (corePage ? app.route(corePage) : app.route('extension', { id: extensionId })),
               help
             )

--- a/framework/core/js/tests/integration/admin/components/GeneralSearchSource.test.ts
+++ b/framework/core/js/tests/integration/admin/components/GeneralSearchSource.test.ts
@@ -1,0 +1,88 @@
+import bootstrapAdmin from '@flarum/jest-config/src/boostrap/admin';
+import GeneralSearchSource from '../../../../src/admin/components/GeneralSearchSource';
+import { app } from '../../../../src/admin';
+
+beforeAll(() => bootstrapAdmin());
+
+describe('GeneralSearchSource', () => {
+  beforeAll(() => {
+    app.boot();
+  });
+
+  describe('search results with tree property', () => {
+    beforeEach(() => {
+      app.generalIndex
+        .group('test-extension', { label: 'Test Extension', icon: { name: 'fas fa-cog' }, link: '/admin/test' })
+        .for('test-extension')
+        .add('settings', [
+          {
+            id: 'test_setting',
+            label: 'Max file size',
+            tree: ['Preferences'],
+          },
+        ]);
+    });
+
+    it('produces an array tree when setting has a tree property', async () => {
+      const source = new GeneralSearchSource();
+      await source.search('max file', 10);
+
+      const results = source['results'].get('max file') ?? [];
+      const result = results.find((r) => r.id.includes('test_setting'));
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result!.tree)).toBe(true);
+      expect(result!.tree).toContain('Max file size');
+      expect(result!.tree).toContain('Preferences');
+    });
+
+    it('does not crash when calling .map() on the tree', async () => {
+      const source = new GeneralSearchSource();
+      await source.search('max file', 10);
+
+      const results = source['results'].get('max file') ?? [];
+      const result = results.find((r) => r.id.includes('test_setting'));
+
+      expect(result).toBeDefined();
+      expect(() => result!.tree.map((part) => part.toUpperCase())).not.toThrow();
+    });
+
+    it('places tree entries before the label', async () => {
+      const source = new GeneralSearchSource();
+      await source.search('max file', 10);
+
+      const results = source['results'].get('max file') ?? [];
+      const result = results.find((r) => r.id.includes('test_setting'));
+
+      expect(result).toBeDefined();
+      expect(result!.tree[0]).toBe('Preferences');
+      expect(result!.tree[result!.tree.length - 1]).toBe('Max file size');
+    });
+  });
+
+  describe('search results without tree property', () => {
+    beforeEach(() => {
+      app.generalIndex
+        .group('test-extension-no-tree', { label: 'Test Extension 2', icon: { name: 'fas fa-cog' }, link: '/admin/test2' })
+        .for('test-extension-no-tree')
+        .add('settings', [
+          {
+            id: 'another_setting',
+            label: 'Upload limit',
+          },
+        ]);
+    });
+
+    it('produces a single-element tree with just the label', async () => {
+      const source = new GeneralSearchSource();
+      await source.search('upload limit', 10);
+
+      const results = source['results'].get('upload limit') ?? [];
+      const result = results.find((r) => r.id.includes('another_setting'));
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result!.tree)).toBe(true);
+      expect(result!.tree).toEqual(['Upload limit']);
+    });
+  });
+});


### PR DESCRIPTION
Array.prototype.push() returns the new length (a number), not the array. Using it as the tree argument caused result.tree.map() to throw "e.tree.map is not a function" when rendering admin search results for any setting with a tree property.

Replace `.map(extractText).push(label)` with `[...map(extractText), label]` to return an array as expected.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4372 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
