### PR TITLE
[2.x] fix(notifications): invalidate unread count cache on delete all

### DIFF
--- a/framework/core/src/Notification/Command/DeleteAllNotificationsHandler.php
+++ b/framework/core/src/Notification/Command/DeleteAllNotificationsHandler.php
@@ -11,6 +11,7 @@ namespace Flarum\Notification\Command;
 
 use Flarum\Notification\Event\DeletedAll;
 use Flarum\Notification\NotificationRepository;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Carbon;
 
@@ -18,7 +19,8 @@ class DeleteAllNotificationsHandler
 {
     public function __construct(
         protected NotificationRepository $notifications,
-        protected Dispatcher $events
+        protected Dispatcher $events,
+        protected CacheRepository $cache
     ) {
     }
 
@@ -29,6 +31,10 @@ class DeleteAllNotificationsHandler
         $actor->assertRegistered();
 
         $this->notifications->deleteAll($actor);
+
+        // Invalidate notification count caches
+        $this->cache->forget("user.{$actor->id}.unread_notification_count");
+        $this->cache->forget("user.{$actor->id}.new_notification_count");
 
         $this->events->dispatch(new DeletedAll($actor, Carbon::now()));
     }

--- a/framework/core/tests/integration/api/notifications/DeleteTest.php
+++ b/framework/core/tests/integration/api/notifications/DeleteTest.php
@@ -14,6 +14,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -69,5 +70,25 @@ class DeleteTest extends TestCase
             [1],
             [2]
         ];
+    }
+
+    #[Test]
+    public function deleting_all_notifications_invalidates_unread_count_cache()
+    {
+        $cache = $this->app()->getContainer()->make(CacheRepository::class);
+
+        // Prime the cache with stale counts so we can verify they are cleared.
+        $cache->put('user.1.unread_notification_count', 99, 300);
+        $cache->put('user.1.new_notification_count', 99, 300);
+
+        $this->assertEquals(99, $cache->get('user.1.unread_notification_count'));
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/notifications', ['authenticatedAs' => 1]),
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull($cache->get('user.1.unread_notification_count'), 'unread_notification_count cache should be cleared after delete');
+        $this->assertNull($cache->get('user.1.new_notification_count'), 'new_notification_count cache should be cleared after delete');
     }
 }


### PR DESCRIPTION
## Regression of #4380

#4380 added 5-minute caching to `getUnreadNotificationCount()` and `getNewNotificationCount()` with active cache invalidation in:

- `ReadNotificationHandler` ✅
- `ReadAllNotificationsHandler` ✅
- `NotificationResource` (index) ✅
- `Notification::notify()` ✅
- `DeleteAllNotificationsHandler` ❌ — **missed**

## Symptom

After clicking "Delete All" in the notifications dropdown, the notifications disappear from the list (optimistic update works) but the unread count badge on the bell icon reappears on the next page load or any API response that includes the user's counts — and stays wrong for up to 5 minutes until the cache naturally expires.

This did not occur in v1.x because notification count caching was introduced in 2.x via #4380.

## Fix

Inject `CacheRepository` into `DeleteAllNotificationsHandler` and call `forget()` on both count keys after deletion — identical pattern to `ReadAllNotificationsHandler`.

## Test

Added a regression test to `DeleteTest` that:
1. Primes both cache keys with a stale value of `99`
2. Sends `DELETE /api/notifications`
3. Asserts both cache keys are `null` after the request

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>