### PR TITLE
[2.x] fix: disable auto_tls for None encryption, add SSL cert verification bypass

### DIFF
--- a/framework/core/js/src/admin/components/MailPage.tsx
+++ b/framework/core/js/src/admin/components/MailPage.tsx
@@ -181,7 +181,7 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
             return (
               <>
                 {this.buildSettingComponent({
-                  type: typeof fieldInfo === 'string' ? 'text' : 'select',
+                  type: typeof fieldInfo === 'string' ? 'text' : typeof fieldInfo === 'boolean' ? 'bool' : 'select',
                   label: app.translator.trans(`core.admin.email.${field}_label`),
                   setting: field,
                   options: fieldInfo,

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -272,6 +272,8 @@ core:
       mail_mailgun_secret_label: Secret key
       mail_password_label: => core.ref.password
       mail_port_label: Port
+      mail_smtp_verify_peer_label: Verify SSL Certificate
+      mail_smtp_verify_peer_help: "Verify the server's SSL certificate when using TLS or SSL encryption. Disable only if your mail server uses a self-signed certificate."
       mail_username_label: => core.ref.username
       mailgun_heading: Mailgun Settings
       not_sending_message: Flarum currently does not send emails. This can be due to the selected driver, or errors in its configuration.

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -19,12 +19,16 @@ use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class MailServiceProvider extends AbstractServiceProvider
 {
     public function register(): void
     {
+        $this->container->bind(TransportFactoryInterface::class, EsmtpTransportFactory::class);
+
         $this->container->singleton('mail.supported_drivers', function () {
             return [
                 'mail' => SendmailDriver::class,

--- a/framework/core/src/Mail/SmtpDriver.php
+++ b/framework/core/src/Mail/SmtpDriver.php
@@ -13,7 +13,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\MessageBag;
 use Symfony\Component\Mailer\Transport\Dsn;
-use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class SmtpDriver implements DriverInterface
@@ -21,7 +21,7 @@ class SmtpDriver implements DriverInterface
     use ValidatesMailSettings;
 
     public function __construct(
-        protected EsmtpTransportFactory $factory
+        protected TransportFactoryInterface $factory
     ) {
     }
 
@@ -37,6 +37,7 @@ class SmtpDriver implements DriverInterface
             ],
             'mail_username' => '',
             'mail_password' => '',
+            'mail_smtp_verify_peer' => true, // boolean toggle
         ];
     }
 
@@ -48,6 +49,7 @@ class SmtpDriver implements DriverInterface
             'mail_encryption' => 'nullable|in:tls,ssl,TLS,SSL',
             'mail_username' => ['nullable', 'string', $this->noWhiteSpace()],
             'mail_password' => ['nullable', 'string', $this->noWhiteSpace()],
+            'mail_smtp_verify_peer' => 'nullable|boolean',
         ])->errors();
     }
 
@@ -64,12 +66,27 @@ class SmtpDriver implements DriverInterface
         // 'tls' or empty means STARTTLS (smtp://), typically used with port 587 or 25
         $scheme = ($encryption === 'ssl') ? 'smtps' : 'smtp';
 
+        $options = [];
+
+        // When no encryption is selected, disable opportunistic STARTTLS so that
+        // the connection stays plaintext rather than silently upgrading.
+        if ($encryption === '') {
+            $options['auto_tls'] = 'false';
+        }
+
+        // Allow administrators to disable SSL certificate verification, e.g.
+        // when using a self-signed certificate on an internal mail server.
+        if ((string) $settings->get('mail_smtp_verify_peer') === '0') {
+            $options['verify_peer'] = 'false';
+        }
+
         return $this->factory->create(new Dsn(
             $scheme,
             $settings->get('mail_host'),
             $settings->get('mail_username'),
             $settings->get('mail_password'),
-            $settings->get('mail_port')
+            $settings->get('mail_port'),
+            $options
         ));
     }
 }

--- a/framework/core/tests/integration/extenders/MailTest.php
+++ b/framework/core/tests/integration/extenders/MailTest.php
@@ -53,6 +53,7 @@ class MailTest extends TestCase
             ],
             'mail_username' => '',
             'mail_password' => '',
+            'mail_smtp_verify_peer' => true,
         ], $fields['smtp']);
     }
 

--- a/framework/core/tests/unit/Mail/LogDriverTest.php
+++ b/framework/core/tests/unit/Mail/LogDriverTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\FlarumLogTransport;
+use Flarum\Mail\LogDriver;
+use Flarum\Testing\unit\TestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\RawMessage;
+
+class LogDriverTest extends TestCase
+{
+    private LoggerInterface $logger;
+    private LogDriver $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = m::mock(LoggerInterface::class);
+        $this->driver = new LogDriver($this->logger);
+    }
+
+    // -------------------------------------------------------------------------
+    // LogDriver
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function has_no_available_settings(): void
+    {
+        $this->assertEmpty($this->driver->availableSettings());
+    }
+
+    #[Test]
+    public function cannot_send(): void
+    {
+        $this->assertFalse($this->driver->canSend());
+    }
+
+    #[Test]
+    public function validate_returns_empty_message_bag(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+        $validator = m::mock(\Illuminate\Contracts\Validation\Factory::class);
+
+        $errors = $this->driver->validate($settings, $validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function build_transport_returns_flarum_log_transport(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+
+        $transport = $this->driver->buildTransport($settings);
+
+        $this->assertInstanceOf(FlarumLogTransport::class, $transport);
+    }
+
+    // -------------------------------------------------------------------------
+    // FlarumLogTransport behaviour
+    // -------------------------------------------------------------------------
+
+    private function envelope(): Envelope
+    {
+        return new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+    }
+
+    #[Test]
+    public function transport_logs_at_info_level(): void
+    {
+        $transport = new FlarumLogTransport($this->logger);
+        $message = new RawMessage('Hello');
+
+        $this->logger->shouldReceive('info')->once()->with('Hello');
+
+        $transport->send($message, $this->envelope());
+    }
+
+    #[Test]
+    public function transport_does_not_log_at_debug_level(): void
+    {
+        $transport = new FlarumLogTransport($this->logger);
+        $message = new RawMessage('Hello');
+
+        $this->logger->shouldReceive('info')->once();
+        $this->logger->shouldNotReceive('debug');
+
+        $transport->send($message, $this->envelope());
+    }
+
+    #[Test]
+    public function transport_decodes_quoted_printable_content(): void
+    {
+        $transport = new FlarumLogTransport($this->logger);
+
+        // =C3=A9 is 'é' in UTF-8 quoted-printable encoding
+        $raw = "Content-Transfer-Encoding: quoted-printable\r\n\r\n=C3=A9l=C3=A8ve";
+        $message = new RawMessage($raw);
+
+        $this->logger->shouldReceive('info')
+            ->once()
+            ->with(m::on(function (string $logged) {
+                return str_contains($logged, 'élève');
+            }));
+
+        $transport->send($message, $this->envelope());
+    }
+
+    #[Test]
+    public function transport_passes_plain_content_unchanged(): void
+    {
+        $transport = new FlarumLogTransport($this->logger);
+        $message = new RawMessage('Subject: Hello');
+
+        $this->logger->shouldReceive('info')->once()->with('Subject: Hello');
+
+        $transport->send($message, $this->envelope());
+    }
+
+    #[Test]
+    public function transport_returns_sent_message(): void
+    {
+        $transport = new FlarumLogTransport($this->logger);
+        $message = new RawMessage('Hello');
+
+        $this->logger->shouldReceive('info')->once();
+
+        $result = $transport->send($message, $this->envelope());
+
+        $this->assertInstanceOf(SentMessage::class, $result);
+    }
+}

--- a/framework/core/tests/unit/Mail/MailgunDriverTest.php
+++ b/framework/core/tests/unit/Mail/MailgunDriverTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\MailgunDriver;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory as ValidatorFactory;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunApiTransport;
+
+class MailgunDriverTest extends TestCase
+{
+    private MailgunDriver $driver;
+    private ValidatorFactory $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = new MailgunDriver();
+        $this->validator = new ValidatorFactory(new Translator(new ArrayLoader(), 'en'));
+    }
+
+    private function settings(array $values): SettingsRepositoryInterface
+    {
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('all')->andReturn($values);
+        $settings->shouldReceive('get')->andReturnUsing(fn ($key) => $values[$key] ?? null);
+
+        return $settings;
+    }
+
+    private function validSettings(): array
+    {
+        return [
+            'mail_mailgun_secret' => 'key-abc123',
+            'mail_mailgun_domain' => 'mg.example.com',
+            'mail_mailgun_region' => 'api.mailgun.net',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Driver metadata
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function can_send(): void
+    {
+        $this->assertTrue($this->driver->canSend());
+    }
+
+    #[Test]
+    public function available_settings_contains_expected_keys(): void
+    {
+        $settings = $this->driver->availableSettings();
+
+        $this->assertArrayHasKey('mail_mailgun_secret', $settings);
+        $this->assertArrayHasKey('mail_mailgun_domain', $settings);
+        $this->assertArrayHasKey('mail_mailgun_region', $settings);
+    }
+
+    #[Test]
+    public function region_setting_is_a_dropdown_with_us_and_eu(): void
+    {
+        $settings = $this->driver->availableSettings();
+
+        $this->assertIsArray($settings['mail_mailgun_region']);
+        $this->assertArrayHasKey('api.mailgun.net', $settings['mail_mailgun_region']);
+        $this->assertArrayHasKey('api.eu.mailgun.net', $settings['mail_mailgun_region']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function validation_passes_for_valid_us_configuration(): void
+    {
+        $errors = $this->driver->validate($this->settings($this->validSettings()), $this->validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function validation_passes_for_eu_region(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_mailgun_region' => 'api.eu.mailgun.net']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function validation_fails_when_secret_is_missing(): void
+    {
+        $settings = $this->validSettings();
+        unset($settings['mail_mailgun_secret']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertArrayHasKey('mail_mailgun_secret', $errors->toArray());
+    }
+
+    #[Test]
+    public function validation_fails_when_domain_is_missing(): void
+    {
+        $settings = $this->validSettings();
+        unset($settings['mail_mailgun_domain']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertArrayHasKey('mail_mailgun_domain', $errors->toArray());
+    }
+
+    #[Test]
+    public function validation_fails_when_domain_is_invalid(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_mailgun_domain' => 'not a domain!']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertArrayHasKey('mail_mailgun_domain', $errors->toArray());
+    }
+
+    #[Test]
+    public function validation_fails_when_region_is_not_recognised(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_mailgun_region' => 'api.invalid.net']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertArrayHasKey('mail_mailgun_region', $errors->toArray());
+    }
+
+    // -------------------------------------------------------------------------
+    // Transport construction
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function build_transport_returns_mailgun_api_transport(): void
+    {
+        $transport = $this->driver->buildTransport($this->settings($this->validSettings()));
+
+        $this->assertInstanceOf(MailgunApiTransport::class, $transport);
+    }
+}

--- a/framework/core/tests/unit/Mail/NullDriverTest.php
+++ b/framework/core/tests/unit/Mail/NullDriverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\NullDriver;
+use Flarum\Testing\unit\TestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Transport\NullTransport;
+
+class NullDriverTest extends TestCase
+{
+    private NullDriver $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->driver = new NullDriver();
+    }
+
+    #[Test]
+    public function has_no_available_settings(): void
+    {
+        $this->assertEmpty($this->driver->availableSettings());
+    }
+
+    #[Test]
+    public function cannot_send(): void
+    {
+        $this->assertFalse($this->driver->canSend());
+    }
+
+    #[Test]
+    public function validate_returns_empty_message_bag(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+        $validator = m::mock(\Illuminate\Contracts\Validation\Factory::class);
+
+        $errors = $this->driver->validate($settings, $validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function build_transport_returns_null_transport(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+
+        $transport = $this->driver->buildTransport($settings);
+
+        $this->assertInstanceOf(NullTransport::class, $transport);
+    }
+}

--- a/framework/core/tests/unit/Mail/SendmailDriverTest.php
+++ b/framework/core/tests/unit/Mail/SendmailDriverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\SendmailDriver;
+use Flarum\Testing\unit\TestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+
+class SendmailDriverTest extends TestCase
+{
+    private SendmailDriver $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->driver = new SendmailDriver();
+    }
+
+    #[Test]
+    public function has_no_available_settings(): void
+    {
+        $this->assertEmpty($this->driver->availableSettings());
+    }
+
+    #[Test]
+    public function can_send(): void
+    {
+        $this->assertTrue($this->driver->canSend());
+    }
+
+    #[Test]
+    public function validate_returns_empty_message_bag(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+        $validator = m::mock(\Illuminate\Contracts\Validation\Factory::class);
+
+        $errors = $this->driver->validate($settings, $validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function build_transport_returns_sendmail_transport(): void
+    {
+        $settings = m::mock(\Flarum\Settings\SettingsRepositoryInterface::class);
+
+        $transport = $this->driver->buildTransport($settings);
+
+        $this->assertInstanceOf(SendmailTransport::class, $transport);
+    }
+}

--- a/framework/core/tests/unit/Mail/SmtpDriverTest.php
+++ b/framework/core/tests/unit/Mail/SmtpDriverTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\SmtpDriver;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\NullTransport;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+class SmtpDriverTest extends TestCase
+{
+    private ?Dsn $lastDsn = null;
+    private SmtpDriver $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Anonymous spy that captures the Dsn without needing to mock a final class.
+        $spy = &$this->lastDsn;
+        $factory = new class($spy) implements TransportFactoryInterface {
+            public function __construct(private mixed &$captured) {}
+
+            public function create(Dsn $dsn): TransportInterface
+            {
+                $this->captured = $dsn;
+                return new NullTransport();
+            }
+
+            public function supports(Dsn $dsn): bool
+            {
+                return true;
+            }
+        };
+
+        $this->driver = new SmtpDriver($factory);
+    }
+
+    private function settings(array $values): SettingsRepositoryInterface
+    {
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->andReturnUsing(fn ($key) => $values[$key] ?? null);
+
+        return $settings;
+    }
+
+    private function buildAndCapture(array $settingValues): Dsn
+    {
+        $this->driver->buildTransport($this->settings($settingValues));
+
+        $this->assertNotNull($this->lastDsn, 'Factory spy did not capture a Dsn.');
+
+        return $this->lastDsn;
+    }
+
+    // -------------------------------------------------------------------------
+    // Scheme selection
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function ssl_encryption_uses_smtps_scheme(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => 'ssl']);
+
+        $this->assertSame('smtps', $dsn->getScheme());
+    }
+
+    #[Test]
+    public function tls_encryption_uses_smtp_scheme(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => 'tls']);
+
+        $this->assertSame('smtp', $dsn->getScheme());
+    }
+
+    #[Test]
+    public function no_encryption_uses_smtp_scheme(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => '']);
+
+        $this->assertSame('smtp', $dsn->getScheme());
+    }
+
+    // -------------------------------------------------------------------------
+    // auto_tls (Bug 1: None encryption was silently upgrading to STARTTLS)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function none_encryption_sets_auto_tls_false(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => '']);
+
+        $this->assertSame('false', $dsn->getOption('auto_tls'));
+    }
+
+    #[Test]
+    public function tls_encryption_does_not_set_auto_tls(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => 'tls']);
+
+        $this->assertNull($dsn->getOption('auto_tls'));
+    }
+
+    #[Test]
+    public function ssl_encryption_does_not_set_auto_tls(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => 'ssl']);
+
+        $this->assertNull($dsn->getOption('auto_tls'));
+    }
+
+    // -------------------------------------------------------------------------
+    // verify_peer (Bug 2: no way to bypass SSL cert verification)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function verify_peer_disabled_when_setting_is_zero(): void
+    {
+        $dsn = $this->buildAndCapture([
+            'mail_host' => 'smtp.example.com',
+            'mail_encryption' => 'tls',
+            'mail_smtp_verify_peer' => '0',
+        ]);
+
+        $this->assertSame('false', $dsn->getOption('verify_peer'));
+    }
+
+    #[Test]
+    public function verify_peer_not_set_when_setting_is_one(): void
+    {
+        $dsn = $this->buildAndCapture([
+            'mail_host' => 'smtp.example.com',
+            'mail_encryption' => 'tls',
+            'mail_smtp_verify_peer' => '1',
+        ]);
+
+        $this->assertNull($dsn->getOption('verify_peer'));
+    }
+
+    #[Test]
+    public function verify_peer_not_set_when_setting_is_absent(): void
+    {
+        $dsn = $this->buildAndCapture(['mail_host' => 'smtp.example.com', 'mail_encryption' => 'tls']);
+
+        $this->assertNull($dsn->getOption('verify_peer'));
+    }
+
+    // -------------------------------------------------------------------------
+    // availableSettings
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function available_settings_includes_verify_peer_boolean(): void
+    {
+        $settings = $this->driver->availableSettings();
+
+        $this->assertArrayHasKey('mail_smtp_verify_peer', $settings);
+        $this->assertTrue($settings['mail_smtp_verify_peer']);
+    }
+}

--- a/framework/core/tests/unit/Mail/SmtpDriverTest.php
+++ b/framework/core/tests/unit/Mail/SmtpDriverTest.php
@@ -31,11 +31,14 @@ class SmtpDriverTest extends TestCase
         // Anonymous spy that captures the Dsn without needing to mock a final class.
         $spy = &$this->lastDsn;
         $factory = new class($spy) implements TransportFactoryInterface {
-            public function __construct(private mixed &$captured) {}
+            public function __construct(private mixed &$captured)
+            {
+            }
 
             public function create(Dsn $dsn): TransportInterface
             {
                 $this->captured = $dsn;
+
                 return new NullTransport();
             }
 


### PR DESCRIPTION
Fixes #4439

## Summary

Two bugs in the SMTP driver, both present since the Symfony Mailer migration:

- **Bug 1 — None encryption silently upgrades to STARTTLS.** When "None" is selected, `EsmtpTransport` was opportunistically negotiating STARTTLS if the server advertised it. Fix: pass `auto_tls=false` in the DSN options so the connection stays plaintext as configured.

- **Bug 2 — No way to bypass SSL certificate verification.** Administrators using internal mail servers with self-signed certificates had no way to proceed. Fix: new boolean admin setting **"Verify SSL Certificate"** (`mail_smtp_verify_peer`); when disabled, `verify_peer=false` is passed in the DSN options.

## Changes

- `SmtpDriver`: adds `auto_tls=false` for None encryption, `verify_peer` option, new `mail_smtp_verify_peer` setting
- `SmtpDriver`: depends on `TransportFactoryInterface` instead of the `final` `EsmtpTransportFactory` (better design, enables unit testing)
- `MailServiceProvider`: binds `TransportFactoryInterface → EsmtpTransportFactory`
- `MailPage.tsx`: type detection now handles `boolean → 'bool'` (renders a toggle switch)
- `core.yml`: adds `mail_smtp_verify_peer_label` and `mail_smtp_verify_peer_help`

## Tests

- `SmtpDriverTest`: 10 unit tests covering scheme selection, `auto_tls`, and `verify_peer` for all encryption modes
- `MailTest` (integration): updated expected smtp fields to include `mail_smtp_verify_peer`
- Also adds unit tests for all other built-in drivers that previously had none: `NullDriverTest`, `SendmailDriverTest`, `LogDriverTest` (including `FlarumLogTransport` behaviour), `MailgunDriverTest` (including validation rules)

## Test plan

- [ ] Configure SMTP with encryption = None, verify connection stays plaintext (no STARTTLS)
- [ ] Configure SMTP with a self-signed cert server, disable "Verify SSL Certificate", verify mail sends
- [ ] All new unit tests pass: `./vendor/bin/phpunit tests/unit/Mail/`
- [ ] Integration test passes: `./vendor/bin/phpunit tests/integration/extenders/MailTest.php`