### PR TITLE
[2.x] fix(a11y/less): LESS mixin definitions and skip-to-content link visibility

### DIFF
--- a/framework/core/js/src/forum/components/PageStructure.tsx
+++ b/framework/core/js/src/forum/components/PageStructure.tsx
@@ -38,6 +38,13 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
   mainItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
+    items.add(
+      'skipToMainContent',
+      <a href="#main-content" className="sr-only sr-only-focusable-custom" oncreate={() => prepareSkipLinks()}>
+        {app.translator.trans('core.forum.index.skip_to_main_content')}
+      </a>,
+      200
+    );
     items.add('hero', this.providedHero(), 100);
     items.add('container', this.container(), 10);
 
@@ -75,14 +82,6 @@ export default class PageStructure<CustomAttrs extends PageStructureAttrs = Page
 
   sidebarItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
-
-    items.add(
-      'skipToMainContent',
-      <a href="#main-content" className="sr-only sr-only-focusable-custom" oncreate={() => prepareSkipLinks()}>
-        {app.translator.trans('core.forum.index.skip_to_main_content')}
-      </a>,
-      200
-    );
 
     items.add('sidebar', (this.attrs.sidebar && this.attrs.sidebar()) || null, 100);
 

--- a/framework/core/less/common/Button.less
+++ b/framework/core/less/common/Button.less
@@ -221,7 +221,7 @@
     margin: 0;
   }
 }
-.Button--block {
+.Button--block() {
   display: flex;
   width: 100%;
   overflow: hidden;
@@ -233,7 +233,7 @@
   }
 }
 // Little round icon buttons
-.Button--icon {
+.Button--icon() {
   width: 36px;
   text-align: center;
   padding: 8px 0;

--- a/framework/core/less/common/Table.less
+++ b/framework/core/less/common/Table.less
@@ -1,4 +1,4 @@
-.Table {
+.Table() {
   background: var(--control-bg);
   border-radius: var(--border-radius);
   border-collapse: collapse;

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -73,7 +73,7 @@ p {
   margin: 0 auto;
 }
 
-.loading-container {
+.loading-container() {
   position: relative;
 
   &::after {
@@ -198,6 +198,18 @@ blockquote ol:last-child {
 
 .text-colored {
   color: var(--color);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .sr-only-focusable-custom:focus {

--- a/framework/core/less/forum/HeaderList.less
+++ b/framework/core/less/forum/HeaderList.less
@@ -120,7 +120,7 @@
   }
 }
 
-.CompactActions {
+.CompactActions() {
   &:hover &-actions,
   &:focus &-actions,
   &:focus-within &-actions {

--- a/framework/core/less/forum/PageStructure.less
+++ b/framework/core/less/forum/PageStructure.less
@@ -1,4 +1,4 @@
-.Page--cols {
+.Page--cols() {
   &-container {
     display: flex;
   }

--- a/framework/core/views/frontend/admin.blade.php
+++ b/framework/core/views/frontend/admin.blade.php
@@ -1,11 +1,12 @@
 <div id="app" class="App">
 
+    <a href="#content" class="sr-only sr-only-focusable-custom">@lang('core.views.layout.skip_to_content')</a>
+
     <div id="app-navigation" class="App-navigation"></div>
 
     <div id="drawer" class="App-drawer">
 
         <header id="header" class="App-header">
-            <a href="#content" class="sr-only sr-only-focusable-custom">@lang('core.views.layout.skip_to_content')</a>
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <div class="Header-title">

--- a/framework/core/views/frontend/forum.blade.php
+++ b/framework/core/views/frontend/forum.blade.php
@@ -2,12 +2,13 @@
 
 <div id="app" class="App">
 
+    <a href="#content" class="sr-only sr-only-focusable-custom">@lang('core.views.layout.skip_to_content')</a>
+
     <div id="app-navigation" class="App-navigation"></div>
 
     <div id="drawer" class="App-drawer">
 
         <header id="header" class="App-header">
-            <a href="#content" class="sr-only sr-only-focusable-custom">@lang('core.views.layout.skip_to_content')</a>
             <div id="header-navigation" class="Header-navigation"></div>
             <div class="container">
                 <div class="Header-title">


### PR DESCRIPTION
## Summary

Three related regressions introduced by the Less.php 5.x upgrade (#4225) and the FontAwesome 7 upgrade (#4388):

### 1. LESS parametric mixin definitions

Less.php 5.x is stricter about calling plain class rulesets with `()` mixin syntax. Six classes were defined as plain rulesets but called with `()` at their call sites, causing a compiler error:

> No matching definition was found for `.Page--cols` with args ``

Fixed by adding `()` to the definitions of:
- `.Page--cols` — `PageStructure.less`
- `.CompactActions` — `HeaderList.less`
- `.Table` — `Table.less`
- `.Button--block` — `Button.less`
- `.Button--icon` — `Button.less`
- `.loading-container` — `scaffolding.less`

As a bonus, parametric mixin definitions (with `()`) are not emitted as CSS selectors into the compiled output, which is the correct behaviour for utility mixins.

### 2. Missing `.sr-only` utility class (FA7 regression)

FA5/FA6 shipped a `.sr-only` utility class in `fontawesome.css` which Flarum relied on to visually hide the skip-to-content link. FA7 removed this class entirely.

Fixed by adding `.sr-only` to `scaffolding.less` so Flarum owns this utility rather than depending on FA to provide it.

### 3. Skip-to-content link visible in mobile drawer

The skip link was rendered inside `#drawer` in both Blade templates. On mobile, `.App-drawer` uses `transform: translateX()` which creates a new CSS containing block — breaking `position: absolute` clipping and making the link visually appear inside the mobile navigation drawer.

Fixed in two places:
- **Blade templates** (`forum.blade.php`, `admin.blade.php`): moved the skip link to be a direct child of `#app`, before `#drawer`
- **`PageStructure.tsx`**: moved the JS-rendered skip link from `sidebarItems()` (which renders inside the drawer on mobile) to `mainItems()` (always in the main page flow)

## Related

- Introduced by: #4225 (Less.php 5.x upgrade) and #4388 (FontAwesome 7 upgrade)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>