### PR TITLE
[2.x] feat: add dark mode logo support

### DIFF
--- a/framework/core/js/src/admin/components/AppearancePage.tsx
+++ b/framework/core/js/src/admin/components/AppearancePage.tsx
@@ -61,6 +61,21 @@ export default class AppearancePage extends AdminPage {
     );
 
     items.add(
+      'logo-dark-mode',
+      <div className="Form-group">
+        <label>{app.translator.trans('core.admin.appearance.logo_dark_mode_heading')}</label>
+        <div className="helpText">{app.translator.trans('core.admin.appearance.logo_dark_mode_text')}</div>
+        <UploadImageButton
+          name="logo-dark-mode"
+          routePath="logo-dark-mode"
+          value={app.data.settings.logo_dark_mode_path}
+          url={app.forum.attribute('logoDarkModeUrl')}
+        />
+      </div>,
+      99
+    );
+
+    items.add(
       'favicon',
       <div className="Form-group">
         <label>{app.translator.trans('core.admin.appearance.favicon_heading')}</label>

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -183,6 +183,19 @@
 .Header-logo {
   display: block;
   max-height: 30px;
+
+  &--dark-mode {
+    display: none;
+  }
+
+  // Replace with dark mode logo if it exists
+  [data-theme^='dark']:has(&--dark-mode) & {
+    display: none;
+
+    &--dark-mode {
+      display: block;
+    }
+  }
 }
 
 // On phones, the header is displayed inside of the drawer. We lay its

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -116,6 +116,8 @@ core:
       favicon_text: Upload an image to be displayed as the forum's shortcut icon.
       logo_heading: Logo
       logo_text: Upload an image to be displayed in place of the forum title.
+      logo_dark_mode_heading: Dark mode logo
+      logo_dark_mode_text: Upload an alternate logo to be displayed when dark mode is enabled.
       title: Appearance
       color_scheme_label: Color Scheme (default)
       color_schemes:

--- a/framework/core/src/Api/Controller/DeleteLogoController.php
+++ b/framework/core/src/Api/Controller/DeleteLogoController.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class DeleteLogoController extends AbstractDeleteController
 {
+    protected string $filePathSettingKey = 'logo_path';
     protected Filesystem $uploadDir;
 
     public function __construct(
@@ -30,9 +31,9 @@ class DeleteLogoController extends AbstractDeleteController
     {
         RequestUtil::getActor($request)->assertAdmin();
 
-        $path = $this->settings->get('logo_path');
+        $path = $this->settings->get($this->filePathSettingKey);
 
-        $this->settings->set('logo_path', null);
+        $this->settings->set($this->filePathSettingKey, null);
 
         if ($this->uploadDir->exists($path)) {
             $this->uploadDir->delete($path);

--- a/framework/core/src/Api/Controller/DeleteLogoDarkModeController.php
+++ b/framework/core/src/Api/Controller/DeleteLogoDarkModeController.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+class DeleteLogoDarkModeController extends DeleteLogoController
+{
+    protected string $filePathSettingKey = 'logo_dark_mode_path';
+}

--- a/framework/core/src/Api/Controller/UploadLogoDarkModeController.php
+++ b/framework/core/src/Api/Controller/UploadLogoDarkModeController.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+class UploadLogoDarkModeController extends UploadLogoController
+{
+    protected string $filePathSettingKey = 'logo_dark_mode_path';
+    protected string $filenamePrefix = 'logo-dark-mode';
+}

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -105,6 +105,8 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn () => $this->settings->get('color_scheme')),
             Schema\Str::make('logoUrl')
                 ->get(fn () => $this->getLogoUrl()),
+            Schema\Str::make('logoDarkModeUrl')
+                ->get(fn () => $this->getLogoDarkModeUrl()),
             Schema\Str::make('faviconUrl')
                 ->get(fn () => $this->getFaviconUrl()),
             Schema\Str::make('headerHtml')
@@ -152,6 +154,13 @@ class ForumResource extends AbstractResource implements Findable
     protected function getLogoUrl(): ?string
     {
         $logoPath = $this->settings->get('logo_path');
+
+        return $logoPath ? $this->getAssetUrl($logoPath) : null;
+    }
+
+    protected function getLogoDarkModeUrl(): ?string
+    {
+        $logoPath = $this->settings->get('logo_dark_mode_path');
 
         return $logoPath ? $this->getAssetUrl($logoPath) : null;
     }

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -128,6 +128,20 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\DeleteLogoController::class)
     );
 
+    // Upload a dark mode logo
+    $map->post(
+        '/logo-dark-mode',
+        'logo-dark-mode',
+        $route->toController(Controller\UploadLogoDarkModeController::class)
+    );
+
+    // Remove the dark mode logo
+    $map->delete(
+        '/logo-dark-mode',
+        'logo-dark-mode.delete',
+        $route->toController(Controller\DeleteLogoDarkModeController::class)
+    );
+
     // Upload a favicon
     $map->post(
         '/favicon',

--- a/framework/core/views/frontend/admin.blade.php
+++ b/framework/core/views/frontend/admin.blade.php
@@ -13,6 +13,9 @@
                     <a href="{{ $forum['baseUrl'] }}">
                         @if ($forum['logoUrl'])
                             <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo">
+                            @if($forum['logoDarkModeUrl'])
+                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode">
+                            @endif
                         @else
                             {{ $forum['title'] }}
                         @endif

--- a/framework/core/views/frontend/forum.blade.php
+++ b/framework/core/views/frontend/forum.blade.php
@@ -15,6 +15,9 @@
                     <a href="{{ $forum['baseUrl'] }}" id="home-link">
                         @if ($forum['logoUrl'])
                             <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo">
+                            @if($forum['logoDarkModeUrl'])
+                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode">
+                            @endif
                         @else
                             {{ $forum['title'] }}
                         @endif


### PR DESCRIPTION
**Changes proposed in this pull request:**

Not every logo works well in both light and dark mode. For example:

| Light mode | Dark mode |
| --- | --- |
| <img width="2796" height="1944" alt="light-mode" src="https://github.com/user-attachments/assets/025d1b0f-5473-416e-a605-c6034538d8ef" /> | <img width="2796" height="1944" alt="dark-mode" src="https://github.com/user-attachments/assets/e19a49b1-7154-436d-b5b8-053c0183dd56" /> |

This PR adds an option to set an alternative logo for dark mode.
If no dark mode logo is set, the regular logo is used in dark mode.

**Screenshot**
| Light mode | Dark mode |
| --- | --- |
| <img width="2796" height="2086" alt="light-mode-after" src="https://github.com/user-attachments/assets/c20558ae-990b-44f7-aa06-bf3b1bd63a70" /> | <img width="2796" height="2086" alt="dark-mode-after" src="https://github.com/user-attachments/assets/45150857-31bd-41d4-aa36-9848ab00f78b" /> |

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
