### PR TITLE
[1.x] chore: accept StyleCI formatting fixes and disable nullable_type_declarations fixer

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,6 +5,7 @@ enabled:
 
 disabled:
   - align_double_arrow
+  - nullable_type_declarations
   - blank_line_after_opening_tag
   - multiline_array_trailing_comma
   - new_with_braces

--- a/extensions/nicknames/src/NicknameDriver.php
+++ b/extensions/nicknames/src/NicknameDriver.php
@@ -26,6 +26,6 @@ class NicknameDriver implements DriverInterface
         // Insert a zero-width space after every dot to prevent email clients
         // from auto-linking dotted strings as domain names (e.g. nasty.com).
         // The zero-width space is invisible in all rendering contexts.
-        return str_replace('.', ".\u{200B}", $name);
+        return str_replace('.', ".\u{200B}", $name); // @styleci-trigger
     }
 }

--- a/extensions/nicknames/src/NicknameDriver.php
+++ b/extensions/nicknames/src/NicknameDriver.php
@@ -26,6 +26,6 @@ class NicknameDriver implements DriverInterface
         // Insert a zero-width space after every dot to prevent email clients
         // from auto-linking dotted strings as domain names (e.g. nasty.com).
         // The zero-width space is invisible in all rendering contexts.
-        return str_replace('.', ".\u{200B}", $name); // @styleci-trigger
+        return str_replace('.', ".\u{200B}", $name);
     }
 }

--- a/extensions/nicknames/tests/integration/api/EditUserTest.php
+++ b/extensions/nicknames/tests/integration/api/EditUserTest.php
@@ -146,8 +146,8 @@ class UpdateTest extends TestCase
         return [
             'markdown link syntax' => ['[CLICK](https://evil.com)'],
             'square brackets only' => ['[username]'],
-            'angle brackets'       => ['<evil.com>'],
-            'parentheses'          => ['evil(com)'],
+            'angle brackets' => ['<evil.com>'],
+            'parentheses' => ['evil(com)'],
         ];
     }
 }

--- a/framework/core/src/Api/Serializer/SystemInfoSerializer.php
+++ b/framework/core/src/Api/Serializer/SystemInfoSerializer.php
@@ -9,8 +9,6 @@
 
 namespace Flarum\Api\Serializer;
 
-use stdClass;
-
 class SystemInfoSerializer extends AbstractSerializer
 {
     protected function getDefaultAttributes($data)

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -131,7 +131,7 @@ class ExtensionManager
                 // Set abandoned status if the package is marked as abandoned in composer
                 // The abandoned field can be either true (no replacement) or a string (replacement package name)
                 $abandoned = Arr::get($package, 'abandoned');
-                if (is_string($abandoned) && !empty($abandoned)) {
+                if (is_string($abandoned) && ! empty($abandoned)) {
                     // Always set abandoned status if a replacement package is specified
                     $extension->setAbandoned($abandoned);
                 } elseif ($abandoned === true) {
@@ -141,7 +141,7 @@ class ExtensionManager
                     $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
 
                     // Only set abandoned if NOT from flarum.org/composer
-                    if (!$isFromFlarumComposer) {
+                    if (! $isFromFlarumComposer) {
                         $extension->setAbandoned($abandoned);
                     }
                 }

--- a/framework/core/src/Foundation/AbstractValidator.php
+++ b/framework/core/src/Foundation/AbstractValidator.php
@@ -98,7 +98,7 @@ abstract class AbstractValidator
     {
         $cache = resolve(Cache::class);
 
-        $cacheKey = 'core.validation.attributes.' . $this->translator->getLocale() . '.' . static::class;
+        $cacheKey = 'core.validation.attributes.'.$this->translator->getLocale().'.'.static::class;
 
         if ($cached = $cache->get($cacheKey)) {
             return $cached;

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -185,8 +185,8 @@ class InfoCommand extends AbstractCommand
     {
         // Try common PHP binary paths for web servers
         $possiblePhpBinaries = [
-            '/usr/bin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-            '/usr/sbin/php-fpm' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            '/usr/bin/php-fpm'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
+            '/usr/sbin/php-fpm'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             '/usr/local/bin/php',
             '/usr/bin/php',
         ];
@@ -197,7 +197,7 @@ class InfoCommand extends AbstractCommand
                 $status = null;
                 exec("$phpBinary -v 2>&1 | head -n 1", $output, $status);
 
-                if ($status === 0 && !empty($output[0])) {
+                if ($status === 0 && ! empty($output[0])) {
                     // Extract version from output like "PHP 8.3.1 (fpm-fcgi) ..."
                     if (preg_match('/PHP\s+([\d.]+)/', $output[0], $matches)) {
                         return $matches[1];
@@ -216,21 +216,21 @@ class InfoCommand extends AbstractCommand
     private function detectWebServerMemoryLimit(): ?string
     {
         // Try to detect PHP-FPM pool configuration
-        $phpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+        $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
 
         $possiblePaths = [
             // Docker PHP paths (most common for containerized setups)
-            "/usr/local/etc/php/php.ini",
-            "/usr/local/etc/php/conf.d/memory.ini",
+            '/usr/local/etc/php/php.ini',
+            '/usr/local/etc/php/conf.d/memory.ini',
             // Common PHP-FPM pool paths
             "/etc/php/{$phpVersion}/fpm/pool.d/www.conf",
             "/etc/php{$phpVersion}/fpm/pool.d/www.conf",
-            "/etc/php-fpm.d/www.conf",
-            "/usr/local/etc/php-fpm.d/www.conf",
+            '/etc/php-fpm.d/www.conf',
+            '/usr/local/etc/php-fpm.d/www.conf',
             // Common php.ini paths for web
             "/etc/php/{$phpVersion}/fpm/php.ini",
             "/etc/php{$phpVersion}/fpm/php.ini",
-            "/etc/php.ini",
+            '/etc/php.ini',
         ];
 
         foreach ($possiblePaths as $path) {
@@ -252,7 +252,7 @@ class InfoCommand extends AbstractCommand
         // Also scan /usr/local/etc/php/conf.d/ directory for any INI files with memory_limit
         $confDir = '/usr/local/etc/php/conf.d';
         if (@is_dir($confDir) && @is_readable($confDir)) {
-            $iniFiles = @glob($confDir . '/*.ini');
+            $iniFiles = @glob($confDir.'/*.ini');
             if ($iniFiles) {
                 foreach ($iniFiles as $iniFile) {
                     if (@is_readable($iniFile)) {

--- a/framework/core/src/Foundation/Event/ApplicationBooted.php
+++ b/framework/core/src/Foundation/Event/ApplicationBooted.php
@@ -14,5 +14,4 @@ namespace Flarum\Foundation\Event;
  */
 class ApplicationBooted
 {
-
 }

--- a/framework/core/src/Mail/MailgunDriver.php
+++ b/framework/core/src/Mail/MailgunDriver.php
@@ -19,7 +19,7 @@ use Swift_Transport;
 class MailgunDriver implements DriverInterface
 {
     use ValidatesMailSettings;
-    
+
     public function availableSettings(): array
     {
         return [

--- a/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
+++ b/framework/core/src/Mail/SetTranslatorLocaleForEmailTrait.php
@@ -27,8 +27,8 @@ trait SetTranslatorLocaleForEmailTrait
     ): void {
         $users = resolve(UserRepository::class);
         $user = $users->findByEmail($email);
-        
-        $locale = $user 
+
+        $locale = $user
             ? ($user->getPreference('locale') ?? $settings->get('default_locale'))
             : $settings->get('default_locale');
 

--- a/framework/core/src/Mail/ValidatesMailSettings.php
+++ b/framework/core/src/Mail/ValidatesMailSettings.php
@@ -20,7 +20,7 @@ trait ValidatesMailSettings
     {
         return function ($attribute, $value, $fail) {
             if ($value !== trim($value)) {
-                $fail('The ' . str_replace('_', ' ', $attribute) . ' must not contain leading or trailing whitespace.');
+                $fail('The '.str_replace('_', ' ', $attribute).' must not contain leading or trailing whitespace.');
             }
         };
     }

--- a/framework/core/tests/integration/api/settings/MailSettingsTest.php
+++ b/framework/core/tests/integration/api/settings/MailSettingsTest.php
@@ -49,7 +49,7 @@ class MailSettingsTest extends TestCase
         );
 
         $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
-        
+
         $data = json_decode((string) $mailSettingsResponse->getBody(), true);
 
         $this->assertFalse($data['data']['attributes']['sending']);
@@ -88,7 +88,7 @@ class MailSettingsTest extends TestCase
         );
 
         $this->assertEquals(200, $mailSettingsResponse->getStatusCode());
-        
+
         $data = json_decode((string) $mailSettingsResponse->getBody(), true);
 
         $this->assertEmpty($data['data']['attributes']['errors']);


### PR DESCRIPTION
## Summary

- Accepts StyleCI's pending formatting fixes for the 1.x branch (whitespace, concat spacing, unused imports — all cosmetic, zero BC impact)
- Disables the `nullable_type_declarations` StyleCI fixer to prevent it from adding `?Type` hints to public method signatures, which would be a breaking change for third-party extensions overriding those methods on PHP 8.0+ (stricter covariance rules)

## Changes

- `.styleci.yml`: add `nullable_type_declarations` to the `disabled` list
- Various files: StyleCI whitespace/concat/import cleanup (safe)