### PR TITLE
[2.x] fix(webpack): prevent `Uncaught ReferenceError` for async default exports

### DIFF
--- a/js-packages/webpack-config/babel.config.cjs
+++ b/js-packages/webpack-config/babel.config.cjs
@@ -1,3 +1,5 @@
+const isTest = process.env.NODE_ENV === 'test';
+
 module.exports = {
   assumptions: {
     // Defines assumptions Babel can make about our
@@ -28,7 +30,7 @@ module.exports = {
     ],
   ],
   plugins: [
-    [require.resolve('@babel/plugin-transform-runtime'), { useESModules: true }],
+    [require.resolve('@babel/plugin-transform-runtime'), { useESModules: !isTest }],
     [require.resolve('@babel/plugin-proposal-class-properties')],
     [require.resolve('@babel/plugin-proposal-private-methods')],
     [

--- a/js-packages/webpack-config/src/autoExportLoader.cjs
+++ b/js-packages/webpack-config/src/autoExportLoader.cjs
@@ -24,7 +24,7 @@ let namespace;
 function addAutoExports(source, pathToModule, moduleName) {
   let addition = '';
 
-  const defaultExportMatches = [...source.matchAll(/export\s+?default\s(?:abstract\s)?(?:(?:function|abstract|class)\s)?([A-Za-z_]*)/gm)];
+  const defaultExportMatches = [...source.matchAll(/export\s+?default\s(?:abstract\s)?(?:async\s)?(?:(?:function|abstract|class)\s)?([A-Za-z_]*)/gm)];
   const defaultExport = defaultExportMatches.length ? defaultExportMatches[0][1] : null;
 
   // In case of an index.js file that exports multiple modules

--- a/js-packages/webpack-config/tests/autoExportLoader.test.js
+++ b/js-packages/webpack-config/tests/autoExportLoader.test.js
@@ -52,3 +52,13 @@ test('Export from with other named exports works', async () => {
     "flarum.reg.add('flarum-framework', 'common/foos/exportFromWithNamedExports', { potato: potato,franz: franz,baz: baz,foo: foo,Bar: Bar,sasha: sasha,forum: forum,david: david, }"
   );
 });
+
+test('Anonymous async arrow functions do not cause invalid exports', async () => {
+  const output = await compile('src/common/foos/asyncAnonymous.js');
+  expect(output).not.toContain("flarum.reg.add('flarum-framework', 'common/foos/asyncAnonymous', async)");
+});
+
+test('Named async functions are exported correctly', async () => {
+  const output = await compile('src/common/foos/asyncNamed.js');
+  expect(output).toContain("flarum.reg.add('flarum-framework', 'common/foos/asyncNamed', myAsyncFunc)");
+});

--- a/js-packages/webpack-config/tests/src/common/foos/asyncAnonymous.js
+++ b/js-packages/webpack-config/tests/src/common/foos/asyncAnonymous.js
@@ -1,0 +1,1 @@
+export default async () => {};

--- a/js-packages/webpack-config/tests/src/common/foos/asyncNamed.js
+++ b/js-packages/webpack-config/tests/src/common/foos/asyncNamed.js
@@ -1,0 +1,1 @@
+export default async function myAsyncFunc() {}


### PR DESCRIPTION
<img width="469" height="124" alt="image" src="https://github.com/user-attachments/assets/c0b64230-c6bb-4a0a-bcd0-269f27a7fee2" />

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

* **`autoExportLoader.cjs`**: Fixed a regex bug that incorrectly captured the `async` keyword as an export name when using anonymous arrow functions (e.g., `export default async () => {}`). This prevents the `Uncaught ReferenceError: async is not defined` runtime error in extensions.
* **`babel.config.cjs`**: Dynamically set `useESModules` based on `process.env.NODE_ENV === 'test'`. This fixes the Jest test suite which was failing due to ESM imports being injected into the CommonJS test environment.
* Added tests for both named and anonymous async exports.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
