### PR TITLE
[2.x] feat(mail): add Postmark driver

### DIFF
--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -272,10 +272,14 @@ core:
       mail_mailgun_secret_label: Secret key
       mail_password_label: => core.ref.password
       mail_port_label: Port
+      mail_postmark_message_stream_label: Message stream
+      mail_postmark_token_label: Server token
       mail_smtp_verify_peer_label: Verify SSL Certificate
       mail_smtp_verify_peer_help: "Verify the server's SSL certificate when using TLS or SSL encryption. Disable only if your mail server uses a self-signed certificate."
       mail_username_label: => core.ref.username
       mailgun_heading: Mailgun Settings
+      postmark_heading: Postmark Settings
+      postmark_description: "Send email via Postmark's HTTP API. Optionally specify a message stream to use a non-default stream."
       not_sending_message: Flarum currently does not send emails. This can be due to the selected driver, or errors in its configuration.
       send_test_mail_button: Send
       send_test_mail_heading: Send Test Mail

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -33,6 +33,7 @@ class MailServiceProvider extends AbstractServiceProvider
             return [
                 'mail' => SendmailDriver::class,
                 'mailgun' => MailgunDriver::class,
+                'postmark' => PostmarkDriver::class,
                 'log' => LogDriver::class,
                 'smtp' => SmtpDriver::class,
                 'null' => NullDriver::class,

--- a/framework/core/src/Mail/PostmarkDriver.php
+++ b/framework/core/src/Mail/PostmarkDriver.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Support\MessageBag;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+class PostmarkDriver implements DriverInterface
+{
+    use ValidatesMailSettings;
+
+    public function availableSettings(): array
+    {
+        return [
+            'mail_postmark_token' => '',
+            'mail_postmark_message_stream' => '',
+        ];
+    }
+
+    public function validate(SettingsRepositoryInterface $settings, Factory $validator): MessageBag
+    {
+        return $validator->make($settings->all(), [
+            'mail_postmark_token' => ['required', $this->noWhitespace()],
+            'mail_postmark_message_stream' => 'nullable|string',
+        ])->errors();
+    }
+
+    public function canSend(): bool
+    {
+        return true;
+    }
+
+    public function buildTransport(SettingsRepositoryInterface $settings): TransportInterface
+    {
+        $factory = new PostmarkTransportFactory();
+
+        $options = [];
+
+        if ($stream = $settings->get('mail_postmark_message_stream')) {
+            $options['message_stream'] = $stream;
+        }
+
+        return $factory->create(new Dsn(
+            'postmark+api',
+            'default',
+            $settings->get('mail_postmark_token'),
+            null,
+            null,
+            $options
+        ));
+    }
+}

--- a/framework/core/tests/integration/extenders/MailTest.php
+++ b/framework/core/tests/integration/extenders/MailTest.php
@@ -58,6 +58,27 @@ class MailTest extends TestCase
     }
 
     #[Test]
+    public function postmark_driver_is_registered_with_correct_fields()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/mail/settings', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $fields = json_decode($body, true)['data']['attributes']['fields'];
+
+        $this->assertArrayHasKey('postmark', $fields);
+        $this->assertEquals([
+            'mail_postmark_token' => '',
+            'mail_postmark_message_stream' => '',
+        ], $fields['postmark']);
+    }
+
+    #[Test]
     public function added_driver_appears_in_mail_settings()
     {
         $this->extend(

--- a/framework/core/tests/unit/Mail/PostmarkDriverTest.php
+++ b/framework/core/tests/unit/Mail/PostmarkDriverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Mail;
+
+use Flarum\Mail\PostmarkDriver;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory as ValidatorFactory;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
+
+class PostmarkDriverTest extends TestCase
+{
+    private PostmarkDriver $driver;
+    private ValidatorFactory $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = new PostmarkDriver();
+        $this->validator = new ValidatorFactory(new Translator(new ArrayLoader(), 'en'));
+    }
+
+    private function settings(array $values): SettingsRepositoryInterface
+    {
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('all')->andReturn($values);
+        $settings->shouldReceive('get')->andReturnUsing(fn ($key) => $values[$key] ?? null);
+
+        return $settings;
+    }
+
+    private function validSettings(): array
+    {
+        return [
+            'mail_postmark_token' => 'abc123def456',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Driver metadata
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function can_send(): void
+    {
+        $this->assertTrue($this->driver->canSend());
+    }
+
+    #[Test]
+    public function available_settings_contains_expected_keys(): void
+    {
+        $settings = $this->driver->availableSettings();
+
+        $this->assertArrayHasKey('mail_postmark_token', $settings);
+        $this->assertArrayHasKey('mail_postmark_message_stream', $settings);
+    }
+
+    #[Test]
+    public function settings_are_plain_string_inputs_not_dropdowns(): void
+    {
+        $settings = $this->driver->availableSettings();
+
+        $this->assertSame('', $settings['mail_postmark_token']);
+        $this->assertSame('', $settings['mail_postmark_message_stream']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function validation_passes_for_valid_configuration(): void
+    {
+        $errors = $this->driver->validate($this->settings($this->validSettings()), $this->validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function validation_passes_when_message_stream_is_provided(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_postmark_message_stream' => 'outbound']);
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertEmpty($errors->all());
+    }
+
+    #[Test]
+    public function validation_fails_when_token_is_missing(): void
+    {
+        $errors = $this->driver->validate($this->settings([]), $this->validator);
+
+        $this->assertArrayHasKey('mail_postmark_token', $errors->toArray());
+    }
+
+    #[Test]
+    public function validation_fails_when_token_has_leading_whitespace(): void
+    {
+        $settings = ['mail_postmark_token' => ' abc123'];
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertNotEmpty($errors->all());
+    }
+
+    #[Test]
+    public function validation_fails_when_token_has_trailing_whitespace(): void
+    {
+        $settings = ['mail_postmark_token' => 'abc123 '];
+
+        $errors = $this->driver->validate($this->settings($settings), $this->validator);
+
+        $this->assertNotEmpty($errors->all());
+    }
+
+    // -------------------------------------------------------------------------
+    // Transport construction
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function build_transport_returns_postmark_api_transport(): void
+    {
+        $transport = $this->driver->buildTransport($this->settings($this->validSettings()));
+
+        $this->assertInstanceOf(PostmarkApiTransport::class, $transport);
+    }
+
+    #[Test]
+    public function build_transport_without_message_stream_succeeds(): void
+    {
+        $transport = $this->driver->buildTransport($this->settings($this->validSettings()));
+
+        $this->assertInstanceOf(PostmarkApiTransport::class, $transport);
+        $this->assertStringNotContainsString('outbound', (string) $transport);
+    }
+
+    #[Test]
+    public function build_transport_with_message_stream_includes_it(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_postmark_message_stream' => 'outbound']);
+
+        $transport = $this->driver->buildTransport($this->settings($settings));
+
+        $this->assertInstanceOf(PostmarkApiTransport::class, $transport);
+        $this->assertStringContainsString('outbound', (string) $transport);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4442.

The `symfony/postmark-mailer` bridge is already a dependency of `flarum/core` but no driver was ever wired up. This adds `PostmarkDriver` following the exact same pattern as the existing `MailgunDriver`.

- **`PostmarkDriver`** — implements `DriverInterface` with `mail_postmark_token` (required server token) and `mail_postmark_message_stream` (optional, for Postmark's message streams feature)
- **`MailServiceProvider`** — registers `'postmark' => PostmarkDriver::class` in the supported drivers map
- **`core.yml`** — adds locale keys: `mail_postmark_token_label`, `mail_postmark_message_stream_label`, `postmark_heading`, `postmark_description`

## Test plan

- [x] 11 unit tests in `PostmarkDriverTest` covering driver metadata, validation (valid config, missing token, whitespace in token, optional message stream), and transport construction (with and without message stream)
- [x] Integration test asserting `postmark` appears in `/api/mail/settings` fields with the correct keys
- [x] All existing `MailTest` integration tests continue to pass