### PR TITLE
[2.x] fix(notifications): scope notification queries to the authenticated user

### DIFF
--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -17,6 +17,7 @@ use Flarum\Notification\Command\ReadNotification;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Database\Eloquent\Builder;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
 
 /**
@@ -42,6 +43,11 @@ class NotificationResource extends AbstractDatabaseResource
     public function model(): string
     {
         return Notification::class;
+    }
+
+    public function scope(Builder $query, \Tobyz\JsonApiServer\Context $context): void
+    {
+        $query->where('user_id', $context->getActor()->id);
     }
 
     public function query(\Tobyz\JsonApiServer\Context $context): object

--- a/framework/core/tests/integration/api/notifications/ListTest.php
+++ b/framework/core/tests/integration/api/notifications/ListTest.php
@@ -9,6 +9,10 @@
 
 namespace Flarum\Tests\integration\api\notifications;
 
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Notification\Notification;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
@@ -28,6 +32,16 @@ class ListTest extends TestCase
         $this->prepareDatabase([
             User::class => [
                 $this->normalUser(),
+                ['id' => 3, 'username' => 'other', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'other@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Foo', 'comment_count' => 1, 'user_id' => 2],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => 'Foo'],
+            ],
+            Notification::class => [
+                ['id' => 1, 'user_id' => 2, 'from_user_id' => 1, 'type' => 'discussionRenamed', 'subject_id' => 1, 'read_at' => null, 'created_at' => Carbon::now()],
             ],
         ]);
     }
@@ -52,5 +66,24 @@ class ListTest extends TestCase
         );
 
         $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function listing_only_returns_own_notifications()
+    {
+        // User 3 has no notifications — the listing must not return user 2's notification.
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $ids = array_column($body['data'], 'id');
+
+        $this->assertNotContains('1', $ids);
+        $this->assertEmpty($ids);
     }
 }

--- a/framework/core/tests/integration/api/notifications/UpdateTest.php
+++ b/framework/core/tests/integration/api/notifications/UpdateTest.php
@@ -32,6 +32,7 @@ class UpdateTest extends TestCase
         $this->prepareDatabase([
             User::class => [
                 $this->normalUser(),
+                ['id' => 3, 'username' => 'attacker', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'attacker@machine.local', 'is_email_confirmed' => 1],
             ],
             Discussion::class => [
                 ['id' => 1, 'title' => 'Foo', 'comment_count' => 1, 'user_id' => 2],
@@ -63,5 +64,87 @@ class UpdateTest extends TestCase
         );
 
         $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function user_cannot_read_another_users_notification()
+    {
+        // Attacker (user 3) sends an empty PATCH for a notification belonging to user 2.
+        // Without the ownership scope this returns 200 and leaks the notification content.
+        $response = $this->send(
+            $this->request('PATCH', '/api/notifications/1', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'type' => 'notifications',
+                        'id' => '1',
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function user_cannot_mark_another_users_notification_as_read()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/notifications/1', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'type' => 'notifications',
+                        'id' => '1',
+                        'attributes' => [
+                            'isRead' => true,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+
+        // Confirm the notification is still unread.
+        $this->assertNull(Notification::find(1)->read_at);
+    }
+
+    #[Test]
+    public function admin_cannot_read_another_users_notification()
+    {
+        // Notifications are personal — even admins should not be able to retrieve
+        // another user's notification via the update endpoint.
+        $response = $this->send(
+            $this->request('PATCH', '/api/notifications/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'type' => 'notifications',
+                        'id' => '1',
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function guest_cannot_update_notification()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/notifications/1', [
+                'json' => [
+                    'data' => [
+                        'type' => 'notifications',
+                        'id' => '1',
+                    ],
+                ],
+            ])
+        );
+
+        // 401 is ideal but the JSON:API layer rejects the malformed body first; either way guests are blocked.
+        $this->assertNotEquals(200, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary

Fixes an IDOR vulnerability in `NotificationResource` where the `Update` endpoint fetched notifications by ID using an unscoped query, allowing any authenticated user to read the contents of any other user's notification by guessing its sequential ID.

- The `Index` (listing) endpoint was correctly scoped via `NotificationRepository` — this is not affected
- The `Update` path falls through to `AbstractDatabaseResource::find()`, which uses an unscoped Eloquent query — this is the affected path
- The write side (marking as read) was separately protected by ownership enforcement in `ReadNotificationHandler`; the exposure was read-only

**Fix:** override `scope()` in `NotificationResource` to filter all queries by `user_id = actor->id`, ensuring any lookup returns 404 for notifications belonging to other users.

**Introduced in:** #3971 (the JSON:API rewrite). This did not exist in 1.x — the old `UpdateNotificationController` exclusively dispatched `ReadNotificationHandler`, which always enforced ownership. The new architecture separates the fetch from the action, and the fetch was left unscoped.

## Tests

Five tests added/extended across `UpdateTest` and `ListTest`:

- `user_cannot_read_another_users_notification` — core IDOR: empty PATCH by another user returns 404
- `user_cannot_mark_another_users_notification_as_read` — PATCH with `isRead: true` returns 404 and leaves `read_at` unchanged
- `admin_cannot_read_another_users_notification` — admins are equally scoped; notifications are personal
- `listing_only_returns_own_notifications` — confirms the listing endpoint is not affected
- `guest_cannot_update_notification` — unauthenticated requests are rejected

The two IDOR tests fail against the unfixed code (returning 200) and pass after the fix.

## Credit

Reported by **Lakshmikanthan K** ([@l3tchupkt](https://github.com/l3tchupkt)) via responsible disclosure. Thanks for the thorough and accurate report.

## Changelog

**Fixed:** Authenticated users could read notification contents belonging to other users via the `PATCH /api/notifications/{id}` endpoint (IDOR). Reported by Lakshmikanthan K.