### PR TITLE
[1.x] chore(package-manager): remove Extiverse references

### DIFF
--- a/extensions/package-manager/js/src/admin/components/Installer.tsx
+++ b/extensions/package-manager/js/src/admin/components/Installer.tsx
@@ -23,7 +23,7 @@ export default class Installer extends Component<InstallerAttrs> {
         <label htmlFor="install-extension">{app.translator.trans('flarum-extension-manager.admin.extensions.install')}</label>
         <p className="helpText">
           {app.translator.trans('flarum-extension-manager.admin.extensions.install_help', {
-            extiverse: <a href="https://extiverse.com">extiverse.com</a>,
+            link: <a href="https://packagist.org/?type=flarum-extension">packagist.org</a>,
             semantic_link: <a href="https://devhints.io/semver" />,
             code: <code />,
           })}

--- a/extensions/package-manager/locale/en.yml
+++ b/extensions/package-manager/locale/en.yml
@@ -4,7 +4,7 @@ flarum-extension-manager:
       add_label: New authentication method
       add_modal:
         host_label: Host
-        host_placeholder: "example: extiverse.com"
+        host_placeholder: "example: packages.example.com"
         submit_button: Submit
         token_label: Token
         type_label: Type
@@ -70,7 +70,7 @@ flarum-extension-manager:
       install: Install a new extension
       install_help: >
         Fill in the extension package name to proceed. You can specify a <semantic_link>semantic version</semantic_link> using the format <code>vendor/package-name:version</code>.
-        Visit {extiverse} to browse extensions.
+        Visit {link} to browse extensions.
       proceed: Proceed
       remove: Uninstall
       successful_install: "{extension} was installed successfully, redirecting.."


### PR DESCRIPTION
## Summary

- Replaces the Extiverse browse-extensions link in `Installer.tsx` with `packagist.org/?type=flarum-extension`
- Updates the auth config host placeholder from `extiverse.com` to `packages.example.com`
- Updates the `install_help` locale string interpolation key from `{extiverse}` to `{link}`

Extiverse became flarum.org (a commercial entity on our domain) which is now being terminated.

## Test plan

- [ ] Verify the install help text renders with a working packagist.org link
- [ ] Verify the auth method modal host field shows the new placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)