### PR TITLE
[2.x] fix: use luma-based text colour for primary buttons to ensure contrast

### DIFF
--- a/framework/core/js/tests/unit/common/helpers/textContrastClass.test.ts
+++ b/framework/core/js/tests/unit/common/helpers/textContrastClass.test.ts
@@ -1,0 +1,36 @@
+import textContrastClass from '../../../../src/common/helpers/textContrastClass';
+
+describe('textContrastClass', () => {
+  it('returns text-contrast--unchanged for null', () => {
+    expect(textContrastClass(null)).toBe('text-contrast--unchanged');
+  });
+
+  it('returns text-contrast--unchanged for undefined', () => {
+    expect(textContrastClass(undefined)).toBe('text-contrast--unchanged');
+  });
+
+  it('returns text-contrast--unchanged for an empty string', () => {
+    expect(textContrastClass('')).toBe('text-contrast--unchanged');
+  });
+
+  it('returns text-contrast--light for a dark colour (needs light text)', () => {
+    // #064635 dark green — the colour that triggered issue #4440
+    expect(textContrastClass('#064635')).toBe('text-contrast--light');
+  });
+
+  it('returns text-contrast--light for #000000', () => {
+    expect(textContrastClass('#000000')).toBe('text-contrast--light');
+  });
+
+  it('returns text-contrast--dark for a light colour (needs dark text)', () => {
+    expect(textContrastClass('#ffffff')).toBe('text-contrast--dark');
+  });
+
+  it('returns text-contrast--dark for a light yellow', () => {
+    expect(textContrastClass('#E8D8B0')).toBe('text-contrast--dark');
+  });
+
+  it('returns text-contrast--light for the default Flarum primary (#536F90)', () => {
+    expect(textContrastClass('#536F90')).toBe('text-contrast--light');
+  });
+});

--- a/framework/core/js/tests/unit/common/utils/isDark.test.ts
+++ b/framework/core/js/tests/unit/common/utils/isDark.test.ts
@@ -1,0 +1,104 @@
+import isDark from '../../../../src/common/utils/isDark';
+
+// isDark uses getComputedStyle(document.body) to read --yiq-threshold.
+// In jsdom that returns '' so the || 128 fallback applies throughout
+// these tests, unless we override it explicitly.
+
+function setYiqThreshold(value: number) {
+  document.body.style.setProperty('--yiq-threshold', String(value));
+}
+
+function clearYiqThreshold() {
+  document.body.style.removeProperty('--yiq-threshold');
+}
+
+describe('isDark', () => {
+  afterEach(() => {
+    clearYiqThreshold();
+  });
+
+  // -------------------------------------------------------------------------
+  // Input guards
+  // -------------------------------------------------------------------------
+
+  it('returns false for null', () => {
+    expect(isDark(null)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isDark('')).toBe(false);
+  });
+
+  it('returns false for a string shorter than 4 characters', () => {
+    expect(isDark('#33')).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3-character hex shorthand
+  // -------------------------------------------------------------------------
+
+  it('treats #000 as dark', () => {
+    expect(isDark('#000')).toBe(true);
+  });
+
+  it('treats #fff as light', () => {
+    expect(isDark('#fff')).toBe(false);
+  });
+
+  it('treats #333 as dark', () => {
+    // YIQ = 51 < 128
+    expect(isDark('#333')).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6-character hex
+  // -------------------------------------------------------------------------
+
+  it('treats #000000 as dark', () => {
+    expect(isDark('#000000')).toBe(true);
+  });
+
+  it('treats #ffffff as light', () => {
+    expect(isDark('#ffffff')).toBe(false);
+  });
+
+  it('treats #064635 (dark green, the issue reporter\'s colour) as dark', () => {
+    // R=6 G=70 B=53 → YIQ ≈ 48.9 < 128
+    expect(isDark('#064635')).toBe(true);
+  });
+
+  it('treats #536F90 (default Flarum primary, medium blue) as dark', () => {
+    // R=83 G=111 B=144 → YIQ ≈ 106.4 < 128
+    expect(isDark('#536F90')).toBe(true);
+  });
+
+  it('treats #E8D8B0 (light yellow) as light', () => {
+    // R=232 G=216 B=176 → YIQ ≈ 216.2 > 128
+    expect(isDark('#E8D8B0')).toBe(false);
+  });
+
+  it('treats #FFD700 (gold) as light', () => {
+    // R=255 G=215 B=0 → YIQ ≈ 202.5 > 128
+    expect(isDark('#FFD700')).toBe(false);
+  });
+
+  it('treats #800000 (dark red) as dark', () => {
+    // R=128 G=0 B=0 → YIQ ≈ 38.3 < 128
+    expect(isDark('#800000')).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Custom --yiq-threshold (CSS variable)
+  // -------------------------------------------------------------------------
+
+  it('uses the --yiq-threshold CSS variable when set', () => {
+    // #536F90 has YIQ ≈ 106.4; with threshold 80 it should be considered light
+    setYiqThreshold(80);
+    expect(isDark('#536F90')).toBe(false);
+  });
+
+  it('falls back to threshold 128 when --yiq-threshold is not set', () => {
+    // #536F90 YIQ ≈ 106.4 < 128 → dark
+    expect(isDark('#536F90')).toBe(true);
+  });
+});

--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -70,7 +70,7 @@
   --discussion-title-color:        mix(@@heading-color, @@body-bg, 55%);
 
   .Button--color-vars(@@control-color, @@control-bg, 'button');
-  .Button--color-vars(@@body-bg, @primary-color, 'button-primary');
+  .Button--color-vars(if(luma(@primary-color) > 50%, @text-on-light, @text-on-dark), @primary-color, 'button-primary');
   .Button--color-vars(@@control-danger-color, @@control-danger-bg, 'control-danger');
   .Button--color-vars(@@muted-more-color, fade(@@muted-more-color, 30%), 'muted-more');
   .Button--color-vars(@@control-color, @@body-bg, 'button-inverted');
@@ -153,8 +153,6 @@
 // COMMON LIGHT/DARK HIGH CONTRAST COLORS
 
 [data-theme=dark-hc], [data-theme=light-hc] {
-  .Button--color-vars(darken(@body-bg-dark, 10), @primary-color, 'button-primary');
-
   [data-colored-header=true]& {
     --header-bg: @header-bg-colored-dark;
     --header-color: @header-color-colored-dark;


### PR DESCRIPTION
## Summary

- The primary button text colour was hardcoded to the page background colour, which fails when the primary colour is dark — producing near-black text on a dark button background (visible in both dark mode and high contrast mode)
- Replaces the static colour with `if(luma(@primary-color) > 50%, @text-on-light, @text-on-dark)`, picking text colour based on the perceptual luminance of the primary colour — the same logic already used by the JS `textContrastClass` / `isDark` helpers
- Removes the now-redundant `button-primary` override from the HC block (the base `.scheme()` mixin now handles it correctly for all themes)
- Adds Jest unit tests for the previously untested `isDark` and `textContrastClass` utilities

Fixes #4440

## Test plan

- [ ] Jest tests pass (`yarn test`)
- [ ] Set primary colour to a dark value (e.g. `#064635`) in Admin → Appearance — button text should be white in all themes including Light/Dark High Contrast
- [ ] Set primary colour to a light value (e.g. `#E8D8B0`) — button text should be dark
- [ ] Default primary (`#536F90`) continues to show white button text

🤖 Generated with [Claude Code](https://claude.com/claude-code)