### PR TITLE
[1.x] fix(notifications): invalidate unread count cache on delete all

### DIFF
--- a/framework/core/src/Notification/Command/DeleteAllNotificationsHandler.php
+++ b/framework/core/src/Notification/Command/DeleteAllNotificationsHandler.php
@@ -49,6 +49,11 @@ class DeleteAllNotificationsHandler
 
         $this->notifications->deleteAll($actor);
 
+        // Invalidate notification count caches
+        $cache = resolve('cache.store');
+        $cache->forget("user.{$actor->id}.unread_notification_count");
+        $cache->forget("user.{$actor->id}.new_notification_count");
+
         $this->events->dispatch(new DeletedAll($actor, Carbon::now()));
     }
 }

--- a/framework/core/tests/integration/api/notifications/DeleteTest.php
+++ b/framework/core/tests/integration/api/notifications/DeleteTest.php
@@ -69,4 +69,26 @@ class DeleteTest extends TestCase
             [2]
         ];
     }
+
+    /**
+     * @test
+     */
+    public function deleting_all_notifications_invalidates_unread_count_cache()
+    {
+        $cache = resolve('cache.store');
+
+        // Prime the cache with stale counts so we can verify they are cleared.
+        $cache->put('user.1.unread_notification_count', 99, 300);
+        $cache->put('user.1.new_notification_count', 99, 300);
+
+        $this->assertEquals(99, $cache->get('user.1.unread_notification_count'));
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/notifications', ['authenticatedAs' => 1]),
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull($cache->get('user.1.unread_notification_count'), 'unread_notification_count cache should be cleared after delete');
+        $this->assertNull($cache->get('user.1.new_notification_count'), 'new_notification_count cache should be cleared after delete');
+    }
 }


### PR DESCRIPTION
## Regression of #4365

Port of #4390 (2.x fix) to 1.x.

#4365 added caching to `getUnreadNotificationCount()` and `getNewNotificationCount()` with active cache invalidation in `ReadAllNotificationsHandler` and `ReadNotificationHandler`. `DeleteAllNotificationsHandler` was missed.

## Symptom

After clicking "Delete All" in the notifications dropdown, the notifications disappear from the list (optimistic update works) but the unread count badge reappears on the next page load and stays wrong for up to 5 minutes until the cache naturally expires.

## Fix

Add `resolve('cache.store')->forget()` calls for both count keys after deletion, matching the pattern already used in `ReadAllNotificationsHandler`.

## Test

Added a regression test that primes both cache keys with a stale value of `99`, calls `DELETE /api/notifications`, and asserts both keys are `null` after the request.

## Related

- 2.x fix: #4390
- Introduced by: #4365

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>