### PR TITLE
fix(tooltip): destroy tooltip instance on component removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- (tooltip) destroy tooltip instance on component removal to prevent orphaned tooltips by @imorland [#4382]
 - (tags) authors unable to rename/hide own discussions in restricted tags by @imorland [#4379]
 - handle null `gotoItem` in `SearchModal` to prevent crash by @imorland [#4376]
 - (tooltip) add `container` prop to fix notification button tooltip positioning by @imorland [#4375]

--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -203,6 +203,18 @@ export default class Tooltip extends Component<TooltipAttrs> {
     this.recreateTooltip();
   }
 
+  onremove(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
+    super.onremove(vnode);
+
+    if (this.childDomNode !== null) {
+      $(this.childDomNode).tooltip(
+        'destroy',
+        // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+        'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+      );
+    }
+  }
+
   private recreateTooltip() {
     if (this.shouldRecreateTooltip && this.childDomNode !== null) {
       $(this.childDomNode).tooltip(


### PR DESCRIPTION
## Problem

When the `container` prop is set to `"body"` (or any element other than the trigger's natural parent), Bootstrap appends the tooltip's DOM node directly to that container rather than adjacent to the trigger element.

When Mithril subsequently removes the trigger element from the DOM — for example, when the notification dropdown is closed — Bootstrap is never informed. The tooltip DOM node is left stranded in `<body>`, remains visible on screen, and cannot be dismissed. The tooltip stays there permanently until the page is reloaded.

This was introduced as a regression by #4375, which correctly added `container="body"` to the notification list tooltips to fix their positioning inside the overflow-clipped dropdown. The positioning fix works, but exposed the missing cleanup.

Without `container`, Bootstrap places the tooltip adjacent to the trigger element in the normal DOM tree; it is removed as part of Mithril's standard DOM cleanup and the problem does not occur.

## Root cause

`Tooltip.tsx` had no `onremove` lifecycle hook. The Bootstrap tooltip instance was never explicitly destroyed when the Mithril component was removed.

## Fix

Add an `onremove` hook that calls `tooltip('destroy')` on the child DOM node before Mithril removes it. This is identical to the `destroy` call already used in `recreateTooltip()` when the tooltip text changes, so the approach is consistent with the existing pattern in this component.

## Impact

- Fixes the stuck/orphaned tooltip on the notification list buttons (mark all as read, delete all)
- Correctly cleans up Bootstrap tooltip instances for **all** `Tooltip` usages on removal, not just `container="body"` — this is the right behaviour regardless
- No behaviour change for the common case where `container` is not set, since Bootstrap already handles cleanup naturally in that case

## Testing

1. Open the notification dropdown
2. Hover over the "mark all as read" or "delete all" button — tooltip appears correctly
3. Close the notification dropdown
4. Confirm the tooltip does **not** remain on screen after the dropdown closes