### PR TITLE
[2.x] revert(admin): remove collapsible extension categories, restore 3-section sidebar

### DIFF
--- a/extensions/akismet/composer.json
+++ b/extensions/akismet/composer.json
@@ -33,7 +33,7 @@
         },
         "flarum-extension": {
             "title": "Akismet",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "image": "icon.jpg",
                 "backgroundSize": "cover",

--- a/extensions/approval/composer.json
+++ b/extensions/approval/composer.json
@@ -33,7 +33,7 @@
         },
         "flarum-extension": {
             "title": "Approval",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-check",
                 "backgroundColor": "#ABDC88",

--- a/extensions/bbcode/composer.json
+++ b/extensions/bbcode/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "BBCode",
-            "category": "formatting",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-bold",
                 "backgroundColor": "#238C59",

--- a/extensions/embed/composer.json
+++ b/extensions/embed/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Embed",
-            "category": "formatting",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-code",
                 "backgroundColor": "#B9D233",

--- a/extensions/emoji/composer.json
+++ b/extensions/emoji/composer.json
@@ -27,7 +27,7 @@
         },
         "flarum-extension": {
             "title": "Emoji",
-            "category": "formatting",
+            "category": "feature",
             "icon": {
                 "image": "icon.svg",
                 "backgroundColor": "#FECC4D"

--- a/extensions/flags/composer.json
+++ b/extensions/flags/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Flags",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-flag",
                 "backgroundColor": "#D659B5",

--- a/extensions/gdpr/composer.json
+++ b/extensions/gdpr/composer.json
@@ -40,7 +40,7 @@
         },
         "flarum-extension": {
             "title": "GDPR Data Management",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "image": "resources/logo.svg",
                 "backgroundColor": "#EBF1FD",

--- a/extensions/likes/composer.json
+++ b/extensions/likes/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Likes",
-            "category": "discussion",
+            "category": "feature",
             "icon": {
                 "name": "far fa-thumbs-up",
                 "backgroundColor": "#3A649D",

--- a/extensions/lock/composer.json
+++ b/extensions/lock/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Lock",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-lock",
                 "backgroundColor": "#ddd",

--- a/extensions/markdown/composer.json
+++ b/extensions/markdown/composer.json
@@ -27,7 +27,7 @@
         },
         "flarum-extension": {
             "title": "Markdown",
-            "category": "formatting",
+            "category": "feature",
             "icon": {
                 "image": "icon.svg",
                 "backgroundColor": "#000",

--- a/extensions/mentions/composer.json
+++ b/extensions/mentions/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Mentions",
-            "category": "discussion",
+            "category": "feature",
             "optional-dependencies": [
                 "flarum/tags"
             ],

--- a/extensions/messages/composer.json
+++ b/extensions/messages/composer.json
@@ -24,7 +24,7 @@
     "extra": {
         "flarum-extension": {
             "title": "Messages",
-            "category": "discussion",
+            "category": "feature",
             "optional-dependencies": [
                 "flarum/tags"
             ],

--- a/extensions/nicknames/composer.json
+++ b/extensions/nicknames/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Nicknames",
-            "category": "discussion",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-user-tag",
                 "backgroundColor": "#8E4529",

--- a/extensions/pusher/composer.json
+++ b/extensions/pusher/composer.json
@@ -36,7 +36,7 @@
         },
         "flarum-extension": {
             "title": "Pusher",
-            "category": "infrastructure",
+            "category": "feature",
             "icon": {
                 "image": "icon.png",
                 "backgroundSize": "46% 63%",

--- a/extensions/realtime/composer.json
+++ b/extensions/realtime/composer.json
@@ -33,7 +33,7 @@
         },
         "flarum-extension": {
             "title": "Realtime",
-            "category": "infrastructure",
+            "category": "feature",
             "icon": {
                 "image": "resources/assets/logo.svg",
                 "backgroundColor": "#E3E7F1",

--- a/extensions/statistics/composer.json
+++ b/extensions/statistics/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Statistics",
-            "category": "analytics",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-chart-bar",
                 "backgroundColor": "#6932d1",

--- a/extensions/sticky/composer.json
+++ b/extensions/sticky/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Sticky",
-            "category": "discussion",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-thumbtack",
                 "backgroundColor": "#D13E32",

--- a/extensions/subscriptions/composer.json
+++ b/extensions/subscriptions/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Subscriptions",
-            "category": "discussion",
+            "category": "feature",
             "optional-dependencies": [
                 "flarum/approval"
             ],

--- a/extensions/suspend/composer.json
+++ b/extensions/suspend/composer.json
@@ -32,7 +32,7 @@
         },
         "flarum-extension": {
             "title": "Suspend",
-            "category": "moderation",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-ban",
                 "backgroundColor": "#ddd",

--- a/extensions/tags/composer.json
+++ b/extensions/tags/composer.json
@@ -37,7 +37,7 @@
         },
         "flarum-extension": {
             "title": "Tags",
-            "category": "discussion",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-tags",
                 "backgroundColor": "#F28326",

--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -94,16 +94,9 @@ export default class AdminApplication extends Application {
   registry = new AdminRegistry();
 
   extensionCategories: Record<string, number> = {
-    feature: 100,
-    moderation: 90,
-    discussion: 80,
-    authentication: 70,
-    formatting: 60,
-    infrastructure: 55,
-    analytics: 52,
-    other: 50,
-    theme: 40,
-    language: 30,
+    feature: 30,
+    theme: 20,
+    language: 10,
   };
 
   history: IHistory = {

--- a/framework/core/js/src/admin/components/AdminNav.js
+++ b/framework/core/js/src/admin/components/AdminNav.js
@@ -7,7 +7,6 @@ import getCategorizedExtensions from '../utils/getCategorizedExtensions';
 import ItemList from '../../common/utils/ItemList';
 import Stream from '../../common/utils/Stream';
 import Input from '../../common/components/Input';
-import Icon from '../../common/components/Icon';
 import extractText from '../../common/utils/extractText';
 
 export default class AdminNav extends Component {
@@ -15,23 +14,6 @@ export default class AdminNav extends Component {
     super.oninit(vnode);
 
     this.query = Stream('');
-    this.collapsed = {};
-
-    // Pre-expand the category of the currently active extension.
-    // m.route.get() may be null on a hard reload before Mithril has processed
-    // the hash, so fall back to parsing window.location.hash directly.
-    const currentRoute = m.route.get() || window.location.hash.replace(/^#/, '');
-    const extensionMatch = currentRoute.match(/\/extensions?\/([^/?]+)/);
-    if (extensionMatch) {
-      const activeId = extensionMatch[1];
-      const categorized = getCategorizedExtensions();
-      for (const [category, extensions] of Object.entries(categorized)) {
-        if (extensions.some((ext) => ext.id === activeId)) {
-          this.collapsed[category] = false;
-          break;
-        }
-      }
-    }
   }
 
   view() {
@@ -70,16 +52,6 @@ export default class AdminNav extends Component {
         time
       );
     }
-  }
-
-  isCollapsed(category) {
-    if (this.query()) return false;
-    return this.collapsed[category] !== false;
-  }
-
-  toggleCollapsed(category) {
-    this.collapsed[category] = !this.isCollapsed(category);
-    m.redraw();
   }
 
   /**
@@ -165,88 +137,43 @@ export default class AdminNav extends Component {
     return items;
   }
 
-  categoryIcon(category) {
-    const icons = {
-      analytics: 'fas fa-chart-bar',
-      authentication: 'fas fa-lock',
-      discussion: 'fas fa-comments',
-      feature: 'fas fa-star',
-      formatting: 'fas fa-paragraph',
-      infrastructure: 'fas fa-server',
-      language: 'fas fa-language',
-      moderation: 'fas fa-shield-alt',
-      other: 'fas fa-cube',
-      theme: 'fas fa-paint-brush',
-    };
-    return icons[category] || 'fas fa-puzzle-piece';
-  }
-
   extensionItems() {
     const items = new ItemList();
 
     const categorizedExtensions = getCategorizedExtensions();
     const categories = app.extensionCategories;
-    const query = this.query().toUpperCase();
 
     Object.keys(categorizedExtensions).map((category) => {
-      const extensions = categorizedExtensions[category];
-      const count = extensions.length;
+      if (!this.query()) {
+        items.add(
+          `category-${category}`,
+          <h4 className="ExtensionListTitle">{app.translator.trans(`core.admin.nav.categories.${category}`)}</h4>,
+          categories[category]
+        );
+      }
 
-      // When searching, only show categories that have matching results
-      const matchingExtensions = extensions.filter((extension) => {
-        if (!query) return true;
-        const title = extension.extra['flarum-extension'].title || '';
-        const description = extension.description || '';
-        return title.toUpperCase().includes(query) || description.toUpperCase().includes(query);
-      });
-
-      if (query && matchingExtensions.length === 0) return;
-
-      const isOpen = !this.isCollapsed(category);
-
-      const abandonedInCategory = extensions.filter((ext) => ext.abandoned);
-      const hasDanger = abandonedInCategory.some((ext) => typeof ext.abandoned === 'string');
-      const categoryBadgeType = abandonedInCategory.length > 0 ? (hasDanger ? 'danger' : 'warning') : null;
-
-      items.add(
-        `category-${category}`,
-        <button
-          className="ExtensionListTitle"
-          onclick={(e) => {
-            e.stopPropagation();
-            this.toggleCollapsed(category);
-          }}
-        >
-          <Icon name={this.categoryIcon(category)} className="ExtensionListTitle-icon" />
-          <span className="ExtensionListTitle-label">{app.translator.trans(`core.admin.nav.categories.${category}`)}</span>
-          {categoryBadgeType && <span className={`Badge Badge--${categoryBadgeType} ExtensionListTitle-badge`}>!</span>}
-          <span className="ExtensionListTitle-count">{count}</span>
-          <Icon name={`fas fa-chevron-${isOpen ? 'down' : 'right'}`} className="ExtensionListTitle-chevron" />
-        </button>,
-        categories[category]
-      );
-
-      if (!isOpen) return;
-
-      matchingExtensions.map((extension) => {
+      categorizedExtensions[category].map((extension) => {
+        const query = this.query().toUpperCase();
         const title = extension.extra['flarum-extension'].title || '';
         const description = extension.description || '';
         const isAbandoned = extension.abandoned;
         const hasReplacement = typeof isAbandoned === 'string';
 
-        items.add(
-          `extension-${extension.id}`,
-          <ExtensionLinkButton
-            href={app.route('extension', { id: extension.id })}
-            extensionId={extension.id}
-            className="ExtensionNavButton"
-            title={description}
-          >
-            {title}
-            {isAbandoned && <span className={`Badge Badge--${hasReplacement ? 'danger' : 'warning'}`}>!</span>}
-          </ExtensionLinkButton>,
-          categories[category]
-        );
+        if (!query || title.toUpperCase().includes(query) || description.toUpperCase().includes(query)) {
+          items.add(
+            `extension-${extension.id}`,
+            <ExtensionLinkButton
+              href={app.route('extension', { id: extension.id })}
+              extensionId={extension.id}
+              className="ExtensionNavButton"
+              title={description}
+            >
+              {title}
+              {isAbandoned && <span className={`Badge Badge--${hasReplacement ? 'danger' : 'warning'}`}>!</span>}
+            </ExtensionLinkButton>,
+            categories[category]
+          );
+        }
       });
     });
 

--- a/framework/core/less/admin/AdminNav.less
+++ b/framework/core/less/admin/AdminNav.less
@@ -178,84 +178,9 @@
 }
 
 .ExtensionListTitle {
-  // Reset button styles
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-
-  // Layout
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin: 12px 0 4px 0;
-  padding: 0 10px 0 15px;
-
-  // Typography
   color: var(--muted-color);
-  font-size: inherit;
-  font-weight: inherit;
-
-  &:hover {
-    color: var(--text-color);
-
-    .ExtensionListTitle-chevron {
-      opacity: 0.8;
-    }
-  }
-}
-
-.ExtensionListTitle-icon {
-  font-size: 11px;
-  flex-shrink: 0;
-  width: 14px;
-  text-align: center;
-}
-
-.ExtensionListTitle-label {
-  flex: 1;
-}
-
-.ExtensionListTitle-badge {
-  .Badge--size(16px);
-  font-size: 10px;
-  font-weight: bold;
-  flex-shrink: 0;
-
-  &.Badge--danger {
-    --badge-bg: @error-color;
-    --badge-color: var(--text-on-dark);
-  }
-
-  &.Badge--warning {
-    --badge-bg: @alert-color;
-    --badge-color: var(--text-on-dark);
-  }
-}
-
-.ExtensionListTitle-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 9px;
-  background: var(--primary-color);
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--primary-color-invert, #fff);
-  text-transform: none;
-  opacity: 0.75;
-}
-
-.ExtensionListTitle-chevron {
-  font-size: 9px;
-  opacity: 0.5;
-  flex-shrink: 0;
-  transition: transform 0.15s ease;
+  text-transform: uppercase;
+  margin: 25px 0 8px 15px;
 }
 
 .ExtensionListItem-Dot {


### PR DESCRIPTION
## Summary

Reverts the collapsible extension category sidebar introduced in #4392, replacing it with the previous 3-section flat list (Features, Themes, Languages).

The collapsible groups caused more problems than they solved:
- Everything collapsed by default — you open the admin panel and can see zero extensions
- Count badges (orange `27`) read like unread notification counts, creating false urgency
- Single-item categories (Infrastructure: 1, Analytics: 1, Themes: 1) added a click with no payoff
- Extensions with specific categories (moderation, discussion, etc.) would have been invisible until manually expanded

## What's kept from #4392

The rest of that PR is preserved:
- Extension health widget on the dashboard (abandoned packages, suggestions, disabled extensions)
- Abandoned package `!` badges on individual extension sidebar items
- `ExtensionLinkButton` tooltip showing title and version
- `ExtensionManager::getInstalledPackageNames()` and `AdminPayload` abandoned override logic

## Changes

- `AdminNav.js`: removed `collapsed` state, `isCollapsed`/`toggleCollapsed`/`categoryIcon` methods, restored plain `<h4>` category headers
- `AdminApplication.tsx`: reverted `extensionCategories` to `{ feature: 30, theme: 20, language: 10 }`
- `AdminNav.less`: reverted `.ExtensionListTitle` to simple muted uppercase heading, removed 5 new CSS classes

Extensions with specific categories (moderation, discussion, formatting, etc.) fall back to the Features section via the existing `getCategorizedExtensions` fallback behaviour.