### PR TITLE
[2.x] fix: normalize database version strings in admin dashboard

### DIFF
--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -73,7 +73,10 @@ class ApplicationInfoProvider
         // Cache for 24 hours since the database version rarely changes
         return $this->cache->remember('flarum:db_version', 86400, function () {
             return match ($this->config['database.driver']) {
-                'mysql', 'mariadb', 'pgsql' => $this->db->selectOne('select version() as version')->version,
+                // Strip distribution suffix (e.g. "10.11.14-MariaDB-0+deb12u2" → "10.11.14")
+                'mysql', 'mariadb' => Str::before($this->db->selectOne('select version() as version')->version, '-'),
+                // SHOW server_version returns a clean version (e.g. "15.3"), unlike SELECT version() which includes platform info
+                'pgsql' => Str::before($this->db->selectOne('show server_version')->server_version, ' '),
                 'sqlite' => $this->db->selectOne('select sqlite_version() as version')->version,
                 default => 'Unknown',
             };


### PR DESCRIPTION
## Problem

The admin dashboard **Status** widget displays database versions inconsistently:

- **MariaDB** `version()` returns `10.11.14-MariaDB-0+deb12u2` — the distribution suffix is noisy and redundant given the driver label already says "MariaDB"
- **PostgreSQL** `version()` returns a full platform string like `PostgreSQL 15.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit` — far too verbose for a status widget
- **MySQL** `version()` can include distro suffixes like `8.0.32-0ubuntu0.20.04.1`
- **SQLite** `sqlite_version()` already returns a clean `3.45.0` — no change needed

## Fix

- **MySQL / MariaDB**: strip everything from the first `-` onwards via `Str::before()`
- **PostgreSQL**: switch from `SELECT version()` to `SHOW server_version`, which returns a clean version string (e.g. `15.3`), consistent with what the installer already uses in `ConnectToDatabase`
- **SQLite**: unchanged

## Result

| Driver | Before | After |
|--------|--------|-------|
| MariaDB | `10.11.14-MariaDB-0+deb12u2` | `10.11.14` |
| PostgreSQL | `PostgreSQL 15.3 on x86_64-pc-linux-gnu, compiled by...` | `15.3` |
| MySQL | `8.0.32-0ubuntu0.20.04.1` | `8.0.32` |
| SQLite | `3.45.0` | `3.45.0` |