### PR TITLE
[2.x] fix(approval): apply opacity to whole unapproved post, not child elements

### DIFF
--- a/extensions/approval/less/forum.less
+++ b/extensions/approval/less/forum.less
@@ -1,10 +1,5 @@
 .Post--unapproved {
-  .Post-header,
-  .Post-body,
-  .EventPost-icon,
-  .EventPost-info {
-    opacity: 0.5;
-  }
+  opacity: 0.5;
 }
 .DiscussionListItem--unapproved {
   .DiscussionListItem--hidden();


### PR DESCRIPTION
## Summary

- Applying `opacity < 1` to `.Post-header` directly creates a new CSS stacking context, which confines the `z-index` of any absolutely-positioned descendants (e.g. the user-card dropdown on avatar hover) to that context — causing the dropdown to disappear when the user tries to navigate to it
- Moving `opacity: 0.5` up to `.Post--unapproved` itself removes the stacking context issue; the visual result is identical (whole post dimmed) and the per-child selector list is no longer needed

Fixes #4212

## Test plan

- [ ] Set a post to awaiting approval
- [ ] Hover over the avatar — user card dropdown should appear and remain visible as the mouse moves into it
- [ ] Visual: unapproved post still appears at 50% opacity
- [ ] Event posts (renamed, hidden, etc.) with unapproved state still appear dimmed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)