### PR TITLE
fix(mentions): resolve editor-ready race condition without arbitrary timeout

### DIFF
--- a/extensions/mentions/js/src/forum/utils/reply.js
+++ b/extensions/mentions/js/src/forum/utils/reply.js
@@ -1,28 +1,29 @@
 import app from 'flarum/forum/app';
 import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 
-export function insertMention(post, composer, quote) {
-  return new Promise((resolve) => {
-    const mention = app.mentionFormats.mentionable('post').replacement(post) + ' ';
+export async function insertMention(post, composer, quote) {
+  await composer.editorReady();
 
-    // If the composer is empty, then assume we're starting a new reply.
-    // In which case we don't want the user to have to confirm if they
-    // close the composer straight away.
-    if (!composer.fields.content()) {
-      composer.body.attrs.originalContent = mention;
-    }
+  const mention = app.mentionFormats.mentionable('post').replacement(post) + ' ';
 
-    const cursorPosition = composer.editor.getSelectionRange()[0];
-    const preceding = composer.fields.content().slice(0, cursorPosition);
-    const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
+  // If the composer is empty, then assume we're starting a new reply.
+  // In which case we don't want the user to have to confirm if they
+  // close the composer straight away.
+  if (!composer.fields.content()) {
+    composer.body.attrs.originalContent = mention;
+  }
 
-    composer.editor.insertAtCursor(
-      Array(precedingNewlines).join('\n') + // Insert up to two newlines, depending on preceding whitespace
-        (quote ? '> ' + mention + quote.trim().replace(/\n/g, '\n> ') + '\n\n' : mention),
-      false
-    );
-    return resolve(composer);
-  });
+  const cursorPosition = composer.editor.getSelectionRange()[0];
+  const preceding = composer.fields.content().slice(0, cursorPosition);
+  const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
+
+  composer.editor.insertAtCursor(
+    Array(precedingNewlines).join('\n') + // Insert up to two newlines, depending on preceding whitespace
+      (quote ? '> ' + mention + quote.trim().replace(/\n/g, '\n> ') + '\n\n' : mention),
+    false
+  );
+
+  return composer;
 }
 
 export default function reply(post, quote) {

--- a/framework/core/js/src/forum/components/Composer.js
+++ b/framework/core/js/src/forum/components/Composer.js
@@ -72,6 +72,7 @@ export default class Composer extends Component {
   }
 
   onTextEditorBuilt() {
+    this.state.resolveEditorReady();
     this.updateContainer();
     this.textEditorBuilt = true;
   }

--- a/framework/core/js/src/forum/states/ComposerState.tsx
+++ b/framework/core/js/src/forum/states/ComposerState.tsx
@@ -36,6 +36,30 @@ class ComposerState {
   editor: EditorDriverInterface | null = null;
 
   /**
+   * Promise that resolves once the text editor has been built and assigned.
+   * Reset each time a new composer body is loaded via `load()`.
+   */
+  protected _editorReadyPromise!: Promise<void>;
+  protected _resolveEditorReady!: () => void;
+
+  /**
+   * Returns a promise that resolves when the text editor is ready.
+   * Resolves immediately if the editor is already available.
+   */
+  editorReady(): Promise<void> {
+    if (this.editor) return Promise.resolve();
+    return this._editorReadyPromise;
+  }
+
+  /**
+   * Resolve the editorReady promise. Called by the Composer component once
+   * the TextEditor has been built and `composer.editor` is set.
+   */
+  resolveEditorReady(): void {
+    this._resolveEditorReady?.();
+  }
+
+  /**
    * If the composer was loaded and mounted.
    */
   mounted: boolean = false;
@@ -72,6 +96,16 @@ class ComposerState {
     if (this.isVisible()) {
       this.clear();
       m.redraw.sync();
+    }
+
+    // Reset the editor-ready promise for the new body being loaded.
+    // If the editor is already assigned (e.g. reusing an open composer
+    // without a full rebuild), resolve immediately.
+    this._editorReadyPromise = new Promise<void>((resolve) => {
+      this._resolveEditorReady = resolve;
+    });
+    if (this.editor) {
+      this._resolveEditorReady();
     }
 
     this.body = body;


### PR DESCRIPTION
Fixes #4401
Supersedes #4407

## Summary

The race condition was caused by `insertMention` running before `TextEditor.onbuild()` had a chance to assign `composer.editor`. The existing `onTextEditorBuilt` callback in `TextEditor` is the correct signal — this PR wires it into a proper promise rather than using any hard-coded wait time.

**Changes:**

- `ComposerState`: adds `editorReady()` which returns a promise that resolves exactly when `Composer.onTextEditorBuilt()` fires (i.e. when `composer.editor` is assigned). Returns a pre-resolved promise if the editor is already set (covers the edit-post reuse path). The promise is reset on each `load()` call.
- `Composer`: calls `state.resolveEditorReady()` in `onTextEditorBuilt()`.
- `reply.js`: simplifies `insertMention` to `async/await composer.editorReady()` — no `Promise.race`, no timeout.

## Test plan

- [ ] Click Reply on a post → mention inserts correctly with no crash
- [ ] Click Quote on a post → quoted mention inserts correctly
- [ ] Quote while an EditPostComposer is already open → inserts correctly (reuse path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)