### PR TITLE
[2.x] feat(package-manager): replace flarum.org API with Packagist search

### DIFF
--- a/extensions/package-manager/js/dist-typings/components/DiscoverSection.d.ts
+++ b/extensions/package-manager/js/dist-typings/components/DiscoverSection.d.ts
@@ -10,15 +10,18 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
     oninit(vnode: Mithril.Vnode<CustomAttrs, this>): void;
     load(page?: number): void;
     view(): JSX.Element;
+    /**
+     * Maps tab keys to the type filter value forwarded to the Packagist search API.
+     * The empty-string key ("") means no type filter (show all flarum-extension packages).
+     */
     tabFilters(): Record<string, {
         label: Mithril.Children;
-        active: () => boolean;
+        packagistType: string | null;
     }>;
     tabItems(): ItemList<unknown>;
     warningItems(): ItemList<Mithril.Children>;
     private applySearch;
     toolbarPrimaryItems(): ItemList<unknown>;
-    toolbarSecondaryItems(): ItemList<unknown>;
     extensionList(): JSX.Element;
     footerItems(): ItemList<Mithril.Children>;
     private setWarningDismissed;

--- a/extensions/package-manager/js/dist-typings/models/ExternalExtension.d.ts
+++ b/extensions/package-manager/js/dist-typings/models/ExternalExtension.d.ts
@@ -12,15 +12,10 @@ export default class ExternalExtension extends Model {
     };
     highestVersion: () => string;
     httpUri: () => string;
-    discussUri: () => string;
     vendor: () => string;
-    isPremium: () => boolean;
     isLocale: () => boolean;
-    locale: () => string;
-    latestFlarumVersionSupported: () => string;
     downloads: () => number;
-    isSupported: () => boolean;
+    abandoned: () => boolean;
     readonly installed = false;
-    isProductionReady(): boolean;
     toLocalExtension(): Extension;
 }

--- a/extensions/package-manager/js/src/admin/components/DiscoverSection.tsx
+++ b/extensions/package-manager/js/src/admin/components/DiscoverSection.tsx
@@ -9,15 +9,13 @@ import Input from 'flarum/common/components/Input';
 import Stream from 'flarum/common/utils/Stream';
 import Alert from 'flarum/common/components/Alert';
 import listItems from 'flarum/common/helpers/listItems';
-import LinkButton from 'flarum/common/components/LinkButton';
-import Dropdown from 'flarum/common/components/Dropdown';
-
-import type ExternalExtension from '../models/ExternalExtension';
-import ExtensionCard from './ExtensionCard';
 import Pagination from 'flarum/common/components/Pagination';
 import InfoTile from 'flarum/common/components/InfoTile';
 import classList from 'flarum/common/utils/classList';
 import { throttle } from 'flarum/common/utils/throttleDebounce';
+
+import type ExternalExtension from '../models/ExternalExtension';
+import ExtensionCard from './ExtensionCard';
 
 export interface IDiscoverSectionAttrs extends ComponentAttrs {}
 
@@ -68,7 +66,6 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
                 <hr className="Tabs-divider" />
                 <div className="ExtensionManager-DiscoverSection-toolbar">
                   <div className="ExtensionManager-DiscoverSection-toolbar-primary">{this.toolbarPrimaryItems().toArray()}</div>
-                  <div className="ExtensionManager-DiscoverSection-toolbar-secondary">{this.toolbarSecondaryItems().toArray()}</div>
                 </div>
                 {this.extensionList()}
                 <div className="ExtensionManager-DiscoverSection-footer">{this.footerItems().toArray()}</div>
@@ -80,23 +77,27 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
     );
   }
 
-  tabFilters(): Record<string, { label: Mithril.Children; active: () => boolean }> {
+  /**
+   * Maps tab keys to the type filter value forwarded to the Packagist search API.
+   * The empty-string key ("") means no type filter (show all flarum-extension packages).
+   */
+  tabFilters(): Record<string, { label: Mithril.Children; packagistType: string | null }> {
     return {
       '': {
         label: app.translator.trans('flarum-extension-manager.admin.sections.discover.tabs.discover'),
-        active: () => !app.extensionManager.extensions.getParams().filter?.type,
+        packagistType: null,
       },
       extension: {
         label: app.translator.trans('flarum-extension-manager.admin.sections.discover.tabs.extensions'),
-        active: () => app.extensionManager.extensions.getParams().filter?.type === 'extension',
+        packagistType: 'extension',
       },
       locale: {
         label: app.translator.trans('flarum-extension-manager.admin.sections.discover.tabs.languages'),
-        active: () => app.extensionManager.extensions.getParams().filter?.type === 'locale',
+        packagistType: 'locale',
       },
       theme: {
         label: app.translator.trans('flarum-extension-manager.admin.sections.discover.tabs.themes'),
-        active: () => app.extensionManager.extensions.getParams().filter?.type === 'theme',
+        packagistType: 'theme',
       },
     };
   }
@@ -108,14 +109,16 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
 
     Object.keys(tabs).forEach((key) => {
       const tab = tabs[key];
+      const currentType = app.extensionManager.extensions.getParams().filter?.type ?? null;
+      const isActive = tab.packagistType === null ? !currentType : currentType === tab.packagistType;
 
       items.add(
         key,
         <Button
           className="Button Button--link"
-          active={tab.active()}
+          active={isActive}
           onclick={() => {
-            app.extensionManager.extensions.changeFilter('type', key);
+            app.extensionManager.extensions.changeFilter('type', tab.packagistType ?? undefined);
           }}
         >
           {tab.label}
@@ -160,64 +163,6 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
         placeholder={app.translator.trans('flarum-extension-manager.admin.sections.discover.search')}
         prefixIcon="fas fa-search"
       />
-    );
-
-    return items;
-  }
-
-  toolbarSecondaryItems() {
-    const items = new ItemList();
-
-    const sortMap = app.extensionManager.extensions.sortMap();
-
-    const sortOptions = Object.keys(sortMap).reduce((acc: any, sortId) => {
-      const sort = sortMap[sortId];
-      acc[sortId] = typeof sort !== 'string' ? sort.label : sort;
-      return acc;
-    }, {});
-
-    items.add(
-      'sort',
-      <Dropdown
-        buttonClassName="Button"
-        label={sortOptions[app.extensionManager.extensions.getParams().sort] || Object.keys(sortMap).map((key) => sortOptions[key])[0]}
-        accessibleToggleLabel={app.translator.trans('flarum-extension-manager.admin.sections.discover.sort.toggle_dropdown_accessible_label')}
-      >
-        {Object.keys(sortOptions).map((value) => {
-          const label = sortOptions[value];
-          const active = app.extensionManager.extensions.getParams().sort === value;
-
-          return (
-            <Button icon={active ? 'fas fa-check' : true} onclick={() => app.extensionManager.extensions.changeSort(value)} active={active}>
-              {label}
-            </Button>
-          );
-        })}
-      </Dropdown>
-    );
-
-    const is = app.extensionManager.extensions.getParams().filter?.is?.[0] ?? null;
-    const activeType = is || 'all';
-
-    items.add(
-      'party',
-      <Dropdown
-        buttonClassName="Button"
-        label={app.translator.trans('flarum-extension-manager.admin.sections.discover.party_filter.' + activeType)}
-        accessibleToggleLabel={app.translator.trans('flarum-extension-manager.admin.sections.discover.party_filter.toggle_dropdown_accessible_label')}
-      >
-        {['all', 'premium'].map((party) => (
-          <Button
-            icon={activeType === party ? 'fas fa-check' : true}
-            onclick={() => {
-              app.extensionManager.extensions.changeFilter('is', party === 'all' ? undefined : [party]);
-            }}
-            active={activeType === party}
-          >
-            {app.translator.trans('flarum-extension-manager.admin.sections.discover.party_filter.' + party)}
-          </Button>
-        ))}
-      </Dropdown>
     );
 
     return items;
@@ -273,19 +218,6 @@ export default class DiscoverSection<CustomAttrs extends IDiscoverSectionAttrs =
           this.load(page);
         }}
       />
-    );
-
-    items.add(
-      'premiumTermsLink',
-      <LinkButton
-        className="Button Button--link"
-        href="https://flarum.org/terms/premium-extensions"
-        external={true}
-        target="_blank"
-        icon="fas fa-circle-info"
-      >
-        {app.translator.trans('flarum-extension-manager.admin.sections.discover.premium_extension_terms')}
-      </LinkButton>
     );
 
     return items;

--- a/extensions/package-manager/js/src/admin/components/ExtensionCard.tsx
+++ b/extensions/package-manager/js/src/admin/components/ExtensionCard.tsx
@@ -97,46 +97,14 @@ export default class ExtensionCard<CustomAttrs extends IExtensionAttrs = IExtens
 
     const extension = this.attrs.extension as ExternalExtension;
 
-    if (extension.isSupported()) {
+    if (extension.abandoned()) {
       items.add(
-        'compatible',
+        'abandoned',
         <Badge
-          icon="fas fa-check"
-          type="success"
-          label={app.translator.trans('flarum-extension-manager.admin.sections.discover.extension.badges.compatible')}
-          className="Badge--flat Badge--square"
-        />
-      );
-    } else {
-      items.add(
-        'incompatible',
-        <Badge
-          icon="fas fa-times"
+          icon="fas fa-triangle-exclamation"
           type="danger"
-          label={app.translator.trans('flarum-extension-manager.admin.sections.discover.extension.badges.incompatible')}
+          label={app.translator.trans('flarum-extension-manager.admin.sections.discover.extension.badges.abandoned')}
           className="Badge--flat Badge--square"
-        />
-      );
-    }
-
-    if (extension.isPremium()) {
-      items.add(
-        'premium',
-        <Badge
-          icon="fas fa-dollar-sign"
-          label={app.translator.trans('flarum-extension-manager.admin.sections.discover.extension.badges.premium')}
-          className="ExtensionCard-badge--premium Badge--flat Badge--square"
-        />
-      );
-    }
-
-    if (!extension.isProductionReady()) {
-      items.add(
-        'unstable',
-        <Badge
-          icon="fas fa-flask"
-          label={app.translator.trans('flarum-extension-manager.admin.sections.discover.extension.badges.unstable')}
-          className="Badge--flat Badge--square Badge--danger"
         />
       );
     }
@@ -201,8 +169,6 @@ export default class ExtensionCard<CustomAttrs extends IExtensionAttrs = IExtens
     }
 
     if (this.attrs.extension instanceof ExternalExtension) {
-      items.add('version', <div className="ExtensionCard-version">v{this.version(this.attrs.extension.highestVersion())}</div>);
-
       items.add(
         'link',
         <LinkButton

--- a/extensions/package-manager/js/src/admin/components/Installer.tsx
+++ b/extensions/package-manager/js/src/admin/components/Installer.tsx
@@ -23,7 +23,7 @@ export default class Installer extends Component<InstallerAttrs> {
         <label htmlFor="install-extension">{app.translator.trans('flarum-extension-manager.admin.extensions.install')}</label>
         <div className="helpText">
           {app.translator.trans('flarum-extension-manager.admin.extensions.install_help', {
-            link: <a href="https://flarum.org/extensions">flarum.org</a>,
+            link: <a href="https://packagist.org/?type=flarum-extension">packagist.org</a>,
             semantic_link: <a href="https://devhints.io/semver" />,
             code: <code />,
           })}

--- a/extensions/package-manager/js/src/admin/models/ExternalExtension.ts
+++ b/extensions/package-manager/js/src/admin/models/ExternalExtension.ts
@@ -1,7 +1,5 @@
 import Model from 'flarum/common/Model';
-import app from 'flarum/admin/app';
 import type { Extension } from 'flarum/admin/AdminApplication';
-import { isProductionReady } from '../utils/versions';
 
 export default class ExternalExtension extends Model {
   extensionId = Model.attribute<string>('extensionId');
@@ -15,25 +13,17 @@ export default class ExternalExtension extends Model {
   }>('icon');
   highestVersion = Model.attribute<string>('highestVersion');
   httpUri = Model.attribute<string>('httpUri');
-  discussUri = Model.attribute<string>('discussUri');
   vendor = Model.attribute<string>('vendor');
-  isPremium = Model.attribute<boolean>('isPremium');
   isLocale = Model.attribute<boolean>('isLocale');
-  locale = Model.attribute<string>('locale');
-  latestFlarumVersionSupported = Model.attribute<string>('latestFlarumVersionSupported');
   downloads = Model.attribute<number>('downloads');
-  isSupported = Model.attribute<boolean>('isSupported');
+  abandoned = Model.attribute<boolean>('abandoned');
   readonly installed = false;
-
-  public isProductionReady(): boolean {
-    return isProductionReady(this.highestVersion());
-  }
 
   public toLocalExtension(): Extension {
     return {
       id: this.extensionId(),
       name: this.name(),
-      version: this.highestVersion(),
+      version: this.highestVersion() ?? '?',
       description: this.description(),
       icon: this.icon() || {
         name: 'fas fa-box-open',
@@ -41,7 +31,6 @@ export default class ExternalExtension extends Model {
         color: '#fff',
       },
       links: {
-        discuss: this.discussUri(),
         website: this.httpUri(),
       },
       extra: {

--- a/extensions/package-manager/js/src/admin/states/ExtensionListState.ts
+++ b/extensions/package-manager/js/src/admin/states/ExtensionListState.ts
@@ -19,10 +19,6 @@ export default class ExtensionListState extends PaginatedListState<ExternalExten
 
   sortMap(): SortMap {
     return {
-      '-createdAt': {
-        sort: '-createdAt',
-        label: app.translator.trans('flarum-extension-manager.admin.sections.discover.sort.latest', {}, true),
-      },
       '-downloads': {
         sort: '-downloads',
         label: app.translator.trans('flarum-extension-manager.admin.sections.discover.sort.top', {}, true),

--- a/extensions/package-manager/less/admin/ExtensionCard.less
+++ b/extensions/package-manager/less/admin/ExtensionCard.less
@@ -25,11 +25,6 @@
   gap: 4px;
 }
 
-.ExtensionCard-badge--premium {
-  --badge-bg: #FBDB33;
-  --badge-color: #4B4940;
-}
-
 .ExtensionCard--core .ExtensionIcon, .ExtensionCard-badge--flarum::before {
   filter: grayscale(1) brightness(3.5);
 }

--- a/extensions/package-manager/locale/en.yml
+++ b/extensions/package-manager/locale/en.yml
@@ -70,7 +70,7 @@ flarum-extension-manager:
       install: Install a new extension
       install_help: >
         Fill in the extension package name to proceed. You can specify a <semantic_link>semantic version</semantic_link> using the format <code>vendor/package-name:version</code>.
-        Visit {link} to browse extensions.
+        Visit {link} to browse available packages.
       proceed: Proceed
       remove: Uninstall
       successful_install: "{extension} was installed successfully, redirecting.."
@@ -109,30 +109,20 @@ flarum-extension-manager:
         empty_results: Looks like there are no extensions available.
         extension:
           badges:
-            compatible: Compatible
+            abandoned: Abandoned
             fof: Friends Of Flarum
             flarum: Flarum
-            incompatible: Incompatible
-            premium: Premium
-            unstable: Unstable
           downloads: "{count, plural, one {{formattedCount} download} other {{formattedCount} downloads}}"
-        premium_extension_terms: Premium extension terms
         search: Search...
         server_error: Service currently unavailable, please try again later.
         sort:
-          toggle_dropdown_accessible_label: Toggle sort options
           top: Most Downloads
-          latest: Latest
         tabs:
           discover: Discover
           extensions: Extensions
           languages: Languages
           themes: Themes
         title: Extensions
-        party_filter:
-          all: All
-          premium: Premium
-          toggle_dropdown_accessible_label: Toggle party filter
       queue:
         columns:
           details: Details

--- a/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
+++ b/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
@@ -31,7 +31,7 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
 {
     /**
      * Packagist search API.
-     * Docs: https://packagist.org/apidoc#search-packages-by-type
+     * Docs: https://packagist.org/apidoc#search-packages-by-type.
      */
     protected const PACKAGIST_SEARCH_URL = 'https://packagist.org/search.json';
 
@@ -43,7 +43,7 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
     protected const TYPE_FILTER_MAP = [
         // 'extension' tab: keep default type, no extra param needed
         'locale' => ['param' => 'q',    'value' => 'flarum-lang'],
-        'theme'  => ['param' => 'q',    'value' => 'flarum theme'],
+        'theme' => ['param' => 'q',    'value' => 'flarum theme'],
     ];
 
     protected ?int $totalResults = null;
@@ -159,17 +159,17 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
                 $nameParts = explode('/', $data['name'], 2);
 
                 return new Extension([
-                    'id'          => $data['name'],
-                    'name'        => $data['name'],
-                    'title'       => $data['name'],
+                    'id' => $data['name'],
+                    'name' => $data['name'],
+                    'title' => $data['name'],
                     'description' => $data['description'] ?? null,
-                    'vendor'      => $nameParts[0] ?? null,
-                    'http_uri'    => $data['url'] ?? null,
-                    'icon_url'    => null,
-                    'icon'        => null,
-                    'downloads'   => (int) ($data['downloads'] ?? 0),
-                    'abandoned'   => ! empty($data['abandoned']),
-                    'is_locale'   => false,
+                    'vendor' => $nameParts[0] ?? null,
+                    'http_uri' => $data['url'] ?? null,
+                    'icon_url' => null,
+                    'icon' => null,
+                    'downloads' => (int) ($data['downloads'] ?? 0),
+                    'abandoned' => ! empty($data['abandoned']),
+                    'is_locale' => false,
                     'highest_version' => null,
                 ]);
             });

--- a/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
+++ b/extensions/package-manager/src/Api/Resource/ExternalExtensionResource.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\ExtensionManager\Api\Resource;
 
-use Composer\Semver\Semver;
 use Flarum\Api\Endpoint;
 use Flarum\Api\Resource\AbstractResource;
 use Flarum\Api\Resource\Contracts\Countable;
@@ -20,18 +19,33 @@ use Flarum\ExtensionManager\Api\Schema\SortColumn;
 use Flarum\ExtensionManager\Exception\CannotFetchExternalExtension;
 use Flarum\ExtensionManager\External\Extension;
 use Flarum\ExtensionManager\External\RequestWrapper;
-use Flarum\Foundation\Application;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
 use Tobyz\JsonApiServer\Schema\CustomFilter;
 
 class ExternalExtensionResource extends AbstractResource implements Listable, Paginatable, Countable
 {
+    /**
+     * Packagist search API.
+     * Docs: https://packagist.org/apidoc#search-packages-by-type
+     */
+    protected const PACKAGIST_SEARCH_URL = 'https://packagist.org/search.json';
+
+    /**
+     * All Flarum packages use the 'flarum-extension' Packagist type.
+     * Language packs and themes cannot be filtered by type; instead we narrow via a search query.
+     * Maps frontend filter[type] value → ['param' => 'type'|'q', 'value' => string].
+     */
+    protected const TYPE_FILTER_MAP = [
+        // 'extension' tab: keep default type, no extra param needed
+        'locale' => ['param' => 'q',    'value' => 'flarum-lang'],
+        'theme'  => ['param' => 'q',    'value' => 'flarum theme'],
+    ];
+
     protected ?int $totalResults = null;
 
     public function __construct(
@@ -69,31 +83,17 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
                 ->property('highest_version'),
             Schema\Str::make('httpUri')
                 ->property('http_uri'),
-            Schema\Str::make('discussUri')
-                ->property('discuss_uri'),
             Schema\Str::make('vendor'),
-            Schema\Boolean::make('isPremium')
-                ->property('is_premium'),
             Schema\Boolean::make('isLocale')
                 ->property('is_locale'),
-            Schema\Str::make('locale'),
-            Schema\Str::make('latestFlarumVersionSupported')
-                ->property('latest_flarum_version_supported'),
-            Schema\Boolean::make('compatibleWithLatestFlarum')
-                ->property('compatible_with_latest_flarum'),
             Schema\Integer::make('downloads'),
-
-            Schema\Boolean::make('isSupported')
-                ->get(function (Extension $extension) {
-                    return Semver::satisfies(Application::VERSION, $extension->latest_flarum_version_supported);
-                }),
+            Schema\Boolean::make('abandoned'),
         ];
     }
 
     public function sorts(): array
     {
         return [
-            SortColumn::make('createdAt'),
             SortColumn::make('downloads'),
         ];
     }
@@ -102,35 +102,20 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
     {
         return [
             CustomFilter::make('type', function (object $query, ?string $value) {
-                if ($value) {
-                    /** @var RequestWrapper $query */
-                    $query->withQueryParams([
-                        'filter' => [
-                            'type' => $value,
-                        ],
-                    ]);
+                /** @var RequestWrapper $query */
+                if (! $value || ! isset(static::TYPE_FILTER_MAP[$value])) {
+                    // 'extension' tab or unknown: keep default type=flarum-extension from query().
+                    return;
                 }
-            }),
 
-            CustomFilter::make('is', function (object $query, null|string|array $value) {
-                if ($value) {
-                    /** @var RequestWrapper $query */
-                    $query->withQueryParams([
-                        'filter' => [
-                            'is' => (array) $value,
-                        ],
-                    ]);
-                }
+                $filter = static::TYPE_FILTER_MAP[$value];
+                $query->setQueryParam($filter['param'], $filter['value']);
             }),
 
             CustomFilter::make('q', function (object $query, ?string $value) {
                 if ($value) {
                     /** @var RequestWrapper $query */
-                    $query->withQueryParams([
-                        'filter' => [
-                            'q' => $value,
-                        ],
-                    ]);
+                    $query->setQueryParam('q', $value);
                 }
             }),
         ];
@@ -138,24 +123,16 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
 
     public function query(Context $context): object
     {
-        return (new RequestWrapper($this->cache, 'https://flarum.org/api/extensions', 'GET', [
+        return (new RequestWrapper($this->cache, static::PACKAGIST_SEARCH_URL, 'GET', [
             'Accept' => 'application/json',
-        ]))->withQueryParams([
-            'filter' => [
-                'compatible-with' => Application::VERSION,
-            ],
-        ]);
+        ]))->setQueryParam('type', 'flarum-extension');
     }
 
     public function paginate(object $query, OffsetPagination $pagination): void
     {
         /** @var RequestWrapper $query */
-        $query->withQueryParams([
-            'page' => [
-                'offset' => $pagination->offset,
-                'limit' => $pagination->limit,
-            ],
-        ]);
+        $query->setQueryParam('page', (int) floor($pagination->offset / $pagination->limit) + 1);
+        $query->setQueryParam('per_page', $pagination->limit);
     }
 
     public function results(object $query, Context $context): iterable
@@ -175,20 +152,26 @@ class ExternalExtensionResource extends AbstractResource implements Listable, Pa
             return json_decode($response->getBody()->getContents(), true);
         });
 
-        $this->totalResults = $json['meta']['page']['total'] ?? null;
+        $this->totalResults = $json['total'] ?? null;
 
-        return (new Collection($json['data']))
+        return (new Collection($json['results'] ?? []))
             ->map(function (array $data) {
-                $attributes = $data['attributes'];
+                $nameParts = explode('/', $data['name'], 2);
 
-                $attributes = array_combine(
-                    array_map(fn ($key) => Str::snake(Str::camel($key)), array_keys($attributes)),
-                    array_values($attributes)
-                );
-
-                return new Extension(array_merge([
-                    'id' => $data['id'],
-                ], $attributes));
+                return new Extension([
+                    'id'          => $data['name'],
+                    'name'        => $data['name'],
+                    'title'       => $data['name'],
+                    'description' => $data['description'] ?? null,
+                    'vendor'      => $nameParts[0] ?? null,
+                    'http_uri'    => $data['url'] ?? null,
+                    'icon_url'    => null,
+                    'icon'        => null,
+                    'downloads'   => (int) ($data['downloads'] ?? 0),
+                    'abandoned'   => ! empty($data['abandoned']),
+                    'is_locale'   => false,
+                    'highest_version' => null,
+                ]);
             });
     }
 

--- a/extensions/package-manager/src/External/Extension.php
+++ b/extensions/package-manager/src/External/Extension.php
@@ -14,19 +14,13 @@ namespace Flarum\ExtensionManager\External;
  * @property string $title
  * @property string $description
  * @property string $icon_url
- * @property array $icon
- * @property string $license
+ * @property array  $icon
  * @property string $highest_version
  * @property string $http_uri
- * @property string $discuss_uri
  * @property string $vendor
- * @property bool $is_premium
- * @property bool $is_locale
- * @property string $locale
- * @property string $latest_flarum_version_supported
- * @property bool $compatible_with_latest_flarum
- * @property bool $listed_privately
- * @property int $downloads
+ * @property bool   $is_locale
+ * @property bool   $abandoned
+ * @property int    $downloads
  */
 class Extension
 {
@@ -40,10 +34,8 @@ class Extension
     protected function casts(): array
     {
         return [
-            'is_premium' => 'bool',
             'is_locale' => 'bool',
-            'compatible_with_latest_flarum' => 'bool',
-            'listed_privately' => 'bool',
+            'abandoned' => 'bool',
             'downloads' => 'int',
         ];
     }

--- a/extensions/package-manager/src/External/RequestWrapper.php
+++ b/extensions/package-manager/src/External/RequestWrapper.php
@@ -43,6 +43,19 @@ class RequestWrapper
         return $this;
     }
 
+    /**
+     * Set (overwrite) a single top-level query parameter by key.
+     */
+    public function setQueryParam(string $key, mixed $value): static
+    {
+        $this->queryParams[$key] = $value;
+
+        $newUri = $this->request->getUri()->withQuery(http_build_query($this->queryParams));
+        $this->request = $this->request->withUri($newUri);
+
+        return $this;
+    }
+
     public function __call(string $name, array $arguments): static
     {
         $new = $this->request->$name(...$arguments);
@@ -63,8 +76,8 @@ class RequestWrapper
 
     public function cache(Closure $callback): array
     {
-        // We will not cache if there is a search query (filter[q]) in the request.
-        if (isset($this->queryParams['filter']['q'])) {
+        // We will not cache if there is a search query in the request.
+        if (isset($this->queryParams['filter']['q']) || isset($this->queryParams['q'])) {
             return $callback($this);
         }
 


### PR DESCRIPTION
## Summary

The flarum.org extension API is being shut down. This PR replaces the Discover tab's data source with the public [Packagist search API](https://packagist.org/apidoc#search-packages-by-type), keeping the feature operational with no new infrastructure required.

- `ExternalExtensionResource` now queries `packagist.org/search.json` instead of `flarum.org/api/extensions`
- Language tab uses `q=flarum-lang`, theme tab uses `q=flarum+theme` (Packagist has no dedicated type for these)
- `RequestWrapper` gains `setQueryParam()` to safely overwrite scalar query params without `array_merge_recursive` collisions
- Premium filter, sort-by-newest, compatible/incompatible/unstable badges removed (data not available from Packagist)
- Abandoned badge added (Packagist provides an `abandoned` flag)
- Dead links (`flarum.org/terms/premium-extensions`, `flarum.org/extensions`) replaced with `packagist.org` equivalents

### What was lost

| Feature | Status |
|---|---|
| Compatible / Incompatible badge per card | Lost — no version data from Packagist search |
| Unstable badge (alpha/beta/rc) | Lost — no version data from Packagist search |
| Premium badge and filter | Lost — Packagist has no premium concept |
| Discuss link per card | Lost — not in Packagist data |
| Extension icon/colors | Lost — falls back to generic icon |
| Human-readable extension title | Lost — uses `vendor/package-name` |
| Sort by newest | Lost — Packagist only supports downloads sort |
| Accurate language/theme tab filtering | Degraded — uses keyword search |

This is intended as a stop-gap. The architecture remains easy to swap out once a new Flarum-owned extension directory API is available.

## Test plan

- [ ] Discover tab loads and paginates (Extensions tab)
- [ ] Languages tab returns language packs
- [ ] Themes tab returns theme results
- [ ] Search box filters results
- [ ] Abandoned extensions show the abandoned badge
- [ ] FoF and Flarum vendor badges display correctly
- [ ] Install button works for uninstalled extensions; shows checkmark for installed ones
- [ ] Packagist link in Installer help text is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)