### PR TITLE
[2.x] fix(package-manager): restrict task list endpoint to admins only

### DIFF
--- a/extensions/package-manager/src/Api/Resource/TaskResource.php
+++ b/extensions/package-manager/src/Api/Resource/TaskResource.php
@@ -31,6 +31,8 @@ class TaskResource extends AbstractDatabaseResource
     {
         return [
             Endpoint\Index::make()
+                ->authenticated()
+                ->admin()
                 ->defaultSort('-createdAt')
                 ->paginate(),
         ];

--- a/extensions/package-manager/tests/integration/api/TaskResourceTest.php
+++ b/extensions/package-manager/tests/integration/api/TaskResourceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\ExtensionManager\Tests\integration\api;
+
+use Flarum\ExtensionManager\Task\Task;
+use Flarum\ExtensionManager\Tests\integration\TestCase;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class TaskResourceTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Task::class => [
+                [
+                    'id' => 1,
+                    'status' => Task::SUCCESS,
+                    'operation' => Task::UPDATE_CHECK,
+                    'command' => 'composer outdated',
+                    'package' => null,
+                    'output' => 'flarum/core 1.0.0',
+                    'created_at' => '2024-01-01 00:00:00',
+                    'started_at' => '2024-01-01 00:00:01',
+                    'finished_at' => '2024-01-01 00:00:02',
+                    'peak_memory_used' => 1024,
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function guest_cannot_list_tasks()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/extension-manager-tasks')
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normal_user_cannot_list_tasks()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/extension-manager-tasks', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_list_tasks()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/extension-manager-tasks', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body['data']);
+        $this->assertEquals('extension-manager-tasks', $body['data'][0]['type']);
+    }
+}


### PR DESCRIPTION
## Summary

- The `TaskResource` index endpoint was missing `->authenticated()->admin()` guards
- This allowed unauthenticated users to `GET /api/extension-manager-tasks` and read task logs containing filesystem paths, package versions, composer error output, PHP version, and peak memory usage
- Adds the missing auth guards and integration tests covering guest (401), normal user (403), and admin (200) access

Fixes #4386

## Test plan

- [ ] `GET /api/extension-manager-tasks` with no auth → 401
- [ ] `GET /api/extension-manager-tasks` as normal user → 403
- [ ] `GET /api/extension-manager-tasks` as admin → 200 with task data

🤖 Generated with [Claude Code](https://claude.com/claude-code)