### PR TITLE
[2.x] fix: handle null gotoItem in SearchModal selectResult to prevent cras…

### DIFF
--- a/framework/core/js/src/common/components/SearchModal.tsx
+++ b/framework/core/js/src/common/components/SearchModal.tsx
@@ -342,15 +342,18 @@ export default class SearchModal<CustomAttrs extends ISearchModalAttrs = ISearch
     if (isResult) {
       const id = item.attr('data-id');
       selectedUrl = id && this.activeSource().gotoItem(id as string);
-    } else if (item.find('a').length) {
-      selectedUrl = item.find('a').attr('href');
+    }
+
+    // Fallback: if gotoItem returned null or item has no data-id, check for a link
+    if (!selectedUrl && item.find('a').length) {
+      selectedUrl = item.find('a').attr('href') || null;
     }
 
     const query = this.query();
 
     if (query && selectedUrl) {
       m.route.set(selectedUrl);
-    } else {
+    } else if (item.find('button').length) {
       item.find('button')[0].click();
     }
   }

--- a/framework/core/js/tests/integration/common/components/SearchModal.test.ts
+++ b/framework/core/js/tests/integration/common/components/SearchModal.test.ts
@@ -1,0 +1,100 @@
+import bootstrapAdmin from '@flarum/jest-config/src/boostrap/admin';
+import { jest } from '@jest/globals';
+import SearchModal from '../../../../src/common/components/SearchModal';
+import GeneralSearchSource from '../../../../src/admin/components/GeneralSearchSource';
+import SearchState from '../../../../src/common/states/SearchState';
+import { app } from '../../../../src/admin';
+import Stream from '../../../../src/common/utils/Stream';
+
+beforeAll(() => bootstrapAdmin());
+
+describe('SearchModal.selectResult', () => {
+  beforeAll(() => app.boot());
+
+  /**
+   * Creates a minimal SearchModal instance with mocked internals
+   * so that selectResult() can be tested without a full DOM mount.
+   */
+  function makeModal(itemHtml: string, query: string = 'test'): SearchModal & { routeSetSpy: jest.Mock; buttonClickSpy: jest.Mock } {
+    const modal = new SearchModal();
+
+    // Set up required Stream properties
+    (modal as any).query = Stream(query);
+    (modal as any).loadingSources = [];
+    (modal as any).searchTimeout = undefined;
+    (modal as any).index = 0;
+    (modal as any).activeSource = Stream(new GeneralSearchSource());
+    (modal as any).searchState = new SearchState();
+    (modal as any).sources = [new GeneralSearchSource()];
+
+    // Build a real jsdom <li> element for getItem() to return
+    const li = document.createElement('li');
+    li.innerHTML = itemHtml;
+
+    // Spy on m.route.set
+    const routeSetSpy = jest.fn();
+    (m as any).route = { set: routeSetSpy };
+
+    // Track button clicks
+    const buttonClickSpy = jest.fn();
+    const button = li.querySelector('button');
+    if (button) {
+      button.addEventListener('click', buttonClickSpy);
+    }
+
+    // Mock getItem() to return a jQuery wrapper of the li
+    (modal as any).getItem = () => $(li);
+
+    return Object.assign(modal, { routeSetSpy, buttonClickSpy });
+  }
+
+  it('navigates via m.route.set when item has data-id and gotoItem returns a URL', () => {
+    const modal = makeModal('<li data-id="ext-id"><a href="/admin/extensions/flarum-foo">Flarum Foo</a></li>');
+
+    // Override gotoItem to return a URL (as forum sources do)
+    (modal as any).activeSource().gotoItem = () => '/admin/extensions/flarum-foo';
+
+    modal.selectResult();
+
+    expect(modal.routeSetSpy).toHaveBeenCalledWith('/admin/extensions/flarum-foo');
+  });
+
+  it('navigates via the anchor href when gotoItem returns null (admin GeneralSearchSource)', () => {
+    // This is the bug case: GeneralSearchSource sets data-id but gotoItem() returns null.
+    // The item contains a <Link> (<a>) — selectResult() should navigate via the href.
+    const modal = makeModal('<li data-id="flarum-tags-tag-name"><a href="/admin/extensions/flarum-tags">Tags</a></li>');
+
+    // gotoItem returns null, as GeneralSearchSource does
+    (modal as any).activeSource().gotoItem = () => null;
+
+    modal.selectResult();
+
+    expect(modal.routeSetSpy).toHaveBeenCalledWith('/admin/extensions/flarum-tags');
+  });
+
+  it('navigates via anchor href when item has no data-id but contains a link', () => {
+    const modal = makeModal('<li><a href="/admin/basics">Basics</a></li>');
+
+    modal.selectResult();
+
+    expect(modal.routeSetSpy).toHaveBeenCalledWith('/admin/basics');
+  });
+
+  it('clicks a button when item has no link and no data-id', () => {
+    const modal = makeModal('<li><button type="button">Go</button></li>', 'test');
+
+    // No link in item, ensure no navigation
+    modal.selectResult();
+
+    expect(modal.routeSetSpy).not.toHaveBeenCalled();
+    expect(modal.buttonClickSpy).toHaveBeenCalled();
+  });
+
+  it('does not throw when item has neither a link nor a button', () => {
+    // Previously this would crash: item.find('button')[0].click() when no button exists
+    const modal = makeModal('<li><span>No interactive element</span></li>');
+
+    expect(() => modal.selectResult()).not.toThrow();
+    expect(modal.routeSetSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…h on Enter key

When a search source (e.g. GeneralSearchSource in admin) sets data-id on results but returns null from gotoItem(), selectResult() would fall through to `item.find('button')[0].click()` — crashing when the item contains a link (<a>) rather than a button.

Fix by consolidating the link-fallback check to run whenever selectedUrl is still null, and guarding the button click with a length check.

Fixes https://github.com/flarum/framework/issues/4281

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4281 **

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
