### PR TITLE
[2.x] fix(theme): return Less_Tree_Keyword for boolean custom Less functions

### DIFF
--- a/framework/core/src/Extend/Theme.php
+++ b/framework/core/src/Extend/Theme.php
@@ -81,7 +81,7 @@ class Theme implements ExtenderInterface
             $return = $callable(...$argVals);
 
             if (is_bool($return)) {
-                return new \Less_Tree_Quoted('', $return ? 'true' : 'false');
+                return new \Less_Tree_Keyword($return ? 'true' : 'false');
             }
 
             if (is_string($return)) {

--- a/framework/core/tests/fixtures/less/custom_function.less
+++ b/framework/core/tests/fixtures/less/custom_function.less
@@ -5,3 +5,10 @@
   width: is-flarum("not flarum") * 10px;
   --y: is-gt(1, 2);
 }
+.mixin(@val) {}
+.mixin(false) {
+  color: red;
+}
+.dummy_func_test3 {
+  .mixin(is-gt(1, 2));
+}

--- a/framework/core/tests/integration/extenders/ThemeTest.php
+++ b/framework/core/tests/integration/extenders/ThemeTest.php
@@ -124,6 +124,8 @@ class ThemeTest extends TestCase
 
         $this->assertStringContainsString('.dummy_func_test{color:green}', $contents);
         $this->assertStringContainsString('.dummy_func_test2{width:1000px;--y:false}', $contents);
+        // Boolean return values must be Less keywords (not quoted strings) so that mixin guards match correctly.
+        $this->assertStringContainsString('.dummy_func_test3{color:red}', $contents);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #4383.

Same bug as the 1.x fix in #4405.

## Problem

`addCustomLessFunction` wrapped boolean return values in `Less_Tree_Quoted('', 'true'/'false')`, producing a **quoted string** in Less. Less's built-in boolean keywords (`true`/`false`) are `Less_Tree_Keyword`, not quoted strings. This meant boolean-returning custom functions could not be used in mixin guards:

```less
// This never matched — value was the string 'false', not the keyword false
.define-header(false) { ... }
```

## Fix

Use `Less_Tree_Keyword` instead of `Less_Tree_Quoted` for boolean return values. CSS custom property output is unchanged (`false` renders as `false` in both cases); only mixin guard matching is fixed.

## Test

Extended the existing `theme_extender_can_add_custom_function` test with a mixin guard that must match `false` — asserting that `.dummy_func_test3{color:red}` appears in the compiled CSS.