### PR TITLE
[2.x] fix(core): add missing method_not_allowed translation for error view

### DIFF
--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -901,6 +901,7 @@ core:
       maintenance_mode_link: Administrator login
       maintenance_mode_message: This forum is currently down for maintenance. Please check back later.
       maintenance_mode_title: Maintenance
+      method_not_allowed: This page does not support that request method.
       not_authenticated: You do not have permission to access this page. Try again after logging in.
       not_found: The page you requested could not be found.
       not_found_return_link: "Return to {forum}"


### PR DESCRIPTION
## Summary

Fixes #4238 (2.x counterpart to #4417)

When a `MethodNotAllowedException` is thrown, the HTTP 405 status code was correctly set, but the error page displayed the generic "An error occurred while trying to load this page." message instead of a specific one.

`ViewFormatter::getMessage()` looks up `core.views.error.{type}` — if the key doesn't exist, the translator returns the key itself, which is detected as a miss and falls through to the generic message. Adding the missing `method_not_allowed` translation key fixes this.

## Test plan

- [ ] Make a GET request to a POST-only route (e.g. `/login`)
- [ ] Confirm the error page shows "This page does not support that request method." with a 405 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)