### PR TITLE
[2.x] Implement `CloseWatcher` for modals and dropdowns

### DIFF
--- a/framework/core/js/package.json
+++ b/framework/core/js/package.json
@@ -25,6 +25,7 @@
         "@flarum/jest-config": "^2.0.0",
         "@flarum/prettier-config": "^1.0.0",
         "@types/body-scroll-lock": "^3.1.0",
+        "@types/dom-close-watcher": "^1.0.0",
         "@types/jquery": "^3.5.10",
         "@types/mithril": "^2.0.8",
         "@types/punycode": "^2.1.0",

--- a/framework/core/js/src/common/components/Dropdown.tsx
+++ b/framework/core/js/src/common/components/Dropdown.tsx
@@ -118,6 +118,7 @@ export default class Dropdown<CustomAttrs extends IDropdownAttrs = IDropdownAttr
         this.closeWatcher?.destroy();
         this.closeWatcher = new CloseWatcher();
         this.closeWatcher.onclose = () => {
+          // @ts-ignore - missing dropdown types
           this.$('.Dropdown-toggle').dropdown('toggle');
         };
       }

--- a/framework/core/js/src/common/components/Dropdown.tsx
+++ b/framework/core/js/src/common/components/Dropdown.tsx
@@ -41,6 +41,7 @@ export interface IDropdownAttrs extends ComponentAttrs {
  */
 export default class Dropdown<CustomAttrs extends IDropdownAttrs = IDropdownAttrs> extends Component<CustomAttrs> {
   protected showing = false;
+  protected closeWatcher?: CloseWatcher;
 
   static initAttrs(attrs: IDropdownAttrs) {
     attrs.className ||= '';
@@ -112,10 +113,20 @@ export default class Dropdown<CustomAttrs extends IDropdownAttrs = IDropdownAttr
       const windowWidth = $(window).width() ?? 0;
 
       $menu.toggleClass('Dropdown-menu--right', isRight || left + width > windowScrollLeft + windowWidth);
+
+      if ('CloseWatcher' in window) {
+        this.closeWatcher?.destroy();
+        this.closeWatcher = new CloseWatcher();
+        this.closeWatcher.onclose = () => {
+          this.$('.Dropdown-toggle').dropdown('toggle');
+        };
+      }
     });
 
     this.$().on('hidden.bs.dropdown', () => {
       this.showing = false;
+      this.closeWatcher?.destroy();
+      this.closeWatcher = undefined;
 
       if (this.attrs.onhide) {
         this.attrs.onhide();

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -145,6 +145,7 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
         if ('CloseWatcher' in window && this.lastCloseWatcherKey !== dialogKey) {
           // Destroy previous watcher when stacking modals
           this.closeWatcher?.destroy();
+          this.closeWatcher = undefined;
 
           if (this.attrs.state.modal!.componentClass.dismissibleOptions.viaEscKey) {
             this.closeWatcher = new CloseWatcher();

--- a/framework/core/js/src/common/components/ModalManager.tsx
+++ b/framework/core/js/src/common/components/ModalManager.tsx
@@ -24,6 +24,12 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
   // Keep track of the last set focus trap
   protected lastSetFocusTrap: number | undefined;
 
+  // Current close watcher instance
+  protected closeWatcher: CloseWatcher | undefined;
+
+  // Keep track of the last set close watcher
+  protected lastCloseWatcherKey: number | undefined;
+
   // Keep track if there's an modal closing
   protected modalClosing: boolean = false;
 
@@ -100,6 +106,11 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
         if (!this.attrs.state.isModalOpen()) {
           document.getElementById('app')?.removeAttribute('aria-hidden');
           this.focusTrap!.deactivate?.();
+
+          // Destroy a close watcher instance
+          this.closeWatcher?.destroy();
+          this.closeWatcher = undefined;
+
           clearAllBodyScrollLocks();
 
           return;
@@ -129,6 +140,22 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
 
         // Update key of current opened modal
         this.lastSetFocusTrap = dialogKey;
+
+        // Initialize CloseWatcher for the new dialog
+        if ('CloseWatcher' in window && this.lastCloseWatcherKey !== dialogKey) {
+          // Destroy previous watcher when stacking modals
+          this.closeWatcher?.destroy();
+
+          if (this.attrs.state.modal!.componentClass.dismissibleOptions.viaEscKey) {
+            this.closeWatcher = new CloseWatcher();
+            this.closeWatcher.onclose = () => {
+              this.animateHide();
+            };
+          }
+
+          // Update key of the current close watcher
+          this.lastCloseWatcherKey = dialogKey;
+        }
       } catch {
         // We can expect errors to occur here due to the nature of mithril rendering
       }
@@ -185,7 +212,8 @@ export default class ModalManager extends Component<IModalManagerAttrs> {
   }
 
   protected handleEscPress(e: KeyboardEvent): void {
-    if (!this.attrs.state.modal) return;
+    // Skip manual Escape handling if CloseWatcher is active
+    if (!this.attrs.state.modal || this.closeWatcher?.onclose) return;
 
     const dismissibleState = this.attrs.state.modal.componentClass.dismissibleOptions;
 

--- a/framework/core/js/src/common/utils/Drawer.js
+++ b/framework/core/js/src/common/utils/Drawer.js
@@ -12,6 +12,11 @@ export default class Drawer {
   focusTrap;
 
   /**
+   * @type {?CloseWatcher}
+   */
+  closeWatcher = null;
+
+  /**
    * @type {HTMLDivElement}
    */
   appElement;
@@ -84,6 +89,7 @@ export default class Drawer {
 
     this.focusTrap.deactivate();
     this.drawerAvailableMediaQuery.removeListener(this.resizeHandler);
+    this.closeWatcher?.destroy();
 
     if (!this.isOpen()) return;
 
@@ -106,6 +112,14 @@ export default class Drawer {
     this.drawerAvailableMediaQuery.addListener(this.resizeHandler);
 
     this.$backdrop = $('<div/>').addClass('drawer-backdrop fade').appendTo('body').on('click', this.hide.bind(this));
+
+    if ('CloseWatcher' in window) {
+      this.closeWatcher = new CloseWatcher();
+      this.closeWatcher.onclose = () => {
+        this.closeWatcher = null;
+        this.hide();
+      };
+    }
 
     requestAnimationFrame(() => {
       this.$backdrop.addClass('in');

--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -117,6 +117,28 @@ export default class PostStreamScrubber extends Component {
   oncreate(vnode) {
     super.oncreate(vnode);
 
+    if ('CloseWatcher' in window) {
+      this.$().on('shown.bs.dropdown', () => {
+        this.closeWatcher?.destroy();
+        this.closeWatcher = new CloseWatcher();
+        this.closeWatcher.onclose = () => {
+          this.$('.Dropdown-toggle').dropdown('toggle');
+        };
+      });
+
+      this.$().on('hidden.bs.dropdown', () => {
+        this.showing = false;
+        this.closeWatcher?.destroy();
+        this.closeWatcher = undefined;
+
+        if (this.attrs.onhide) {
+          this.attrs.onhide();
+        }
+
+        m.redraw();
+      });
+    }
+
     // Whenever the window is resized, adjust the height of the scrollbar
     // so that it fills the height of the sidebar.
     $(window)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,11 @@
   resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.2.tgz#1ae7857d98180dbe6c3b05abbe7ec1fa67b614e3"
   integrity sha512-ELhtuphE/YbhEcpBf/rIV9Tl3/O0A0gpCVD+oYFSS8bWstHFJUgA4nNw1ZakVlRC38XaQEIsBogUZKWIPBvpfQ==
 
+"@types/dom-close-watcher@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/dom-close-watcher/-/dom-close-watcher-1.0.0.tgz#aa23a076e226070397a10ead5b712881b29e632f"
+  integrity sha512-7pL0By56sVVGMSJ3HdSY+u08Id0ljStCaf1VnGFxwfpuNdA0HMz0sl2J24eSi9M6ptl9ySkVK35jF75Fn8trUg==
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"


### PR DESCRIPTION
**Changes proposed in this pull request:**
On mobile devices users intuitively use the "back" gesture/button to dismiss open modals. Currently, this triggers a browser history back navigation, leading to frustrating unintended page departures.

https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher

Components updated:
- [x] Drawer
- [x] ModalManager
- [x] Dropdowns
- [x] PostStreamScrubber

On browsers without `CloseWatcher` support, the affected components behave as before.

**Screenshot**

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/896f8d46-67b9-4935-a500-527882c0157a"></video> | <video src="https://github.com/user-attachments/assets/2cf3bf1e-b894-4902-9b59-e95f523ed869"></video> |


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
