### PR TITLE
[2.x] feat(gdpr): PII field declarations and anonymized context support

### DIFF
--- a/extensions/gdpr/README.md
+++ b/extensions/gdpr/README.md
@@ -27,7 +27,7 @@ From here, users may self-service export their data from the forum, or start an 
 If your forum runs multiple queues, ie `low` and `high`, you may specify which queue jobs for this extension are run on in your skeleton's `extend.php` file:
 
 ```php
-Blomstra\Gdpr\Jobs\GdprJob::$onQueue = 'low';
+Flarum\Gdpr\Jobs\GdprJob::$onQueue = 'low';
 
 return [
     ... your current extenders,
@@ -40,12 +40,12 @@ You can easily register a new Data type, remove an existing Data type, or exclud
 
 #### Registering a new Data Type:
 
-Your data type class should implement the `Blomstra\Gdpr\Contracts\DataType`:
+Your data type class should implement the `Flarum\Gdpr\Contracts\DataType`:
 ```php
 <?php
 
-use Blomstra\Gdpr\Extend\UserData;
-use Blomstra\Extend;
+use Flarum\Gdpr\Extend\UserData;
+use Flarum\Extend;
 
 return [
     (new Extend\Conditional())
@@ -65,8 +65,8 @@ name the file and always prefix it with your extension slug (flarum-something-fi
 #### Removing a Data Type:
 If for any reason you want to exclude a certain DataType from the export:
 ```php
-use Blomstra\Gdpr\Extend\UserData;
-use Blomstra\Extend;
+use Flarum\Gdpr\Extend\UserData;
+use Flarum\Extend;
 
 return [
     (new Extend\Conditional())
@@ -79,21 +79,96 @@ return [
 ];
 ```
 
-#### Exclude specific columns from the user table during export:
+#### Redacting specific user table columns from exports:
+
+By default, the `User` data type exports all columns from the `users` table except `id`, `password`, `groups`, and `anonymized`. If your extension adds a column to the `users` table that should not appear in the export (e.g. a sensitive internal token), you can register it via `removeUserColumns()`.
+
+The column's value will be **set to `null` on the in-memory user object** before the export ZIP is generated — the column still appears in `user.json` but with a `null` value. This is visible in the admin GDPR overview under "User Table Data".
+
 ```php
-use Blomstra\Gdpr\Extend\UserData;
+use Flarum\Gdpr\Extend\UserData;
 
 return [
     (new Extend\Conditional())
         ->whenExtensionEnabled('flarum-gdpr', fn () => [
             (new UserData())
-                ->removeUserColumn('column_name') // For a single column
-                ->removeUserColumns(['column1', 'column2']), // For multiple columns
+                ->removeUserColumns(['column1', 'column2']),
 
             ... other conditional extenders as required ...
         ]),
 ];
 ```
+
+#### PII fields and anonymized contexts
+
+##### What is an "anonymized context"?
+
+Some extensions need to share Flarum data with external systems — for example, publishing events to a message broker, syncing to a search index, or sending webhooks. In these scenarios there are typically two audiences:
+
+- **Full-data consumers** — internal systems that are authorised to process PII (e.g. a private analytics pipeline).
+- **Anonymized consumers** — systems where PII must not appear (e.g. a public event stream, a third-party integration, or any consumer that doesn't need identifying information).
+
+An "anonymized context" is any such output where PII keys must be redacted before the data leaves the application. For example, [glowingblue/rabbit-dispatcher](https://github.com/glowingblue/rabbit-dispatcher) publishes Flarum events to RabbitMQ on two exchanges simultaneously: one with full payloads, and one with all PII keys replaced by `[redacted]`. The PII key list comes from `flarum/gdpr` so that every registered extension's sensitive fields are automatically covered.
+
+The GDPR admin page ("User Table Data" section) shows which fields are currently registered as PII, giving admins visibility into what will be redacted.
+
+##### Declaring PII fields on your data type
+
+If your extension stores personally identifiable information, declare which keys are PII by overriding `piiFields()` on your data type class. This is the preferred approach — the declaration lives alongside your `anonymize()` logic, and the keys are automatically included in the PII registry as soon as your type is registered.
+
+```php
+use Flarum\Gdpr\Data\Type;
+
+class MyData extends Type
+{
+    public static function piiFields(): array
+    {
+        return ['custom_field', 'another_pii_field'];
+    }
+
+    // ... export(), anonymize(), delete() ...
+}
+```
+
+##### Declaring PII fields without a data type
+
+If your extension stores PII in a field that doesn't belong to any registered data type (e.g. a column on a model you don't export via GDPR), register the keys via the `UserData` extender instead:
+
+```php
+use Flarum\Gdpr\Extend\UserData;
+
+return [
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-gdpr', fn () => [
+            (new UserData())
+                ->addPiiKeysForSerialization(['custom_field', 'another_pii_field']),
+        ]),
+];
+```
+
+##### Building an anonymized context (consuming the PII list)
+
+If you are building an extension that serializes Flarum data for an external system and want to support PII redaction, resolve the PII key list from `DataProcessor` at runtime. Always check whether `flarum-gdpr` is enabled first and provide your own fallback for when it is not:
+
+```php
+use Flarum\Extension\ExtensionManager;
+use Flarum\Gdpr\DataProcessor;
+
+$extensions = resolve(ExtensionManager::class);
+
+if ($extensions->isEnabled('flarum-gdpr')) {
+    $piiKeys = resolve(DataProcessor::class)->getPiiKeysForSerialization();
+} else {
+    // Fallback covering common fields — used when flarum/gdpr is not installed.
+    $piiKeys = ['email', 'username', 'ip_address', 'last_ip_address'];
+}
+
+// Recursively redact PII from your serialized payload before sending externally.
+$anonymizedPayload = redactKeys($payload, $piiKeys);
+```
+
+`getPiiKeysForSerialization()` aggregates fields declared by all registered data types (via `piiFields()`) plus any extras registered via `addPiiKeysForSerialization()`. This means every enabled extension that participates in the GDPR registry contributes its PII fields automatically — your consumer code doesn't need to know about them individually.
+
 ### Flarum extensions
 
 These are the known extensions which offer GDPR data integration with this extension. Don't see a required extension listed? Contact the author to request it

--- a/extensions/gdpr/js/src/admin/components/GdprPage.tsx
+++ b/extensions/gdpr/js/src/admin/components/GdprPage.tsx
@@ -7,6 +7,7 @@ import DataType from '../models/DataType';
 import Tooltip from 'flarum/common/components/Tooltip';
 import ExtensionLink from './ExtensionLink';
 import LinkButton from 'flarum/common/components/LinkButton';
+import Form from 'flarum/common/components/Form';
 import Icon from 'flarum/common/components/Icon';
 
 type ColumnMeta = { type: string; length: number | null; default: string | null; nullable: boolean };
@@ -63,51 +64,61 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
       return <LoadingIndicator />;
     }
 
-    const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.${key}`);
-
     return (
       <div className="GdprPage">
-        <h3>{t('settings.heading')}</h3>
-        <p className="helpText">{t('settings.help_text')}</p>
-        <LinkButton className="Button" href={app.route('extension', { id: 'flarum-gdpr' })}>
-          {t('settings.extension_settings_button')}
-        </LinkButton>
-        <hr />
-        <h3>{t('data_types.title')}</h3>
-        <p className="helpText">{t('data_types.help_text')}</p>
-
-        <div className="GdprGrid">
-          <div class="GdprGrid-row">
-            <div className="GdprGrid-header">{t('data_types.type')}</div>
-            <div className="GdprGrid-header">{t('data_types.export_description')}</div>
-            <div className="GdprGrid-header">{t('data_types.anonymize_description')}</div>
-            <div className="GdprGrid-header">{t('data_types.delete_description')}</div>
-            <div className="GdprGrid-header">{t('data_types.extension')}</div>
+        <Form>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.heading')}</label>
+            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.help_text')}</p>
+            <LinkButton className="Button" href={app.route('extension', { id: 'flarum-gdpr' })}>
+              {app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.extension_settings_button')}
+            </LinkButton>
           </div>
 
-          {this.gdprDataTypes.map((dataType) => (
-            <>
-              <div class="GdprGrid-row">
-                <div>
-                  <Tooltip text={dataType.id()}>
-                    <span className="helpText">{dataType.type()}</span>
-                  </Tooltip>
-                </div>
-                <div className="helpText">{dataType.exportDescription()}</div>
-                <div className="helpText">{dataType.anonymizeDescription()}</div>
-                <div className="helpText">{dataType.deleteDescription()}</div>
-                <div>
-                  <ExtensionLink extension={dataType.extension() ? app.data.extensions[dataType.extension() as string] : null} />
-                </div>
-              </div>
-            </>
-          ))}
-        </div>
-        <hr />
-        <h3>{t('user_table_data.title')}</h3>
-        <p className="helpText">{t('user_table_data.help_text')}</p>
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.title')}</label>
+            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.help_text')}</p>
+            {this.grid()}
+          </div>
 
-        {this.userColumnsData ? this.userColumnTable(this.userColumnsData) : <LoadingIndicator />}
+          <div className="Form-group">
+            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.title')}</label>
+            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.help_text')}</p>
+            {this.userColumnsData ? this.userColumnTable(this.userColumnsData) : <LoadingIndicator />}
+          </div>
+        </Form>
+      </div>
+    );
+  }
+
+  grid() {
+    return (
+      <div className="GdprGrid">
+        <div class="GdprGrid-row">
+          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.type')}</div>
+          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.export_description')}</div>
+          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.anonymize_description')}</div>
+          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.delete_description')}</div>
+          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.extension')}</div>
+        </div>
+
+        {this.gdprDataTypes.map((dataType) => (
+          <>
+            <div class="GdprGrid-row">
+              <div>
+                <Tooltip text={dataType.id()}>
+                  <span className="helpText">{dataType.type()}</span>
+                </Tooltip>
+              </div>
+              <div className="helpText">{dataType.exportDescription()}</div>
+              <div className="helpText">{dataType.anonymizeDescription()}</div>
+              <div className="helpText">{dataType.deleteDescription()}</div>
+              <div>
+                <ExtensionLink extension={dataType.extension() ? app.data.extensions[dataType.extension() as string] : null} />
+              </div>
+            </div>
+          </>
+        ))}
       </div>
     );
   }

--- a/extensions/gdpr/js/src/admin/components/GdprPage.tsx
+++ b/extensions/gdpr/js/src/admin/components/GdprPage.tsx
@@ -7,15 +7,25 @@ import DataType from '../models/DataType';
 import Tooltip from 'flarum/common/components/Tooltip';
 import ExtensionLink from './ExtensionLink';
 import LinkButton from 'flarum/common/components/LinkButton';
-import Form from 'flarum/common/components/Form';
+import Icon from 'flarum/common/components/Icon';
+
+type ColumnMeta = { type: string; length: number | null; default: string | null; nullable: boolean };
+type UserColumnsData = {
+  allColumns: Record<string, ColumnMeta>;
+  removableColumns: Record<string, string | null>;
+  piiKeys: string[];
+  piiKeyExtensions: Record<string, string | null>;
+};
 
 export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   gdprDataTypes: DataType[] = [];
+  userColumnsData: UserColumnsData | null = null;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
 
     this.loadGdprDataTypes();
+    this.loadUserColumnsData();
   }
 
   headerInfo(): AdminHeaderAttrs {
@@ -36,66 +46,125 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
     });
   }
 
+  loadUserColumnsData() {
+    app
+      .request<{ data: UserColumnsData }>({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/gdpr-datatypes/user-columns',
+      })
+      .then((response) => {
+        this.userColumnsData = response.data;
+        m.redraw();
+      });
+  }
+
   content(): Mithril.Children {
     if (this.loading) {
       return <LoadingIndicator />;
     }
 
+    const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.${key}`);
+
     return (
       <div className="GdprPage">
-        <Form>
-          <div className="Form-group">
-            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.heading')}</label>
-            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.help_text')}</p>
-            <LinkButton className="Button" href={app.route('extension', { id: 'flarum-gdpr' })}>
-              {app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.extension_settings_button')}
-            </LinkButton>
+        <h3>{t('settings.heading')}</h3>
+        <p className="helpText">{t('settings.help_text')}</p>
+        <LinkButton className="Button" href={app.route('extension', { id: 'flarum-gdpr' })}>
+          {t('settings.extension_settings_button')}
+        </LinkButton>
+        <hr />
+        <h3>{t('data_types.title')}</h3>
+        <p className="helpText">{t('data_types.help_text')}</p>
+
+        <div className="GdprGrid">
+          <div class="GdprGrid-row">
+            <div className="GdprGrid-header">{t('data_types.type')}</div>
+            <div className="GdprGrid-header">{t('data_types.export_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.anonymize_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.delete_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.extension')}</div>
           </div>
 
-          <div className="Form-group">
-            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.title')}</label>
-            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.help_text')}</p>
-            {this.grid()}
-          </div>
+          {this.gdprDataTypes.map((dataType) => (
+            <>
+              <div class="GdprGrid-row">
+                <div>
+                  <Tooltip text={dataType.id()}>
+                    <span className="helpText">{dataType.type()}</span>
+                  </Tooltip>
+                </div>
+                <div className="helpText">{dataType.exportDescription()}</div>
+                <div className="helpText">{dataType.anonymizeDescription()}</div>
+                <div className="helpText">{dataType.deleteDescription()}</div>
+                <div>
+                  <ExtensionLink extension={dataType.extension() ? app.data.extensions[dataType.extension() as string] : null} />
+                </div>
+              </div>
+            </>
+          ))}
+        </div>
+        <hr />
+        <h3>{t('user_table_data.title')}</h3>
+        <p className="helpText">{t('user_table_data.help_text')}</p>
 
-          <div className="Form-group">
-            <label>{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.title')}</label>
-            <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.help_text')}</p>
-            <div className="GdprUserColumnData">{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.not_yet_implemented')}</div>
-          </div>
-        </Form>
+        {this.userColumnsData ? this.userColumnTable(this.userColumnsData) : <LoadingIndicator />}
       </div>
     );
   }
 
-  grid() {
+  userColumnTable({ allColumns, removableColumns, piiKeys, piiKeyExtensions }: UserColumnsData): Mithril.Children {
+    const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.user_table_data.${key}`);
+
     return (
-      <div className="GdprGrid">
-        <div class="GdprGrid-row">
-          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.type')}</div>
-          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.export_description')}</div>
-          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.anonymize_description')}</div>
-          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.delete_description')}</div>
-          <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.extension')}</div>
+      <div className="GdprGrid GdprGrid--userColumns">
+        <div className="GdprGrid-row">
+          <div className="GdprGrid-header">{t('column')}</div>
+          <div className="GdprGrid-header">{t('type')}</div>
+          <div className="GdprGrid-header">{t('nullable')}</div>
+          <div className="GdprGrid-header">{t('pii')}</div>
+          <div className="GdprGrid-header">{t('redacted_on_export')}</div>
+          <div className="GdprGrid-header">{t('extension')}</div>
         </div>
 
-        {this.gdprDataTypes.map((dataType) => (
-          <>
-            <div class="GdprGrid-row">
+        {Object.entries(allColumns).map(([column, meta]) => {
+          const isPii = piiKeys.includes(column);
+          const redactedByExtension = column in removableColumns ? removableColumns[column] : undefined;
+          const isRedacted = redactedByExtension !== undefined;
+          const extensionId = redactedByExtension ?? (column in piiKeyExtensions ? piiKeyExtensions[column] : null);
+
+          return (
+            <div className="GdprGrid-row">
               <div>
-                <Tooltip text={dataType.id()}>
-                  <span className="helpText">{dataType.type()}</span>
-                </Tooltip>
+                <code>{column}</code>
               </div>
-              <div className="helpText">{dataType.exportDescription()}</div>
-              <div className="helpText">{dataType.anonymizeDescription()}</div>
-              <div className="helpText">{dataType.deleteDescription()}</div>
+              <div className="helpText">{meta.type}</div>
+              <div className="helpText">{meta.nullable ? t('yes') : t('no')}</div>
               <div>
-                <ExtensionLink extension={dataType.extension() ? app.data.extensions[dataType.extension() as string] : null} />
+                {isPii ? (
+                  <Tooltip text={t('pii_tooltip')}>
+                    <span className="GdprPiiBadge">
+                      <Icon name="fas fa-user-secret" /> {t('yes')}
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <span className="helpText">{t('no')}</span>
+                )}
+              </div>
+              <div>
+                {isRedacted ? (
+                  <Tooltip text={t('redacted_on_export_tooltip')}>
+                    <span>{t('yes')}</span>
+                  </Tooltip>
+                ) : (
+                  <span className="helpText">{t('no')}</span>
+                )}
+              </div>
+              <div>
+                <ExtensionLink extension={extensionId ? (app.data.extensions[extensionId] ?? null) : null} />
               </div>
             </div>
-          </>
-        ))}
+          );
+        })}
       </div>
     );
   }

--- a/extensions/gdpr/js/src/admin/extend.tsx
+++ b/extensions/gdpr/js/src/admin/extend.tsx
@@ -15,19 +15,15 @@ export default [
     .add('gdpr-datatypes', DataType),
 
   new Extend.Admin()
-    .setting(() => ({
-      setting: 'flarum-gdpr.gdpr_page_link',
-      type: 'custom',
-      component: () => (
-        <div className="Form-group">
-          <label>{app.translator.trans('flarum-gdpr.admin.settings.gdpr_page.title')}</label>
-          <p className="helpText">{app.translator.trans('flarum-gdpr.admin.settings.gdpr_page.help_text')}</p>
-          <LinkButton href={app.route('gdpr')} icon="fas fa-user-shield" className="Button">
-            {app.translator.trans('flarum-gdpr.admin.nav.gdpr_button')}
-          </LinkButton>
-        </div>
-      ),
-    }))
+    .customSetting(() => (
+      <div className="Form-group">
+        <label>{app.translator.trans('flarum-gdpr.admin.settings.gdpr_page.title')}</label>
+        <p className="helpText">{app.translator.trans('flarum-gdpr.admin.settings.gdpr_page.help_text')}</p>
+        <LinkButton href={app.route('gdpr')} icon="fas fa-user-shield" className="Button">
+          {app.translator.trans('flarum-gdpr.admin.nav.gdpr_button')}
+        </LinkButton>
+      </div>
+    ))
     .setting(() => ({
       setting: 'flarum-gdpr.allow-anonymization',
       label: app.translator.trans('flarum-gdpr.admin.settings.allow_anonymization'),
@@ -52,7 +48,7 @@ export default [
     }))
     .setting(() => ({
       setting: 'flarum-gdpr.default-anonymous-username',
-      type: 'string',
+      type: 'text',
       label: app.translator.trans('flarum-gdpr.admin.settings.default_anonymous_username'),
       help: app.translator.trans('flarum-gdpr.admin.settings.default_anonymous_username_help'),
     }))

--- a/extensions/gdpr/js/src/forum/components/ExportAvailableNotification.ts
+++ b/extensions/gdpr/js/src/forum/components/ExportAvailableNotification.ts
@@ -8,11 +8,15 @@ export default class ExportAvailableNotification extends Notification {
     return 'fas fa-file-export';
   }
 
-  href() {
+  exportUrl() {
     const exportModel = this.attrs.notification.subject() as Export;
-
-    // Building the full url scheme so that Mithril treats this as an external link, so the download will work correctly.
     return app.forum.attribute<string>('baseUrl') + `/gdpr/export/${exportModel.file()}`;
+  }
+
+  href() {
+    // Return a non-navigating href; the download is opened via window.open() in
+    // markAsRead() so the mark-as-read XHR is not aborted by a page navigation.
+    return '#';
   }
 
   content() {
@@ -24,5 +28,17 @@ export default class ExportAvailableNotification extends Notification {
 
   excerpt() {
     return null;
+  }
+
+  markAsRead() {
+    // Open the download in a new tab so the current page is not navigated away
+    // from, keeping the mark-as-read XHR alive.
+    window.open(this.exportUrl(), '_blank');
+
+    if (this.attrs.notification.isRead()) return;
+
+    app.session.user?.pushAttributes({ unreadNotificationCount: (app.session.user.unreadNotificationCount() ?? 1) - 1 });
+
+    this.attrs.notification.save({ isRead: true });
   }
 }

--- a/extensions/gdpr/resources/less/admin.less
+++ b/extensions/gdpr/resources/less/admin.less
@@ -38,14 +38,28 @@
         background-color: var(--control-bg);
         color: var(--control-color);
         border-bottom: 1px solid var(--muted-color);
-  
+
         > div {
           background-color: var(--control-bg);
         }
       }
     }
+
+    .GdprGrid--userColumns {
+      .GdprGrid-row {
+        grid-template-columns: 2fr 1fr 1fr 1fr 1fr 1fr;
+      }
+    }
+
+    .GdprPiiBadge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: @primary-color;
+      font-weight: 600;
+    }
   }
-  
+
 
 [data-theme^=light] {
   --body-bg-darken-3: darken(@body-bg-light, 3%);

--- a/extensions/gdpr/resources/locale/en.yml
+++ b/extensions/gdpr/resources/locale/en.yml
@@ -18,11 +18,20 @@ flarum-gdpr:
                 help_text: Looking for GDPR settings? They're found on the extension page.
                 extension_settings_button: GDPR Settings
             user_table_data:
-                not_yet_implemented: Not yet implemented
                 title: User Table Data
                 help_text: |
                     On the most part, any columns added to the <code>user</code> table will be handled automatically, both for exporting data and for erasure.
                     However, there are some special cases, which are listed below.
+                column: Column
+                type: Type
+                nullable: Nullable
+                pii: PII
+                redacted_on_export: Redacted on export
+                extension: Extension
+                yes: Yes
+                no: No
+                pii_tooltip: This column is considered personally identifiable information and will be redacted in anonymized contexts (e.g. anonymized event payloads).
+                redacted_on_export_tooltip: "This column's value is blanked (set to null) when generating a user data export. The column still appears in the export with a null value."
         nav:
             gdpr_button: GDPR Integrations
             gdpr_title: => flarum-gdpr.admin.gdpr_page.description
@@ -62,6 +71,7 @@ flarum-gdpr:
                 export_description: Exports all discussions the user has started. Data restricted to title and creation date.
             forum:
                 export_description: Exports the forum title, url, username, email and the current date.
+            default_user_action: "No action, handled by default user table data handling."
             no_action: No action taken.
             posts:
                 anonymize_description: Removes the IP address from all posts the user has made.

--- a/extensions/gdpr/src/Api/Resource/DataTypeResource.php
+++ b/extensions/gdpr/src/Api/Resource/DataTypeResource.php
@@ -46,12 +46,16 @@ class DataTypeResource extends Resource\AbstractResource implements Resource\Con
                 ->route('GET', '/user-columns')
                 ->admin()
                 ->action(function () {
-                    $removableColumns = $this->processor->removableUserColumns();
                     $allColumns = $this->processor->allUserColumns();
 
-                    return compact('removableColumns', 'allColumns');
+                    return [
+                        'removableColumns' => $this->processor->removableUserColumnsWithExtensions(),
+                        'allColumns'       => $allColumns,
+                        'piiKeys'          => $this->processor->getPiiKeysForSerialization(),
+                        'piiKeyExtensions' => $this->processor->getPiiKeysWithExtensions(),
+                    ];
                 })
-                ->response(function (array $data) {
+                ->response(function (OriginalContext $context, array $data) {
                     return new JsonResponse(compact('data'));
                 }),
         ];

--- a/extensions/gdpr/src/Api/Resource/DataTypeResource.php
+++ b/extensions/gdpr/src/Api/Resource/DataTypeResource.php
@@ -50,8 +50,8 @@ class DataTypeResource extends Resource\AbstractResource implements Resource\Con
 
                     return [
                         'removableColumns' => $this->processor->removableUserColumnsWithExtensions(),
-                        'allColumns'       => $allColumns,
-                        'piiKeys'          => $this->processor->getPiiKeysForSerialization(),
+                        'allColumns' => $allColumns,
+                        'piiKeys' => $this->processor->getPiiKeysForSerialization(),
                         'piiKeyExtensions' => $this->processor->getPiiKeysWithExtensions(),
                     ];
                 })

--- a/extensions/gdpr/src/Contracts/DataType.php
+++ b/extensions/gdpr/src/Contracts/DataType.php
@@ -58,4 +58,13 @@ interface DataType
      * @return void
      */
     public function delete(): void;
+
+    /**
+     * Keys within this data type that contain PII.
+     * Used to redact sensitive fields when serializing for non-PII contexts
+     * (e.g. anonymized event payloads to a message broker).
+     *
+     * @return string[]
+     */
+    public static function piiFields(): array;
 }

--- a/extensions/gdpr/src/Data/Posts.php
+++ b/extensions/gdpr/src/Data/Posts.php
@@ -14,6 +14,11 @@ use Illuminate\Support\Arr;
 
 class Posts extends Type
 {
+    public static function piiFields(): array
+    {
+        return ['ip_address'];
+    }
+
     public function export(): ?array
     {
         $exportData = [];

--- a/extensions/gdpr/src/Data/Tokens.php
+++ b/extensions/gdpr/src/Data/Tokens.php
@@ -27,6 +27,11 @@ class Tokens extends Type
         PasswordToken::class,
     ];
 
+    public static function piiFields(): array
+    {
+        return ['last_ip_address'];
+    }
+
     public function export(): ?array
     {
         $exportData = [];

--- a/extensions/gdpr/src/Data/Type.php
+++ b/extensions/gdpr/src/Data/Type.php
@@ -57,6 +57,11 @@ abstract class Type implements DataType
         return Str::afterLast(static::class, '\\');
     }
 
+    public static function piiFields(): array
+    {
+        return [];
+    }
+
     public function getDisk(?string $name): Filesystem
     {
         return $this->factory->disk($name);

--- a/extensions/gdpr/src/Data/User.php
+++ b/extensions/gdpr/src/Data/User.php
@@ -15,6 +15,11 @@ use Illuminate\Support\Str;
 
 class User extends Type
 {
+    public static function piiFields(): array
+    {
+        return ['email', 'username', 'last_seen_at', 'joined_at', 'preferences', 'nickname', 'suspend_reason', 'suspend_message'];
+    }
+
     public function export(): ?array
     {
         $remove = ['id', 'password', 'groups', 'anonymized'];

--- a/extensions/gdpr/src/DataProcessor.php
+++ b/extensions/gdpr/src/DataProcessor.php
@@ -33,7 +33,7 @@ final class DataProcessor
     ];
 
     /**
-     * @var string[] List of user columns to be removed.
+     * @var array<string, string|null> Map of column name => extension ID (or null for core).
      */
     private static array $removeUserColumns = [];
 
@@ -41,6 +41,15 @@ final class DataProcessor
      * @var ColumnAction[]
      */
     private static $columnActions = [];
+
+    /**
+     * Additional PII keys for serialization anonymization, beyond those declared by registered
+     * data types via {@see DataType::piiFields()}. Use this only for PII fields that don't
+     * belong to any registered data type.
+     *
+     * @var array<string, string|null> Map of key name => extension ID (or null for core).
+     */
+    private static array $extraPiiKeysForSerialization = [];
 
     /**
      * Add a data type to the list.
@@ -81,11 +90,22 @@ final class DataProcessor
     /**
      * Add columns to the list of user columns to be removed.
      *
-     * @param string[] $columns List of column names.
+     * @param string[]    $columns     List of column names.
+     * @param string|null $extensionId The ID of the extension registering the columns.
      */
-    public static function removeUserColumns(array $columns): void
+    public static function removeUserColumns(array $columns, ?string $extensionId = null): void
     {
-        self::$removeUserColumns = array_merge(self::$removeUserColumns, $columns);
+        foreach ($columns as $column) {
+            self::$removeUserColumns[$column] = $extensionId;
+        }
+    }
+
+    /**
+     * Reset the removable user columns list. Intended for use in tests.
+     */
+    public static function resetRemovableUserColumns(): void
+    {
+        self::$removeUserColumns = [];
     }
 
     /**
@@ -99,11 +119,21 @@ final class DataProcessor
     }
 
     /**
-     * Retrieve the list of user columns to be removed.
+     * Retrieve the list of user columns to be removed (column names only).
      *
      * @return string[] List of column names.
      */
     public function removableUserColumns(): array
+    {
+        return array_keys(self::$removeUserColumns);
+    }
+
+    /**
+     * Retrieve the full map of removable user columns with their registering extension IDs.
+     *
+     * @return array<string, string|null> Map of column name => extension ID (or null for core).
+     */
+    public function removableUserColumnsWithExtensions(): array
     {
         return self::$removeUserColumns;
     }
@@ -143,5 +173,74 @@ final class DataProcessor
     public function getColumnActions(): array
     {
         return self::$columnActions;
+    }
+
+    /**
+     * Reset the extra PII keys list. Intended for use in tests.
+     */
+    public static function resetExtraPiiKeysForSerialization(): void
+    {
+        self::$extraPiiKeysForSerialization = [];
+    }
+
+    /**
+     * Register additional PII keys for serialization anonymization that are not declared
+     * by any registered data type. Prefer declaring PII fields on the data type itself
+     * via {@see DataType::piiFields()} wherever possible.
+     *
+     * @param string[]    $keys
+     * @param string|null $extensionId The ID of the extension registering the keys.
+     */
+    public static function addPiiKeysForSerialization(array $keys, ?string $extensionId = null): void
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, self::$extraPiiKeysForSerialization)) {
+                self::$extraPiiKeysForSerialization[$key] = $extensionId;
+            }
+        }
+    }
+
+    /**
+     * Get a map of every PII key to the extension ID that declared it.
+     * Keys declared by built-in types or core are mapped to null.
+     * When two sources declare the same key, the first wins (type-declared > extra).
+     *
+     * @return array<string, string|null> Map of key name => extension ID (or null for core).
+     */
+    public function getPiiKeysWithExtensions(): array
+    {
+        $result = [];
+
+        foreach (self::$types as $typeClass => $extensionId) {
+            foreach ($typeClass::piiFields() as $field) {
+                if (!array_key_exists($field, $result)) {
+                    $result[$field] = $extensionId;
+                }
+            }
+        }
+
+        foreach (self::$extraPiiKeysForSerialization as $field => $extensionId) {
+            if (!array_key_exists($field, $result)) {
+                $result[$field] = $extensionId;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the full list of PII keys for serialization anonymization.
+     * Aggregates fields declared by all registered data types, plus any extras
+     * added via {@see addPiiKeysForSerialization()}.
+     *
+     * @return string[]
+     */
+    public function getPiiKeysForSerialization(): array
+    {
+        $fromTypes = array_merge(
+            ...array_map(fn (string $type) => $type::piiFields(), array_keys(self::$types))
+        );
+
+        return array_values(array_unique(array_merge($fromTypes, array_keys(self::$extraPiiKeysForSerialization))));
     }
 }

--- a/extensions/gdpr/src/DataProcessor.php
+++ b/extensions/gdpr/src/DataProcessor.php
@@ -194,7 +194,7 @@ final class DataProcessor
     public static function addPiiKeysForSerialization(array $keys, ?string $extensionId = null): void
     {
         foreach ($keys as $key) {
-            if (!array_key_exists($key, self::$extraPiiKeysForSerialization)) {
+            if (! array_key_exists($key, self::$extraPiiKeysForSerialization)) {
                 self::$extraPiiKeysForSerialization[$key] = $extensionId;
             }
         }
@@ -213,14 +213,14 @@ final class DataProcessor
 
         foreach (self::$types as $typeClass => $extensionId) {
             foreach ($typeClass::piiFields() as $field) {
-                if (!array_key_exists($field, $result)) {
+                if (! array_key_exists($field, $result)) {
                     $result[$field] = $extensionId;
                 }
             }
         }
 
         foreach (self::$extraPiiKeysForSerialization as $field => $extensionId) {
-            if (!array_key_exists($field, $result)) {
+            if (! array_key_exists($field, $result)) {
                 $result[$field] = $extensionId;
             }
         }

--- a/extensions/gdpr/src/DataProcessor.php
+++ b/extensions/gdpr/src/DataProcessor.php
@@ -237,10 +237,14 @@ final class DataProcessor
      */
     public function getPiiKeysForSerialization(): array
     {
+        /** @var string[] $fromTypes */
         $fromTypes = array_merge(
             ...array_map(fn (string $type) => $type::piiFields(), array_keys(self::$types))
         );
 
-        return array_values(array_unique(array_merge($fromTypes, array_keys(self::$extraPiiKeysForSerialization))));
+        /** @var string[] $merged */
+        $merged = array_unique(array_merge($fromTypes, array_keys(self::$extraPiiKeysForSerialization)));
+
+        return array_values($merged);
     }
 }

--- a/extensions/gdpr/src/Exporter.php
+++ b/extensions/gdpr/src/Exporter.php
@@ -57,6 +57,10 @@ class Exporter
 
             $data = $segment->export();
 
+            if ($data === null) {
+                continue;
+            }
+
             // Check if the array is an indexed array of associative arrays
             if (is_array($data) && array_values($data) === $data) {
                 // Handling list of associative arrays

--- a/extensions/gdpr/src/Extend/UserData.php
+++ b/extensions/gdpr/src/Extend/UserData.php
@@ -19,6 +19,7 @@ class UserData implements ExtenderInterface
     protected array $types = [];
     protected array $removeTypes = [];
     protected array $removeUserColumns = [];
+    protected array $piiKeysForSerialization = [];
 
     public function extend(Container $container, ?Extension $extension = null): void
     {
@@ -30,7 +31,8 @@ class UserData implements ExtenderInterface
             DataProcessor::removeType($type);
         }
 
-        DataProcessor::removeUserColumns($this->removeUserColumns);
+        DataProcessor::removeUserColumns($this->removeUserColumns, $extension?->getId());
+        DataProcessor::addPiiKeysForSerialization($this->piiKeysForSerialization, $extension?->getId());
     }
 
     /**
@@ -74,6 +76,24 @@ class UserData implements ExtenderInterface
     {
         $columns = (array) $columns;
         $this->removeUserColumns = array_merge($this->removeUserColumns, $columns);
+
+        return $this;
+    }
+
+    /**
+     * Register additional PII keys for serialization anonymization that are not covered by
+     * any registered data type. Prefer implementing {@see \Flarum\Gdpr\Contracts\DataType::piiFields()}
+     * on your data type class instead — that keeps the PII declaration co-located with the
+     * anonymization logic. Use this method only for PII fields that don't belong to any type.
+     *
+     * @param string|string[] $keys
+     *
+     * @return self
+     */
+    public function addPiiKeysForSerialization($keys): self
+    {
+        $keys = (array) $keys;
+        $this->piiKeysForSerialization = array_merge($this->piiKeysForSerialization, $keys);
 
         return $this;
     }

--- a/extensions/gdpr/tests/integration/api/ExtenderTest.php
+++ b/extensions/gdpr/tests/integration/api/ExtenderTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Gdpr\Tests\integration\api;
 
 use Flarum\Gdpr\Data\Forum;
+use Flarum\Gdpr\Data\Type;
 use Flarum\Gdpr\DataProcessor;
 use Flarum\Gdpr\Extend\UserData;
 use Flarum\Testing\integration\TestCase;
@@ -94,6 +95,66 @@ class ExtenderTest extends TestCase
         $this->assertContains('another_column', $columns);
     }
 
+    #[Test]
+    public function custom_pii_key_can_be_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization('custom_pii_field')
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('custom_pii_field', $keys);
+    }
+
+    #[Test]
+    public function multiple_custom_pii_keys_can_be_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization(['field_a', 'field_b'])
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('field_a', $keys);
+        $this->assertContains('field_b', $keys);
+    }
+
+    #[Test]
+    public function built_in_pii_fields_are_present_without_any_extender()
+    {
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('email', $keys);
+        $this->assertContains('username', $keys);
+        $this->assertContains('ip_address', $keys);
+        $this->assertContains('last_ip_address', $keys);
+    }
+
+    #[Test]
+    public function pii_fields_from_custom_data_type_are_included()
+    {
+        $this->extend(
+            (new UserData())
+                ->addType(DataTypeWithPii::class)
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('bio', $keys);
+        $this->assertContains('location', $keys);
+    }
+
     protected function getDataProcessor(): DataProcessor
     {
         return $this->app()->getContainer()->make(DataProcessor::class);
@@ -105,5 +166,41 @@ class MyNewDataType
     public static function dataType(): string
     {
         return 'my-new-data-type';
+    }
+}
+
+class DataTypeWithPii extends Type
+{
+    public static function piiFields(): array
+    {
+        return ['bio', 'location'];
+    }
+
+    public static function exportDescription(): string
+    {
+        return '';
+    }
+
+    public function export(): ?array
+    {
+        return null;
+    }
+
+    public static function anonymizeDescription(): string
+    {
+        return '';
+    }
+
+    public function anonymize(): void
+    {
+    }
+
+    public static function deleteDescription(): string
+    {
+        return '';
+    }
+
+    public function delete(): void
+    {
     }
 }

--- a/extensions/gdpr/tests/integration/api/ListUserColumnsDataControllerTest.php
+++ b/extensions/gdpr/tests/integration/api/ListUserColumnsDataControllerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Tests\integration\Api;
+
+use Flarum\Gdpr\Extend\UserData;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ListUserColumnsDataControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+
+        $this->extension('flarum-gdpr');
+    }
+
+    #[Test]
+    public function non_admin_cannot_access_user_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_access_user_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('data', $body);
+        $this->assertArrayHasKey('allColumns', $body['data']);
+        $this->assertArrayHasKey('removableColumns', $body['data']);
+        $this->assertArrayHasKey('piiKeys', $body['data']);
+    }
+
+    #[Test]
+    public function response_includes_built_in_pii_keys()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $piiKeys = $body['data']['piiKeys'];
+
+        $this->assertContains('email', $piiKeys);
+        $this->assertContains('username', $piiKeys);
+        $this->assertContains('last_seen_at', $piiKeys);
+        $this->assertContains('joined_at', $piiKeys);
+        $this->assertContains('preferences', $piiKeys);
+    }
+
+    #[Test]
+    public function response_includes_extra_pii_keys_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization('custom_pii_field')
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $piiKeys = $body['data']['piiKeys'];
+
+        $this->assertContains('custom_pii_field', $piiKeys);
+        $this->assertContains('email', $piiKeys); // built-in keys still present
+    }
+
+    #[Test]
+    public function response_includes_removable_columns_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->removeUserColumns(['my_custom_column'])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('my_custom_column', $body['data']['removableColumns']);
+    }
+
+    #[Test]
+    public function all_columns_includes_standard_user_table_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr-datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $allColumns = $body['data']['allColumns'];
+
+        $this->assertArrayHasKey('id', $allColumns);
+        $this->assertArrayHasKey('username', $allColumns);
+        $this->assertArrayHasKey('email', $allColumns);
+
+        // Each column entry has the expected metadata shape
+        $this->assertArrayHasKey('type', $allColumns['id']);
+        $this->assertArrayHasKey('nullable', $allColumns['id']);
+    }
+}

--- a/extensions/gdpr/tests/unit/DataProcessorTest.php
+++ b/extensions/gdpr/tests/unit/DataProcessorTest.php
@@ -20,16 +20,17 @@ class DataProcessorTest extends TestCase
     {
         parent::setUp();
 
-        // Resetting the types and removeUserColumns properties before each test
+        // Resetting all static state before each test
         DataProcessor::setTypes([
-            Data\Forum::class => null,
-            Data\Assets::class => null,
-            Data\Posts::class => null,
-            Data\Tokens::class => null,
+            Data\Forum::class       => null,
+            Data\Assets::class      => null,
+            Data\Posts::class       => null,
+            Data\Tokens::class      => null,
             Data\Discussions::class => null,
-            Data\User::class => null,
+            Data\User::class        => null,
         ]);
-        DataProcessor::removeUserColumns([]);
+        DataProcessor::resetRemovableUserColumns();
+        DataProcessor::resetExtraPiiKeysForSerialization();
     }
 
     #[Test]
@@ -101,5 +102,100 @@ class DataProcessorTest extends TestCase
         // Then
         $types = $processor->types();
         $this->assertEquals(Data\User::class, array_key_last($types));
+    }
+
+    #[Test]
+    public function it_aggregates_pii_fields_from_registered_types()
+    {
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        // Fields declared by built-in types
+        $this->assertContains('email', $keys);           // Data\User
+        $this->assertContains('username', $keys);        // Data\User
+        $this->assertContains('last_seen_at', $keys);    // Data\User
+        $this->assertContains('joined_at', $keys);       // Data\User
+        $this->assertContains('preferences', $keys);     // Data\User
+        $this->assertContains('ip_address', $keys);      // Data\Posts
+        $this->assertContains('last_ip_address', $keys); // Data\Tokens
+    }
+
+    #[Test]
+    public function it_merges_extra_pii_keys_with_type_pii_fields()
+    {
+        $processor = new DataProcessor();
+
+        DataProcessor::addPiiKeysForSerialization(['custom_field']);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertContains('custom_field', $keys);
+        $this->assertContains('email', $keys); // still includes type-sourced keys
+    }
+
+    #[Test]
+    public function it_deduplicates_pii_keys()
+    {
+        $processor = new DataProcessor();
+
+        // 'email' is already declared by Data\User::piiFields()
+        DataProcessor::addPiiKeysForSerialization(['email', 'email', 'custom_field']);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertCount(1, array_filter($keys, fn ($k) => $k === 'email'));
+        $this->assertCount(1, array_filter($keys, fn ($k) => $k === 'custom_field'));
+    }
+
+    #[Test]
+    public function removing_a_type_removes_its_pii_fields()
+    {
+        $processor = new DataProcessor();
+
+        DataProcessor::removeType(Data\Posts::class);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertNotContains('ip_address', $keys);
+    }
+
+    #[Test]
+    public function types_with_no_pii_fields_contribute_nothing()
+    {
+        // Forum and Discussions declare no PII fields
+        DataProcessor::setTypes([
+            Data\Forum::class       => null,
+            Data\Discussions::class => null,
+        ]);
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertEmpty($keys);
+    }
+
+    #[Test]
+    public function extra_pii_keys_are_included_even_when_no_types_declare_pii()
+    {
+        DataProcessor::setTypes([Data\Forum::class => null]);
+        DataProcessor::addPiiKeysForSerialization(['my_field']);
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertEquals(['my_field'], $keys);
+    }
+
+    #[Test]
+    public function reset_clears_extra_pii_keys()
+    {
+        DataProcessor::addPiiKeysForSerialization(['my_field']);
+        DataProcessor::resetExtraPiiKeysForSerialization();
+
+        $processor = new DataProcessor();
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertNotContains('my_field', $keys);
     }
 }

--- a/extensions/gdpr/tests/unit/DataProcessorTest.php
+++ b/extensions/gdpr/tests/unit/DataProcessorTest.php
@@ -22,12 +22,12 @@ class DataProcessorTest extends TestCase
 
         // Resetting all static state before each test
         DataProcessor::setTypes([
-            Data\Forum::class       => null,
-            Data\Assets::class      => null,
-            Data\Posts::class       => null,
-            Data\Tokens::class      => null,
+            Data\Forum::class => null,
+            Data\Assets::class => null,
+            Data\Posts::class => null,
+            Data\Tokens::class => null,
             Data\Discussions::class => null,
-            Data\User::class        => null,
+            Data\User::class => null,
         ]);
         DataProcessor::resetRemovableUserColumns();
         DataProcessor::resetExtraPiiKeysForSerialization();
@@ -165,7 +165,7 @@ class DataProcessorTest extends TestCase
     {
         // Forum and Discussions declare no PII fields
         DataProcessor::setTypes([
-            Data\Forum::class       => null,
+            Data\Forum::class => null,
             Data\Discussions::class => null,
         ]);
         $processor = new DataProcessor();

--- a/extensions/gdpr/tests/unit/TypeTest.php
+++ b/extensions/gdpr/tests/unit/TypeTest.php
@@ -10,7 +10,10 @@
 namespace Flarum\Gdpr\tests\unit;
 
 use Flarum\Database\AbstractModel;
+use Flarum\Gdpr\Data\Posts;
+use Flarum\Gdpr\Data\Tokens;
 use Flarum\Gdpr\Data\Type;
+use Flarum\Gdpr\Data\User as UserData;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -141,6 +144,39 @@ class TypeTest extends TestCase
 
         // Then
         $this->assertEquals($columns, $returnedColumns);
+    }
+
+    #[Test]
+    public function base_type_returns_empty_pii_fields()
+    {
+        $this->assertEquals([], TestableType::piiFields());
+    }
+
+    #[Test]
+    public function user_data_type_declares_expected_pii_fields()
+    {
+        $fields = UserData::piiFields();
+
+        $this->assertContains('email', $fields);
+        $this->assertContains('username', $fields);
+        $this->assertContains('last_seen_at', $fields);
+        $this->assertContains('joined_at', $fields);
+        $this->assertContains('preferences', $fields);
+        $this->assertContains('nickname', $fields);
+        $this->assertContains('suspend_reason', $fields);
+        $this->assertContains('suspend_message', $fields);
+    }
+
+    #[Test]
+    public function posts_data_type_declares_expected_pii_fields()
+    {
+        $this->assertEquals(['ip_address'], Posts::piiFields());
+    }
+
+    #[Test]
+    public function tokens_data_type_declares_expected_pii_fields()
+    {
+        $this->assertEquals(['last_ip_address'], Tokens::piiFields());
     }
 }
 


### PR DESCRIPTION
## Summary

Port of [flarum/gdpr#65](https://github.com/flarum/gdpr/pull/65), [#67](https://github.com/flarum/gdpr/pull/67), [#68](https://github.com/flarum/gdpr/pull/68), and [#69](https://github.com/flarum/gdpr/pull/69) from the standalone 1.x repo to the 2.x monorepo.

### Backend
- Add `piiFields(): array` to the `DataType` interface and `Type` base class (default returns `[]`); implement on `User` (5+3 fields), `Posts` (`ip_address`), `Tokens` (`last_ip_address`)
- `DataProcessor::getPiiKeysForSerialization()` aggregates PII fields from all registered types plus extras
- `DataProcessor::getPiiKeysWithExtensions()` builds a unified key→extensionId map (type-declared wins over extras, replaces `getExtraPiiKeysWithExtensions()`)
- `DataProcessor::$removeUserColumns` refactored from `string[]` to `array<string, string|null>` (column→extensionId map); new `removableUserColumnsWithExtensions()` and `resetRemovableUserColumns()` methods
- `UserData` extender gains `addPiiKeysForSerialization()` and now passes extensionId to `removeUserColumns()`
- `DataTypeResource` `user-columns` endpoint updated to return `piiKeys`, `piiKeyExtensions`, `removableColumns` (as object/map), `allColumns`
- `Exporter` guards against `null` return from `DataType::export()`

### Frontend
- Admin GDPR page "User Table Data" section fully implemented — replaces "Not yet implemented" stub with a 6-column grid: Column, Type, Nullable, PII (badge + tooltip), Redacted on export (tooltip), Extension
- `ExportAvailableNotification` opens download in new tab via `markAsRead()` to prevent XHR abort on navigation (uses `Icon` component, 2.x pattern)

### Locale
- Added `flarum-gdpr.lib.data.default_user_action` key
- Added 10 `user_table_data.*` keys for the new column grid UI

### README
- Fixed lingering `Blomstra\` namespace references
- Added developer docs section: PII fields, anonymized contexts, and how to consume the PII list from an extension

## Test plan

- [ ] All 30 unit tests pass (`phpunit.unit.xml`)
- [ ] All 70 integration tests pass (`phpunit.integration.xml`) — including 6 new tests in `ListUserColumnsDataControllerTest`
- [ ] `yarn build` compiles without errors
- [ ] `yarn format` reports all files unchanged
- [ ] Admin → GDPR page → "User Table Data" shows 6-column grid with PII badges on `email`, `username`, etc.
- [ ] `GET /api/gdpr-datatypes/user-columns` returns `piiKeys`, `piiKeyExtensions`, `removableColumns` (object), `allColumns`
- [ ] Exporting data for a user with a type that returns `null` from `export()` does not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)