### PR TITLE
[1.x] fix(core): add missing method_not_allowed translation for error view

### DIFF
--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -721,6 +721,7 @@ core:
       csrf_token_mismatch_return_link: Go back, to try again
       invalid_confirmation_token: This confirmation link has already been used or is invalid.
       not_authenticated: You do not have permission to access this page. Try again after logging in.
+      method_not_allowed: This page does not support that request method.
       not_found: The page you requested could not be found.
       not_found_return_link: "Return to {forum}"
       permission_denied: You do not have permission to access this page.


### PR DESCRIPTION
## Summary

Fixes #4238

When a `MethodNotAllowedException` is thrown, the HTTP 405 status code was correctly set, but the error page displayed the generic "An error occurred while trying to load this page." message instead of a specific one.

`ViewFormatter::getMessage()` looks up `core.views.error.{type}` — if the key doesn't exist, the translator returns the key itself, which is detected as a miss and falls through to the generic message. Adding the missing `method_not_allowed` translation key fixes this.

A corresponding PR for 2.x will follow.

## Test plan

- [ ] Make a GET request to a POST-only route (e.g. `/login`)
- [ ] Confirm the error page shows "This page does not support that request method." with a 405 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)