### PR TITLE
[2.x] feat(core, mentions, likes): implement `IdWithDisplayNameSlugDriver`

### DIFF
--- a/extensions/likes/js/src/forum/extend.ts
+++ b/extensions/likes/js/src/forum/extend.ts
@@ -2,6 +2,7 @@ import Extend from 'flarum/common/extenders';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
 import LikesUserPage from './components/LikesUserPage';
+import UserPageResolver from 'flarum/forum/resolvers/UserPageResolver';
 import PostLikedNotification from './components/PostLikedNotification';
 
 import commonExtend from '../common/extend';
@@ -10,7 +11,7 @@ export default [
   ...commonExtend,
 
   new Extend.Routes() //
-    .add('user.likes', '/u/:username/likes', LikesUserPage),
+    .add('user.likes', '/u/:username/likes', LikesUserPage, UserPageResolver),
 
   new Extend.Notification() //
     .add('postLiked', PostLikedNotification),

--- a/extensions/mentions/js/src/forum/extend.ts
+++ b/extensions/mentions/js/src/forum/extend.ts
@@ -1,6 +1,7 @@
 import Extend from 'flarum/common/extenders';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
+import UserPageResolver from 'flarum/forum/resolvers/UserPageResolver';
 import MentionsUserPage from './components/MentionsUserPage';
 import PostMentionedNotification from './components/PostMentionedNotification';
 import UserMentionedNotification from './components/UserMentionedNotification';
@@ -12,7 +13,7 @@ export default [
   ...commonExtend,
 
   new Extend.Routes() //
-    .add('user.mentions', '/u/:username/mentions', MentionsUserPage),
+    .add('user.mentions', '/u/:username/mentions', MentionsUserPage, UserPageResolver),
 
   new Extend.Model(Post) //
     .hasMany<Post>('mentionedBy')

--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -70,6 +70,7 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
         'Flarum\\User\\User': {
           default: extractText(app.translator.trans('core.admin.basics.slug_driver_options.users.default')),
           id: extractText(app.translator.trans('core.admin.basics.slug_driver_options.users.id')),
+          id_with_display_name: extractText(app.translator.trans('core.admin.basics.slug_driver_options.users.id_with_display_name')),
         },
       },
     };

--- a/framework/core/js/src/common/extenders/Routes.ts
+++ b/framework/core/js/src/common/extenders/Routes.ts
@@ -1,5 +1,6 @@
 import type Application from '../Application';
 import type { AsyncNewComponent, FlarumGenericRoute, NewComponent } from '../Application';
+import DefaultResolver from '../resolvers/DefaultResolver';
 import IExtender, { IExtensionModule } from './IExtender';
 
 type HelperRoute = (...args: any) => string;
@@ -14,9 +15,16 @@ export default class Routes implements IExtender {
    * @param name The name of the route.
    * @param path The path of the route.
    * @param component must extend `Page` component.
+   * @param resolverClass An optional custom route resolver class.
    */
-  add(name: string, path: `/${string}`, component: NewComponent<any> | AsyncNewComponent<any>): Routes {
-    this.routes[name] = { path, component };
+  add(name: string, path: `/${string}`, component: NewComponent<any> | AsyncNewComponent<any>, resolverClass?: typeof DefaultResolver): Routes {
+    const route: FlarumGenericRoute = { path, component };
+
+    if (resolverClass) {
+      route.resolverClass = resolverClass;
+    }
+
+    this.routes[name] = route;
 
     return this;
   }

--- a/framework/core/js/src/forum/forum.ts
+++ b/framework/core/js/src/forum/forum.ts
@@ -50,5 +50,6 @@ import './components/Search';
 import './components/DiscussionListItem';
 import './components/PostsUserPage';
 import './resolvers/DiscussionPageResolver';
+import './resolvers/UserPageResolver';
 import './routes';
 import './ForumApplication';

--- a/framework/core/js/src/forum/resolvers/UserPageResolver.ts
+++ b/framework/core/js/src/forum/resolvers/UserPageResolver.ts
@@ -1,0 +1,37 @@
+import app from '../../forum/app';
+import DefaultResolver from '../../common/resolvers/DefaultResolver';
+import UserPage, { IUserPageAttrs } from '../components/UserPage';
+
+import type User from '../../common/models/User';
+import type Mithril from 'mithril';
+
+export default class UserPageResolver<
+  Attrs extends IUserPageAttrs = IUserPageAttrs,
+  RouteArgs extends Record<string, unknown> = {}
+> extends DefaultResolver<Attrs, UserPage<Attrs>, RouteArgs> {
+  canonicalizeUserSlug(slug: string | undefined) {
+    if (!slug) return;
+    return slug.split('-')[0];
+  }
+
+  makeKey() {
+    const params = { ...m.route.param() };
+    params.username = this.canonicalizeUserSlug(params.username);
+    return this.routeName + JSON.stringify(params);
+  }
+
+  render(vnode: Mithril.Vnode<Attrs, UserPage<Attrs>>) {
+    const currentSlug = m.route.param('username');
+    const id = this.canonicalizeUserSlug(currentSlug);
+
+    if (id) {
+      const user = app.store.getById<User>('users', id);
+
+      if (user && user.slug() && currentSlug !== user.slug()) {
+        window.history.replaceState(null, '', app.route('user', { username: user.slug() }));
+      }
+    }
+
+    return super.render(vnode);
+  }
+}

--- a/framework/core/js/src/forum/resolvers/UserPageResolver.ts
+++ b/framework/core/js/src/forum/resolvers/UserPageResolver.ts
@@ -28,7 +28,7 @@ export default class UserPageResolver<
       const user = app.store.getById<User>('users', id);
 
       if (user && user.slug() && currentSlug !== user.slug()) {
-        window.history.replaceState(null, '', app.route('user', { username: user.slug() }));
+        window.history.replaceState(null, '', app.route(this.routeName, { username: user.slug() }));
       }
     }
 

--- a/framework/core/js/src/forum/routes.ts
+++ b/framework/core/js/src/forum/routes.ts
@@ -3,6 +3,7 @@ import IndexPage from './components/IndexPage';
 import DiscussionPage from './components/DiscussionPage';
 import PostsUserPage from './components/PostsUserPage';
 import DiscussionPageResolver from './resolvers/DiscussionPageResolver';
+import UserPageResolver from './resolvers/UserPageResolver';
 import Discussion from '../common/models/Discussion';
 import type Post from '../common/models/Post';
 import type User from '../common/models/User';
@@ -27,12 +28,16 @@ export default function (app: ForumApplication) {
     discussion: { path: '/d/:id', component: DiscussionPage, resolverClass: DiscussionPageResolver },
     'discussion.near': { path: '/d/:id/:near', component: DiscussionPage, resolverClass: DiscussionPageResolver },
 
-    user: { path: '/u/:username', component: PostsUserPage },
-    'user.posts': { path: '/u/:username', component: PostsUserPage },
-    'user.discussions': { path: '/u/:username/discussions', component: () => import('./components/DiscussionsUserPage') },
+    user: { path: '/u/:username', component: PostsUserPage, resolverClass: UserPageResolver },
+    'user.posts': { path: '/u/:username', component: PostsUserPage, resolverClass: UserPageResolver },
+    'user.discussions': {
+      path: '/u/:username/discussions',
+      component: () => import('./components/DiscussionsUserPage'),
+      resolverClass: UserPageResolver,
+    },
 
     settings: { path: '/settings', component: () => import('./components/SettingsPage') },
-    'user.security': { path: '/u/:username/security', component: () => import('./components/UserSecurityPage') },
+    'user.security': { path: '/u/:username/security', component: () => import('./components/UserSecurityPage'), resolverClass: UserPageResolver },
     notifications: { path: '/notifications', component: () => import('./components/NotificationsPage') },
   };
 }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -153,6 +153,7 @@ core:
         users:
           default: Username
           id: ID
+          id_with_display_name: ID with Display Name
       slug_driver_heading: "Slug Driver: {model}"
       slug_driver_text: Select a driver to be used for slugging this model.
       title: Basics

--- a/framework/core/src/Http/HttpServiceProvider.php
+++ b/framework/core/src/Http/HttpServiceProvider.php
@@ -16,6 +16,7 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Http\Access\ScopeAccessTokenVisibility;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\IdSlugDriver;
+use Flarum\User\IdWithDisplayNameSlugDriver;
 use Flarum\User\User;
 use Flarum\User\UsernameSlugDriver;
 use Illuminate\Contracts\Container\Container;
@@ -41,7 +42,8 @@ class HttpServiceProvider extends AbstractServiceProvider
                 ],
                 User::class => [
                     'default' => UsernameSlugDriver::class,
-                    'id' => IdSlugDriver::class
+                    'id' => IdSlugDriver::class,
+                    'id_with_display_name' => IdWithDisplayNameSlugDriver::class,
                 ],
             ];
         });

--- a/framework/core/src/User/IdWithDisplayNameSlugDriver.php
+++ b/framework/core/src/User/IdWithDisplayNameSlugDriver.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Http\SlugDriverInterface;
+use Illuminate\Support\Str;
+
+/**
+ * @implements SlugDriverInterface<User>
+ */
+class IdWithDisplayNameSlugDriver implements SlugDriverInterface
+{
+    public function __construct(
+        protected UserRepository $users
+    ) {
+    }
+
+    /**
+     * @param User $instance
+     */
+    public function toSlug(AbstractModel $instance): string
+    {
+        return $instance->id.'-'.Str::slug($instance->display_name);
+    }
+
+    /**
+     * @return User
+     */
+    public function fromSlug(string $slug, User $actor): AbstractModel
+    {
+        if (strpos($slug, '-')) {
+            $slug_array = explode('-', $slug);
+            $slug = $slug_array[0];
+        }
+
+        return $this->users->findOrFail($slug, $actor);
+    }
+}

--- a/framework/core/src/User/IdWithDisplayNameSlugDriver.php
+++ b/framework/core/src/User/IdWithDisplayNameSlugDriver.php
@@ -36,7 +36,7 @@ class IdWithDisplayNameSlugDriver implements SlugDriverInterface
      */
     public function fromSlug(string $slug, User $actor): AbstractModel
     {
-        if (strpos($slug, '-')) {
+        if (strpos($slug, '-') !== false) {
             $slug_array = explode('-', $slug);
             $slug = $slug_array[0];
         }

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -86,6 +86,7 @@ class SlugDriverTest extends TestCase
 
             ['default', User::class, 2, 'normal'],
             ['id', User::class, 2, '2'],
+            ['id_with_display_name', User::class, 2, '2-normal'],
         ];
     }
 }

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -87,8 +87,8 @@ class SlugDriverTest extends TestCase
     public static function fromUserSlugVariantsDataProvider(): array
     {
         return [
-            'canonical slug'     => ['2-normal', 2],
-            'bare ID'            => ['2', 2],
+            'canonical slug' => ['2-normal', 2],
++            'bare ID' => ['2', 2],
             'wrong display name' => ['2-wrong-slug', 2],
         ];
     }

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -11,6 +11,7 @@ namespace integration\slugger;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Http\SlugDriverInterface;
 use Flarum\Http\SlugManager;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
@@ -69,6 +70,27 @@ class SlugDriverTest extends TestCase
         $slugger = $this->app()->getContainer()->make(SlugManager::class)->forResource($modelClassName);
 
         $this->assertEquals($modelClassName::query()->find($id), $slugger->fromSlug($slug, User::query()->find(1)));
+    }
+
+    #[Test]
+    #[DataProvider('fromUserSlugVariantsDataProvider')]
+    public function id_with_display_name_driver_resolves_user_from_slug_variants(string $slug, int $expectedId)
+    {
+        $this->setting('slug_driver_'.User::class, 'id_with_display_name');
+
+        /** @var SlugDriverInterface $slugger */
+        $slugger = $this->app()->getContainer()->make(SlugManager::class)->forResource(User::class);
+
+        $this->assertEquals(User::query()->find($expectedId), $slugger->fromSlug($slug, User::query()->find(1)));
+    }
+
+    public static function fromUserSlugVariantsDataProvider(): array
+    {
+        return [
+            'canonical slug'     => ['2-normal', 2],
+            'bare ID'            => ['2', 2],
+            'wrong display name' => ['2-wrong-slug', 2],
+        ];
     }
 
     public static function slugInstancePairDataProvider(): array

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -88,7 +88,7 @@ class SlugDriverTest extends TestCase
     {
         return [
             'canonical slug' => ['2-normal', 2],
-+            'bare ID' => ['2', 2],
++           'bare ID' => ['2', 2],
             'wrong display name' => ['2-wrong-slug', 2],
         ];
     }

--- a/framework/core/tests/integration/slugger/SlugDriverTest.php
+++ b/framework/core/tests/integration/slugger/SlugDriverTest.php
@@ -88,7 +88,7 @@ class SlugDriverTest extends TestCase
     {
         return [
             'canonical slug' => ['2-normal', 2],
-+           'bare ID' => ['2', 2],
+            'bare ID' => ['2', 2],
             'wrong display name' => ['2-wrong-slug', 2],
         ];
     }


### PR DESCRIPTION
_Documentation PR at https://github.com/flarum/docs/pull/514_

**Fixes #0000**

**Changes proposed in this pull request:**
Implements a new slug driver for `User`. This slug driver works very similarly to the `Discussion` Slug driver in that that  the id is used as the main mechanism for routing, but the models slug added for cosmetics. 

Modifies the frontend routes extender to support adding a custom resolver class. The new `UserPageResolver` is needed to patch the URL in case the user has changed their username/nickname.

Example:
`http://localhost/u/1-nonsense-slug-which-is-not-the-actual-user-or-nickname/likes` is replaced with `http://localhost/u/1-admin-username/likes`

**Reviewers should focus on:**
Should in theory be backwards compatible. Needs a accompanying documentation PR for extension developers to start to consume the `UserPageResolver` when adding routes like this:

```tsx
new Extend.Routes() //
    .add('user.foobar', '/u/:username/foobar', FoobarUserPage, UserPageResolver),
```

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
