### PR TITLE
[2.x] [messages] fix: refresh DialogMessage after create to resolve number Expression

### DIFF
--- a/extensions/messages/src/Api/Resource/DialogMessageResource.php
+++ b/extensions/messages/src/Api/Resource/DialogMessageResource.php
@@ -250,6 +250,12 @@ class DialogMessageResource extends Resource\AbstractDatabaseResource
      */
     public function created(object $model, OriginalContext $context): ?object
     {
+        // Refresh to replace the DB Expression used for atomic message numbering
+        // (set during the Eloquent creating event) with the actual integer value.
+        // Without this, serializing the response throws a type cast error:
+        // "Object of class Expression could not be converted to int".
+        $model->refresh();
+
         if ($model->dialog->last_message_id !== $model->id) {
             $model->dialog->setLastMessage($model);
         }

--- a/extensions/messages/tests/integration/api/dialog_messages/CreateTest.php
+++ b/extensions/messages/tests/integration/api/dialog_messages/CreateTest.php
@@ -45,6 +45,38 @@ class CreateTest extends TestCase
         ]);
     }
 
+    public function test_created_message_response_contains_integer_number_not_expression(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/dialog-messages', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'type' => 'dialog-messages',
+                        'attributes' => [
+                            'content' => 'Hello, Bob!',
+                            'users' => [
+                                ['id' => 4],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $number = $data['data']['attributes']['number'];
+
+        // Regression test: DialogMessage::creating() sets $message->number to a raw
+        // DB Expression for atomic post numbering. If the model is not refreshed after
+        // save, the Expression leaks into serialization where the integer cast throws
+        // "Object of class Expression could not be converted to int".
+        $this->assertIsInt($number, 'number attribute should be a concrete integer, not a DB Expression object');
+        $this->assertGreaterThanOrEqual(1, $number);
+    }
+
     public function test_can_create_a_direct_private_conversation_with_someone(): void
     {
         $response = $this->send(


### PR DESCRIPTION
## Problem

Every time a user sends a private message, the following error is logged:

```
ErrorException: Object of class Illuminate\Database\Query\Expression could not be converted to int
in vendor/illuminate/database/Eloquent/Concerns/HasAttributes.php
```

## Root Cause

`DialogMessage::creating()` sets `$message->number` to a raw `DB Expression` object — a subquery that computes `COALESCE(MAX(number), 0) + 1` — which Eloquent embeds directly in the INSERT statement for atomic, race-condition-safe message numbering within a dialog. This mirrors the same pattern used in `Post::creating()`.

The problem is that `Post` has a corresponding `Post::created()` Eloquent boot hook that calls `$post->refresh()` to replace the Expression with the real integer value from the DB. **`DialogMessage` has no such hook.**

When the API's `Create` endpoint serializes the newly-created `DialogMessage` in the response, `$model->number` is still the `Expression` object. Eloquent's `integer` cast then attempts `(int) $expression`, which:

- On PHP 8.3: produces a **warning** (coerced silently to `0`, so the response returns `"number": 0`)
- On production: Sentry's error handler promotes PHP warnings to `ErrorException`, causing every message send to log an error

## Fix

Call `$model->refresh()` at the top of `DialogMessageResource::created()`. This re-queries the database on the write PDO connection and replaces the `Expression` with the actual integer before any further processing or serialization.

## Test

Added `test_created_message_response_contains_integer_number_not_expression` to `CreateTest`. Before the fix, this test triggers the PHP warning (confirming the bug). After the fix, all 3 tests pass cleanly with no warnings.

```
Before fix:
  1 test triggered 1 PHP warning:
  Object of class Illuminate\Database\Query\Expression could not be converted to int

After fix:
  OK (3 tests, 14 assertions)
```