### PR TITLE
[2.x] feat(mail): log send failures and fire EmailSendFailed event

### DIFF
--- a/framework/core/src/Mail/Event/EmailSendFailed.php
+++ b/framework/core/src/Mail/Event/EmailSendFailed.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Mail\Event;
 
+use Flarum\User\User;
 use Throwable;
 
 class EmailSendFailed
@@ -17,6 +18,7 @@ class EmailSendFailed
         public readonly ?string $recipientEmail,
         public readonly ?string $recipientName,
         public readonly Throwable $exception,
+        public readonly ?User $recipient = null,
     ) {
     }
 }

--- a/framework/core/src/Mail/Event/EmailSendFailed.php
+++ b/framework/core/src/Mail/Event/EmailSendFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail\Event;
+
+use Throwable;
+
+class EmailSendFailed
+{
+    public function __construct(
+        public readonly ?string $recipientEmail,
+        public readonly ?string $recipientName,
+        public readonly Throwable $exception,
+    ) {
+    }
+}

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -14,10 +14,10 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
-use Psr\Log\LoggerInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class MailServiceProvider extends AbstractServiceProvider

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -11,6 +11,7 @@ namespace Flarum\Mail;
 
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\UserRepository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
@@ -74,6 +75,7 @@ class MailServiceProvider extends AbstractServiceProvider
                 $container['events'],
                 $settings,
                 $container->make(LoggerInterface::class),
+                $container->make(UserRepository::class),
             );
 
             if ($container->bound('queue')) {

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -14,6 +14,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
+use Psr\Log\LoggerInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
@@ -72,6 +73,7 @@ class MailServiceProvider extends AbstractServiceProvider
                 $container['symfony.mailer.transport'],
                 $container['events'],
                 $settings,
+                $container->make(LoggerInterface::class),
             );
 
             if ($container->bound('queue')) {

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -49,8 +49,8 @@ class Mailer extends IlluminateMailer
         } catch (\Throwable $e) {
             $this->logger->error('Failed to send email.', [
                 'recipient_email' => Arr::get($data, 'userEmail'),
-                'recipient_name'  => Arr::get($data, 'username'),
-                'reason'          => $e->getMessage(),
+                'recipient_name' => Arr::get($data, 'username'),
+                'reason' => $e->getMessage(),
                 'exception_class' => get_class($e),
             ]);
 

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -53,8 +53,8 @@ class Mailer extends IlluminateMailer
 
             $this->logger->error('Failed to send email.', [
                 'recipient_email' => $recipientEmail,
-                'recipient_name'  => $recipientName,
-                'reason'          => $e->getMessage(),
+                'recipient_name' => $recipientName,
+                'reason' => $e->getMessage(),
                 'exception_class' => get_class($e),
             ]);
 

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Mail;
 
+use Flarum\Mail\Event\EmailSendFailed;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
@@ -47,12 +48,17 @@ class Mailer extends IlluminateMailer
         try {
             return parent::send($view, $data, $callback);
         } catch (\Throwable $e) {
+            $recipientEmail = Arr::get($data, 'userEmail');
+            $recipientName = Arr::get($data, 'username');
+
             $this->logger->error('Failed to send email.', [
-                'recipient_email' => Arr::get($data, 'userEmail'),
-                'recipient_name' => Arr::get($data, 'username'),
-                'reason' => $e->getMessage(),
+                'recipient_email' => $recipientEmail,
+                'recipient_name'  => $recipientName,
+                'reason'          => $e->getMessage(),
                 'exception_class' => get_class($e),
             ]);
+
+            $this->events?->dispatch(new EmailSendFailed($recipientEmail, $recipientName, $e));
 
             throw $e;
         }

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -11,6 +11,7 @@ namespace Flarum\Mail;
 
 use Flarum\Mail\Event\EmailSendFailed;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\UserRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Mailer as IlluminateMailer;
@@ -27,6 +28,7 @@ class Mailer extends IlluminateMailer
         ?Dispatcher $events,
         protected SettingsRepositoryInterface $settings,
         protected LoggerInterface $logger,
+        protected UserRepository $users,
     ) {
         parent::__construct($name, $views, $transport, $events);
     }
@@ -58,7 +60,9 @@ class Mailer extends IlluminateMailer
                 'exception_class' => get_class($e),
             ]);
 
-            $this->events?->dispatch(new EmailSendFailed($recipientEmail, $recipientName, $e));
+            $recipient = $recipientEmail ? $this->users->findByEmail($recipientEmail) : null;
+
+            $this->events?->dispatch(new EmailSendFailed($recipientEmail, $recipientName, $e, $recipient));
 
             throw $e;
         }

--- a/framework/core/src/Mail/Mailer.php
+++ b/framework/core/src/Mail/Mailer.php
@@ -13,6 +13,8 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Mailer as IlluminateMailer;
+use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class Mailer extends IlluminateMailer
@@ -22,7 +24,8 @@ class Mailer extends IlluminateMailer
         Factory $views,
         TransportInterface $transport,
         ?Dispatcher $events,
-        protected SettingsRepositoryInterface $settings
+        protected SettingsRepositoryInterface $settings,
+        protected LoggerInterface $logger,
     ) {
         parent::__construct($name, $views, $transport, $events);
     }
@@ -41,6 +44,17 @@ class Mailer extends IlluminateMailer
                 // case 'multipart' is the default, where Flarum will send both HTML and text versions of emails, so that the recipient's email client can choose which one to display.
         }
 
-        return parent::send($view, $data, $callback);
+        try {
+            return parent::send($view, $data, $callback);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to send email.', [
+                'recipient_email' => Arr::get($data, 'userEmail'),
+                'recipient_name'  => Arr::get($data, 'username'),
+                'reason'          => $e->getMessage(),
+                'exception_class' => get_class($e),
+            ]);
+
+            throw $e;
+        }
     }
 }

--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -18,7 +18,6 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Arr;
-use Psr\Log\LoggerInterface;
 
 class NotificationMailer
 {
@@ -28,7 +27,6 @@ class NotificationMailer
         protected SettingsRepositoryInterface $settings,
         protected UrlGenerator $url,
         protected Factory $view,
-        protected LoggerInterface $logger,
     ) {
     }
 
@@ -52,27 +50,14 @@ class NotificationMailer
 
         $this->view->share($data);
 
-        try {
-            $this->mailer->send(
-                $this->getEmailViews($blueprint),
-                $data,
-                function (Message $message) use ($blueprint, $user) {
-                    $message->to($user->email, $user->display_name)
-                            ->subject($blueprint->getEmailSubject($this->translator));
-                }
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error('Email notification could not be sent.', [
-                'notification_type' => $blueprint::getType(),
-                'recipient_id' => $user->id,
-                'recipient_email' => $user->email,
-                'recipient_name' => $user->display_name,
-                'reason' => $e->getMessage(),
-                'exception_class' => get_class($e),
-            ]);
-
-            throw $e;
-        }
+        $this->mailer->send(
+            $this->getEmailViews($blueprint),
+            $data,
+            function (Message $message) use ($blueprint, $user) {
+                $message->to($user->email, $user->display_name)
+                        ->subject($blueprint->getEmailSubject($this->translator));
+            }
+        );
     }
 
     protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken

--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
 
 class NotificationMailer
 {
@@ -27,6 +28,7 @@ class NotificationMailer
         protected SettingsRepositoryInterface $settings,
         protected UrlGenerator $url,
         protected Factory $view,
+        protected LoggerInterface $logger,
     ) {
     }
 
@@ -36,7 +38,7 @@ class NotificationMailer
         $this->translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
 
         // Generate and save the unsubscribe token:
-        $unsubscribeRecord = UnsubscribeToken::generate($user->id, $blueprint::getType());
+        $unsubscribeRecord = $this->generateUnsubscribeToken($user->id, $blueprint::getType());
         $unsubscribeRecord->save();
 
         $unsubscribeLink = $this->url->to('forum')->route('notifications.unsubscribe', ['userId' => $user->id, 'token' => $unsubscribeRecord->token]);
@@ -50,14 +52,27 @@ class NotificationMailer
 
         $this->view->share($data);
 
-        $this->mailer->send(
-            $this->getEmailViews($blueprint),
-            $data,
-            function (Message $message) use ($blueprint, $user) {
-                $message->to($user->email, $user->display_name)
-                        ->subject($blueprint->getEmailSubject($this->translator));
-            }
-        );
+        try {
+            $this->mailer->send(
+                $this->getEmailViews($blueprint),
+                $data,
+                function (Message $message) use ($blueprint, $user) {
+                    $message->to($user->email, $user->display_name)
+                            ->subject($blueprint->getEmailSubject($this->translator));
+                }
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Email notification could not be sent.', [
+                'notification_type' => $blueprint::getType(),
+                'recipient_id'      => $user->id,
+                'recipient_email'   => $user->email,
+                'recipient_name'    => $user->display_name,
+                'reason'            => $e->getMessage(),
+                'exception_class'   => get_class($e),
+            ]);
+
+            throw $e;
+        }
     }
 
     /**
@@ -70,6 +85,11 @@ class NotificationMailer
      *     html: string
      * }
      */
+    protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
+    {
+        return UnsubscribeToken::generate($userId, $emailType);
+    }
+
     protected function getEmailViews(MailableInterface&BlueprintInterface $blueprint): array
     {
         $views = $blueprint->getEmailViews();

--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -64,11 +64,11 @@ class NotificationMailer
         } catch (\Throwable $e) {
             $this->logger->error('Email notification could not be sent.', [
                 'notification_type' => $blueprint::getType(),
-                'recipient_id'      => $user->id,
-                'recipient_email'   => $user->email,
-                'recipient_name'    => $user->display_name,
-                'reason'            => $e->getMessage(),
-                'exception_class'   => get_class($e),
+                'recipient_id' => $user->id,
+                'recipient_email' => $user->email,
+                'recipient_name' => $user->display_name,
+                'reason' => $e->getMessage(),
+                'exception_class' => get_class($e),
             ]);
 
             throw $e;

--- a/framework/core/src/Notification/NotificationMailer.php
+++ b/framework/core/src/Notification/NotificationMailer.php
@@ -75,6 +75,11 @@ class NotificationMailer
         }
     }
 
+    protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
+    {
+        return UnsubscribeToken::generate($userId, $emailType);
+    }
+
     /**
      * Retrieves the email views from the blueprint, and enforces that both a
      * plain text and HTML view are provided.
@@ -85,11 +90,6 @@ class NotificationMailer
      *     html: string
      * }
      */
-    protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
-    {
-        return UnsubscribeToken::generate($userId, $emailType);
-    }
-
     protected function getEmailViews(MailableInterface&BlueprintInterface $blueprint): array
     {
         $views = $blueprint->getEmailViews();

--- a/framework/core/tests/unit/Mail/MailerTest.php
+++ b/framework/core/tests/unit/Mail/MailerTest.php
@@ -9,9 +9,12 @@
 
 namespace Flarum\Tests\unit\Mail;
 
+use Flarum\Mail\Event\EmailSendFailed;
 use Flarum\Mail\Mailer;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\unit\TestCase;
+use Flarum\User\User;
+use Flarum\User\UserRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
 use Mockery as m;
@@ -24,7 +27,7 @@ class MailerTest extends TestCase
 {
     private SettingsRepositoryInterface $settings;
     private LoggerInterface $logger;
-    private Mailer $mailer;
+    private UserRepository $users;
 
     protected function setUp(): void
     {
@@ -32,21 +35,37 @@ class MailerTest extends TestCase
 
         $this->settings = m::mock(SettingsRepositoryInterface::class);
         $this->logger = m::mock(LoggerInterface::class);
+        $this->users = m::mock(UserRepository::class);
 
         $this->settings->shouldReceive('get')->with('mail_format')->andReturn('multipart');
+    }
 
-        $views = m::mock(Factory::class);
-        $views->shouldReceive('make')->andReturn(m::mock(\Illuminate\Contracts\View\View::class)->shouldIgnoreMissing());
-        $views->shouldReceive('exists')->andReturn(true);
-        $views->shouldReceive('share')->andReturnSelf();
+    /**
+     * Build a partial Mailer mock that stubs parent::send() internals so we
+     * control whether an exception is thrown without needing a real transport.
+     */
+    private function makeMailer(?RuntimeException $throwOnParseView = null): Mailer
+    {
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
+            $this->settings,
+            $this->logger,
+            $this->users,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
 
-        $transport = m::mock(TransportInterface::class);
+        if ($throwOnParseView) {
+            $mailer->shouldReceive('parseView')->andThrow($throwOnParseView);
+        } else {
+            $mailer->shouldReceive('parseView')->andReturn(['html-content', 'text-content', null]);
+            $mailer->shouldReceive('addContent')->andReturn(null);
+            $mailer->shouldReceive('createMessage')->andReturn(m::mock(\Illuminate\Mail\Message::class)->shouldIgnoreMissing());
+            $mailer->shouldReceive('shouldSendMessage')->andReturn(false);
+        }
 
-        $dispatcher = m::mock(Dispatcher::class);
-        $dispatcher->shouldReceive('until')->andReturn(null);
-        $dispatcher->shouldReceive('dispatch')->andReturn(null);
-
-        $this->mailer = new Mailer('flarum', $views, $transport, $dispatcher, $this->settings, $this->logger);
+        return $mailer;
     }
 
     #[Test]
@@ -54,25 +73,7 @@ class MailerTest extends TestCase
     {
         $this->logger->shouldNotReceive('error');
 
-        // parent::send() will try to actually send — stub at the transport level isn't straightforward,
-        // so we verify the logger is never called when no exception is thrown by using a partial mock.
-        $mailer = m::mock(Mailer::class, [
-            'flarum',
-            m::mock(Factory::class)->shouldIgnoreMissing(),
-            m::mock(TransportInterface::class),
-            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
-            $this->settings,
-            $this->logger,
-        ])->makePartial()->shouldAllowMockingProtectedMethods();
-
-        $mailer->shouldReceive('parseView')->andReturn(['html-content', 'text-content', null]);
-        $mailer->shouldReceive('addContent')->andReturn(null);
-        $mailer->shouldReceive('createMessage')->andReturn(m::mock(\Illuminate\Mail\Message::class)->shouldIgnoreMissing());
-        $mailer->shouldReceive('shouldSendMessage')->andReturn(false); // skip actual transport
-
-        $this->logger->shouldNotReceive('error');
-
-        $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+        $this->makeMailer()->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
     }
 
     #[Test]
@@ -80,16 +81,7 @@ class MailerTest extends TestCase
     {
         $exception = new RuntimeException('SMTP connection refused');
 
-        $mailer = m::mock(Mailer::class, [
-            'flarum',
-            m::mock(Factory::class)->shouldIgnoreMissing(),
-            m::mock(TransportInterface::class),
-            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
-            $this->settings,
-            $this->logger,
-        ])->makePartial()->shouldAllowMockingProtectedMethods();
-
-        $mailer->shouldReceive('parseView')->andThrow($exception);
+        $this->users->shouldReceive('findByEmail')->with('user@example.com')->andReturn(null);
 
         $this->logger->shouldReceive('error')
             ->once()
@@ -105,6 +97,45 @@ class MailerTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        $this->makeMailer($exception)->send(
+            ['html' => 'view.html', 'text' => 'view.text'],
+            ['userEmail' => 'user@example.com', 'username' => 'Jane Doe'],
+            function () {}
+        );
+    }
+
+    #[Test]
+    public function failed_send_includes_user_model_when_email_matches_account(): void
+    {
+        $exception = new RuntimeException('Mailbox not found');
+        $user = m::mock(User::class);
+
+        $this->users->shouldReceive('findByEmail')->with('user@example.com')->andReturn($user);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('until')->andReturn(null);
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function (EmailSendFailed $event) use ($user) {
+                return $event->recipient === $user
+                    && $event->recipientEmail === 'user@example.com';
+            }));
+
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            $dispatcher,
+            $this->settings,
+            $this->logger,
+            $this->users,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $mailer->shouldReceive('parseView')->andThrow($exception);
+        $this->logger->shouldReceive('error')->once();
+
+        $this->expectException(RuntimeException::class);
+
         $mailer->send(
             ['html' => 'view.html', 'text' => 'view.text'],
             ['userEmail' => 'user@example.com', 'username' => 'Jane Doe'],
@@ -117,16 +148,7 @@ class MailerTest extends TestCase
     {
         $exception = new RuntimeException('Transport error');
 
-        $mailer = m::mock(Mailer::class, [
-            'flarum',
-            m::mock(Factory::class)->shouldIgnoreMissing(),
-            m::mock(TransportInterface::class),
-            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
-            $this->settings,
-            $this->logger,
-        ])->makePartial()->shouldAllowMockingProtectedMethods();
-
-        $mailer->shouldReceive('parseView')->andThrow($exception);
+        $this->users->shouldNotReceive('findByEmail');
 
         $this->logger->shouldReceive('error')
             ->once()
@@ -140,7 +162,7 @@ class MailerTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
-        $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+        $this->makeMailer($exception)->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
     }
 
     #[Test]
@@ -148,20 +170,11 @@ class MailerTest extends TestCase
     {
         $exception = new RuntimeException('Mailbox full');
 
-        $mailer = m::mock(Mailer::class, [
-            'flarum',
-            m::mock(Factory::class)->shouldIgnoreMissing(),
-            m::mock(TransportInterface::class),
-            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
-            $this->settings,
-            $this->logger,
-        ])->makePartial()->shouldAllowMockingProtectedMethods();
-
-        $mailer->shouldReceive('parseView')->andThrow($exception);
+        $this->users->shouldReceive('findByEmail')->andReturn(null);
         $this->logger->shouldReceive('error')->once();
 
         try {
-            $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+            $this->makeMailer($exception)->send(['html' => 'view.html', 'text' => 'view.text'], ['userEmail' => 'x@x.com'], function () {});
             $this->fail('Expected exception was not thrown');
         } catch (RuntimeException $caught) {
             $this->assertSame($exception, $caught, 'The exact original exception instance must be re-thrown');

--- a/framework/core/tests/unit/Mail/MailerTest.php
+++ b/framework/core/tests/unit/Mail/MailerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\Mailer;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\View\Factory;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+class MailerTest extends TestCase
+{
+    private SettingsRepositoryInterface $settings;
+    private LoggerInterface $logger;
+    private Mailer $mailer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->settings = m::mock(SettingsRepositoryInterface::class);
+        $this->logger = m::mock(LoggerInterface::class);
+
+        $this->settings->shouldReceive('get')->with('mail_format')->andReturn('multipart');
+
+        $views = m::mock(Factory::class);
+        $views->shouldReceive('make')->andReturn(m::mock(\Illuminate\Contracts\View\View::class)->shouldIgnoreMissing());
+        $views->shouldReceive('exists')->andReturn(true);
+        $views->shouldReceive('share')->andReturnSelf();
+
+        $transport = m::mock(TransportInterface::class);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('until')->andReturn(null);
+        $dispatcher->shouldReceive('dispatch')->andReturn(null);
+
+        $this->mailer = new Mailer('flarum', $views, $transport, $dispatcher, $this->settings, $this->logger);
+    }
+
+    #[Test]
+    public function successful_send_does_not_log_anything(): void
+    {
+        $this->logger->shouldNotReceive('error');
+
+        // parent::send() will try to actually send — stub at the transport level isn't straightforward,
+        // so we verify the logger is never called when no exception is thrown by using a partial mock.
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
+            $this->settings,
+            $this->logger,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $mailer->shouldReceive('parseView')->andReturn(['html-content', 'text-content', null]);
+        $mailer->shouldReceive('addContent')->andReturn(null);
+        $mailer->shouldReceive('createMessage')->andReturn(m::mock(\Illuminate\Mail\Message::class)->shouldIgnoreMissing());
+        $mailer->shouldReceive('shouldSendMessage')->andReturn(false); // skip actual transport
+
+        $this->logger->shouldNotReceive('error');
+
+        $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+    }
+
+    #[Test]
+    public function failed_send_logs_structured_error_with_recipient_context(): void
+    {
+        $exception = new RuntimeException('SMTP connection refused');
+
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
+            $this->settings,
+            $this->logger,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $mailer->shouldReceive('parseView')->andThrow($exception);
+
+        $this->logger->shouldReceive('error')
+            ->once()
+            ->with(
+                'Failed to send email.',
+                m::on(function (array $context) use ($exception) {
+                    return $context['recipient_email'] === 'user@example.com'
+                        && $context['recipient_name'] === 'Jane Doe'
+                        && $context['reason'] === $exception->getMessage()
+                        && $context['exception_class'] === RuntimeException::class;
+                })
+            );
+
+        $this->expectException(RuntimeException::class);
+
+        $mailer->send(
+            ['html' => 'view.html', 'text' => 'view.text'],
+            ['userEmail' => 'user@example.com', 'username' => 'Jane Doe'],
+            function () {}
+        );
+    }
+
+    #[Test]
+    public function failed_send_logs_with_null_context_when_data_keys_absent(): void
+    {
+        $exception = new RuntimeException('Transport error');
+
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
+            $this->settings,
+            $this->logger,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $mailer->shouldReceive('parseView')->andThrow($exception);
+
+        $this->logger->shouldReceive('error')
+            ->once()
+            ->with(
+                'Failed to send email.',
+                m::on(function (array $context) {
+                    return $context['recipient_email'] === null
+                        && $context['recipient_name'] === null;
+                })
+            );
+
+        $this->expectException(RuntimeException::class);
+
+        $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+    }
+
+    #[Test]
+    public function failed_send_rethrows_original_exception(): void
+    {
+        $exception = new RuntimeException('Mailbox full');
+
+        $mailer = m::mock(Mailer::class, [
+            'flarum',
+            m::mock(Factory::class)->shouldIgnoreMissing(),
+            m::mock(TransportInterface::class),
+            m::mock(Dispatcher::class)->shouldIgnoreMissing(),
+            $this->settings,
+            $this->logger,
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $mailer->shouldReceive('parseView')->andThrow($exception);
+        $this->logger->shouldReceive('error')->once();
+
+        try {
+            $mailer->send(['html' => 'view.html', 'text' => 'view.text'], [], function () {});
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $caught) {
+            $this->assertSame($exception, $caught, 'The exact original exception instance must be re-thrown');
+        }
+    }
+}

--- a/framework/core/tests/unit/Notification/NotificationMailerTest.php
+++ b/framework/core/tests/unit/Notification/NotificationMailerTest.php
@@ -59,14 +59,7 @@ class NotificationMailerTest extends TestCase
         $this->view->shouldReceive('share')->once();
 
         // Use a testable subclass that stubs out the DB-touching unsubscribe token
-        $this->notificationMailer = new class(
-            $this->mailer,
-            $this->translator,
-            $this->settings,
-            $this->url,
-            $this->view,
-            $this->logger,
-        ) extends NotificationMailer {
+        $this->notificationMailer = new class($this->mailer, $this->translator, $this->settings, $this->url, $this->view, $this->logger) extends NotificationMailer {
             protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
             {
                 $token = m::mock(UnsubscribeToken::class)->shouldIgnoreMissing();

--- a/framework/core/tests/unit/Notification/NotificationMailerTest.php
+++ b/framework/core/tests/unit/Notification/NotificationMailerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Notification;
+
+use Flarum\Http\RouteCollectionUrlGenerator;
+use Flarum\Http\UrlGenerator;
+use Flarum\Locale\TranslatorInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
+use Flarum\Notification\NotificationMailer;
+use Flarum\Notification\UnsubscribeToken;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\View\Factory;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class NotificationMailerTest extends TestCase
+{
+    private Mailer $mailer;
+    private TranslatorInterface $translator;
+    private SettingsRepositoryInterface $settings;
+    private UrlGenerator $url;
+    private Factory $view;
+    private LoggerInterface $logger;
+    private NotificationMailer $notificationMailer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mailer = m::mock(Mailer::class);
+        $this->translator = m::mock(TranslatorInterface::class);
+        $this->settings = m::mock(SettingsRepositoryInterface::class);
+        $this->url = m::mock(UrlGenerator::class);
+        $this->view = m::mock(Factory::class);
+        $this->logger = m::mock(LoggerInterface::class);
+
+        // Common stub setup
+        $this->translator->shouldReceive('setLocale')->once();
+        $this->settings->shouldReceive('get')->with('default_locale')->andReturn('en');
+        $this->settings->shouldReceive('get')->with('forum_title')->andReturn('Test Forum');
+
+        $routeGenerator = m::mock(RouteCollectionUrlGenerator::class);
+        $routeGenerator->shouldReceive('route')->andReturn('https://example.com/some-url');
+        $this->url->shouldReceive('to')->andReturn($routeGenerator);
+
+        $this->view->shouldReceive('share')->once();
+
+        // Use a testable subclass that stubs out the DB-touching unsubscribe token
+        $this->notificationMailer = new class(
+            $this->mailer,
+            $this->translator,
+            $this->settings,
+            $this->url,
+            $this->view,
+            $this->logger,
+        ) extends NotificationMailer {
+            protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
+            {
+                $token = m::mock(UnsubscribeToken::class)->shouldIgnoreMissing();
+                $token->shouldReceive('save')->once();
+                $token->token = 'fake-token';
+
+                return $token;
+            }
+        };
+    }
+
+    #[Test]
+    public function successful_send_does_not_log_anything(): void
+    {
+        $this->mailer->shouldReceive('send')->once();
+        $this->logger->shouldNotReceive('error');
+
+        $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
+    }
+
+    #[Test]
+    public function failed_send_logs_structured_error_context(): void
+    {
+        $exception = new RuntimeException('Connection refused by SMTP server');
+
+        $this->mailer->shouldReceive('send')->once()->andThrow($exception);
+
+        $this->logger->shouldReceive('error')
+            ->once()
+            ->with(
+                'Email notification could not be sent.',
+                m::on(function (array $context) use ($exception) {
+                    return $context['notification_type'] === 'testNotification'
+                        && $context['recipient_id'] === 42
+                        && $context['recipient_email'] === 'user@example.com'
+                        && $context['recipient_name'] === 'Test User'
+                        && $context['reason'] === $exception->getMessage()
+                        && $context['exception_class'] === RuntimeException::class;
+                })
+            );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Connection refused by SMTP server');
+
+        $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
+    }
+
+    #[Test]
+    public function failed_send_rethrows_original_exception(): void
+    {
+        $exception = new RuntimeException('Mailbox full');
+
+        $this->mailer->shouldReceive('send')->once()->andThrow($exception);
+        $this->logger->shouldReceive('error')->once();
+
+        try {
+            $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $caught) {
+            $this->assertSame($exception, $caught, 'The exact original exception instance must be re-thrown');
+        }
+    }
+
+    private function makeBlueprint(): MailableInterface&BlueprintInterface
+    {
+        $blueprint = m::mock(MailableInterface::class, BlueprintInterface::class);
+        $blueprint->shouldReceive('getEmailViews')->andReturn(['text' => 'emails.test', 'html' => 'emails.test-html']);
+        $blueprint->shouldReceive('getEmailSubject')->andReturn('Test Subject');
+        $blueprint->allows('getType')->andReturn('testNotification');
+
+        return $blueprint;
+    }
+
+    private function makeUser(): User
+    {
+        $user = m::mock(User::class)->shouldIgnoreMissing();
+        $user->shouldReceive('getAttribute')->with('id')->andReturn(42);
+        $user->shouldReceive('getAttribute')->with('email')->andReturn('user@example.com');
+        $user->shouldReceive('getAttribute')->with('display_name')->andReturn('Test User');
+        $user->shouldReceive('getPreference')->with('locale')->andReturn(null);
+
+        return $user;
+    }
+}

--- a/framework/core/tests/unit/Notification/NotificationMailerTest.php
+++ b/framework/core/tests/unit/Notification/NotificationMailerTest.php
@@ -23,7 +23,6 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class NotificationMailerTest extends TestCase
@@ -33,7 +32,6 @@ class NotificationMailerTest extends TestCase
     private SettingsRepositoryInterface $settings;
     private UrlGenerator $url;
     private Factory $view;
-    private LoggerInterface $logger;
     private NotificationMailer $notificationMailer;
 
     protected function setUp(): void
@@ -45,7 +43,6 @@ class NotificationMailerTest extends TestCase
         $this->settings = m::mock(SettingsRepositoryInterface::class);
         $this->url = m::mock(UrlGenerator::class);
         $this->view = m::mock(Factory::class);
-        $this->logger = m::mock(LoggerInterface::class);
 
         // Common stub setup
         $this->translator->shouldReceive('setLocale')->once();
@@ -59,7 +56,7 @@ class NotificationMailerTest extends TestCase
         $this->view->shouldReceive('share')->once();
 
         // Use a testable subclass that stubs out the DB-touching unsubscribe token
-        $this->notificationMailer = new class($this->mailer, $this->translator, $this->settings, $this->url, $this->view, $this->logger) extends NotificationMailer {
+        $this->notificationMailer = new class($this->mailer, $this->translator, $this->settings, $this->url, $this->view) extends NotificationMailer {
             protected function generateUnsubscribeToken(int $userId, string $emailType): UnsubscribeToken
             {
                 $token = m::mock(UnsubscribeToken::class)->shouldIgnoreMissing();
@@ -72,55 +69,24 @@ class NotificationMailerTest extends TestCase
     }
 
     #[Test]
-    public function successful_send_does_not_log_anything(): void
+    public function successful_send_delegates_to_mailer(): void
     {
         $this->mailer->shouldReceive('send')->once();
-        $this->logger->shouldNotReceive('error');
 
         $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
     }
 
     #[Test]
-    public function failed_send_logs_structured_error_context(): void
+    public function mailer_exception_propagates_to_caller(): void
     {
         $exception = new RuntimeException('Connection refused by SMTP server');
 
         $this->mailer->shouldReceive('send')->once()->andThrow($exception);
 
-        $this->logger->shouldReceive('error')
-            ->once()
-            ->with(
-                'Email notification could not be sent.',
-                m::on(function (array $context) use ($exception) {
-                    return $context['notification_type'] === 'testNotification'
-                        && $context['recipient_id'] === 42
-                        && $context['recipient_email'] === 'user@example.com'
-                        && $context['recipient_name'] === 'Test User'
-                        && $context['reason'] === $exception->getMessage()
-                        && $context['exception_class'] === RuntimeException::class;
-                })
-            );
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Connection refused by SMTP server');
 
         $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
-    }
-
-    #[Test]
-    public function failed_send_rethrows_original_exception(): void
-    {
-        $exception = new RuntimeException('Mailbox full');
-
-        $this->mailer->shouldReceive('send')->once()->andThrow($exception);
-        $this->logger->shouldReceive('error')->once();
-
-        try {
-            $this->notificationMailer->send($this->makeBlueprint(), $this->makeUser());
-            $this->fail('Expected exception was not thrown');
-        } catch (RuntimeException $caught) {
-            $this->assertSame($exception, $caught, 'The exact original exception instance must be re-thrown');
-        }
     }
 
     private function makeBlueprint(): MailableInterface&BlueprintInterface


### PR DESCRIPTION
## Problem

When the mailer throws during an email send — SMTP rejection, connection timeout, invalid address, full mailbox — the exception produced no useful log entry. The raw exception would bubble up to the queue worker (or caller), making it very hard to diagnose which recipient or mail type caused the failure.

This affected both `SendEmailNotificationJob` and `SendInformationalEmailJob`, plus any future mail sender.

## Solution

`Flarum\Mail\Mailer::send()` now wraps `parent::send()` in a `try/catch`. On failure it:

1. Logs a structured `error` entry before re-throwing:
```
production.ERROR: Failed to send email. {
  "recipient_email": "user@example.com",
  "recipient_name": "JohnDoe",
  "reason": "Connection could not be established with host smtp.example.com",
  "exception_class": "Symfony\\Component\\Mailer\\Exception\\TransportException"
}
```

2. Dispatches a new `Flarum\Mail\Event\EmailSendFailed` event with recipient email, name, the original exception, and a best-effort resolved `?User` model (looked up by email via `UserRepository`). Extensions can listen to this event to take action — e.g. marking an address as unconfirmed, disabling email notifications for that account, notifying admins.

Because this is in `Mailer::send()` itself, it fires for every email Flarum sends — queued or synchronous, notification or informational, regardless of queue driver. The exception is always re-thrown so the caller still handles it normally. The `UserRepository` lookup only happens on the failure path, so there is no performance impact on successful sends.

No default listener is registered — the event is a hook point for extensions and future Flarum releases.

## Changes

- `Flarum\Mail\Mailer`: add `LoggerInterface` and `UserRepository` constructor dependencies; wrap `parent::send()` in try/catch with structured logging, user lookup, and `EmailSendFailed` event dispatch
- `Flarum\Mail\Event\EmailSendFailed`: new event class (`recipientEmail`, `recipientName`, `exception`, `recipient`)
- `MailServiceProvider`: inject `LoggerInterface` and `UserRepository` when constructing the `Mailer` singleton
- `Flarum\Notification\NotificationMailer`: remove now-redundant `LoggerInterface` and try/catch; retain `protected generateUnsubscribeToken()` for testability
- `MailerTest`: unit tests covering success (no log), failure with context, failure with matched User, missing data keys, and exact exception rethrow identity
- `NotificationMailerTest`: updated to reflect simplified `NotificationMailer`

## Test plan

- [ ] Run unit tests: `vendor/bin/phpunit -c tests/phpunit.unit.xml tests/unit/Mail/ tests/unit/Notification/`
- [ ] Verify existing notification integration tests still pass
- [ ] On staging: trigger a notification email to a broken address and confirm the structured log entry appears in the application log

🤖 Generated with [Claude Code](https://claude.com/claude-code)