### PR TITLE
[2.x] feat: announcements widget on admin dashboard

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -68,6 +68,8 @@ export interface AdminApplicationData extends ApplicationData {
   maintenanceByConfig: boolean;
   safeModeExtensions?: string[] | null;
   safeModeExtensionsConfig?: string[] | null;
+  announcementsDisabled: boolean;
+
   fontawesomeByConfig: boolean;
   fontawesomeConfig?: {
     source: string;

--- a/framework/core/js/src/admin/admin.ts
+++ b/framework/core/js/src/admin/admin.ts
@@ -33,6 +33,9 @@ import './components/AdminHeader';
 import './components/EditCustomCssModal';
 import './components/EditGroupModal';
 import './components/CreateUserModal';
+import './components/AnnouncementsWidget';
+import './components/AnnouncementList';
+import './components/AnnouncementItem';
 
 import './routes';
 import './AdminApplication';

--- a/framework/core/js/src/admin/components/AnnouncementItem.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementItem.tsx
@@ -1,0 +1,68 @@
+import app from '../../admin/app';
+import Component from '../../common/Component';
+import type Mithril from 'mithril';
+import Icon from '../../common/components/Icon';
+import Link from '../../common/components/Link';
+import dayjs from 'dayjs';
+
+export interface AnnouncementData {
+  id: string;
+  title: string;
+  slug: string;
+  commentCount: number;
+  createdAt: string;
+  isSticky: boolean;
+  url: string;
+  excerpt: string;
+  authorName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface IAnnouncementItemAttrs {
+  announcement: AnnouncementData;
+}
+
+export default class AnnouncementItem extends Component<IAnnouncementItemAttrs> {
+  view() {
+    const a = this.attrs.announcement;
+    const date = dayjs(a.createdAt).format('MMM D, YYYY');
+
+    return (
+      <Link className="AnnouncementItem" href={a.url} external={true} target="_blank">
+        <div className="AnnouncementItem-body">
+          <h3 className="AnnouncementItem-title">
+            {a.isSticky && <Icon name="fas fa-thumbtack" className="AnnouncementItem-stickyIcon" />}
+            {a.title}
+          </h3>
+          {a.excerpt && <p className="AnnouncementItem-excerpt">{a.excerpt}</p>}
+        </div>
+        <div className="AnnouncementItem-footer">
+          <div className="AnnouncementItem-byline">
+            {a.avatarUrl ? (
+              <img className="AnnouncementItem-avatar" src={a.avatarUrl} alt={a.authorName ?? ''} loading="lazy" />
+            ) : (
+              <span className="AnnouncementItem-avatarFallback">
+                <Icon name="fas fa-user" />
+              </span>
+            )}
+            <div className="AnnouncementItem-bylineText">
+              {a.authorName && <span className="AnnouncementItem-authorName">{a.authorName}</span>}
+              <span className="AnnouncementItem-meta">
+                <span className="AnnouncementItem-date">{date}</span>
+                <span className="AnnouncementItem-sep">·</span>
+                <span className="AnnouncementItem-comments">
+                  <Icon name="fas fa-comment-alt" />
+                  {app.translator.trans('core.admin.announcements.comments_label', { count: a.commentCount })}
+                </span>
+              </span>
+            </div>
+          </div>
+          <div className="AnnouncementItem-readMore">
+            {app.translator.trans('core.admin.announcements.read_more')}
+            <Icon name="fas fa-arrow-right" />
+          </div>
+        </div>
+      </Link>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/AnnouncementList.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementList.tsx
@@ -1,0 +1,60 @@
+import Component from '../../common/Component';
+import AnnouncementItem, { AnnouncementData } from './AnnouncementItem';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Icon from '../../common/components/Icon';
+import Link from '../../common/components/Link';
+import app from '../../admin/app';
+
+export interface IAnnouncementListAttrs {
+  announcements: AnnouncementData[] | null;
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+}
+
+export default class AnnouncementList extends Component<IAnnouncementListAttrs> {
+  view() {
+    const { announcements, loading, error, onRetry } = this.attrs;
+
+    if (loading) {
+      return (
+        <div className="AnnouncementList-state">
+          <LoadingIndicator />
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="AnnouncementList-state AnnouncementList-state--error">
+          <Icon name="fas fa-exclamation-circle" />
+          <p>{app.translator.trans('core.admin.announcements.load_error')}</p>
+          <button className="Button" onclick={onRetry}>
+            {app.translator.trans('core.admin.announcements.retry')}
+          </button>
+        </div>
+      );
+    }
+
+    if (!announcements?.length) {
+      return (
+        <div className="AnnouncementList-state AnnouncementList-state--empty">
+          <Icon name="fas fa-bullhorn" />
+          <p>{app.translator.trans('core.admin.announcements.empty')}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="AnnouncementList">
+        {announcements.map((a) => (
+          <AnnouncementItem key={a.id} announcement={a} />
+        ))}
+        <Link className="AnnouncementList-viewAll" href="https://discuss.flarum.org/t/blog" external={true} target="_blank">
+          <Icon name="fas fa-external-link-alt" />
+          {app.translator.trans('core.admin.announcements.view_all')}
+        </Link>
+      </div>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
@@ -2,6 +2,7 @@ import app from '../../admin/app';
 import DashboardWidget from './DashboardWidget';
 import AnnouncementList from './AnnouncementList';
 import type { AnnouncementData } from './AnnouncementItem';
+import type { IDashboardWidgetAttrs } from './DashboardWidget';
 import type Mithril from 'mithril';
 import Icon from '../../common/components/Icon';
 import Button from '../../common/components/Button';
@@ -15,7 +16,7 @@ export default class AnnouncementsWidget extends DashboardWidget {
   loading = false;
   hidden = false;
 
-  oninit(vnode: Mithril.Vnode) {
+  oninit(vnode: Mithril.Vnode<IDashboardWidgetAttrs, this>) {
     super.oninit(vnode);
     this.hidden = localStorage.getItem(HIDDEN_KEY) === '1';
 

--- a/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
@@ -1,0 +1,98 @@
+import app from '../../admin/app';
+import DashboardWidget from './DashboardWidget';
+import AnnouncementList from './AnnouncementList';
+import type { AnnouncementData } from './AnnouncementItem';
+import type Mithril from 'mithril';
+import Icon from '../../common/components/Icon';
+import Button from '../../common/components/Button';
+import Tooltip from '../../common/components/Tooltip';
+
+const HIDDEN_KEY = 'flarum.announcements.hidden';
+
+export default class AnnouncementsWidget extends DashboardWidget {
+  announcements: AnnouncementData[] | null = null;
+  loadError = false;
+  loading = false;
+  hidden = false;
+
+  oninit(vnode: Mithril.Vnode) {
+    super.oninit(vnode);
+    this.hidden = localStorage.getItem(HIDDEN_KEY) === '1';
+
+    if (!this.hidden) {
+      this.load();
+    }
+  }
+
+  className() {
+    return 'AnnouncementsWidget' + (this.hidden ? ' AnnouncementsWidget--hidden' : '');
+  }
+
+  async load(bust = false) {
+    this.loading = true;
+    this.loadError = false;
+    m.redraw();
+
+    try {
+      const url = app.forum.attribute('apiUrl') + '/flarum/announcements' + (bust ? '?bust=1' : '');
+      const data = (await app.request({ method: 'GET', url })) as unknown as AnnouncementData[];
+      this.announcements = data;
+    } catch (e) {
+      this.loadError = true;
+    } finally {
+      this.loading = false;
+      m.redraw();
+    }
+  }
+
+  toggleHidden() {
+    this.hidden = !this.hidden;
+
+    if (this.hidden) {
+      localStorage.setItem(HIDDEN_KEY, '1');
+    } else {
+      localStorage.removeItem(HIDDEN_KEY);
+      if (!this.announcements && !this.loading) {
+        this.load();
+      }
+    }
+
+    m.redraw();
+  }
+
+  content() {
+    return (
+      <>
+        <div className="AnnouncementsWidget-header">
+          <h2 className="AnnouncementsWidget-title">
+            <Icon name="fas fa-bullhorn" />
+            {app.translator.trans('core.admin.announcements.title')}
+            <Tooltip text={app.translator.trans('core.admin.announcements.about')}>
+              <span className="AnnouncementsWidget-info">
+                <Icon name="fas fa-info-circle" />
+              </span>
+            </Tooltip>
+          </h2>
+          <div className="AnnouncementsWidget-controls">
+            {!this.hidden && (
+              <Tooltip text={app.translator.trans('core.admin.announcements.refresh')}>
+                <Button
+                  className="Button Button--icon"
+                  icon={this.loading ? 'fas fa-sync-alt fa-spin' : 'fas fa-sync-alt'}
+                  disabled={this.loading}
+                  onclick={() => this.load(true)}
+                />
+              </Tooltip>
+            )}
+            <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
+              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
+            </Tooltip>
+          </div>
+        </div>
+        {!this.hidden && (
+          <AnnouncementList announcements={this.announcements} loading={this.loading} error={this.loadError} onRetry={() => this.load()} />
+        )}
+      </>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import app from '../../admin/app';
 import StatusWidget from './StatusWidget';
 import ExtensionsWidget from './ExtensionsWidget';
+import AnnouncementsWidget from './AnnouncementsWidget';
 import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { Children } from 'mithril';
@@ -79,7 +80,11 @@ export default class DashboardPage extends AdminPage {
       );
     }
 
-    items.add('status', <StatusWidget />, 30);
+    items.add('status', <StatusWidget />, 80);
+
+    if (!app.data.announcementsDisabled) {
+      items.add('announcements', <AnnouncementsWidget />, 70);
+    }
 
     items.add('extensions', <ExtensionsWidget />, 10);
 

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -19,3 +19,4 @@
 @import "admin/NoJs";
 @import "admin/UsersListPage";
 @import "admin/GeneralSearchResult";
+@import "admin/AnnouncementsPage";

--- a/framework/core/less/admin/AnnouncementsPage.less
+++ b/framework/core/less/admin/AnnouncementsPage.less
@@ -1,0 +1,287 @@
+// ── Widget wrapper ────────────────────────────────────────────────────────────
+
+.AnnouncementsWidget {
+  padding: 0;
+}
+
+.AnnouncementsWidget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 20px;
+}
+
+.AnnouncementsWidget-controls {
+  > .Button {
+    margin-left: 8px;
+  }
+}
+
+.AnnouncementsWidget-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 20px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-color);
+
+  .icon {
+    font-size: 12px;
+    opacity: 0.7;
+  }
+}
+
+.AnnouncementsWidget-info {
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  opacity: 0.4;
+  font-size: 11px;
+  transition: opacity 0.15s;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+// ── List (responsive wrapping grid) ──────────────────────────────────────────
+
+.AnnouncementList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  padding: 0 20px 20px;
+
+  &-viewAll {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: var(--body-bg);
+    border-radius: var(--border-radius);
+    border: 1px dashed var(--control-bg);
+    text-decoration: none;
+    color: var(--muted-color);
+    font-size: 12px;
+    font-weight: 600;
+    min-height: 80px;
+    transition: border-color 0.15s, color 0.15s;
+
+    .icon {
+      font-size: 16px;
+      opacity: 0.5;
+    }
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: none;
+      border-color: var(--primary-color);
+      color: var(--primary-color);
+
+      .icon {
+        opacity: 1;
+      }
+    }
+  }
+
+  &-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 24px 20px;
+    color: var(--muted-color);
+    text-align: center;
+    width: 100%;
+
+    .icon {
+      font-size: 22px;
+      opacity: 0.4;
+    }
+
+    p {
+      margin: 0;
+      font-size: 13px;
+    }
+
+    &--error .icon {
+      color: @error-color;
+      opacity: 0.8;
+    }
+  }
+}
+
+// ── Item card ─────────────────────────────────────────────────────────────────
+
+.AnnouncementItem {
+  display: flex;
+  flex-direction: column;
+  background: var(--body-bg);
+  border-radius: var(--border-radius);
+  border: 1px solid transparent;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: none;
+    color: inherit;
+    border-color: var(--primary-color);
+    box-shadow: 0 3px 10px fade(#000, 12%);
+    transform: translateY(-2px);
+
+    .AnnouncementItem-readMore {
+      opacity: 1;
+      gap: 5px;
+    }
+  }
+
+  // ── Body (title + excerpt) ──
+
+  &-body {
+    flex: 1;
+    padding: 14px 14px 10px;
+  }
+
+  &-title {
+    margin: 0 0 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--heading-color);
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &-stickyIcon {
+    font-size: 10px;
+    color: var(--primary-color);
+    opacity: 0.8;
+    margin-right: 4px;
+    vertical-align: middle;
+    transform: rotate(45deg);
+    display: inline-block;
+  }
+
+  &-excerpt {
+    margin: 0;
+    font-size: 12px;
+    color: var(--muted-color);
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  // ── Footer ──
+
+  &-footer {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 14px 12px;
+    border-top: 1px solid var(--control-bg);
+  }
+
+  // Avatar + author name + date/comments stacked
+  &-byline {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    object-fit: cover;
+  }
+
+  &-avatarFallback {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--control-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    color: var(--muted-color);
+    flex-shrink: 0;
+  }
+
+  &-bylineText {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  &-authorName {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.2;
+  }
+
+  // Date · N comments row
+  &-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--muted-color);
+    white-space: nowrap;
+    line-height: 1.2;
+  }
+
+  &-sep {
+    opacity: 0.4;
+  }
+
+  &-comments {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+
+    .icon {
+      font-size: 9px;
+      opacity: 0.6;
+    }
+  }
+
+  &-date {
+    opacity: 0.8;
+  }
+
+  // "Read more →" — appears on hover, sits below byline
+  &-readMore {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--primary-color);
+    opacity: 0;
+    transition: opacity 0.15s, gap 0.15s;
+
+    .icon {
+      font-size: 9px;
+    }
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -170,6 +170,21 @@ core:
       use_random_password: Generate random password
       username_placeholder: => core.ref.username
 
+    # These translations are used in the Announcements page.
+    announcements:
+      comments_label: "{count, plural, one {# comment} other {# comments}}"
+      description: Latest news and announcements from the Flarum Team.
+      empty: No announcements found.
+      load_error: Could not load announcements. Please try again later.
+      about: Latest news and announcements pulled from the official Flarum community at discuss.flarum.org.
+      hide: Hide announcements
+      read_more: Read more
+      refresh: Refresh announcements
+      retry: Try again
+      show: Show announcements
+      title: Announcements
+      view_all: View all on discuss.flarum.org
+
     # These translations are used in the Dashboard page.
     dashboard:
       clear_cache_button: Clear Cache

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -101,6 +101,8 @@ class AdminPayload
         $document->payload['safeModeExtensions'] = $this->maintenance->safeModeExtensions();
         $document->payload['safeModeExtensionsConfig'] = $this->config->safeModeExtensions();
 
+        $document->payload['announcementsDisabled'] = (bool) $this->config['flarum_announcements.disabled'];
+
         $document->payload['fontawesomeByConfig'] = $this->fontAwesome->configOverride();
 
         // If FontAwesome is configured via config.php, pass the actual config values to frontend

--- a/framework/core/src/Announcements/AnnouncementsFetcher.php
+++ b/framework/core/src/Announcements/AnnouncementsFetcher.php
@@ -34,16 +34,16 @@ class AnnouncementsFetcher
     public function fetch(): array
     {
         $url = self::API_BASE_URL.'?'.http_build_query([
-            'filter'  => ['tag' => self::TAG],
-            'sort'    => '-createdAt',
-            'page'    => ['limit' => self::FETCH_LIMIT],
+            'filter' => ['tag' => self::TAG],
+            'sort' => '-createdAt',
+            'page' => ['limit' => self::FETCH_LIMIT],
             'include' => 'firstPost,user',
         ]);
 
         try {
             $response = $this->client->get($url, [
                 'headers' => [
-                    'Accept'     => 'application/json',
+                    'Accept' => 'application/json',
                     'User-Agent' => 'Flarum/'.Application::VERSION
                         .' PHP/'.$this->appInfo->identifyPHPVersion()
                         .' Database/'.$this->appInfo->identifyDatabaseDriver().'/'.$this->appInfo->identifyDatabaseVersion(),
@@ -71,9 +71,9 @@ class AnnouncementsFetcher
 
         $items = [];
         foreach ($body['data'] as $discussion) {
-            $id    = Arr::get($discussion, 'id');
+            $id = Arr::get($discussion, 'id');
             $title = Arr::get($discussion, 'attributes.title');
-            $slug  = Arr::get($discussion, 'attributes.slug');
+            $slug = Arr::get($discussion, 'attributes.slug');
             $createdAt = Arr::get($discussion, 'attributes.createdAt');
 
             // Skip any discussion missing the fields we require to render a card.
@@ -88,16 +88,16 @@ class AnnouncementsFetcher
             $user = $userId ? ($users[$userId] ?? null) : null;
 
             $items[] = [
-                'id'           => $id,
-                'title'        => $title,
-                'slug'         => $slug,
+                'id' => $id,
+                'title' => $title,
+                'slug' => $slug,
                 'commentCount' => Arr::get($discussion, 'attributes.commentCount', 0),
-                'createdAt'    => $createdAt,
-                'isSticky'     => (bool) Arr::get($discussion, 'attributes.isSticky', false),
-                'url'          => 'https://discuss.flarum.org/d/'.$slug,
-                'excerpt'      => $this->makeExcerpt(Arr::get($firstPost, 'attributes.contentHtml', '')),
-                'authorName'   => Arr::get($user, 'attributes.displayName'),
-                'avatarUrl'    => Arr::get($user, 'attributes.avatarUrl'),
+                'createdAt' => $createdAt,
+                'isSticky' => (bool) Arr::get($discussion, 'attributes.isSticky', false),
+                'url' => 'https://discuss.flarum.org/d/'.$slug,
+                'excerpt' => $this->makeExcerpt(Arr::get($firstPost, 'attributes.contentHtml', '')),
+                'authorName' => Arr::get($user, 'attributes.displayName'),
+                'avatarUrl' => Arr::get($user, 'attributes.avatarUrl'),
             ];
         }
 

--- a/framework/core/src/Announcements/AnnouncementsFetcher.php
+++ b/framework/core/src/Announcements/AnnouncementsFetcher.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements;
+
+use Flarum\Foundation\Application;
+use Flarum\Foundation\ApplicationInfoProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
+use RuntimeException;
+
+class AnnouncementsFetcher
+{
+    private Client $client;
+
+    public function __construct(
+        protected ApplicationInfoProvider $appInfo
+    ) {
+        $this->client = new Client(['timeout' => 10]);
+    }
+    protected const API_BASE_URL = 'https://discuss.flarum.org/api/discussions';
+    protected const TAG = 'blog';
+    protected const LIMIT = 8;
+    protected const FETCH_LIMIT = 20;
+    protected const EXCERPT_LENGTH = 200;
+
+    public function fetch(): array
+    {
+        $url = self::API_BASE_URL.'?'.http_build_query([
+            'filter'  => ['tag' => self::TAG],
+            'sort'    => '-createdAt',
+            'page'    => ['limit' => self::FETCH_LIMIT],
+            'include' => 'firstPost,user',
+        ]);
+
+        try {
+            $response = $this->client->get($url, [
+                'headers' => [
+                    'Accept'     => 'application/json',
+                    'User-Agent' => 'Flarum/'.Application::VERSION
+                        .' PHP/'.$this->appInfo->identifyPHPVersion()
+                        .' Database/'.$this->appInfo->identifyDatabaseDriver().'/'.$this->appInfo->identifyDatabaseVersion(),
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('Could not fetch announcements from discuss.flarum.org: '.$e->getMessage(), 0, $e);
+        }
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($body['data'] ?? null)) {
+            throw new RuntimeException('Unexpected response from discuss.flarum.org.');
+        }
+
+        $posts = [];
+        $users = [];
+        foreach ($body['included'] ?? [] as $resource) {
+            if (Arr::get($resource, 'type') === 'posts') {
+                $posts[$resource['id']] = $resource;
+            } elseif (Arr::get($resource, 'type') === 'users') {
+                $users[$resource['id']] = $resource;
+            }
+        }
+
+        $items = [];
+        foreach ($body['data'] as $discussion) {
+            $id    = Arr::get($discussion, 'id');
+            $title = Arr::get($discussion, 'attributes.title');
+            $slug  = Arr::get($discussion, 'attributes.slug');
+            $createdAt = Arr::get($discussion, 'attributes.createdAt');
+
+            // Skip any discussion missing the fields we require to render a card.
+            if (! $id || ! $title || ! $slug || ! $createdAt) {
+                continue;
+            }
+
+            $firstPostId = Arr::get($discussion, 'relationships.firstPost.data.id');
+            $firstPost = $firstPostId ? ($posts[$firstPostId] ?? null) : null;
+
+            $userId = Arr::get($discussion, 'relationships.user.data.id');
+            $user = $userId ? ($users[$userId] ?? null) : null;
+
+            $items[] = [
+                'id'           => $id,
+                'title'        => $title,
+                'slug'         => $slug,
+                'commentCount' => Arr::get($discussion, 'attributes.commentCount', 0),
+                'createdAt'    => $createdAt,
+                'isSticky'     => (bool) Arr::get($discussion, 'attributes.isSticky', false),
+                'url'          => 'https://discuss.flarum.org/d/'.$slug,
+                'excerpt'      => $this->makeExcerpt(Arr::get($firstPost, 'attributes.contentHtml', '')),
+                'authorName'   => Arr::get($user, 'attributes.displayName'),
+                'avatarUrl'    => Arr::get($user, 'attributes.avatarUrl'),
+            ];
+        }
+
+        usort($items, fn (array $a, array $b) => $b['isSticky'] <=> $a['isSticky']);
+
+        return array_slice($items, 0, self::LIMIT);
+    }
+
+    private function makeExcerpt(string $html): string
+    {
+        $plain = strip_tags($html);
+        $plain = trim(preg_replace('/\s+/', ' ', $plain));
+
+        return mb_strimwidth($plain, 0, self::EXCERPT_LENGTH, '…');
+    }
+}

--- a/framework/core/src/Announcements/AnnouncementsServiceProvider.php
+++ b/framework/core/src/Announcements/AnnouncementsServiceProvider.php
@@ -31,8 +31,8 @@ class AnnouncementsServiceProvider extends AbstractServiceProvider
 
         $container->extend('flarum.console.scheduled', function (array $scheduled) {
             $scheduled[] = [
-                'command'  => RefreshAnnouncementsCommand::class,
-                'args'     => [],
+                'command' => RefreshAnnouncementsCommand::class,
+                'args' => [],
                 'callback' => new WeeklySchedule(),
             ];
 

--- a/framework/core/src/Announcements/AnnouncementsServiceProvider.php
+++ b/framework/core/src/Announcements/AnnouncementsServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements;
+
+use Flarum\Announcements\Console\RefreshAnnouncementsCommand;
+use Flarum\Announcements\Console\WeeklySchedule;
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
+use Illuminate\Contracts\Container\Container;
+
+class AnnouncementsServiceProvider extends AbstractServiceProvider
+{
+    public function boot(Container $container, Config $config): void
+    {
+        if ($config['flarum_announcements.disabled'] ?? false) {
+            return;
+        }
+
+        $container->extend('flarum.console.commands', function (array $commands) {
+            $commands[] = RefreshAnnouncementsCommand::class;
+
+            return $commands;
+        });
+
+        $container->extend('flarum.console.scheduled', function (array $scheduled) {
+            $scheduled[] = [
+                'command'  => RefreshAnnouncementsCommand::class,
+                'args'     => [],
+                'callback' => new WeeklySchedule(),
+            ];
+
+            return $scheduled;
+        });
+    }
+}

--- a/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
+++ b/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements\Console;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Api\Controller\ListAnnouncementsController;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class RefreshAnnouncementsCommand extends Command
+{
+    protected $signature = 'flarum:refresh-announcements';
+    protected $description = 'Fetch and cache the latest announcements from discuss.flarum.org.';
+
+    public function handle(CacheRepository $cache, AnnouncementsFetcher $fetcher): int
+    {
+        $this->info('Fetching announcements from discuss.flarum.org...');
+
+        try {
+            $announcements = $fetcher->fetch();
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $cache->put(ListAnnouncementsController::CACHE_KEY, $announcements, ListAnnouncementsController::CACHE_STALE_TTL);
+
+        $this->info('Cached '.count($announcements).' announcements.');
+
+        return self::SUCCESS;
+    }
+}

--- a/framework/core/src/Announcements/Console/WeeklySchedule.php
+++ b/framework/core/src/Announcements/Console/WeeklySchedule.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements\Console;
+
+use Illuminate\Console\Scheduling\Event;
+
+class WeeklySchedule
+{
+    public function __invoke(Event $event): void
+    {
+        $event->weekly()->withoutOverlapping();
+    }
+}

--- a/framework/core/src/Api/Controller/ListAnnouncementsController.php
+++ b/framework/core/src/Api/Controller/ListAnnouncementsController.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Http\RequestUtil;
+use Illuminate\Cache\Repository as CacheRepository;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ListAnnouncementsController implements RequestHandlerInterface
+{
+    public const CACHE_KEY = 'flarum.announcements';
+    public const CACHE_FRESH_TTL = 1 * 24 * 3600;  // serve fresh for 1 day
+    public const CACHE_STALE_TTL = 14 * 24 * 3600; // allow stale for 14 days
+    public const CACHE_TTL = self::CACHE_STALE_TTL; // used by the console command
+
+    public function __construct(
+        protected CacheRepository $cache,
+        protected AnnouncementsFetcher $fetcher
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        if ($request->getQueryParams()['bust'] ?? false) {
+            try {
+                $announcements = $this->fetcher->fetch();
+                $this->cache->put(self::CACHE_KEY, $announcements, self::CACHE_STALE_TTL);
+            } catch (\RuntimeException) {
+                $announcements = $this->cache->get(self::CACHE_KEY, []);
+            }
+
+            return new JsonResponse($announcements);
+        }
+
+        $announcements = $this->cache->flexible(
+            self::CACHE_KEY,
+            [self::CACHE_FRESH_TTL, self::CACHE_STALE_TTL],
+            function () {
+                try {
+                    return $this->fetcher->fetch();
+                } catch (\RuntimeException) {
+                    return null; // keep existing cached value
+                }
+            }
+        ) ?? [];
+
+        return new JsonResponse($announcements);
+    }
+}

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -183,4 +183,11 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         'mailTest',
         $route->toController(Controller\SendTestMailController::class)
     );
+
+    // List Flarum community announcements from discuss.flarum.org
+    $map->get(
+        '/flarum/announcements',
+        'announcements.list',
+        $route->toController(Controller\ListAnnouncementsController::class)
+    );
 };

--- a/framework/core/src/Foundation/InstalledSite.php
+++ b/framework/core/src/Foundation/InstalledSite.php
@@ -10,6 +10,7 @@
 namespace Flarum\Foundation;
 
 use Flarum\Admin\AdminServiceProvider;
+use Flarum\Announcements\AnnouncementsServiceProvider;
 use Flarum\Api\ApiServiceProvider;
 use Flarum\Bus\BusServiceProvider;
 use Flarum\Console\ConsoleServiceProvider;
@@ -101,6 +102,7 @@ class InstalledSite implements SiteInterface
         $this->registerCache($app);
 
         $app->register(AdminServiceProvider::class);
+        $app->register(AnnouncementsServiceProvider::class);
         $app->register(ApiServiceProvider::class);
         $app->register(BusServiceProvider::class);
         $app->register(ConsoleServiceProvider::class);
@@ -185,6 +187,7 @@ class InstalledSite implements SiteInterface
             return new CacheRepository($container->make('cache.filestore'));
         });
         $container->alias('cache.store', Repository::class);
+        $container->alias('cache.store', \Illuminate\Cache\Repository::class);
 
         $container->singleton('cache.filestore', function () {
             return new FileStore(new Filesystem, $this->paths->storage.'/cache');

--- a/framework/core/tests/integration/api/announcements/ListTest.php
+++ b/framework/core/tests/integration/api/announcements/ListTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\announcements;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Extend;
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+
+class ListTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Replace the real fetcher with a stub so tests never hit discuss.flarum.org
+        $this->extend(
+            (new Extend\ServiceProvider())->register(StubAnnouncementsProvider::class)
+        );
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    #[Test]
+    public function guest_cannot_list_announcements(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/flarum/announcements')
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function non_admin_cannot_list_announcements(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/flarum/announcements', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_list_announcements(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/flarum/announcements', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+        $this->assertArrayHasKey('id', $data[0]);
+        $this->assertArrayHasKey('title', $data[0]);
+        $this->assertArrayHasKey('url', $data[0]);
+    }
+
+    #[Test]
+    public function bust_param_forces_cache_refresh(): void
+    {
+        // Prime the cache
+        $this->send(
+            $this->request('GET', '/api/flarum/announcements', ['authenticatedAs' => 1])
+        );
+
+        // Bust it — should still return valid data
+        $response = $this->send(
+            $this->request('GET', '/api/flarum/announcements?bust=1', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertNotEmpty($data);
+    }
+
+    #[Test]
+    public function bust_returns_empty_array_when_fetcher_fails_and_no_cache(): void
+    {
+        // Swap the fetcher to one that always fails, before app boots
+        $this->extend(
+            (new Extend\ServiceProvider())->register(FailingAnnouncementsProvider::class)
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/flarum/announcements?bust=1', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertIsArray($data);
+        $this->assertEmpty($data);
+    }
+}
+
+class StubAnnouncementsFetcher extends AnnouncementsFetcher
+{
+    public function fetch(): array
+    {
+        return [[
+            'id'           => '1',
+            'title'        => 'Test Announcement',
+            'slug'         => 'test-announcement',
+            'commentCount' => 3,
+            'createdAt'    => '2026-01-01T00:00:00+00:00',
+            'isSticky'     => false,
+            'url'          => 'https://discuss.flarum.org/d/test-announcement',
+            'excerpt'      => 'This is a test.',
+            'authorName'   => 'IanM',
+            'avatarUrl'    => null,
+        ]];
+    }
+}
+
+class FailingAnnouncementsFetcher extends AnnouncementsFetcher
+{
+    public function fetch(): array
+    {
+        throw new \RuntimeException('discuss.flarum.org is unreachable');
+    }
+}
+
+class StubAnnouncementsProvider extends AbstractServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->bind(AnnouncementsFetcher::class, fn (Container $container) => new StubAnnouncementsFetcher(
+            $container->make(\Flarum\Foundation\ApplicationInfoProvider::class)
+        ));
+    }
+}
+
+class FailingAnnouncementsProvider extends AbstractServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->bind(AnnouncementsFetcher::class, fn (Container $container) => new FailingAnnouncementsFetcher(
+            $container->make(\Flarum\Foundation\ApplicationInfoProvider::class)
+        ));
+    }
+}

--- a/framework/core/tests/integration/api/announcements/ListTest.php
+++ b/framework/core/tests/integration/api/announcements/ListTest.php
@@ -122,16 +122,16 @@ class StubAnnouncementsFetcher extends AnnouncementsFetcher
     public function fetch(): array
     {
         return [[
-            'id'           => '1',
-            'title'        => 'Test Announcement',
-            'slug'         => 'test-announcement',
+            'id' => '1',
+            'title' => 'Test Announcement',
+            'slug' => 'test-announcement',
             'commentCount' => 3,
-            'createdAt'    => '2026-01-01T00:00:00+00:00',
-            'isSticky'     => false,
-            'url'          => 'https://discuss.flarum.org/d/test-announcement',
-            'excerpt'      => 'This is a test.',
-            'authorName'   => 'IanM',
-            'avatarUrl'    => null,
+            'createdAt' => '2026-01-01T00:00:00+00:00',
+            'isSticky' => false,
+            'url' => 'https://discuss.flarum.org/d/test-announcement',
+            'excerpt' => 'This is a test.',
+            'authorName' => 'IanM',
+            'avatarUrl' => null,
         ]];
     }
 }

--- a/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
+++ b/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Announcements;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Foundation\ApplicationInfoProvider;
+use Flarum\Testing\unit\TestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Mockery as m;
+
+class AnnouncementsFetcherTest extends TestCase
+{
+    private ApplicationInfoProvider $appInfo;
+
+    protected function setUp(): void
+    {
+        $this->appInfo = m::mock(ApplicationInfoProvider::class);
+        $this->appInfo->shouldReceive('identifyPHPVersion')->andReturn('8.3.0');
+        $this->appInfo->shouldReceive('identifyDatabaseDriver')->andReturn('MySQL');
+        $this->appInfo->shouldReceive('identifyDatabaseVersion')->andReturn('8.0.32');
+    }
+
+    private function makeFetcher(array $responses): AnnouncementsFetcher
+    {
+        $mock = new MockHandler($responses);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $fetcher = new AnnouncementsFetcher($this->appInfo);
+
+        // Inject the mock client via reflection
+        $ref = new \ReflectionProperty($fetcher, 'client');
+        $ref->setAccessible(true);
+        $ref->setValue($fetcher, $client);
+
+        return $fetcher;
+    }
+
+    private function makeApiResponse(array $discussions, array $included = []): Response
+    {
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode([
+            'data'     => $discussions,
+            'included' => $included,
+        ]));
+    }
+
+    private function makeDiscussion(array $attrs = [], array $relationships = []): array
+    {
+        return [
+            'id'            => $attrs['id'] ?? '1',
+            'type'          => 'discussions',
+            'attributes'    => array_merge([
+                'title'        => 'Test Discussion',
+                'slug'         => 'test-discussion',
+                'commentCount' => 5,
+                'createdAt'    => '2026-01-01T00:00:00+00:00',
+                'isSticky'     => false,
+            ], $attrs),
+            'relationships' => $relationships,
+        ];
+    }
+
+    public function test_transforms_discussion_to_expected_shape(): void
+    {
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse([$this->makeDiscussion()]),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('1', $result[0]['id']);
+        $this->assertEquals('Test Discussion', $result[0]['title']);
+        $this->assertEquals('test-discussion', $result[0]['slug']);
+        $this->assertEquals(5, $result[0]['commentCount']);
+        $this->assertEquals('https://discuss.flarum.org/d/test-discussion', $result[0]['url']);
+        $this->assertFalse($result[0]['isSticky']);
+        $this->assertNull($result[0]['authorName']);
+        $this->assertNull($result[0]['avatarUrl']);
+    }
+
+    public function test_sticky_discussions_sorted_first(): void
+    {
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse([
+                $this->makeDiscussion(['id' => '1', 'title' => 'Regular', 'slug' => 'regular', 'isSticky' => false]),
+                $this->makeDiscussion(['id' => '2', 'title' => 'Sticky', 'slug' => 'sticky', 'isSticky' => true]),
+                $this->makeDiscussion(['id' => '3', 'title' => 'Also Regular', 'slug' => 'also-regular', 'isSticky' => false]),
+            ]),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertEquals('2', $result[0]['id']);
+        $this->assertEquals('1', $result[1]['id']);
+        $this->assertEquals('3', $result[2]['id']);
+    }
+
+    public function test_resolves_author_from_included(): void
+    {
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion([], [
+                    'user' => ['data' => ['type' => 'users', 'id' => '42']],
+                ])],
+                [[
+                    'type'       => 'users',
+                    'id'         => '42',
+                    'attributes' => ['displayName' => 'IanM', 'avatarUrl' => 'https://example.com/avatar.jpg'],
+                ]]
+            ),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertEquals('IanM', $result[0]['authorName']);
+        $this->assertEquals('https://example.com/avatar.jpg', $result[0]['avatarUrl']);
+    }
+
+    public function test_resolves_excerpt_from_first_post(): void
+    {
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion([], [
+                    'firstPost' => ['data' => ['type' => 'posts', 'id' => '99']],
+                ])],
+                [[
+                    'type'       => 'posts',
+                    'id'         => '99',
+                    'attributes' => ['contentHtml' => '<p>Hello <strong>world</strong> this is content.</p>'],
+                ]]
+            ),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertEquals('Hello world this is content.', $result[0]['excerpt']);
+    }
+
+    public function test_excerpt_is_truncated_to_200_chars(): void
+    {
+        $longText = str_repeat('a', 250);
+
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse(
+                [$this->makeDiscussion([], [
+                    'firstPost' => ['data' => ['type' => 'posts', 'id' => '1']],
+                ])],
+                [[
+                    'type'       => 'posts',
+                    'id'         => '1',
+                    'attributes' => ['contentHtml' => $longText],
+                ]]
+            ),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertLessThanOrEqual(201, mb_strlen($result[0]['excerpt'])); // 200 chars + ellipsis
+        $this->assertStringEndsWith('…', $result[0]['excerpt']);
+    }
+
+    public function test_skips_discussions_missing_required_fields(): void
+    {
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse([
+                $this->makeDiscussion(['title' => 'Valid', 'slug' => 'valid']),
+                // Missing title
+                ['id' => '2', 'type' => 'discussions', 'attributes' => ['slug' => 'no-title', 'createdAt' => '2026-01-01T00:00:00+00:00'], 'relationships' => []],
+                // Missing slug
+                ['id' => '3', 'type' => 'discussions', 'attributes' => ['title' => 'No Slug', 'createdAt' => '2026-01-01T00:00:00+00:00'], 'relationships' => []],
+            ]),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Valid', $result[0]['title']);
+    }
+
+    public function test_throws_on_network_failure(): void
+    {
+        $fetcher = $this->makeFetcher([
+            new ConnectException('Connection refused', new Request('GET', 'test')),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Could not fetch announcements/');
+
+        $fetcher->fetch();
+    }
+
+    public function test_throws_on_garbled_response(): void
+    {
+        $fetcher = $this->makeFetcher([
+            new Response(200, ['Content-Type' => 'application/json'], 'not valid json at all'),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Unexpected response/');
+
+        $fetcher->fetch();
+    }
+
+    public function test_throws_on_missing_data_key(): void
+    {
+        $fetcher = $this->makeFetcher([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['meta' => []])),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+
+        $fetcher->fetch();
+    }
+
+    public function test_results_sliced_to_limit(): void
+    {
+        $discussions = array_map(fn ($i) => $this->makeDiscussion([
+            'id'    => (string) $i,
+            'title' => "Discussion $i",
+            'slug'  => "discussion-$i",
+        ]), range(1, 20));
+
+        $fetcher = $this->makeFetcher([
+            $this->makeApiResponse($discussions),
+        ]);
+
+        $result = $fetcher->fetch();
+
+        $this->assertCount(8, $result);
+    }
+}

--- a/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
+++ b/framework/core/tests/unit/Announcements/AnnouncementsFetcherTest.php
@@ -50,7 +50,7 @@ class AnnouncementsFetcherTest extends TestCase
     private function makeApiResponse(array $discussions, array $included = []): Response
     {
         return new Response(200, ['Content-Type' => 'application/json'], json_encode([
-            'data'     => $discussions,
+            'data' => $discussions,
             'included' => $included,
         ]));
     }
@@ -58,14 +58,14 @@ class AnnouncementsFetcherTest extends TestCase
     private function makeDiscussion(array $attrs = [], array $relationships = []): array
     {
         return [
-            'id'            => $attrs['id'] ?? '1',
-            'type'          => 'discussions',
-            'attributes'    => array_merge([
-                'title'        => 'Test Discussion',
-                'slug'         => 'test-discussion',
+            'id' => $attrs['id'] ?? '1',
+            'type' => 'discussions',
+            'attributes' => array_merge([
+                'title' => 'Test Discussion',
+                'slug' => 'test-discussion',
                 'commentCount' => 5,
-                'createdAt'    => '2026-01-01T00:00:00+00:00',
-                'isSticky'     => false,
+                'createdAt' => '2026-01-01T00:00:00+00:00',
+                'isSticky' => false,
             ], $attrs),
             'relationships' => $relationships,
         ];
@@ -115,8 +115,8 @@ class AnnouncementsFetcherTest extends TestCase
                     'user' => ['data' => ['type' => 'users', 'id' => '42']],
                 ])],
                 [[
-                    'type'       => 'users',
-                    'id'         => '42',
+                    'type' => 'users',
+                    'id' => '42',
                     'attributes' => ['displayName' => 'IanM', 'avatarUrl' => 'https://example.com/avatar.jpg'],
                 ]]
             ),
@@ -136,8 +136,8 @@ class AnnouncementsFetcherTest extends TestCase
                     'firstPost' => ['data' => ['type' => 'posts', 'id' => '99']],
                 ])],
                 [[
-                    'type'       => 'posts',
-                    'id'         => '99',
+                    'type' => 'posts',
+                    'id' => '99',
                     'attributes' => ['contentHtml' => '<p>Hello <strong>world</strong> this is content.</p>'],
                 ]]
             ),
@@ -158,8 +158,8 @@ class AnnouncementsFetcherTest extends TestCase
                     'firstPost' => ['data' => ['type' => 'posts', 'id' => '1']],
                 ])],
                 [[
-                    'type'       => 'posts',
-                    'id'         => '1',
+                    'type' => 'posts',
+                    'id' => '1',
                     'attributes' => ['contentHtml' => $longText],
                 ]]
             ),
@@ -227,9 +227,9 @@ class AnnouncementsFetcherTest extends TestCase
     public function test_results_sliced_to_limit(): void
     {
         $discussions = array_map(fn ($i) => $this->makeDiscussion([
-            'id'    => (string) $i,
+            'id' => (string) $i,
             'title' => "Discussion $i",
-            'slug'  => "discussion-$i",
+            'slug' => "discussion-$i",
         ]), range(1, 20));
 
         $fetcher = $this->makeFetcher([

--- a/framework/core/tests/unit/Announcements/ListAnnouncementsControllerTest.php
+++ b/framework/core/tests/unit/Announcements/ListAnnouncementsControllerTest.php
@@ -26,16 +26,16 @@ class ListAnnouncementsControllerTest extends TestCase
     private ListAnnouncementsController $controller;
 
     private array $stubAnnouncements = [[
-        'id'           => '1',
-        'title'        => 'Test',
-        'slug'         => 'test',
+        'id' => '1',
+        'title' => 'Test',
+        'slug' => 'test',
         'commentCount' => 0,
-        'createdAt'    => '2026-01-01T00:00:00+00:00',
-        'isSticky'     => false,
-        'url'          => 'https://discuss.flarum.org/d/test',
-        'excerpt'      => '',
-        'authorName'   => null,
-        'avatarUrl'    => null,
+        'createdAt' => '2026-01-01T00:00:00+00:00',
+        'isSticky' => false,
+        'url' => 'https://discuss.flarum.org/d/test',
+        'excerpt' => '',
+        'authorName' => null,
+        'avatarUrl' => null,
     ]];
 
     protected function setUp(): void

--- a/framework/core/tests/unit/Announcements/ListAnnouncementsControllerTest.php
+++ b/framework/core/tests/unit/Announcements/ListAnnouncementsControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Announcements;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Api\Controller\ListAnnouncementsController;
+use Flarum\Http\ActorReference;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\User;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository as CacheRepository;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+
+class ListAnnouncementsControllerTest extends TestCase
+{
+    private CacheRepository $cache;
+    private AnnouncementsFetcher $fetcher;
+    private ListAnnouncementsController $controller;
+
+    private array $stubAnnouncements = [[
+        'id'           => '1',
+        'title'        => 'Test',
+        'slug'         => 'test',
+        'commentCount' => 0,
+        'createdAt'    => '2026-01-01T00:00:00+00:00',
+        'isSticky'     => false,
+        'url'          => 'https://discuss.flarum.org/d/test',
+        'excerpt'      => '',
+        'authorName'   => null,
+        'avatarUrl'    => null,
+    ]];
+
+    protected function setUp(): void
+    {
+        $this->cache = new CacheRepository(new ArrayStore());
+        $this->fetcher = m::mock(AnnouncementsFetcher::class);
+        $this->controller = new ListAnnouncementsController($this->cache, $this->fetcher);
+    }
+
+    private function adminRequest(array $queryParams = []): ServerRequest
+    {
+        $actor = m::mock(User::class);
+        $actor->shouldReceive('assertAdmin')->andReturn(null);
+
+        $actorRef = new ActorReference();
+        $actorRef->setActor($actor);
+
+        $request = (new ServerRequest([], [], '/api/flarum/announcements', 'GET'))
+            ->withQueryParams($queryParams);
+
+        return $request->withAttribute('actorReference', $actorRef);
+    }
+
+    public function test_returns_fetched_data(): void
+    {
+        $this->fetcher->shouldReceive('fetch')->once()->andReturn($this->stubAnnouncements);
+
+        $response = $this->controller->handle($this->adminRequest([]));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals('1', $data[0]['id']);
+    }
+
+    public function test_caches_result_on_first_call(): void
+    {
+        $this->fetcher->shouldReceive('fetch')->once()->andReturn($this->stubAnnouncements);
+
+        // Two requests — fetcher should only be called once
+        $this->controller->handle($this->adminRequest([]));
+        $this->controller->handle($this->adminRequest([]));
+    }
+
+    public function test_bust_refetches_and_updates_cache(): void
+    {
+        $fresh = array_merge($this->stubAnnouncements, [['id' => '2', 'title' => 'Fresh', 'slug' => 'fresh',
+            'commentCount' => 0, 'createdAt' => '2026-01-01T00:00:00+00:00',
+            'isSticky' => false, 'url' => 'https://discuss.flarum.org/d/fresh',
+            'excerpt' => '', 'authorName' => null, 'avatarUrl' => null]]);
+
+        $this->fetcher->shouldReceive('fetch')->once()->andReturn($fresh);
+
+        $response = $this->controller->handle($this->adminRequest(['bust' => '1']));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertCount(2, $data);
+
+        // Verify cache was updated
+        $this->assertEquals($fresh, $this->cache->get(ListAnnouncementsController::CACHE_KEY));
+    }
+
+    public function test_bust_falls_back_to_stale_cache_on_fetch_failure(): void
+    {
+        $stale = [['id' => '999', 'title' => 'Stale', 'slug' => 'stale',
+            'commentCount' => 0, 'createdAt' => '2026-01-01T00:00:00+00:00',
+            'isSticky' => false, 'url' => 'https://discuss.flarum.org/d/stale',
+            'excerpt' => '', 'authorName' => null, 'avatarUrl' => null]];
+
+        $this->cache->put(ListAnnouncementsController::CACHE_KEY, $stale, 3600);
+
+        $this->fetcher->shouldReceive('fetch')->once()->andThrow(new \RuntimeException('discuss is down'));
+
+        $response = $this->controller->handle($this->adminRequest(['bust' => '1']));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals('999', $data[0]['id']);
+    }
+
+    public function test_bust_returns_empty_array_when_fetch_fails_and_no_cache(): void
+    {
+        $this->fetcher->shouldReceive('fetch')->once()->andThrow(new \RuntimeException('discuss is down'));
+
+        $response = $this->controller->handle($this->adminRequest(['bust' => '1']));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertEmpty($data);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an **Announcements** widget to the admin dashboard, showing the latest posts from the official Flarum community (discuss.flarum.org)
- Sticky discussions are listed first
- Results are cached with a 1-day fresh / 14-day stale strategy using `cache->flexible()` (Laravel 13)
- A `flarum:refresh-announcements` console command warms the cache; it runs weekly via the scheduler
- Admins can manually **refresh** (bust cache) or **hide/show** the widget (persisted in `localStorage`)
- An info tooltip explains where the data comes from
- Everything is skipped when `flarum_announcements.disabled => true` is set in `config.php`

## Backend

- `AnnouncementsFetcher` — HTTP fetch + transform, enriched User-Agent (`Flarum/VERSION PHP/x DB/driver/version`)
- `ListAnnouncementsController` — admin-only `GET /api/flarum/announcements`, `?bust=1` for forced refresh
- `RefreshAnnouncementsCommand` + `WeeklySchedule` — scheduled weekly cache warming
- `AnnouncementsServiceProvider` — conditionally registers command + schedule
- Route registered in `Api/routes.php`
- `AdminPayload` injects `announcementsDisabled` flag

## Frontend

- `AnnouncementsWidget`, `AnnouncementList`, `AnnouncementItem` components
- Refresh / hide / show controls (Horizon button pattern)
- Sticky indicator (thumbtack icon)
- "View all" card linking to discuss.flarum.org
- `announcementsDisabled` gates the widget in `DashboardPage`

## Tests

- Unit: `AnnouncementsFetcherTest` (10 cases, Guzzle `MockHandler`), `ListAnnouncementsControllerTest` (5 cases, `ArrayStore`)
- Integration: `ListTest` (5 cases — auth, bust, failing fetcher)

## Docs

flarum/docs#515

## Checklist

- [x] Backend implementation
- [x] Frontend implementation
- [x] Unit + integration tests
- [x] Docs PR linked