### PR TITLE
[2.x] fix(mentions): wait for async TextEditor loading before injecting composer mentions/quotes

### DIFF
--- a/extensions/mentions/js/src/forum/utils/reply.js
+++ b/extensions/mentions/js/src/forum/utils/reply.js
@@ -3,25 +3,42 @@ import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 
 export function insertMention(post, composer, quote) {
   return new Promise((resolve) => {
-    const mention = app.mentionFormats.mentionable('post').replacement(post) + ' ';
+    const doInsert = () => {
+      const mention = app.mentionFormats.mentionable('post').replacement(post) + ' ';
 
-    // If the composer is empty, then assume we're starting a new reply.
-    // In which case we don't want the user to have to confirm if they
-    // close the composer straight away.
-    if (!composer.fields.content()) {
-      composer.body.attrs.originalContent = mention;
+      // If the composer is empty, then assume we're starting a new reply.
+      // In which case we don't want the user to have to confirm if they
+      // close the composer straight away.
+      if (!composer.fields.content()) {
+        composer.body.attrs.originalContent = mention;
+      }
+
+      const cursorPosition = composer.editor.getSelectionRange()[0];
+      const preceding = composer.fields.content().slice(0, cursorPosition);
+      const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
+
+      composer.editor.insertAtCursor(
+        Array(precedingNewlines).join('\n') + // Insert up to two newlines, depending on preceding whitespace
+          (quote ? '> ' + mention + quote.trim().replace(/\n/g, '\n> ') + '\n\n' : mention),
+        false
+      );
+      return resolve(composer);
+    };
+
+    if (composer.editorReady) {
+      let timeout;
+      Promise.race([
+        composer.editorReady(),
+        new Promise((resolve) => {
+          timeout = setTimeout(resolve, 3000);
+        }),
+      ]).then(() => {
+        clearTimeout(timeout);
+        doInsert();
+      });
+    } else {
+      doInsert();
     }
-
-    const cursorPosition = composer.editor.getSelectionRange()[0];
-    const preceding = composer.fields.content().slice(0, cursorPosition);
-    const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
-
-    composer.editor.insertAtCursor(
-      Array(precedingNewlines).join('\n') + // Insert up to two newlines, depending on preceding whitespace
-        (quote ? '> ' + mention + quote.trim().replace(/\n/g, '\n> ') + '\n\n' : mention),
-      false
-    );
-    return resolve(composer);
   });
 }
 

--- a/framework/core/js/src/forum/states/ComposerState.tsx
+++ b/framework/core/js/src/forum/states/ComposerState.tsx
@@ -33,7 +33,27 @@ class ComposerState {
   /**
    * A reference to the text editor that allows text manipulation.
    */
-  editor: EditorDriverInterface | null = null;
+  protected _editor: EditorDriverInterface | null = null;
+  protected _editorReadyPromise!: Promise<void>;
+  protected _resolveEditorReady!: () => void;
+
+  get editor(): EditorDriverInterface | null {
+    return this._editor;
+  }
+
+  set editor(editor: EditorDriverInterface | null) {
+    this._editor = editor;
+    if (editor) {
+      this._resolveEditorReady();
+    }
+  }
+
+  /**
+   * Request a promise that resolves when the text editor is ready and assigned to the composer.
+   */
+  editorReady(): Promise<void> {
+    return this._editorReadyPromise;
+  }
 
   /**
    * If the composer was loaded and mounted.
@@ -91,10 +111,14 @@ class ComposerState {
       content: Stream(''),
     };
 
-    if (this.editor) {
-      this.editor.destroy();
+    if (this._editor) {
+      this._editor.destroy();
     }
-    this.editor = null;
+    this._editor = null;
+
+    this._editorReadyPromise = new Promise((resolve) => {
+      this._resolveEditorReady = resolve;
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4401**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Waits for composer editor to be ready before interaction

Resolves a race condition where actions like inserting mentions or quotes could attempt to modify the composer's text editor before it has been fully initialized and assigned.

Introduces an `editorReady` promise in `ComposerState` that resolves once the editor is available. Updates the `insertMention` utility to await this promise, ensuring the editor is ready for content manipulation. A timeout is included as a fallback for robustness.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

In `reply.js`, I wrapped the `editorReady()` call in a `Promise.race()` with a 3000ms timeout:
https://github.com/huoxin233/flarum-framework/blob/14d9f283f5a92fbd516ba189bddcef979c8ae36a/extensions/mentions/js/src/forum/utils/reply.js#L28-L38

I added it for the purpose of: If a severe error from another extension completely breaks the `TextEditor` and prevents the editor from ever loading, `editorReady()` would ordinarily remain pending forever. By forcing it to try to insert after 3000ms, the code aggressively throws the native `TypeError: Cannot read properties of null exception`, preserving the stack trace in the browser console for easier debugging.

But, I am not quite sure how much timeout is needed, would 3000ms be enough?


**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Before:

https://github.com/user-attachments/assets/0d42dcb2-7bd6-4f93-b160-dc42f6aef153

After:

https://github.com/user-attachments/assets/cbe8a723-416d-4418-8bb1-2d63211bc728


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**