### PR TITLE
[1.x] fix(tests): call app() before resolving cache.store in DeleteTest

### DIFF
--- a/framework/core/tests/integration/api/notifications/DeleteTest.php
+++ b/framework/core/tests/integration/api/notifications/DeleteTest.php
@@ -75,6 +75,8 @@ class DeleteTest extends TestCase
      */
     public function deleting_all_notifications_invalidates_unread_count_cache()
     {
+        $this->app();
+
         $cache = resolve('cache.store');
 
         // Prime the cache with stale counts so we can verify they are cleared.


### PR DESCRIPTION
## Problem

The regression test added in #4391 calls `resolve('cache.store')` before `$this->app()`, so the container hasn't been bootstrapped yet and the `cache.store` binding doesn't exist — causing a test failure.

## Fix

Add `$this->app()` before the `resolve('cache.store')` call in `deleting_all_notifications_invalidates_unread_count_cache()`, matching the pattern already used in the other test in the same file.

## Related

- Regression introduced by: #4391