### PR TITLE
[2.x] fix(core): skip password check on update page for passwordless drivers

### DIFF
--- a/framework/core/src/Update/Controller/IndexController.php
+++ b/framework/core/src/Update/Controller/IndexController.php
@@ -28,7 +28,8 @@ class IndexController extends AbstractHtmlController
         $view = $this->view->make('flarum.update::app')->with('title', 'Update Flarum');
 
         $view->with('content', $this->view->make('flarum.update::update')->with(
-            'needsPassword', $this->config['database.password'] !== null
+            'needsPassword',
+            $this->config['database.password'] !== null
         ));
 
         return $view;

--- a/framework/core/src/Update/Controller/IndexController.php
+++ b/framework/core/src/Update/Controller/IndexController.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Update\Controller;
 
+use Flarum\Foundation\Config;
 use Flarum\Http\Controller\AbstractHtmlController;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Factory;
@@ -17,7 +18,8 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class IndexController extends AbstractHtmlController
 {
     public function __construct(
-        protected Factory $view
+        protected Factory $view,
+        protected Config $config
     ) {
     }
 
@@ -25,7 +27,9 @@ class IndexController extends AbstractHtmlController
     {
         $view = $this->view->make('flarum.update::app')->with('title', 'Update Flarum');
 
-        $view->with('content', $this->view->make('flarum.update::update'));
+        $view->with('content', $this->view->make('flarum.update::update')->with(
+            'needsPassword', $this->config['database.password'] !== null
+        ));
 
         return $view;
     }

--- a/framework/core/src/Update/Controller/UpdateController.php
+++ b/framework/core/src/Update/Controller/UpdateController.php
@@ -26,7 +26,8 @@ class UpdateController implements RequestHandlerInterface
     public function __construct(
         protected MigrateCommand $command,
         protected Config $config
-    ) {}
+    ) {
+    }
 
     public function handle(Request $request): ResponseInterface
     {

--- a/framework/core/src/Update/Controller/UpdateController.php
+++ b/framework/core/src/Update/Controller/UpdateController.php
@@ -33,7 +33,8 @@ class UpdateController implements RequestHandlerInterface
     {
         $input = $request->getParsedBody();
 
-        if (Arr::get($input, 'databasePassword') !== $this->config['database.password']) {
+        if ($this->databaseHasPassword()
+            && Arr::get($input, 'databasePassword') !== $this->config['database.password']) {
             return new HtmlResponse('Incorrect database password.', 500);
         }
 
@@ -48,5 +49,10 @@ class UpdateController implements RequestHandlerInterface
         }
 
         return new Response($body, 200);
+    }
+
+    private function databaseHasPassword(): bool
+    {
+        return $this->config['database.password'] !== null;
     }
 }

--- a/framework/core/src/Update/Controller/UpdateController.php
+++ b/framework/core/src/Update/Controller/UpdateController.php
@@ -26,15 +26,16 @@ class UpdateController implements RequestHandlerInterface
     public function __construct(
         protected MigrateCommand $command,
         protected Config $config
-    ) {
-    }
+    ) {}
 
     public function handle(Request $request): ResponseInterface
     {
         $input = $request->getParsedBody();
 
-        if ($this->databaseHasPassword()
-            && Arr::get($input, 'databasePassword') !== $this->config['database.password']) {
+        if (
+            $this->databaseHasPassword()
+            && Arr::get($input, 'databasePassword') !== $this->config['database.password']
+        ) {
             return new HtmlResponse('Incorrect database password.', 500);
         }
 

--- a/framework/core/views/install/update.php
+++ b/framework/core/views/install/update.php
@@ -1,16 +1,22 @@
 <h2>Update Flarum</h2>
 
+<?php if ($needsPassword): ?>
 <p>Enter your database password to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<?php else: ?>
+<p>Click the button below to update Flarum. Before you proceed, you should <strong>back up your database</strong>. If you have any trouble, get help on the <a href="https://docs.flarum.org/update" target="_blank">Flarum website</a>.</p>
+<?php endif; ?>
 
 <form method="post">
   <div id="error" style="display:none"></div>
 
+  <?php if ($needsPassword): ?>
   <div class="FormGroup">
     <div class="FormField">
       <label>Database Password</label>
       <input class="FormControl" type="password" name="databasePassword">
     </div>
   </div>
+  <?php endif; ?>
 
   <div class="FormButtons">
     <button type="submit">Update Flarum</button>
@@ -19,7 +25,8 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    document.querySelector('form input').select();
+    var input = document.querySelector('form input');
+    if (input) input.select();
 
     document.querySelector('form').addEventListener('submit', function(e) {
       e.preventDefault();
@@ -53,4 +60,3 @@
     });
   });
 </script>
-


### PR DESCRIPTION
## Summary

The update page always asks for a database password, but SQLite (and any driver without credentials) never stores a `password` key in config. This causes the strict comparison to always fail since `"" !== null`.