### PR TITLE
[2.x] fix(nicknames): sanitize display names to prevent injection in HTML notification emails

### DIFF
--- a/extensions/nicknames/src/Api/UserResourceFields.php
+++ b/extensions/nicknames/src/Api/UserResourceFields.php
@@ -39,6 +39,9 @@ class UserResourceFields
                     return $context->getActor()->can('editNickname', $user);
                 })
                 ->nullable()
+                // Reject characters used in markdown/HTML link syntax that email clients
+                // may render as hyperlinks in notification emails.
+                ->rule('not_regex:/[\[\]()<>]/')
                 ->regex($regex ?? '', ! empty($regex))
                 ->minLength($this->settings->get('flarum-nicknames.min'))
                 ->maxLength($this->settings->get('flarum-nicknames.max'))
@@ -46,6 +49,7 @@ class UserResourceFields
                 ->unique('users', 'username', true, (bool) $this->settings->get('flarum-nicknames.unique'))
                 ->validationMessages([
                     'nickname.regex' => $this->translator->trans('flarum-nicknames.api.invalid_nickname_message'),
+                    'nickname.not_regex' => $this->translator->trans('flarum-nicknames.api.invalid_nickname_message'),
                 ])
                 ->set(function (User $user, ?string $nickname) {
                     $user->nickname = $user->username === $nickname ? null : $nickname;

--- a/extensions/nicknames/src/NicknameDriver.php
+++ b/extensions/nicknames/src/NicknameDriver.php
@@ -16,6 +16,16 @@ class NicknameDriver implements DriverInterface
 {
     public function displayName(User $user): string
     {
-        return $user->nickname ?: $user->username;
+        $name = $user->nickname ?: $user->username;
+
+        // Strip characters used in markdown/HTML link syntax to prevent email
+        // clients from rendering display names as hyperlinks. This also covers
+        // nicknames stored before the save-time validation rule was introduced.
+        $name = str_replace(['[', ']', '(', ')', '<', '>'], '', $name);
+
+        // Insert a zero-width space after every dot to prevent email clients
+        // from auto-linking dotted strings as domain names (e.g. nasty.com).
+        // The zero-width space is invisible in all rendering contexts.
+        return str_replace('.', ".\u{200B}", $name);
     }
 }

--- a/extensions/nicknames/tests/integration/api/EditUserTest.php
+++ b/extensions/nicknames/tests/integration/api/EditUserTest.php
@@ -170,11 +170,11 @@ class EditUserTest extends TestCase
     public static function nicknamesWithInjectionChars(): array
     {
         return [
-            'markdown link syntax'  => ['[CLICK](https://evil.com)'],
-            'square brackets only'  => ['[username]'],
-            'angle brackets'        => ['<evil.com>'],
-            'parentheses'           => ['evil(com)'],
-            'html open tag'         => ['<script>'],
+            'markdown link syntax' => ['[CLICK](https://evil.com)'],
+            'square brackets only' => ['[username]'],
+            'angle brackets' => ['<evil.com>'],
+            'parentheses' => ['evil(com)'],
+            'html open tag' => ['<script>'],
             'html attribute inject' => ['"><img src=x>'],
         ];
     }

--- a/extensions/nicknames/tests/integration/api/EditUserTest.php
+++ b/extensions/nicknames/tests/integration/api/EditUserTest.php
@@ -14,6 +14,7 @@ use Flarum\Locale\TranslatorInterface;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class EditUserTest extends TestCase
@@ -109,5 +110,72 @@ class EditUserTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode(), $body);
         $this->assertStringContainsString($this->app()->getContainer()->make(TranslatorInterface::class)->trans('flarum-nicknames.api.invalid_nickname_message'), $body);
+    }
+
+    #[Test]
+    public function nickname_with_dots_is_allowed(): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.editOwnNickname', 'group_id' => Group::MEMBER_ID],
+            ]
+        ]);
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'nickname' => 'jane.smith',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+        $this->assertEquals('jane.smith', User::find(2)->nickname);
+    }
+
+    #[Test]
+    #[DataProvider('nicknamesWithInjectionChars')]
+    public function nickname_with_injection_chars_is_rejected(string $nickname): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.editOwnNickname', 'group_id' => Group::MEMBER_ID],
+            ]
+        ]);
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/2', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'nickname' => $nickname,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode(), $response->getBody()->getContents());
+        $this->assertNull(User::find(2)->nickname);
+    }
+
+    public static function nicknamesWithInjectionChars(): array
+    {
+        return [
+            'markdown link syntax'  => ['[CLICK](https://evil.com)'],
+            'square brackets only'  => ['[username]'],
+            'angle brackets'        => ['<evil.com>'],
+            'parentheses'           => ['evil(com)'],
+            'html open tag'         => ['<script>'],
+            'html attribute inject' => ['"><img src=x>'],
+        ];
     }
 }

--- a/extensions/nicknames/tests/unit/NicknameDriverTest.php
+++ b/extensions/nicknames/tests/unit/NicknameDriverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Nicknames\Tests\unit;
+
+use Flarum\Nicknames\NicknameDriver;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class NicknameDriverTest extends TestCase
+{
+    private function displayName(?string $nickname, string $username = 'username'): string
+    {
+        $driver = new NicknameDriver();
+
+        $user = new User();
+        $user->nickname = $nickname;
+        $user->username = $username;
+
+        return $driver->displayName($user);
+    }
+
+    #[Test]
+    public function clean_nickname_is_unchanged(): void
+    {
+        $this->assertSame('Jane Smith', $this->displayName('Jane Smith'));
+    }
+
+    #[Test]
+    public function falls_back_to_username_when_no_nickname(): void
+    {
+        $this->assertSame('alice', $this->displayName(null, 'alice'));
+    }
+
+    #[Test]
+    public function dot_gets_zero_width_space_inserted(): void
+    {
+        $this->assertSame("nasty.\u{200B}com", $this->displayName('nasty.com'));
+    }
+
+    #[Test]
+    public function multiple_dots_all_get_zero_width_space(): void
+    {
+        $this->assertSame("first.\u{200B}last.\u{200B}com", $this->displayName('first.last.com'));
+    }
+
+    #[Test]
+    public function square_brackets_are_stripped(): void
+    {
+        $this->assertSame('CLICK', $this->displayName('[CLICK]'));
+    }
+
+    #[Test]
+    public function parentheses_are_stripped(): void
+    {
+        $this->assertSame('evilcom', $this->displayName('evil(com)'));
+    }
+
+    #[Test]
+    public function angle_brackets_are_stripped(): void
+    {
+        $this->assertSame("evil.\u{200B}com", $this->displayName('<evil.com>'));
+    }
+
+    #[Test]
+    public function markdown_link_syntax_is_neutralised(): void
+    {
+        $this->assertSame("CLICKhttps://evil.\u{200B}com", $this->displayName('[CLICK](https://evil.com)'));
+    }
+
+    #[Test]
+    public function username_fallback_also_gets_sanitized(): void
+    {
+        $this->assertSame("nasty.\u{200B}com", $this->displayName(null, 'nasty.com'));
+    }
+
+    #[Test]
+    #[DataProvider('safeNicknames')]
+    public function safe_nicknames_are_preserved(string $nickname, string $expected): void
+    {
+        $this->assertSame($expected, $this->displayName($nickname));
+    }
+
+    public static function safeNicknames(): array
+    {
+        return [
+            'plain name'        => ['Alice',          'Alice'],
+            'name with space'   => ['Jane Smith',      'Jane Smith'],
+            'name with hyphen'  => ['Anne-Marie',      'Anne-Marie'],
+            'name with numbers' => ['user42',          'user42'],
+            'unicode name'      => ['Ánna',            'Ánna'],
+        ];
+    }
+}

--- a/extensions/nicknames/tests/unit/NicknameDriverTest.php
+++ b/extensions/nicknames/tests/unit/NicknameDriverTest.php
@@ -92,11 +92,11 @@ class NicknameDriverTest extends TestCase
     public static function safeNicknames(): array
     {
         return [
-            'plain name'        => ['Alice',          'Alice'],
-            'name with space'   => ['Jane Smith',      'Jane Smith'],
-            'name with hyphen'  => ['Anne-Marie',      'Anne-Marie'],
+            'plain name' => ['Alice',          'Alice'],
+            'name with space' => ['Jane Smith',      'Jane Smith'],
+            'name with hyphen' => ['Anne-Marie',      'Anne-Marie'],
             'name with numbers' => ['user42',          'user42'],
-            'unicode name'      => ['Ánna',            'Ánna'],
+            'unicode name' => ['Ánna',            'Ánna'],
         ];
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4399. Port of the GHSA-3c4m-j3g4-hh25 fix from 1.x (nicknames v1.8.3) adapted for 2.x's additional HTML email rendering context.

2.x sends HTML notification emails where display names are:
- Embedded in translation strings then passed through `$formatter->convert()` (markdown→HTML), allowing `[CLICK](https://evil.com)` to become a live `<a>` tag
- Output via `{!! !!}` in the greeting template, allowing raw HTML injection

**Changes:**

- **`NicknameDriver::displayName()`** — strips `[`, `]`, `(`, `)`, `<`, `>` from the returned name (neutralises markdown/HTML link syntax), and inserts a zero-width space after every `.` (breaks `nasty.com` domain autolinks). Covers nicknames stored before the validation rule existed.
- **`UserResourceFields`** — adds `not_regex:/[\[\]()<>]/` as a hard validation rule so these characters are rejected at save time going forward.

## Test plan

- [x] Unit tests for `NicknameDriver` sanitization (10 cases: clean names, dots, brackets, parens, angle brackets, full markdown link syntax, username fallback)
- [x] Integration tests for validation rejection (6 injection patterns → 422) and that `jane.smith` still saves successfully
- [x] Full nicknames test suite passes (14 unit + 20 integration)