### PR TITLE
[2.x] fix: make user search case-insensitive across all supported databases

### DIFF
--- a/framework/core/src/User/Search/FulltextFilter.php
+++ b/framework/core/src/User/Search/FulltextFilter.php
@@ -26,23 +26,38 @@ class FulltextFilter extends AbstractFulltextFilter
     ) {
     }
 
-    /**
-     * @return Builder<User>
-     */
-    private function getUserSearchSubQuery(string $searchValue): Builder
-    {
-        return $this->users
-            ->query()
-            ->select('id')
-            ->where('username', 'like', "$searchValue%");
-    }
-
     public function search(SearchState $state, string $value): void
     {
         $state->getQuery()
             ->whereIn(
                 'id',
-                $this->getUserSearchSubQuery($value)
+                match ($state->getQuery()->getConnection()->getDriverName()) {
+                    'pgsql' => $this->getUserSearchSubQuery($value, 'ilike'),
+                    'sqlite' => $this->getUserSearchSubQueryLower($value),
+                    default => $this->getUserSearchSubQuery($value, 'like'),
+                }
             );
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    private function getUserSearchSubQuery(string $searchValue, string $operator): Builder
+    {
+        return $this->users
+            ->query()
+            ->select('id')
+            ->where('username', $operator, "$searchValue%");
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    private function getUserSearchSubQueryLower(string $searchValue): Builder
+    {
+        return $this->users
+            ->query()
+            ->select('id')
+            ->whereRaw('LOWER(username) LIKE ?', [strtolower($searchValue).'%']);
     }
 }

--- a/framework/core/src/User/UserRepository.php
+++ b/framework/core/src/User/UserRepository.php
@@ -97,9 +97,22 @@ class UserRepository
     {
         $string = $this->escapeLikeString($string);
 
-        $query = $this->query()->where('username', 'like', '%'.$string.'%')
-            ->orderByRaw('username = ? desc', [$string])
-            ->orderByRaw('username like ? desc', [$string.'%']);
+        $query = $this->query();
+
+        match ($query->getConnection()->getDriverName()) {
+            'pgsql' => $query
+                ->where('username', 'ilike', '%'.$string.'%')
+                ->orderByRaw('username = ? desc', [$string])
+                ->orderByRaw('username ilike ? desc', [$string.'%']),
+            'sqlite' => $query
+                ->whereRaw('LOWER(username) LIKE ?', ['%'.strtolower($string).'%'])
+                ->orderByRaw('LOWER(username) = ? desc', [strtolower($string)])
+                ->orderByRaw('LOWER(username) LIKE ? desc', [strtolower($string).'%']),
+            default => $query
+                ->where('username', 'like', '%'.$string.'%')
+                ->orderByRaw('username = ? desc', [$string])
+                ->orderByRaw('username like ? desc', [$string.'%']),
+        };
 
         return $this->scopeVisibleTo($query, $actor)->pluck('id')->all();
     }


### PR DESCRIPTION
## Summary

- PostgreSQL's `LIKE` operator is case-sensitive, causing user search on the `/users` page (and mention autocomplete) to miss results that differ only in case
- `FulltextFilter` now uses `ILIKE` on PostgreSQL, `LOWER(username) LIKE` on SQLite, and unchanged `LIKE` on MySQL/MariaDB (already case-insensitive via collation)
- `UserRepository::getIdsForUsername` receives the same treatment, including its prefix-match `ORDER BY` clauses
- Follows the same per-driver `match()` pattern already used in `Discussion\Search\FulltextFilter`

## Test plan

- [ ] Search for a user by uppercase username on a PostgreSQL install — should return results
- [ ] Same test on MySQL — results unchanged
- [ ] Same test on SQLite — results unchanged
- [ ] Mention autocomplete (`@Username` with wrong case) works on PostgreSQL