### PR TITLE
[2.x] fix(testing): narrow database types via PHPDoc to fix Intelephense warnings

### DIFF
--- a/php-packages/testing/src/integration/Setup/Bootstrapper.php
+++ b/php-packages/testing/src/integration/Setup/Bootstrapper.php
@@ -16,6 +16,7 @@ use Flarum\Testing\integration\Extend\BeginTransactionAndSetDatabase;
 use Flarum\Testing\integration\Extend\OverrideExtensionManagerForTests;
 use Flarum\Testing\integration\Extend\SetSettingsBeforeBoot;
 use Flarum\Testing\integration\UsesTmpDir;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
 
@@ -23,6 +24,7 @@ class Bootstrapper
 {
     use UsesTmpDir;
 
+    /** @var Connection|null */
     public ?ConnectionInterface $database = null;
 
     public function __construct(

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -13,6 +13,7 @@ use Flarum\Database\AbstractModel;
 use Flarum\Extend\ExtenderInterface;
 use Flarum\Testing\integration\Setup\Bootstrapper;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -168,8 +169,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $this->server;
     }
 
+    /** @var Connection|null */
     protected $database;
 
+    /** @return Connection */
     protected function database(): ConnectionInterface
     {
         $this->app();


### PR DESCRIPTION
## Summary

- Keeps `ConnectionInterface` as the actual PHP type on `Bootstrapper::$database` and `TestCase::database()` so custom connection implementations remain compatible at runtime
- Adds `@var Connection|null` and `@return Connection` PHPDoc annotations so Intelephense / PHPStan resolve concrete methods (e.g. `getDriverName()`, `getSchemaBuilder()`)

Fixes #4432

## Test plan

- [ ] Confirm Intelephense no longer reports "Undefined method 'getDriverName'" on `$this->database()->getDriverName()` in test files
- [ ] Existing integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)