### PR TITLE
[2.x] fix: add left padding to posts on mobile

### DIFF
--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -367,6 +367,9 @@
 }
 
 @media @phone {
+  .Post {
+    padding-left: var(--post-padding);
+  }
   .Post-side {
     .Post-avatar {
       display: none;


### PR DESCRIPTION
## Summary

- Fixes uneven post padding on mobile devices (issue #4415)
- `.Post` base style has `padding-left: 0` since the avatar grid column provides implicit left spacing on desktop/tablet; on mobile the grid and avatar are removed, leaving content flush against the left edge
- Adds `padding-left: var(--post-padding)` inside `@media @phone` so both sides have symmetrical 20px padding

## Test plan

- [ ] Open a discussion on a mobile device or browser devtools at ≤767px viewport width
- [ ] Verify posts have equal left and right padding on both comment posts and event posts
- [ ] Verify event post icons still align correctly
- [ ] Verify thread divider lines between posts still render correctly

Closes #4415

🤖 Generated with [Claude Code](https://claude.com/claude-code)