### PR TITLE
[2.x] fix: reduce post horizontal padding on mobile to 15px

### DIFF
--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -368,7 +368,8 @@
 
 @media @phone {
   .Post {
-    padding-left: var(--post-padding);
+    padding-left: 15px;
+    padding-right: 15px;
   }
   .Post-side {
     .Post-avatar {


### PR DESCRIPTION
## Summary

Follow-up to #4422.

The fix in #4422 added `padding-left: var(--post-padding)` (20px) to match the existing right padding on mobile, but 20px on both sides feels excessive on small screens.

This reduces both sides to 15px on mobile, which:
- Matches the existing `PostStream-item` horizontal padding pattern on mobile (`padding: 0 15px`)
- Gives a consistent, symmetric 15px on left and right
- Frees up a little more content width on small screens

## Test plan

- [ ] Verify posts have symmetric 15px left and right padding on mobile (≤767px)
- [ ] Verify event posts, dividers, and badges still render correctly