### PR TITLE
[2.x] Fixed tags mutation shows [deleted] in some cases, together with improvements

### DIFF
--- a/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
+++ b/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
@@ -2,18 +2,43 @@ import EventPost from 'flarum/forum/components/EventPost';
 import tagsLabel from '../../common/helpers/tagsLabel';
 
 export default class DiscussionTaggedPost extends EventPost {
-  static initAttrs(attrs) {
-    super.initAttrs(attrs);
+  oninit(vnode) {
+    super.oninit(vnode);
 
-    const oldTags = attrs.post.content()[0];
-    const newTags = attrs.post.content()[1];
+    const oldTags = this.attrs.post.content()[0];
+    const newTags = this.attrs.post.content()[1];
 
-    function diffTags(tags1, tags2) {
-      return tags1.filter((tag) => tags2.indexOf(tag) === -1).map((id) => app.store.getById('tags', id));
+    this.tagsAdded = [];
+    this.tagsRemoved = [];
+
+    this.fetchRequired = false;
+    this.loading = true;
+
+    const tagsMutation = [...this.diffTags(newTags, oldTags), ...this.diffTags(oldTags, newTags)];
+    if (tagsMutation.includes(undefined)) {
+      this.fetchRequired = true;
     }
 
-    attrs.tagsAdded = diffTags(newTags, oldTags);
-    attrs.tagsRemoved = diffTags(oldTags, newTags);
+    const afterFetch = () => {
+      this.tagsAdded = this.diffTags(newTags, oldTags);
+      this.tagsRemoved = this.diffTags(oldTags, newTags);
+
+      this.loading = false;
+      m.redraw();
+    };
+
+    if (this.fetchRequired) {
+      app.store.find('tags').then(afterFetch);
+    } else {
+      afterFetch();
+    }
+  }
+
+  diffTags(tags1, tags2) {
+    return tags1
+      .filter((tag) => tags2.indexOf(tag) === -1)
+      .map((id) => app.store.getById('tags', id))
+      // .filter(Boolean);
   }
 
   icon() {
@@ -21,8 +46,8 @@ export default class DiscussionTaggedPost extends EventPost {
   }
 
   descriptionKey() {
-    if (this.attrs.tagsAdded.length) {
-      if (this.attrs.tagsRemoved.length) {
+    if (this.tagsAdded.length) {
+      if (this.tagsRemoved.length) {
         return 'flarum-tags.forum.post_stream.added_and_removed_tags_text';
       }
 
@@ -35,17 +60,17 @@ export default class DiscussionTaggedPost extends EventPost {
   descriptionData() {
     const data = {};
 
-    if (this.attrs.tagsAdded.length) {
+    if (this.tagsAdded.length) {
       data.tagsAdded = app.translator.trans('flarum-tags.forum.post_stream.tags_text', {
-        tags: tagsLabel(this.attrs.tagsAdded, { link: true }),
-        count: this.attrs.tagsAdded.length,
+        tags: tagsLabel(this.tagsAdded, { link: true }),
+        count: this.tagsAdded.length,
       });
     }
 
-    if (this.attrs.tagsRemoved.length) {
+    if (this.tagsRemoved.length) {
       data.tagsRemoved = app.translator.trans('flarum-tags.forum.post_stream.tags_text', {
-        tags: tagsLabel(this.attrs.tagsRemoved, { link: true }),
-        count: this.attrs.tagsRemoved.length,
+        tags: tagsLabel(this.tagsRemoved, { link: true }),
+        count: this.tagsRemoved.length,
       });
     }
 

--- a/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
+++ b/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
@@ -28,7 +28,10 @@ export default class DiscussionTaggedPost extends EventPost {
     };
 
     if (this.fetchRequired) {
-      app.store.find('tags').then(afterFetch);
+      app.store.find('tags').then(afterFetch).catch(() => {
+        this.loading = false;
+        m.redraw();
+      });
     } else {
       afterFetch();
     }

--- a/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
+++ b/extensions/tags/js/src/forum/components/DiscussionTaggedPost.js
@@ -28,20 +28,21 @@ export default class DiscussionTaggedPost extends EventPost {
     };
 
     if (this.fetchRequired) {
-      app.store.find('tags').then(afterFetch).catch(() => {
-        this.loading = false;
-        m.redraw();
-      });
+      app.store
+        .find('tags')
+        .then(afterFetch)
+        .catch(() => {
+          this.loading = false;
+          m.redraw();
+        });
     } else {
       afterFetch();
     }
   }
 
   diffTags(tags1, tags2) {
-    return tags1
-      .filter((tag) => tags2.indexOf(tag) === -1)
-      .map((id) => app.store.getById('tags', id))
-      // .filter(Boolean);
+    return tags1.filter((tag) => tags2.indexOf(tag) === -1).map((id) => app.store.getById('tags', id));
+    // .filter(Boolean);
   }
 
   icon() {

--- a/extensions/tags/less/forum.less
+++ b/extensions/tags/less/forum.less
@@ -2,6 +2,7 @@
 
 @import "forum/TagCloud";
 @import "forum/TagHero";
+@import "forum/TagPost";
 @import "forum/TagTiles";
 @import "forum/ToggleButton";
 

--- a/extensions/tags/less/forum/TagPost.less
+++ b/extensions/tags/less/forum/TagPost.less
@@ -1,3 +1,6 @@
 .EventPost.DiscussionTaggedPost.Post.Post--loading {
     height: 62px;
 }
+.DiscussionTaggedPost .LoadingIndicator-container--block {
+    height: auto;
+}

--- a/extensions/tags/less/forum/TagPost.less
+++ b/extensions/tags/less/forum/TagPost.less
@@ -1,0 +1,3 @@
+.EventPost.DiscussionTaggedPost.Post.Post--loading {
+    height: 62px;
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

As title. If a tag was deleted from a discussion, it will no longer be included in its relationship, causing the DiscussionTaggedPost shows [deleted].
I modernized the component, added loading indicator, and now it will fetch tags list if any uncached tag is mentioned in mutation.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Maybe adding deleted tags in discussions' relationship is a better solution? Though I don't think it's necessary.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
