### PR TITLE
[2.x] feat(core): add haptic feedback user preference

### DIFF
--- a/framework/core/js/src/common/utils/haptic.ts
+++ b/framework/core/js/src/common/utils/haptic.ts
@@ -15,6 +15,7 @@
  * @see https://github.com/lochie/web-haptics
  */
 
+import app from '../app';
 import { WebHaptics } from 'web-haptics';
 import type { HapticInput } from 'web-haptics';
 
@@ -54,5 +55,7 @@ const _haptics = new WebHaptics();
  * haptic([100, 50, 100]); // vibrate 100ms, pause 50ms, vibrate 100ms
  */
 export default function haptic(pattern: HapticInput = 'light'): void {
+  if (app.session?.user && app.session.user.preferences()?.hapticFeedback === false) return;
+
   _haptics.trigger(pattern as HapticInput);
 }

--- a/framework/core/js/src/forum/components/SettingsPage.tsx
+++ b/framework/core/js/src/forum/components/SettingsPage.tsx
@@ -22,6 +22,7 @@ import { ComponentAttrs } from '../../common/Component';
 export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPageAttrs> extends UserPage<CustomAttrs> {
   discloseOnlineLoading?: boolean;
   colorSchemeLoading?: boolean;
+  hapticFeedbackLoading?: boolean;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
@@ -55,8 +56,8 @@ export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPage
   settingsItems() {
     const items = new ItemList<Mithril.Children>();
 
-    ['account', 'notifications', 'privacy', 'colorScheme'].forEach((section, index) => {
-      const sectionItems = `${section}Items` as 'accountItems' | 'notificationsItems' | 'privacyItems';
+    ['account', 'notifications', 'privacy', 'device', 'colorScheme'].forEach((section, index) => {
+      const sectionItems = `${section}Items` as 'accountItems' | 'notificationsItems' | 'privacyItems' | 'deviceItems';
 
       const { className, visible, ...props } = this.sectionProps()[section] || {};
 
@@ -135,6 +136,35 @@ export default class SettingsPage<CustomAttrs extends IUserPageAttrs = IUserPage
         loading={this.discloseOnlineLoading}
       >
         {app.translator.trans('core.forum.settings.privacy_disclose_online_label')}
+      </Switch>,
+      100
+    );
+
+    return items;
+  }
+
+  /**
+   * Build an item list for the user's device settings.
+   */
+  deviceItems() {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'hapticFeedback',
+      <Switch
+        state={this.user!.preferences()?.hapticFeedback}
+        onchange={(value: boolean) => {
+          this.hapticFeedbackLoading = true;
+
+          this.user!.savePreferences({ hapticFeedback: value }).then(() => {
+            this.hapticFeedbackLoading = false;
+            m.redraw();
+          });
+        }}
+        loading={this.hapticFeedbackLoading}
+      >
+        {app.translator.trans('core.forum.settings.haptic_feedback_label')}
+        <span className="helpText">{app.translator.trans('core.forum.settings.haptic_feedback_help')}</span>
       </Switch>,
       100
     );

--- a/framework/core/less/forum/SettingsPage.less
+++ b/framework/core/less/forum/SettingsPage.less
@@ -19,5 +19,10 @@
       margin-bottom: 15px;
     }
   }
+
+  .Checkbox .helpText {
+    display: block;
+    margin-top: 3px;
+  }
 }
 

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -710,6 +710,9 @@ core:
       notify_by_email_heading: => core.ref.email
       notify_by_web_heading: Web
       notify_discussion_renamed_label: Someone renames a discussion I started
+      device_heading: Device
+      haptic_feedback_help: Only available on supported mobile devices
+      haptic_feedback_label: Enable haptic feedback
       privacy_disclose_online_label: Allow others to see when I am online
       privacy_heading: Privacy
       title: => core.ref.settings

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -150,6 +150,7 @@ class UserServiceProvider extends AbstractServiceProvider
         User::registerPreference('indexProfile', 'boolval', true);
         User::registerPreference('locale');
         User::registerPreference('colorScheme', 'strval', 'auto');
+        User::registerPreference('hapticFeedback', 'boolval', true);
 
         User::registerVisibilityScoper(new ScopeUserVisibility(), 'view');
     }


### PR DESCRIPTION
## Summary

- Registers a `hapticFeedback` user preference (`boolval`, default `true`) in `UserServiceProvider`
- `haptic()` now checks the preference before triggering — logged-in users who opt out receive no vibration; guests always get haptics
- Adds a **Device** settings section to `SettingsPage` with a toggle to enable/disable haptic feedback
- Help text under the toggle clarifies it only takes effect on supported mobile devices
- Adds `.Checkbox .helpText` layout fix in `SettingsPage.less` so the help text renders below the switch label

## Test plan

- [ ] On mobile (Android/iOS), log in and go to Settings → Device — toggle should appear
- [ ] Disable haptics → trigger a haptic action (e.g. like a post) — should be silent
- [ ] Re-enable → haptics return
- [ ] Log out → haptics fire regardless of prior preference
- [ ] Desktop browser → toggle still appears (with help text), haptic() silently no-ops as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)