### PR TITLE
[2.x] feat: convert uploaded logos to WebP, support animated GIF

### DIFF
--- a/framework/core/src/Api/Controller/UploadImageController.php
+++ b/framework/core/src/Api/Controller/UploadImageController.php
@@ -27,7 +27,7 @@ use Psr\Http\Message\UploadedFileInterface;
 abstract class UploadImageController extends ShowForumController
 {
     protected Filesystem $uploadDir;
-    protected string $fileExtension = 'png';
+    protected string $fileExtension = 'webp';
     protected string $filePathSettingKey = '';
     protected string $filenamePrefix = '';
 

--- a/framework/core/src/Api/Controller/UploadLogoController.php
+++ b/framework/core/src/Api/Controller/UploadLogoController.php
@@ -10,17 +10,31 @@
 namespace Flarum\Api\Controller;
 
 use Intervention\Image\Interfaces\EncodedImageInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 class UploadLogoController extends UploadImageController
 {
     protected string $filePathSettingKey = 'logo_path';
     protected string $filenamePrefix = 'logo';
+    private string $resolvedExtension = 'webp';
 
     protected function makeImage(UploadedFileInterface $file): EncodedImageInterface
     {
-        return $this->imageManager->read($file->getStream()->getMetadata('uri'))
-            ->scale(height: 60)
-            ->toPng();
+        $image = $this->imageManager->read($file->getStream()->getMetadata('uri'))
+            ->scale(height: 60);
+
+        if ($image->isAnimated()) {
+            $this->resolvedExtension = 'gif';
+            return $image->toGif();
+        }
+
+        $this->resolvedExtension = 'webp';
+        return $image->toWebp();
+    }
+
+    protected function fileExtension(ServerRequestInterface $request, UploadedFileInterface $file): string
+    {
+        return $this->resolvedExtension;
     }
 }

--- a/framework/core/src/Api/Controller/UploadLogoController.php
+++ b/framework/core/src/Api/Controller/UploadLogoController.php
@@ -26,10 +26,12 @@ class UploadLogoController extends UploadImageController
 
         if ($image->isAnimated()) {
             $this->resolvedExtension = 'gif';
+
             return $image->toGif();
         }
 
         $this->resolvedExtension = 'webp';
+
         return $image->toWebp();
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

Converts forum logo uploads to WebP (matching the approach used for avatars in #4431), and adds support for animated GIF logos.

- Static logos → WebP
- Animated logos → GIF (preserving animation)
- `UploadImageController` default extension updated from `png` to `webp`
- `UploadLogoDarkModeController` inherits this behaviour automatically

Favicon upload is unaffected — it explicitly sets its own extension and `.ico` passthrough is preserved.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.