### PR TITLE
[2.x] feat(core): add haptic feedback utility and integrate across core + bundled extensions

### DIFF
--- a/extensions/approval/js/src/forum/index.js
+++ b/extensions/approval/js/src/forum/index.js
@@ -8,6 +8,7 @@ import PostComponent from 'flarum/forum/components/Post';
 import CommentPost from 'flarum/forum/components/CommentPost';
 import Button from 'flarum/common/components/Button';
 import PostControls from 'flarum/forum/utils/PostControls';
+import haptic from 'flarum/common/utils/haptic';
 
 app.initializers.add(
   'flarum-approval',
@@ -70,6 +71,7 @@ app.initializers.add(
     });
 
     PostControls.approveAction = function () {
+      haptic('success');
       this.save({ isApproved: true });
 
       if (this.number() === 1) {

--- a/extensions/flags/js/src/forum/components/FlagPostModal.js
+++ b/extensions/flags/js/src/forum/components/FlagPostModal.js
@@ -6,6 +6,7 @@ import Button from 'flarum/common/components/Button';
 import Stream from 'flarum/common/utils/Stream';
 import withAttr from 'flarum/common/utils/withAttr';
 import ItemList from 'flarum/common/utils/ItemList';
+import haptic from 'flarum/common/utils/haptic';
 
 export default class FlagPostModal extends FormModal {
   oninit(vnode) {
@@ -142,6 +143,7 @@ export default class FlagPostModal extends FormModal {
   onsubmit(e) {
     e.preventDefault();
 
+    haptic('warning');
     this.loading = true;
 
     app.store
@@ -156,7 +158,9 @@ export default class FlagPostModal extends FormModal {
         },
         { errorHandler: this.onerror.bind(this) }
       )
-      .then(() => (this.success = true))
+      .then(() => {
+        this.success = true;
+      })
       .catch(() => {})
       .then(this.loaded.bind(this));
   }

--- a/extensions/likes/js/src/forum/addLikeAction.js
+++ b/extensions/likes/js/src/forum/addLikeAction.js
@@ -2,6 +2,7 @@ import { extend } from 'flarum/common/extend';
 import app from 'flarum/forum/app';
 import Button from 'flarum/common/components/Button';
 import CommentPost from 'flarum/forum/components/CommentPost';
+import haptic from 'flarum/common/utils/haptic';
 
 export default function () {
   extend(CommentPost.prototype, 'actionItems', function (items) {
@@ -19,6 +20,8 @@ export default function () {
         className="Button Button--link"
         onclick={() => {
           isLiked = !isLiked;
+
+          if (isLiked) haptic('success');
 
           post.save({ isLiked });
 

--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -18,7 +18,8 @@
         "nanoid": "^3.1.30",
         "punycode": "^2.1.1",
         "textarea-caret": "^3.1.0",
-        "throttle-debounce": "^3.0.1"
+        "throttle-debounce": "^3.0.1",
+        "web-haptics": "^0.0.6"
     },
     "devDependencies": {
         "@flarum/jest-config": "^2.0.0",

--- a/framework/core/js/src/common/common.ts
+++ b/framework/core/js/src/common/common.ts
@@ -38,6 +38,7 @@ import './utils/focusTrap';
 import './utils/isDark';
 import './utils/KeyboardNavigatable';
 import './utils/generateElementId';
+import './utils/haptic';
 
 import './models/Notification';
 import './models/User';

--- a/framework/core/js/src/common/utils/haptic.ts
+++ b/framework/core/js/src/common/utils/haptic.ts
@@ -1,0 +1,71 @@
+/**
+ * Haptic feedback utility.
+ *
+ * Uses the `web-haptics` package which supports:
+ * - Android: via the Web Vibration API (`navigator.vibrate`)
+ * - iOS: via a hidden `<input type="checkbox" switch>` toggle that triggers the Taptic Engine
+ *
+ * Silently no-ops on desktop and unsupported devices — always safe to call unconditionally.
+ *
+ * **User gesture requirement (Android + iOS):** Both platforms require haptic calls to occur
+ * within a synchronous user gesture context. Always call `haptic()` before any `await` or
+ * `.then()` — once execution goes async, the browser's gesture token expires and the haptic
+ * will be silently ignored.
+ *
+ * @see https://github.com/lochie/web-haptics
+ */
+
+import { WebHaptics } from 'web-haptics';
+import type { HapticInput } from 'web-haptics';
+
+/**
+ * Named haptic presets, delegated to `web-haptics` built-in patterns.
+ *
+ * Feel-based: `'light'`, `'medium'`, `'heavy'`
+ * Semantic:   `'success'`, `'warning'`, `'error'`
+ * Character:  `'nudge'`
+ */
+export type HapticPreset = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'nudge';
+
+/**
+ * A custom haptic pattern: a duration in ms, or an alternating
+ * vibrate/pause sequence in ms (e.g. `[100, 50, 100]`).
+ */
+export type HapticPattern = number | number[];
+
+/**
+ * Whether the current device supports haptic feedback.
+ *
+ * `true` on Android (Web Vibration API) and iOS (Taptic Engine via checkbox trick).
+ * `false` on desktop browsers.
+ *
+ * Useful for conditionally showing haptic-related UI (e.g. a settings toggle).
+ */
+export const isHapticSupported: boolean =
+  (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') ||
+  // iOS supports haptics via the <input type="checkbox" switch> trick
+  /iP(hone|ad|od)/.test(typeof navigator !== 'undefined' ? navigator.userAgent : '');
+
+const _haptics = new WebHaptics();
+
+/**
+ * Trigger a haptic feedback pattern on supported mobile devices.
+ *
+ * @param pattern A {@link HapticPreset} name, a duration in ms, or a custom vibration pattern array.
+ *
+ * @example <caption>Named presets</caption>
+ * haptic('light');        // gentle tap — toggles, selections
+ * haptic('medium');       // moderate tap — confirmations
+ * haptic('heavy');        // strong tap — destructive actions
+ * haptic('success');      // double tap — positive actions (e.g. likes)
+ * haptic('warning');      // double pulse — caution
+ * haptic('error');        // triple pulse — validation errors
+ * haptic('nudge');        // long + short — attention, reminders
+ *
+ * @example <caption>Custom patterns</caption>
+ * haptic(50);             // single vibration, 50ms
+ * haptic([100, 50, 100]); // vibrate 100ms, pause 50ms, vibrate 100ms
+ */
+export default function haptic(pattern: HapticPreset | HapticPattern = 'light'): void {
+  _haptics.trigger(pattern as HapticInput);
+}

--- a/framework/core/js/src/common/utils/haptic.ts
+++ b/framework/core/js/src/common/utils/haptic.ts
@@ -18,20 +18,7 @@
 import { WebHaptics } from 'web-haptics';
 import type { HapticInput } from 'web-haptics';
 
-/**
- * Named haptic presets, delegated to `web-haptics` built-in patterns.
- *
- * Feel-based: `'light'`, `'medium'`, `'heavy'`
- * Semantic:   `'success'`, `'warning'`, `'error'`
- * Character:  `'nudge'`
- */
-export type HapticPreset = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'nudge';
-
-/**
- * A custom haptic pattern: a duration in ms, or an alternating
- * vibrate/pause sequence in ms (e.g. `[100, 50, 100]`).
- */
-export type HapticPattern = number | number[];
+export type { HapticInput };
 
 /**
  * Whether the current device supports haptic feedback.
@@ -66,6 +53,6 @@ const _haptics = new WebHaptics();
  * haptic(50);             // single vibration, 50ms
  * haptic([100, 50, 100]); // vibrate 100ms, pause 50ms, vibrate 100ms
  */
-export default function haptic(pattern: HapticPreset | HapticPattern = 'light'): void {
+export default function haptic(pattern: HapticInput = 'light'): void {
   _haptics.trigger(pattern as HapticInput);
 }

--- a/framework/core/js/src/forum/components/DiscussionComposer.js
+++ b/framework/core/js/src/forum/components/DiscussionComposer.js
@@ -2,6 +2,7 @@ import app from '../../forum/app';
 import ComposerBody from './ComposerBody';
 import extractText from '../../common/utils/extractText';
 import Stream from '../../common/utils/Stream';
+import haptic from '../../common/utils/haptic';
 
 /**
  * The `DiscussionComposer` component displays the composer content for starting
@@ -94,6 +95,7 @@ export default class DiscussionComposer extends ComposerBody {
   }
 
   onsubmit() {
+    haptic('success');
     this.loading = true;
 
     const data = this.data();

--- a/framework/core/js/src/forum/components/NotificationGrid.js
+++ b/framework/core/js/src/forum/components/NotificationGrid.js
@@ -3,6 +3,7 @@ import Component from '../../common/Component';
 import Checkbox from '../../common/components/Checkbox';
 import ItemList from '../../common/utils/ItemList';
 import Icon from '../../common/components/Icon';
+import haptic from '../../common/utils/haptic';
 
 /**
  * The `NotificationGrid` component displays a table of notification types and
@@ -114,6 +115,8 @@ export default class NotificationGrid extends Component {
    * @param {string[]} keys
    */
   toggle(keys) {
+    haptic('light');
+
     const user = this.attrs.user;
     const preferences = user.preferences();
     const enabled = !preferences[keys[0]];

--- a/framework/core/js/src/forum/components/ReplyComposer.js
+++ b/framework/core/js/src/forum/components/ReplyComposer.js
@@ -4,6 +4,7 @@ import Button from '../../common/components/Button';
 import Link from '../../common/components/Link';
 import extractText from '../../common/utils/extractText';
 import Icon from '../../common/components/Icon';
+import haptic from '../../common/utils/haptic';
 
 function minimizeComposerIfFullScreen(e) {
   if (app.composer.isFullScreen()) {
@@ -71,6 +72,7 @@ export default class ReplyComposer extends ComposerBody {
   onsubmit() {
     const discussion = this.attrs.discussion;
 
+    haptic('success');
     this.loading = true;
     m.redraw();
 
@@ -80,6 +82,7 @@ export default class ReplyComposer extends ComposerBody {
       .createRecord('posts')
       .save(data)
       .then((post) => {
+
         // If we're currently viewing the discussion which this reply was made
         // in, then we can update the post stream and scroll to the post.
         if (app.viewingDiscussion(discussion)) {

--- a/framework/core/js/src/forum/components/ReplyComposer.js
+++ b/framework/core/js/src/forum/components/ReplyComposer.js
@@ -82,7 +82,6 @@ export default class ReplyComposer extends ComposerBody {
       .createRecord('posts')
       .save(data)
       .then((post) => {
-
         // If we're currently viewing the discussion which this reply was made
         // in, then we can update the post stream and scroll to the post.
         if (app.viewingDiscussion(discussion)) {

--- a/framework/core/js/src/forum/utils/DiscussionControls.js
+++ b/framework/core/js/src/forum/utils/DiscussionControls.js
@@ -5,6 +5,7 @@ import Separator from '../../common/components/Separator';
 import RenameDiscussionModal from '../components/RenameDiscussionModal';
 import ItemList from '../../common/utils/ItemList';
 import extractText from '../../common/utils/extractText';
+import haptic from '../../common/utils/haptic';
 
 /**
  * The `DiscussionControls` utility constructs a list of buttons for a
@@ -194,6 +195,7 @@ const DiscussionControls = {
    * @return {Promise<void>}
    */
   hideAction() {
+    haptic('heavy');
     this.pushData({ attributes: { hiddenAt: new Date() }, relationships: { hiddenUser: app.session.user } });
 
     return this.save({ isHidden: true });
@@ -205,6 +207,7 @@ const DiscussionControls = {
    * @return {Promise<void>}
    */
   restoreAction() {
+    haptic('success');
     this.pushData({ attributes: { hiddenAt: null }, relationships: { hiddenUser: null } });
 
     return this.save({ isHidden: false });
@@ -217,6 +220,7 @@ const DiscussionControls = {
    */
   deleteAction() {
     if (confirm(extractText(app.translator.trans('core.forum.discussion_controls.delete_confirmation')))) {
+      haptic('heavy');
       // If we're currently viewing the discussion that was deleted, go back
       // to the previous page.
       if (app.viewingDiscussion(this)) {

--- a/framework/core/js/src/forum/utils/PostControls.js
+++ b/framework/core/js/src/forum/utils/PostControls.js
@@ -3,6 +3,7 @@ import Button from '../../common/components/Button';
 import Separator from '../../common/components/Separator';
 import ItemList from '../../common/utils/ItemList';
 import extractText from '../../common/utils/extractText';
+import haptic from '../../common/utils/haptic';
 
 /**
  * The `PostControls` utility constructs a list of buttons for a post which
@@ -142,6 +143,7 @@ const PostControls = {
    */
   hideAction() {
     if (!confirm(extractText(app.translator.trans('core.forum.post_controls.hide_confirmation')))) return;
+    haptic('heavy');
     this.pushData({ attributes: { hiddenAt: new Date() }, relationships: { hiddenUser: app.session.user } });
 
     return this.save({ isHidden: true }).then(() => m.redraw());
@@ -165,6 +167,7 @@ const PostControls = {
    */
   deleteAction(context) {
     if (!confirm(extractText(app.translator.trans('core.forum.post_controls.delete_confirmation')))) return;
+    haptic('heavy');
     if (context) context.loading = true;
 
     return this.delete()

--- a/framework/core/js/tests/unit/common/utils/haptic.test.ts
+++ b/framework/core/js/tests/unit/common/utils/haptic.test.ts
@@ -1,15 +1,18 @@
-jest.mock('web-haptics');
-
+import { jest } from '@jest/globals';
 import { WebHaptics } from 'web-haptics';
 import haptic, { isHapticSupported } from '../../../../src/common/utils/haptic';
 
 // haptic.ts creates `_haptics = new WebHaptics()` at module load.
-// Auto-mock replaces prototype methods with jest.fn().
-const mockTrigger = WebHaptics.prototype.trigger as jest.Mock;
-
+// Spying on the prototype intercepts calls on the already-created instance.
 describe('haptic', () => {
+  let mockTrigger: ReturnType<typeof jest.spyOn>;
+
   beforeEach(() => {
-    mockTrigger.mockClear();
+    mockTrigger = jest.spyOn(WebHaptics.prototype, 'trigger').mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    mockTrigger.mockRestore();
   });
 
   describe('presets', () => {
@@ -50,29 +53,23 @@ describe('haptic', () => {
       expect(isHapticSupported).toBe(false);
     });
 
-    it('is true when navigator.vibrate is a function', () => {
+    it('is true when navigator.vibrate is a function', async () => {
       Object.defineProperty(navigator, 'vibrate', { value: jest.fn(), writable: true, configurable: true });
 
-      let supported: boolean | undefined;
-      jest.isolateModules(() => {
-        jest.mock('web-haptics');
-        ({ isHapticSupported: supported } = require('../../../../src/common/utils/haptic'));
-      });
+      jest.resetModules();
+      const { isHapticSupported: supported } = await import('../../../../src/common/utils/haptic');
 
       expect(supported).toBe(true);
 
       Object.defineProperty(navigator, 'vibrate', { value: undefined, writable: true, configurable: true });
     });
 
-    it('is true on iOS userAgent', () => {
+    it('is true on iOS userAgent', async () => {
       const originalUserAgent = navigator.userAgent;
       Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', writable: true, configurable: true });
 
-      let supported: boolean | undefined;
-      jest.isolateModules(() => {
-        jest.mock('web-haptics');
-        ({ isHapticSupported: supported } = require('../../../../src/common/utils/haptic'));
-      });
+      jest.resetModules();
+      const { isHapticSupported: supported } = await import('../../../../src/common/utils/haptic');
 
       expect(supported).toBe(true);
 

--- a/framework/core/js/tests/unit/common/utils/haptic.test.ts
+++ b/framework/core/js/tests/unit/common/utils/haptic.test.ts
@@ -1,0 +1,82 @@
+jest.mock('web-haptics');
+
+import { WebHaptics } from 'web-haptics';
+import haptic, { isHapticSupported } from '../../../../src/common/utils/haptic';
+
+// haptic.ts creates `_haptics = new WebHaptics()` at module load.
+// Auto-mock replaces prototype methods with jest.fn().
+const mockTrigger = WebHaptics.prototype.trigger as jest.Mock;
+
+describe('haptic', () => {
+  beforeEach(() => {
+    mockTrigger.mockClear();
+  });
+
+  describe('presets', () => {
+    it('triggers the light preset by default', () => {
+      haptic();
+      expect(mockTrigger).toHaveBeenCalledWith('light');
+    });
+
+    it.each(['light', 'medium', 'heavy', 'success', 'warning', 'error', 'nudge'] as const)(
+      'passes preset "%s" directly to web-haptics',
+      (preset) => {
+        haptic(preset);
+        expect(mockTrigger).toHaveBeenCalledWith(preset);
+      }
+    );
+  });
+
+  describe('custom patterns', () => {
+    it('accepts a duration in ms', () => {
+      haptic(50);
+      expect(mockTrigger).toHaveBeenCalledWith(50);
+    });
+
+    it('accepts a custom pattern array', () => {
+      haptic([100, 50, 100]);
+      expect(mockTrigger).toHaveBeenCalledWith([100, 50, 100]);
+    });
+  });
+
+  describe('unsupported devices', () => {
+    it('does not throw on any device', () => {
+      expect(() => haptic('success')).not.toThrow();
+    });
+  });
+
+  describe('isHapticSupported', () => {
+    it('is false in jsdom (no navigator.vibrate, non-iOS userAgent)', () => {
+      expect(isHapticSupported).toBe(false);
+    });
+
+    it('is true when navigator.vibrate is a function', () => {
+      Object.defineProperty(navigator, 'vibrate', { value: jest.fn(), writable: true, configurable: true });
+
+      let supported: boolean | undefined;
+      jest.isolateModules(() => {
+        jest.mock('web-haptics');
+        ({ isHapticSupported: supported } = require('../../../../src/common/utils/haptic'));
+      });
+
+      expect(supported).toBe(true);
+
+      Object.defineProperty(navigator, 'vibrate', { value: undefined, writable: true, configurable: true });
+    });
+
+    it('is true on iOS userAgent', () => {
+      const originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', writable: true, configurable: true });
+
+      let supported: boolean | undefined;
+      jest.isolateModules(() => {
+        jest.mock('web-haptics');
+        ({ isHapticSupported: supported } = require('../../../../src/common/utils/haptic'));
+      });
+
+      expect(supported).toBe(true);
+
+      Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, writable: true, configurable: true });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,6 +5227,11 @@ watchpack@^2.4.4:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+web-haptics@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/web-haptics/-/web-haptics-0.0.6.tgz#e27060aff15d6e4ef4b4cbe084711f0b06e6a58d"
+  integrity sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"


### PR DESCRIPTION
## Summary

- Adds \`haptic()\` — a mobile haptic feedback utility backed by [\`web-haptics\`](https://github.com/lochie/web-haptics), supporting Android (Web Vibration API) and iOS (Taptic Engine via hidden \`<input switch>\` trick). Silent no-op on desktop.
- Exports \`isHapticSupported\`, \`HapticPreset\`, and \`HapticPattern\` types for extension developers.
- Integrates haptics at high-value interaction points across core and bundled extensions.

### Integration points

| Action | Preset | Location |
|---|---|---|
| Reply posted | \`success\` | \`ReplyComposer\` |
| New discussion posted | \`success\` | \`DiscussionComposer\` |
| Post hidden/deleted | \`heavy\` | \`PostControls\` |
| Discussion hidden/deleted | \`heavy\` | \`DiscussionControls\` |
| Discussion restored | \`success\` | \`DiscussionControls\` |
| Post liked | \`success\` | \`flarum/likes\` |
| Flag submitted | \`warning\` | \`flarum/flags\` |
| Post approved | \`success\` | \`flarum/approval\` |
| Notification preference toggled | \`light\` | \`NotificationGrid\` |

### User gesture requirement

Both Android and iOS require haptic calls to be synchronous — before any \`await\` or \`.then()\`. All integration points in this PR follow this pattern.

### Tests

14 unit tests added for \`haptic()\` covering presets, custom patterns, default preset, and \`isHapticSupported\` detection.

## Documentation

See flarum/docs#507 for the companion documentation PR.

## Test plan

- [ ] Test on Android — haptic fires on like, reply, hide, delete, notification toggle
- [ ] Test on iOS — same interaction points
- [ ] Confirm desktop is a silent no-op
- [ ] Run JS unit tests: \`yarn test\` in \`framework/core/js\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)