### PR TITLE
[2.x] fix(translator): preserve translations when switching locale

### DIFF
--- a/framework/core/js/src/common/Translator.tsx
+++ b/framework/core/js/src/common/Translator.tsx
@@ -33,10 +33,13 @@ export default class Translator {
    * Sets the formatter's locale to the provided value.
    */
   setLocale(locale: string) {
+    const previousLocale = this.getLocale();
+    const allTranslations = this.formatter.setup().translations;
+
     this.formatter.setup({
       locale,
       translations: {
-        [locale]: this.formatter.setup().translations[locale] ?? {},
+        [locale]: Object.assign({}, allTranslations[previousLocale] ?? {}, allTranslations[locale] ?? {}),
       },
     });
   }

--- a/framework/core/js/tests/unit/common/utils/Translator.test.ts
+++ b/framework/core/js/tests/unit/common/utils/Translator.test.ts
@@ -67,3 +67,15 @@ test('plural rules 2', () => {
   expect(extractText(translator.trans('test5', { count: 5 }))).toBe('5 postów');
   expect(extractText(translator.trans('test5', { count: 1.5 }))).toBe('1,5 posta');
 });
+
+test('translations added before setLocale are retained', () => {
+  // Simulates the real page load order: locale JS files execute and call
+  // addTranslations() before app.load() calls setLocale().
+  const translator = new Translator();
+  translator.addTranslations({
+    test6: 'Witaj świecie',
+  });
+  translator.setLocale('pl');
+
+  expect(extractText(translator.trans('test6', {}))).toBe('Witaj świecie');
+});


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in #4088 (switch to `format-message`) where non-English language packs had their translations silently discarded
- `setLocale()` was replacing the entire translation store with only entries keyed to the new locale. Since locale JS files (e.g. `forum-pl.js`) execute synchronously before `app.load()` calls `setLocale()`, their translations were stored under `format-message`'s default locale (`'en'`). When `setLocale('pl')` ran, it set translations to `{ pl: {} }`, discarding everything
- English worked by coincidence — the default locale matched
- Fix: merge translations from the previous/default locale into the new locale key so nothing loaded before `setLocale()` is lost
- Adds a test covering the real page-load order (`addTranslations()` before `setLocale()`)

## Test plan

- [ ] Switch forum language to a non-English language pack (e.g. Polish `flarum-lang/polish`) — translations should now load correctly
- [ ] English still works
- [ ] `yarn jest tests/unit/common/utils/Translator.test.ts` passes (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)