### PR TITLE
[2.x] fix(formatter): handle null content in HasFormattedContent and mentions unparsers

### DIFF
--- a/extensions/mentions/src/Formatter/UnparsePostMentions.php
+++ b/extensions/mentions/src/Formatter/UnparsePostMentions.php
@@ -21,8 +21,12 @@ class UnparsePostMentions
     ) {
     }
 
-    public function __invoke(mixed $context, string $xml): string
+    public function __invoke(mixed $context, ?string $xml): ?string
     {
+        if ($xml === null) {
+            return null;
+        }
+
         return $this->unparsePostMentionTags(
             $this->updatePostMentionTags($context, $xml)
         );

--- a/extensions/mentions/src/Formatter/UnparseTagMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseTagMentions.php
@@ -15,8 +15,12 @@ use s9e\TextFormatter\Utils;
 
 class UnparseTagMentions
 {
-    public function __invoke(mixed $context, string $xml): string
+    public function __invoke(mixed $context, ?string $xml): ?string
     {
+        if ($xml === null) {
+            return null;
+        }
+
         return $this->unparseTagMentionTags(
             $this->updateTagMentionTags($context, $xml)
         );

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -21,8 +21,12 @@ class UnparseUserMentions
     ) {
     }
 
-    public function __invoke(mixed $context, string $xml): string
+    public function __invoke(mixed $context, ?string $xml): ?string
     {
+        if ($xml === null) {
+            return null;
+        }
+
         return $this->unparseUserMentionTags(
             $this->updateUserMentionTags($context, $xml)
         );

--- a/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/extensions/mentions/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -36,6 +36,10 @@ class UpdateMentionsMetadataWhenVisible
 
         $content = $event->post->parsed_content;
 
+        if ($content === null) {
+            return;
+        }
+
         $this->syncUserMentions(
             $event->post,
             $userMentions = Utils::getAttributeValues($content, 'USERMENTION', 'id')

--- a/extensions/mentions/tests/integration/api/CreatePostWithEmptyContentTest.php
+++ b/extensions/mentions/tests/integration/api/CreatePostWithEmptyContentTest.php
@@ -16,7 +16,7 @@ use Flarum\Testing\integration\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
- * Regression tests for https://github.com/flarum/framework/issues/4416
+ * Regression tests for https://github.com/flarum/framework/issues/4416.
  *
  * Reading $post->content in a Saving listener must not throw when content
  * is empty/null — HasFormattedContent::getContentAttribute() was passing an

--- a/extensions/mentions/tests/integration/api/CreatePostWithEmptyContentTest.php
+++ b/extensions/mentions/tests/integration/api/CreatePostWithEmptyContentTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\api;
+
+use Flarum\Extend;
+use Flarum\Post\Event\Saving;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for https://github.com/flarum/framework/issues/4416
+ *
+ * Reading $post->content in a Saving listener must not throw when content
+ * is empty/null — HasFormattedContent::getContentAttribute() was passing an
+ * empty string to Formatter::unparse() and the mentions unparsers, which
+ * have a `string` type hint that does not accept null.
+ */
+class CreatePostWithEmptyContentTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        // Simulate a third-party extension that reads $post->content in a
+        // Saving listener — the pattern that triggers the bug.
+        $this->extend(
+            (new Extend\Event())
+                ->listen(Saving::class, function ($event) {
+                    $event->post->content;
+                })
+        );
+
+        $this->prepareDatabase([
+            \Flarum\User\User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function creating_discussion_with_empty_content_returns_validation_error(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Test discussion',
+                            'content' => '',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        // Must be 422 (validation), not 500 (TypeError from unparse receiving null/empty).
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function creating_discussion_without_content_returns_validation_error(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Test discussion',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function creating_discussion_with_null_content_returns_validation_error(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Test discussion',
+                            'content' => null,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+}

--- a/extensions/mentions/tests/integration/api/EditPostWithEmptyContentTest.php
+++ b/extensions/mentions/tests/integration/api/EditPostWithEmptyContentTest.php
@@ -19,7 +19,7 @@ use Flarum\Testing\integration\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
- * Regression tests for https://github.com/flarum/framework/issues/4416 (edit path)
+ * Regression tests for https://github.com/flarum/framework/issues/4416 (edit path).
  */
 class EditPostWithEmptyContentTest extends TestCase
 {

--- a/extensions/mentions/tests/integration/api/EditPostWithEmptyContentTest.php
+++ b/extensions/mentions/tests/integration/api/EditPostWithEmptyContentTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Event\Saving;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for https://github.com/flarum/framework/issues/4416 (edit path)
+ */
+class EditPostWithEmptyContentTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        $this->extend(
+            (new Extend\Event())
+                ->listen(Saving::class, function ($event) {
+                    $event->post->content;
+                })
+        );
+
+        $this->prepareDatabase([
+            \Flarum\User\User::class => [
+                $this->normalUser(),
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Test discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Original content</p></t>'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function editing_post_with_empty_content_returns_validation_error(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        // Must not be a 500 — reading $post->content in the Saving listener must not
+        // throw a TypeError when content is null (the empty string is stored as null).
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function editing_post_with_null_content_returns_validation_error(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => null,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertNotEquals(500, $response->getStatusCode());
+    }
+}

--- a/framework/core/src/Formatter/Formatter.php
+++ b/framework/core/src/Formatter/Formatter.php
@@ -94,8 +94,12 @@ class Formatter
         return $renderer->render($xml);
     }
 
-    public function unparse(string $xml, mixed $context = null): string
+    public function unparse(?string $xml, mixed $context = null): ?string
     {
+        if ($xml === null) {
+            return null;
+        }
+
         foreach ($this->unparsingCallbacks as $callback) {
             $xml = $callback($context, $xml);
         }

--- a/framework/core/src/Formatter/HasFormattedContent.php
+++ b/framework/core/src/Formatter/HasFormattedContent.php
@@ -15,19 +15,19 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * A trait to add formatted content to a model.
  *
- * @property string $content
- * @property string $parsed_content
+ * @property string|null $content
+ * @property string|null $parsed_content
  */
 trait HasFormattedContent
 {
     protected static Formatter $formatter;
 
-    public function getContentAttribute(string $value): string
+    public function getContentAttribute(?string $value): ?string
     {
-        return static::$formatter->unparse($value, $this);
+        return $value ? static::$formatter->unparse($value, $this) : $value;
     }
 
-    public function getParsedContentAttribute(): string
+    public function getParsedContentAttribute(): ?string
     {
         return $this->attributes['content'];
     }
@@ -47,6 +47,10 @@ trait HasFormattedContent
      */
     public function formatContent(?ServerRequestInterface $request = null): string
     {
+        if (empty($this->attributes['content'])) {
+            return '';
+        }
+
         return static::$formatter->render($this->attributes['content'], $this, $request);
     }
 


### PR DESCRIPTION
## Summary

Port of the 1.x fix (#4059) for issue #4416.

When a `Saving` listener reads `$post->content` and the content attribute is `null` (stored as such when an empty string is submitted via `setContentAttribute`), PHP throws a `TypeError` because the getter and formatter methods only accepted non-nullable strings.

The 2.x fix covers more of the call chain than 1.x because the `PATCH` response serialises `contentHtml` (calling `formatContent` → `render`), which 1.x never hit since validation rejected empty content before saving.

**Files changed:**
- `HasFormattedContent::getContentAttribute` — `string → ?string`, null guard
- `HasFormattedContent::getParsedContentAttribute` — `string → ?string`
- `HasFormattedContent::formatContent` — early return `''` if content is empty/null
- `Formatter::unparse` — `string → ?string`, null guard
- `UnparsePostMentions` / `UnparseTagMentions` / `UnparseUserMentions` — `?string` + null guard on `__invoke`
- `UpdateMentionsMetadataWhenVisible` — null guard on `parsed_content` before `Utils::getAttributeValues()`

Fixes #4416

## Test plan

- [ ] New regression tests pass: `CreatePostWithEmptyContentTest`, `EditPostWithEmptyContentTest`
- [ ] Full mentions integration suite passes (78 tests)
- [ ] Register a `Saving` listener that reads `$event->post->content`, submit a post with empty content — must not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)