### PR TITLE
[2.x] fix(tooltip): add container prop and fix notification button tooltip …

### DIFF
--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -123,7 +123,17 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const children = vnode.children as Mithril.ChildArray | undefined;
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, tooltipVisible, showOnFocus = true, position = 'top', ignoreTitleWarning = false, html = false, delay = 0, container = false, ...attrs } = this.attrs;
+    const {
+      text,
+      tooltipVisible,
+      showOnFocus = true,
+      position = 'top',
+      ignoreTitleWarning = false,
+      html = false,
+      delay = 0,
+      container = false,
+      ...attrs
+    } = this.attrs;
 
     if ((this.attrs as any).title && !ignoreTitleWarning) {
       console.warn(

--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -54,6 +54,15 @@ export interface TooltipAttrs extends Mithril.CommonAttributes<TooltipAttrs, Too
    */
   delay?: number;
   /**
+   * Appends the tooltip to a specific element. Useful when the tooltip trigger
+   * is inside a container with `overflow: hidden` or `overflow: scroll` that
+   * would otherwise clip the tooltip. Accepts a CSS selector string or DOM
+   * element — `'body'` is the most common value.
+   *
+   * Default: `false` (appended adjacent to the trigger element).
+   */
+  container?: string | HTMLElement | false;
+  /**
    * Used to disable the warning for passing text to the `title` attribute.
    *
    * Tooltip text should be passed to the `text` attribute.
@@ -114,7 +123,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const children = vnode.children as Mithril.ChildArray | undefined;
 
     // We remove these to get the remaining attrs to pass to the DOM element
-    const { text, tooltipVisible, showOnFocus = true, position = 'top', ignoreTitleWarning = false, html = false, delay = 0, ...attrs } = this.attrs;
+    const { text, tooltipVisible, showOnFocus = true, position = 'top', ignoreTitleWarning = false, html = false, delay = 0, container = false, ...attrs } = this.attrs;
 
     if ((this.attrs as any).title && !ignoreTitleWarning) {
       console.warn(
@@ -228,6 +237,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
       delay,
       // This will have no effect when switching to CSS tooltips
       html = false,
+      container = false,
       tooltipVisible,
       text,
     } = this.attrs;
@@ -246,6 +256,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
         delay,
         placement: position,
         trigger,
+        container,
       },
       // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
       'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'

--- a/framework/core/js/src/forum/components/NotificationList.js
+++ b/framework/core/js/src/forum/components/NotificationList.js
@@ -39,10 +39,9 @@ export default class NotificationList extends Component {
 
     items.add(
       'mark_all_as_read',
-      <Tooltip text={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}>
+      <Tooltip text={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')} container="body">
         <Button
           className="Button Button--link"
-          data-container=".NotificationList"
           icon="fas fa-check"
           title={app.translator.trans('core.forum.notifications.mark_all_as_read_tooltip')}
           onclick={state.markAllAsRead.bind(state)}
@@ -53,10 +52,9 @@ export default class NotificationList extends Component {
 
     items.add(
       'delete_all',
-      <Tooltip text={app.translator.trans('core.forum.notifications.delete_all_tooltip')}>
+      <Tooltip text={app.translator.trans('core.forum.notifications.delete_all_tooltip')} container="body">
         <Button
           className="Button Button--link"
-          data-container=".NotificationList"
           icon="fas fa-trash-alt"
           title={app.translator.trans('core.forum.notifications.delete_all_tooltip')}
           onclick={() => {


### PR DESCRIPTION
…positioning

The Bootstrap tooltip `container` option was not exposed by the Tooltip component, so tooltips on elements inside overflow-clipped containers (like the notification dropdown) were positioned incorrectly. At certain screen resolutions this caused the tooltip to appear over the cursor, triggering a mousein/mouseout flicker loop that made the button hard to click.

Add a `container` prop to `TooltipAttrs` and pass it through to the Bootstrap tooltip initialisation. Update `NotificationList` to use `container="body"`, which appends the tooltip to the document body so Bootstrap can position it correctly relative to the viewport regardless of any ancestor overflow constraints. Also removes the now-redundant `data-container` attributes from the Button elements, which were never read by the tooltip system.

Fixes: https://github.com/flarum/framework/issues/4353

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4353 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
