### PR TITLE
[2.x] perf: eliminate redundant DB writes in auth middleware and cache notification counts

### DIFF
--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -16,6 +16,7 @@ use Flarum\Bus\Dispatcher;
 use Flarum\Notification\Command\ReadNotification;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationRepository;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
 
 /**
@@ -28,6 +29,7 @@ class NotificationResource extends AbstractDatabaseResource
     public function __construct(
         protected Dispatcher $bus,
         protected NotificationRepository $notifications,
+        protected CacheRepository $cache,
     ) {
         $this->initialized = true;
     }
@@ -64,7 +66,10 @@ class NotificationResource extends AbstractDatabaseResource
             Endpoint\Index::make()
                 ->authenticated()
                 ->before(function (Context $context) {
-                    $context->getActor()->markNotificationsAsRead()->save();
+                    $actor = $context->getActor();
+                    $actor->markNotificationsAsRead()->save();
+                    // Invalidate new notification count cache since read_notifications_at changed
+                    $this->cache->forget("user.{$actor->id}.new_notification_count");
                 })
                 ->defaultInclude(array_filter([
                     'fromUser',

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -70,11 +70,14 @@ class ApplicationInfoProvider
 
     public function identifyDatabaseVersion(): string
     {
-        return match ($this->config['database.driver']) {
-            'mysql', 'mariadb', 'pgsql' => $this->db->selectOne('select version() as version')->version,
-            'sqlite' => $this->db->selectOne('select sqlite_version() as version')->version,
-            default => 'Unknown',
-        };
+        // Cache for 24 hours since the database version rarely changes
+        return $this->cache->remember('flarum:db_version', 86400, function () {
+            return match ($this->config['database.driver']) {
+                'mysql', 'mariadb', 'pgsql' => $this->db->selectOne('select version() as version')->version,
+                'sqlite' => $this->db->selectOne('select sqlite_version() as version')->version,
+                default => 'Unknown',
+            };
+        });
     }
 
     public function identifyDatabaseDriver(): string

--- a/framework/core/src/Http/AccessToken.php
+++ b/framework/core/src/Http/AccessToken.php
@@ -115,12 +115,20 @@ class AccessToken extends AbstractModel
         }
 
         if ($request) {
-            $this->last_ip_address = $request->getAttribute('ipAddress');
+            $newIp = $request->getAttribute('ipAddress');
             // We truncate user agent so it fits in the database column
             // The length is hard-coded as the column length
             // It seems like MySQL or Laravel already truncates values, but we'll play safe and do it ourselves
             $agent = Arr::get($request->getServerParams(), 'HTTP_USER_AGENT');
-            $this->last_user_agent = substr($agent ?? '', 0, 255);
+            $newUserAgent = substr($agent ?? '', 0, 255);
+
+            // Only update if values have changed to avoid unnecessary dirty-marking
+            if ($this->last_ip_address !== $newIp) {
+                $this->last_ip_address = $newIp;
+            }
+            if ($this->last_user_agent !== $newUserAgent) {
+                $this->last_user_agent = $newUserAgent;
+            }
         } else {
             // If no request is provided, we set the values back to null
             // That way the values always match with the date logged in last_activity
@@ -128,7 +136,12 @@ class AccessToken extends AbstractModel
             $this->last_user_agent = null;
         }
 
-        return $this->save();
+        // Only save if model has changes (throttles unnecessary DB writes)
+        if ($this->isDirty()) {
+            return $this->save();
+        }
+
+        return true;
     }
 
     public function user(): BelongsTo

--- a/framework/core/src/Http/Middleware/AuthenticateWithHeader.php
+++ b/framework/core/src/Http/Middleware/AuthenticateWithHeader.php
@@ -47,7 +47,12 @@ class AuthenticateWithHeader implements Middleware
             }
 
             if (isset($actor)) {
-                $actor->updateLastSeen()->save();
+                $actor->updateLastSeen();
+
+                // Only save if last_seen_at was actually updated (throttled to 180 seconds)
+                if ($actor->isDirty()) {
+                    $actor->save();
+                }
 
                 $request = RequestUtil::withActor($request, $actor);
                 $request = $request->withAttribute('bypassCsrfToken', true);

--- a/framework/core/src/Http/Middleware/AuthenticateWithSession.php
+++ b/framework/core/src/Http/Middleware/AuthenticateWithSession.php
@@ -39,7 +39,12 @@ class AuthenticateWithSession implements Middleware
 
             if ($token) {
                 $actor = $token->user;
-                $actor->updateLastSeen()->save();
+                $actor->updateLastSeen();
+
+                // Only save if last_seen_at was actually updated (throttled to 180 seconds)
+                if ($actor->isDirty()) {
+                    $actor->save();
+                }
 
                 $token->touch(request: $request);
 

--- a/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
+++ b/framework/core/src/Notification/Command/ReadAllNotificationsHandler.php
@@ -11,6 +11,7 @@ namespace Flarum\Notification\Command;
 
 use Flarum\Notification\Event\ReadAll;
 use Flarum\Notification\NotificationRepository;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Carbon;
 
@@ -18,7 +19,8 @@ class ReadAllNotificationsHandler
 {
     public function __construct(
         protected NotificationRepository $notifications,
-        protected Dispatcher $events
+        protected Dispatcher $events,
+        protected CacheRepository $cache
     ) {
     }
 
@@ -32,6 +34,10 @@ class ReadAllNotificationsHandler
         $actor->assertRegistered();
 
         $this->notifications->markAllAsRead($actor);
+
+        // Invalidate notification count caches
+        $this->cache->forget("user.{$actor->id}.unread_notification_count");
+        $this->cache->forget("user.{$actor->id}.new_notification_count");
 
         $this->events->dispatch(new ReadAll($actor, Carbon::now()));
     }

--- a/framework/core/src/Notification/Command/ReadNotificationHandler.php
+++ b/framework/core/src/Notification/Command/ReadNotificationHandler.php
@@ -12,12 +12,14 @@ namespace Flarum\Notification\Command;
 use Carbon\Carbon;
 use Flarum\Notification\Event\Read;
 use Flarum\Notification\Notification;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class ReadNotificationHandler
 {
     public function __construct(
-        protected Dispatcher $events
+        protected Dispatcher $events,
+        protected CacheRepository $cache
     ) {
     }
 
@@ -43,6 +45,10 @@ class ReadNotificationHandler
             ->update(['read_at' => Carbon::now()]);
 
         $notification->read_at = Carbon::now();
+
+        // Invalidate notification count caches
+        $this->cache->forget("user.{$actor->id}.unread_notification_count");
+        $this->cache->forget("user.{$actor->id}.new_notification_count");
 
         $this->events->dispatch(new Read($actor, $notification, Carbon::now()));
 

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -187,6 +187,13 @@ class Notification extends AbstractModel
                 ];
             }, $recipients)
         );
+
+        // Invalidate notification count caches for all recipients
+        $cache = resolve('cache.store');
+        foreach ($recipients as $user) {
+            $cache->forget("user.{$user->id}.unread_notification_count");
+            $cache->forget("user.{$user->id}.new_notification_count");
+        }
     }
 
     /**

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -338,7 +338,11 @@ class User extends AbstractModel
 
     public function getUnreadNotificationCount(): int
     {
-        return $this->unreadNotifications()->count();
+        // Cache for 5 minutes; actively invalidated when notifications are marked read or created.
+        // The TTL is a safety net for edge cases such as direct DB updates.
+        return resolve('cache.store')->remember("user.{$this->id}.unread_notification_count", 300, function () {
+            return $this->unreadNotifications()->count();
+        });
     }
 
     /**
@@ -363,11 +367,14 @@ class User extends AbstractModel
      */
     public function getNewNotificationCount(): int
     {
-        return $this->unreadNotifications()
-            ->when($this->read_notifications_at, function (Builder|HasMany $query) {
-                $query->where('created_at', '>', $this->read_notifications_at);
-            })
-            ->count();
+        // Cache for 5 minutes; actively invalidated when notifications change or user views notifications.
+        return resolve('cache.store')->remember("user.{$this->id}.new_notification_count", 300, function () {
+            return $this->unreadNotifications()
+                ->when($this->read_notifications_at, function (Builder|HasMany $query) {
+                    $query->where('created_at', '>', $this->read_notifications_at);
+                })
+                ->count();
+        });
     }
 
     /**


### PR DESCRIPTION
Ports the performance improvements from #4365 (1.x) to 2.x, adapting for API changes in 2.x.

## Changes

### `AccessToken::touch()`
Only update `last_ip_address` / `last_user_agent` when the values have actually changed, and only call `save()` when the model is dirty. On high-traffic sites this eliminates a DB write on every token touch when `last_activity_at` has not yet elapsed the update threshold.

### `AuthenticateWithHeader` / `AuthenticateWithSession`
Guard `$actor->save()` with `isDirty()` after `updateLastSeen()`. Since `updateLastSeen()` is throttled to 180 seconds, requests within that window were previously triggering an unconditional DB write even when nothing changed.

### Notification count caching
Cache `getUnreadNotificationCount()` and `getNewNotificationCount()` for 5 minutes with active invalidation on all write paths. The TTL is a safety net; the cache is eagerly invalidated whenever:
- `Notification::notify()` creates new notifications for recipients
- `ReadNotificationHandler` marks a notification read
- `ReadAllNotificationsHandler` marks all notifications read
- `NotificationResource` (index) updates `read_notifications_at` via `markNotificationsAsRead()`

For `ReadAllNotificationsHandler` and `ReadNotificationHandler`, `CacheRepository` is injected via the constructor for testability rather than using `resolve()`.

### `ApplicationInfoProvider::identifyDatabaseVersion()`
Cache the DB version query for 24 hours. `$this->cache` (`CacheRepository`) is already injected into the class. In 2.x the query uses a `match` expression for SQLite vs MySQL/MariaDB/PostgreSQL, which is preserved inside the closure.

## 2.x adaptations
- `ListNotificationsController` no longer exists; its `markNotificationsAsRead()` call is now in `NotificationResource`'s `Index` endpoint `before()` hook — cache invalidation added there
- `identifyDatabaseVersion()` in 2.x uses a `match` expression (handles SQLite separately); both branches are wrapped in the cache closure