### PR TITLE
[2.x] fix(package-manager): reject extensions incompatible with current Flarum major version

### DIFF
--- a/extensions/package-manager/js/src/admin/utils/errorHandler.ts
+++ b/extensions/package-manager/js/src/admin/utils/errorHandler.ts
@@ -5,7 +5,11 @@ export default function (e: any) {
 
   const error = e.response.errors[0];
 
-  if (!['composer_command_failure', 'extension_already_installed', 'extension_not_installed'].includes(error.code)) {
+  if (
+    !['composer_command_failure', 'extension_already_installed', 'extension_not_installed', 'extension_incompatible_with_instance'].includes(
+      error.code
+    )
+  ) {
     throw e;
   }
 
@@ -28,6 +32,14 @@ export default function (e: any) {
 
     case 'extension_not_installed':
       app.alerts.show({ type: 'error' }, app.translator.trans('flarum-extension-manager.admin.exceptions.extension_not_installed'));
+      app.modal.close();
+      break;
+
+    case 'extension_incompatible_with_instance':
+      app.alerts.show(
+        { type: 'error' },
+        app.translator.trans('flarum-extension-manager.admin.exceptions.guessed_cause.extension_incompatible_with_instance')
+      );
       app.modal.close();
   }
 }

--- a/extensions/package-manager/src/Command/RequireExtensionHandler.php
+++ b/extensions/package-manager/src/Command/RequireExtensionHandler.php
@@ -9,14 +9,20 @@
 
 namespace Flarum\ExtensionManager\Command;
 
+use Composer\Semver\Semver;
 use Flarum\Extension\Extension;
 use Flarum\Extension\ExtensionManager;
 use Flarum\ExtensionManager\Composer\ComposerAdapter;
 use Flarum\ExtensionManager\Exception\ComposerRequireFailedException;
 use Flarum\ExtensionManager\Exception\ExtensionAlreadyInstalledException;
+use Flarum\ExtensionManager\Exception\ExtensionIncompatibleWithFlarumException;
 use Flarum\ExtensionManager\Extension\Event\Installed;
 use Flarum\ExtensionManager\RequirePackageValidator;
+use Flarum\Foundation\Application;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\StringInput;
 
 class RequireExtensionHandler
@@ -25,7 +31,8 @@ class RequireExtensionHandler
         protected ComposerAdapter $composer,
         protected ExtensionManager $extensions,
         protected RequirePackageValidator $validator,
-        protected Dispatcher $events
+        protected Dispatcher $events,
+        protected Client $http,
     ) {
     }
 
@@ -53,6 +60,8 @@ class RequireExtensionHandler
             $packageName .= ':*';
         }
 
+        $this->assertFlarumCompatibility($packageName);
+
         $output = $this->composer->run(
             new StringInput("require $packageName -W"),
             $command->task ?? null,
@@ -68,5 +77,63 @@ class RequireExtensionHandler
         );
 
         return ['id' => $extensionId];
+    }
+
+    /**
+     * Check the package's latest stable release on Packagist to confirm it declares
+     * a flarum/core constraint that is satisfied by the running Flarum version.
+     *
+     * Packages with "*" or other overly broad constraints pass Composer's resolver
+     * but may not actually work on the current major version.
+     *
+     * If Packagist is unreachable or the package has no stable releases, we allow
+     * the install to proceed and let Composer's own resolver be the final gate.
+     *
+     * @throws ExtensionIncompatibleWithFlarumException
+     */
+    protected function assertFlarumCompatibility(string $packageName): void
+    {
+        $rawName = preg_replace('/^([A-z0-9-_\/]+)(?::.*|)$/i', '$1', $packageName);
+
+        try {
+            $response = $this->http->get("https://repo.packagist.org/p2/{$rawName}.json");
+        } catch (GuzzleException) {
+            // If Packagist is unreachable, let Composer try — it will fail with its own error.
+            return;
+        }
+
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            return;
+        }
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $packages = new Collection($json['packages'][$rawName] ?? []);
+
+        if ($packages->isEmpty()) {
+            return;
+        }
+
+        // Find the latest stable (non-dev) release.
+        $latest = $packages->first(fn (array $p) => ! str_contains($p['version'] ?? '', 'dev-'));
+
+        if (! $latest) {
+            return;
+        }
+
+        $coreConstraint = $latest['require']['flarum/core'] ?? null;
+
+        if (! $coreConstraint) {
+            return;
+        }
+
+        // A constraint that satisfies both 1.x and 2.x (e.g. "*") is too broad
+        // to trust — the extension was almost certainly written for one major version only.
+        // Reject it unless it was explicitly authored for the current major.
+        $tooPermissive = Semver::satisfies('1.0.0', $coreConstraint) && Semver::satisfies('2.0.0', $coreConstraint);
+
+        if ($tooPermissive || ! Semver::satisfies(Application::VERSION, $coreConstraint)) {
+            throw new ExtensionIncompatibleWithFlarumException($rawName, $coreConstraint);
+        }
     }
 }

--- a/extensions/package-manager/src/Exception/ExtensionIncompatibleWithFlarumException.php
+++ b/extensions/package-manager/src/Exception/ExtensionIncompatibleWithFlarumException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\ExtensionManager\Exception;
+
+use Exception;
+use Flarum\Foundation\KnownError;
+
+class ExtensionIncompatibleWithFlarumException extends Exception implements KnownError
+{
+    public function __construct(string $package, string $constraint)
+    {
+        parent::__construct("Extension $package requires flarum/core $constraint which is incompatible with the installed version.");
+    }
+
+    public function getType(): string
+    {
+        return 'extension_incompatible_with_instance';
+    }
+}

--- a/extensions/package-manager/tests/unit/RequireExtensionCompatibilityTest.php
+++ b/extensions/package-manager/tests/unit/RequireExtensionCompatibilityTest.php
@@ -95,10 +95,10 @@ class RequireExtensionCompatibilityTest extends TestCase
     public static function incompatibleConstraints(): array
     {
         return [
-            'wildcard *'          => ['*'],
-            '1.x constraint'      => ['^1.0'],
+            'wildcard *' => ['*'],
+            '1.x constraint' => ['^1.0'],
             'broad >= constraint' => ['>=1.0'],
-            '1.x range'          => ['>=1.0,<2.0'],
+            '1.x range' => ['>=1.0,<2.0'],
         ];
     }
 

--- a/extensions/package-manager/tests/unit/RequireExtensionCompatibilityTest.php
+++ b/extensions/package-manager/tests/unit/RequireExtensionCompatibilityTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\ExtensionManager\Tests\unit;
+
+use Flarum\ExtensionManager\Command\RequireExtensionHandler;
+use Flarum\ExtensionManager\Exception\ExtensionIncompatibleWithFlarumException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class RequireExtensionCompatibilityTest extends TestCase
+{
+    /**
+     * Expose the protected assertFlarumCompatibility method for testing.
+     */
+    private function makeHandler(Client $http): object
+    {
+        return new class($http) extends RequireExtensionHandler {
+            public function __construct(Client $http)
+            {
+                // Bypass the normal constructor — we only need the HTTP client for these tests.
+                $this->http = $http;
+            }
+
+            public function checkCompatibility(string $packageName): void
+            {
+                $this->assertFlarumCompatibility($packageName);
+            }
+        };
+    }
+
+    private function makeClient(string $responseBody, int $status = 200): Client
+    {
+        $mock = new MockHandler([new Response($status, [], $responseBody)]);
+
+        return new Client(['handler' => HandlerStack::create($mock)]);
+    }
+
+    private function packagistPayload(string $package, string $coreConstraint, string $version = 'v2.0.0'): string
+    {
+        return json_encode([
+            'packages' => [
+                $package => [
+                    [
+                        'name' => $package,
+                        'version' => $version,
+                        'require' => [
+                            'flarum/core' => $coreConstraint,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function allows_extension_with_explicit_2x_constraint(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $handler = $this->makeHandler($this->makeClient($this->packagistPayload('acme/test', '^2.0.0-beta.1')));
+
+        $handler->checkCompatibility('acme/test:*');
+    }
+
+    #[Test]
+    public function allows_extension_with_beta_2x_constraint_satisfied_by_current_version(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $handler = $this->makeHandler($this->makeClient($this->packagistPayload('acme/test', '^2.0.0-beta.5')));
+
+        $handler->checkCompatibility('acme/test');
+    }
+
+    #[Test]
+    #[DataProvider('incompatibleConstraints')]
+    public function rejects_extension_with_incompatible_constraint(string $constraint): void
+    {
+        $handler = $this->makeHandler($this->makeClient($this->packagistPayload('acme/test', $constraint)));
+
+        $this->expectException(ExtensionIncompatibleWithFlarumException::class);
+        $handler->checkCompatibility('acme/test');
+    }
+
+    public static function incompatibleConstraints(): array
+    {
+        return [
+            'wildcard *'          => ['*'],
+            '1.x constraint'      => ['^1.0'],
+            'broad >= constraint' => ['>=1.0'],
+            '1.x range'          => ['>=1.0,<2.0'],
+        ];
+    }
+
+    #[Test]
+    public function allows_install_when_packagist_returns_non_200(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $handler = $this->makeHandler($this->makeClient('', 503));
+
+        // Fail open when Packagist is unavailable.
+        $handler->checkCompatibility('acme/test');
+    }
+
+    #[Test]
+    public function allows_install_when_package_has_no_releases(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $payload = json_encode(['packages' => ['acme/test' => []]]);
+        $handler = $this->makeHandler($this->makeClient($payload));
+
+        $handler->checkCompatibility('acme/test');
+    }
+
+    #[Test]
+    public function allows_install_when_package_has_no_flarum_core_requirement(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $payload = json_encode([
+            'packages' => [
+                'acme/test' => [
+                    ['name' => 'acme/test', 'version' => 'v1.0.0', 'require' => []],
+                ],
+            ],
+        ]);
+        $handler = $this->makeHandler($this->makeClient($payload));
+
+        $handler->checkCompatibility('acme/test');
+    }
+
+    #[Test]
+    public function allows_install_when_only_dev_releases_exist(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $payload = json_encode([
+            'packages' => [
+                'acme/test' => [
+                    [
+                        'name' => 'acme/test',
+                        'version' => 'dev-main',
+                        'require' => ['flarum/core' => '*'],
+                    ],
+                ],
+            ],
+        ]);
+        $handler = $this->makeHandler($this->makeClient($payload));
+
+        // dev-only packages are skipped — fail open.
+        $handler->checkCompatibility('acme/test');
+    }
+
+    #[Test]
+    public function strips_version_specifier_from_package_name_before_api_call(): void
+    {
+        $this->expectNotToPerformAssertions();
+        // The Packagist URL must use just the package name, not "acme/test:^2.0".
+        // We verify this indirectly: the payload keyed by the bare name is found correctly.
+        $handler = $this->makeHandler($this->makeClient($this->packagistPayload('acme/test', '^2.0.0')));
+
+        $handler->checkCompatibility('acme/test:^2.0');
+    }
+}


### PR DESCRIPTION
Fixes #4408

## Summary

Extensions with `"flarum/core": "*"` (or other overly broad constraints like `"^1.0"`) pass Composer's resolver on 2.x — because `*` technically satisfies `^2.0` — but the extension code was written for 1.x and breaks at runtime.

This adds a **pre-install compatibility check** via the Packagist p2 API before handing off to Composer:

1. Fetch `repo.packagist.org/p2/{package}.json` to get the latest stable release's `composer.json` metadata.
2. Check the `flarum/core` constraint using `Composer\Semver`:
   - Constraints that satisfy **both** `1.0.0` and `2.0.0` (e.g. `*`, `>=1.0`) are treated as **too permissive** and rejected — an extension genuinely targeting 2.x would use `^2.0`.
   - Constraints that don't satisfy the running Flarum version (e.g. `^1.0`) are rejected.
3. **Fails open** — if Packagist is unreachable, the package has no stable releases, or there's no `flarum/core` requirement, the install proceeds and Composer's own resolver is the final gate.

The frontend already has a translation string for `extension_incompatible_with_instance`; the error handler is updated to catch the new `KnownError` type and display it as an alert.

## Changes

- **`RequireExtensionHandler`** — injects `GuzzleHttp\Client`, runs `assertFlarumCompatibility()` before Composer
- **`ExtensionIncompatibleWithFlarumException`** — new `KnownError` with type `extension_incompatible_with_instance`
- **`errorHandler.ts`** — handles `extension_incompatible_with_instance` directly (shows alert, closes modal)
- **`RequireExtensionCompatibilityTest`** — 11 unit tests using `GuzzleHttp\Handler\MockHandler`, covering all constraint scenarios and fail-open cases

## Test plan

- [ ] Try installing a 1.x-only extension (`"flarum/core": "^1.0"`) → error alert appears immediately, Composer never runs
- [ ] Try installing an extension with `"flarum/core": "*"` → same result
- [ ] Try installing a valid 2.x extension → installs normally
- [ ] Run `composer test:unit` → all 11 unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)