### PR TITLE
[2.x] fix: use correct --page-bottom-padding CSS variable in App

### DIFF
--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -1,7 +1,7 @@
 .App {
   position: relative !important;
   padding-top: var(--header-height);
-  padding-bottom: var(--app-bottom-padding);
+  padding-bottom: var(--page-bottom-padding);
   min-height: 100vh;
 
   @media @phone {


### PR DESCRIPTION
## Summary

Fixes #4424.

`--app-bottom-padding` was introduced in #4173 but was never defined anywhere. The correct variable is `--page-bottom-padding` (defined in `root.less` and used consistently in `PageStructure.less` and `AdminPage.less`).

## Changes

- `App.less`: replace `var(--app-bottom-padding)` → `var(--page-bottom-padding)`