### PR TITLE
[1.x] feat: announcements widget on admin dashboard

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -42,6 +42,7 @@ export interface AdminApplicationData extends ApplicationData {
   displayNameDrivers: string[];
   slugDrivers: Record<string, string[]>;
   permissions: Record<string, string[]>;
+  announcementsDisabled: boolean;
 }
 
 export default class AdminApplication extends Application {

--- a/framework/core/js/src/admin/components/AnnouncementItem.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementItem.tsx
@@ -40,9 +40,7 @@ export default class AnnouncementItem extends Component<IAnnouncementItemAttrs> 
             {a.avatarUrl ? (
               <img className="AnnouncementItem-avatar" src={a.avatarUrl} alt={a.authorName ?? ''} loading="lazy" />
             ) : (
-              <span className="AnnouncementItem-avatarFallback">
-                {icon('fas fa-user')}
-              </span>
+              <span className="AnnouncementItem-avatarFallback">{icon('fas fa-user')}</span>
             )}
             <div className="AnnouncementItem-bylineText">
               {a.authorName && <span className="AnnouncementItem-authorName">{a.authorName}</span>}

--- a/framework/core/js/src/admin/components/AnnouncementItem.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementItem.tsx
@@ -1,0 +1,67 @@
+import app from '../../admin/app';
+import Component from '../../common/Component';
+import icon from '../../common/helpers/icon';
+import Link from '../../common/components/Link';
+import dayjs from 'dayjs';
+
+export interface AnnouncementData {
+  id: string;
+  title: string;
+  slug: string;
+  commentCount: number;
+  createdAt: string;
+  isSticky: boolean;
+  url: string;
+  excerpt: string;
+  authorName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface IAnnouncementItemAttrs {
+  announcement: AnnouncementData;
+}
+
+export default class AnnouncementItem extends Component<IAnnouncementItemAttrs> {
+  view() {
+    const a = this.attrs.announcement;
+    const date = dayjs(a.createdAt).format('MMM D, YYYY');
+
+    return (
+      <Link className="AnnouncementItem" href={a.url} external={true} target="_blank">
+        <div className="AnnouncementItem-body">
+          <h3 className="AnnouncementItem-title">
+            {a.isSticky && icon('fas fa-thumbtack', { className: 'AnnouncementItem-stickyIcon' })}
+            {a.title}
+          </h3>
+          {a.excerpt && <p className="AnnouncementItem-excerpt">{a.excerpt}</p>}
+        </div>
+        <div className="AnnouncementItem-footer">
+          <div className="AnnouncementItem-byline">
+            {a.avatarUrl ? (
+              <img className="AnnouncementItem-avatar" src={a.avatarUrl} alt={a.authorName ?? ''} loading="lazy" />
+            ) : (
+              <span className="AnnouncementItem-avatarFallback">
+                {icon('fas fa-user')}
+              </span>
+            )}
+            <div className="AnnouncementItem-bylineText">
+              {a.authorName && <span className="AnnouncementItem-authorName">{a.authorName}</span>}
+              <span className="AnnouncementItem-meta">
+                <span className="AnnouncementItem-date">{date}</span>
+                <span className="AnnouncementItem-sep">·</span>
+                <span className="AnnouncementItem-comments">
+                  {icon('fas fa-comment-alt')}
+                  {app.translator.trans('core.admin.announcements.comments_label', { count: a.commentCount })}
+                </span>
+              </span>
+            </div>
+          </div>
+          <div className="AnnouncementItem-readMore">
+            {app.translator.trans('core.admin.announcements.read_more')}
+            {icon('fas fa-arrow-right')}
+          </div>
+        </div>
+      </Link>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/AnnouncementList.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementList.tsx
@@ -1,0 +1,60 @@
+import Component from '../../common/Component';
+import AnnouncementItem, { AnnouncementData } from './AnnouncementItem';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import icon from '../../common/helpers/icon';
+import Link from '../../common/components/Link';
+import app from '../../admin/app';
+
+export interface IAnnouncementListAttrs {
+  announcements: AnnouncementData[] | null;
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+}
+
+export default class AnnouncementList extends Component<IAnnouncementListAttrs> {
+  view() {
+    const { announcements, loading, error, onRetry } = this.attrs;
+
+    if (loading) {
+      return (
+        <div className="AnnouncementList-state">
+          <LoadingIndicator />
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="AnnouncementList-state AnnouncementList-state--error">
+          {icon('fas fa-exclamation-circle')}
+          <p>{app.translator.trans('core.admin.announcements.load_error')}</p>
+          <button className="Button" onclick={onRetry}>
+            {app.translator.trans('core.admin.announcements.retry')}
+          </button>
+        </div>
+      );
+    }
+
+    if (!announcements?.length) {
+      return (
+        <div className="AnnouncementList-state AnnouncementList-state--empty">
+          {icon('fas fa-bullhorn')}
+          <p>{app.translator.trans('core.admin.announcements.empty')}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="AnnouncementList">
+        {announcements.map((a) => (
+          <AnnouncementItem key={a.id} announcement={a} />
+        ))}
+        <Link className="AnnouncementList-viewAll" href="https://discuss.flarum.org/t/blog" external={true} target="_blank">
+          {icon('fas fa-external-link-alt')}
+          {app.translator.trans('core.admin.announcements.view_all')}
+        </Link>
+      </div>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/AnnouncementWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementWidget.tsx
@@ -69,9 +69,7 @@ export default class AnnouncementsWidget extends DashboardWidget {
             {icon('fas fa-bullhorn')}
             {app.translator.trans('core.admin.announcements.title')}
             <Tooltip text={app.translator.trans('core.admin.announcements.about')}>
-              <span className="AnnouncementsWidget-info">
-                {icon('fas fa-info-circle')}
-              </span>
+              <span className="AnnouncementsWidget-info">{icon('fas fa-info-circle')}</span>
             </Tooltip>
           </h2>
           <div className="AnnouncementsWidget-controls">

--- a/framework/core/js/src/admin/components/AnnouncementWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementWidget.tsx
@@ -1,0 +1,99 @@
+import app from '../../admin/app';
+import DashboardWidget from './DashboardWidget';
+import AnnouncementList from './AnnouncementList';
+import type { AnnouncementData } from './AnnouncementItem';
+import type { IDashboardWidgetAttrs } from './DashboardWidget';
+import type Mithril from 'mithril';
+import icon from '../../common/helpers/icon';
+import Button from '../../common/components/Button';
+import Tooltip from '../../common/components/Tooltip';
+
+const HIDDEN_KEY = 'flarum.announcements.hidden';
+
+export default class AnnouncementsWidget extends DashboardWidget {
+  announcements: AnnouncementData[] | null = null;
+  loadError = false;
+  loading = false;
+  hidden = false;
+
+  oninit(vnode: Mithril.Vnode<IDashboardWidgetAttrs, this>) {
+    super.oninit(vnode);
+    this.hidden = localStorage.getItem(HIDDEN_KEY) === '1';
+
+    if (!this.hidden) {
+      this.load();
+    }
+  }
+
+  className() {
+    return 'AnnouncementsWidget' + (this.hidden ? ' AnnouncementsWidget--hidden' : '');
+  }
+
+  async load(bust = false) {
+    this.loading = true;
+    this.loadError = false;
+    m.redraw();
+
+    try {
+      const url = app.forum.attribute('apiUrl') + '/flarum/announcements' + (bust ? '?bust=1' : '');
+      const data = (await app.request({ method: 'GET', url })) as unknown as AnnouncementData[];
+      this.announcements = data;
+    } catch (e) {
+      this.loadError = true;
+    } finally {
+      this.loading = false;
+      m.redraw();
+    }
+  }
+
+  toggleHidden() {
+    this.hidden = !this.hidden;
+
+    if (this.hidden) {
+      localStorage.setItem(HIDDEN_KEY, '1');
+    } else {
+      localStorage.removeItem(HIDDEN_KEY);
+      if (!this.announcements && !this.loading) {
+        this.load();
+      }
+    }
+
+    m.redraw();
+  }
+
+  content() {
+    return (
+      <>
+        <div className="AnnouncementsWidget-header">
+          <h2 className="AnnouncementsWidget-title">
+            {icon('fas fa-bullhorn')}
+            {app.translator.trans('core.admin.announcements.title')}
+            <Tooltip text={app.translator.trans('core.admin.announcements.about')}>
+              <span className="AnnouncementsWidget-info">
+                {icon('fas fa-info-circle')}
+              </span>
+            </Tooltip>
+          </h2>
+          <div className="AnnouncementsWidget-controls">
+            {!this.hidden && (
+              <Tooltip text={app.translator.trans('core.admin.announcements.refresh')}>
+                <Button
+                  className="Button Button--icon"
+                  icon={this.loading ? 'fas fa-sync-alt fa-spin' : 'fas fa-sync-alt'}
+                  disabled={this.loading}
+                  onclick={() => this.load(true)}
+                />
+              </Tooltip>
+            )}
+            <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
+              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
+            </Tooltip>
+          </div>
+        </div>
+        {!this.hidden && (
+          <AnnouncementList announcements={this.announcements} loading={this.loading} error={this.loadError} onRetry={() => this.load()} />
+        )}
+      </>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -5,6 +5,7 @@ import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { Children } from 'mithril';
 import DebugWarningWidget from './DebugWarningWidget';
+import AnnouncementsWidget from './AnnouncementWidget';
 
 export default class DashboardPage extends AdminPage {
   headerInfo() {
@@ -30,6 +31,10 @@ export default class DashboardPage extends AdminPage {
     items.add('status', <StatusWidget />, 30);
 
     items.add('extensions', <ExtensionsWidget />, 10);
+
+    if (!app.data.announcementsDisabled) {
+      items.add('announcements', <AnnouncementsWidget />, 29);
+    }
 
     return items;
   }

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -15,3 +15,4 @@
 @import "admin/MailPage";
 @import "admin/NoJs";
 @import "admin/UsersListPage";
+@import "admin/AnnouncementsPage";

--- a/framework/core/less/admin/AnnouncementsPage.less
+++ b/framework/core/less/admin/AnnouncementsPage.less
@@ -1,0 +1,287 @@
+// ── Widget wrapper ────────────────────────────────────────────────────────────
+
+.AnnouncementsWidget {
+  padding: 0;
+}
+
+.AnnouncementsWidget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 20px;
+}
+
+.AnnouncementsWidget-controls {
+  > .Button {
+    margin-left: 8px;
+  }
+}
+
+.AnnouncementsWidget-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 20px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-color);
+
+  .icon {
+    font-size: 12px;
+    opacity: 0.7;
+  }
+}
+
+.AnnouncementsWidget-info {
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  opacity: 0.4;
+  font-size: 11px;
+  transition: opacity 0.15s;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+// ── List (responsive wrapping grid) ──────────────────────────────────────────
+
+.AnnouncementList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  padding: 0 20px 20px;
+
+  &-viewAll {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: var(--body-bg);
+    border-radius: var(--border-radius);
+    border: 1px dashed var(--control-bg);
+    text-decoration: none;
+    color: var(--muted-color);
+    font-size: 12px;
+    font-weight: 600;
+    min-height: 80px;
+    transition: border-color 0.15s, color 0.15s;
+
+    .icon {
+      font-size: 16px;
+      opacity: 0.5;
+    }
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: none;
+      border-color: var(--primary-color);
+      color: var(--primary-color);
+
+      .icon {
+        opacity: 1;
+      }
+    }
+  }
+
+  &-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 24px 20px;
+    color: var(--muted-color);
+    text-align: center;
+    width: 100%;
+
+    .icon {
+      font-size: 22px;
+      opacity: 0.4;
+    }
+
+    p {
+      margin: 0;
+      font-size: 13px;
+    }
+
+    &--error .icon {
+      color: @error-color;
+      opacity: 0.8;
+    }
+  }
+}
+
+// ── Item card ─────────────────────────────────────────────────────────────────
+
+.AnnouncementItem {
+  display: flex;
+  flex-direction: column;
+  background: var(--body-bg);
+  border-radius: var(--border-radius);
+  border: 1px solid transparent;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: none;
+    color: inherit;
+    border-color: var(--primary-color);
+    box-shadow: 0 3px 10px fade(#000, 12%);
+    transform: translateY(-2px);
+
+    .AnnouncementItem-readMore {
+      opacity: 1;
+      gap: 5px;
+    }
+  }
+
+  // ── Body (title + excerpt) ──
+
+  &-body {
+    flex: 1;
+    padding: 14px 14px 10px;
+  }
+
+  &-title {
+    margin: 0 0 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--heading-color);
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &-stickyIcon {
+    font-size: 10px;
+    color: var(--primary-color);
+    opacity: 0.8;
+    margin-right: 4px;
+    vertical-align: middle;
+    transform: rotate(45deg);
+    display: inline-block;
+  }
+
+  &-excerpt {
+    margin: 0;
+    font-size: 12px;
+    color: var(--muted-color);
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  // ── Footer ──
+
+  &-footer {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 14px 12px;
+    border-top: 1px solid var(--control-bg);
+  }
+
+  // Avatar + author name + date/comments stacked
+  &-byline {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    object-fit: cover;
+  }
+
+  &-avatarFallback {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--control-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    color: var(--muted-color);
+    flex-shrink: 0;
+  }
+
+  &-bylineText {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  &-authorName {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.2;
+  }
+
+  // Date · N comments row
+  &-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--muted-color);
+    white-space: nowrap;
+    line-height: 1.2;
+  }
+
+  &-sep {
+    opacity: 0.4;
+  }
+
+  &-comments {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+
+    .icon {
+      font-size: 9px;
+      opacity: 0.6;
+    }
+  }
+
+  &-date {
+    opacity: 0.8;
+  }
+
+  // "Read more →" — appears on hover, sits below byline
+  &-readMore {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--primary-color);
+    opacity: 0;
+    transition: opacity 0.15s, gap 0.15s;
+
+    .icon {
+      font-size: 9px;
+    }
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -63,6 +63,22 @@ core:
       use_random_password: Generate random password
       username_placeholder: => core.ref.username
 
+    # These translations are used in the Announcements widget.
+    announcements:
+      comments_label: "{count, plural, one {# comment} other {# comments}}"
+      description: Latest news and announcements from the Flarum Team.
+      empty: No announcements found.
+      load_error: Could not load announcements. Please try again later.
+      about: Latest news and announcements pulled from the official Flarum community at discuss.flarum.org.
+      hide: Hide announcements
+      read_more: Read more
+      refresh: Refresh announcements
+      retry: Try again
+      show: Show announcements
+      title: Announcements
+      view_all: View all on discuss.flarum.org
+
+
     # These translations are used in the Dashboard page.
     dashboard:
       clear_cache_button: Clear Cache

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -127,5 +127,7 @@ class AdminPayload
                 'total' => User::count()
             ]
         ];
+
+        $document->payload['announcementsDisabled'] = (bool) $this->config['flarum_announcements.disabled'];
     }
 }

--- a/framework/core/src/Announcements/AnnouncementsFetcher.php
+++ b/framework/core/src/Announcements/AnnouncementsFetcher.php
@@ -18,18 +18,27 @@ use RuntimeException;
 
 class AnnouncementsFetcher
 {
-    private Client $client;
-
-    public function __construct(
-        protected ApplicationInfoProvider $appInfo
-    ) {
-        $this->client = new Client(['timeout' => 10]);
-    }
     protected const API_BASE_URL = 'https://discuss.flarum.org/api/discussions';
     protected const TAG = 'blog';
     protected const LIMIT = 8;
     protected const FETCH_LIMIT = 20;
     protected const EXCERPT_LENGTH = 200;
+
+    /**
+     * @var ApplicationInfoProvider
+     */
+    protected $appInfo;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(ApplicationInfoProvider $appInfo)
+    {
+        $this->appInfo = $appInfo;
+        $this->client = new Client(['timeout' => 10]);
+    }
 
     public function fetch(): array
     {
@@ -101,7 +110,9 @@ class AnnouncementsFetcher
             ];
         }
 
-        usort($items, fn (array $a, array $b) => $b['isSticky'] <=> $a['isSticky']);
+        usort($items, function (array $a, array $b) {
+            return $b['isSticky'] <=> $a['isSticky'];
+        });
 
         return array_slice($items, 0, self::LIMIT);
     }

--- a/framework/core/src/Announcements/AnnouncementsFetcher.php
+++ b/framework/core/src/Announcements/AnnouncementsFetcher.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements;
+
+use Flarum\Foundation\Application;
+use Flarum\Foundation\ApplicationInfoProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
+use RuntimeException;
+
+class AnnouncementsFetcher
+{
+    private Client $client;
+
+    public function __construct(
+        protected ApplicationInfoProvider $appInfo
+    ) {
+        $this->client = new Client(['timeout' => 10]);
+    }
+    protected const API_BASE_URL = 'https://discuss.flarum.org/api/discussions';
+    protected const TAG = 'blog';
+    protected const LIMIT = 8;
+    protected const FETCH_LIMIT = 20;
+    protected const EXCERPT_LENGTH = 200;
+
+    public function fetch(): array
+    {
+        $url = self::API_BASE_URL.'?'.http_build_query([
+            'filter' => ['tag' => self::TAG],
+            'sort' => '-createdAt',
+            'page' => ['limit' => self::FETCH_LIMIT],
+            'include' => 'firstPost,user',
+        ]);
+
+        try {
+            $response = $this->client->get($url, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Flarum/'.Application::VERSION
+                        .' PHP/'.$this->appInfo->identifyPHPVersion()
+                        .' Database/'.$this->appInfo->identifyDatabaseVersion(),
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('Could not fetch announcements from discuss.flarum.org: '.$e->getMessage(), 0, $e);
+        }
+
+        $body = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($body['data'] ?? null)) {
+            throw new RuntimeException('Unexpected response from discuss.flarum.org.');
+        }
+
+        $posts = [];
+        $users = [];
+        foreach ($body['included'] ?? [] as $resource) {
+            if (Arr::get($resource, 'type') === 'posts') {
+                $posts[$resource['id']] = $resource;
+            } elseif (Arr::get($resource, 'type') === 'users') {
+                $users[$resource['id']] = $resource;
+            }
+        }
+
+        $items = [];
+        foreach ($body['data'] as $discussion) {
+            $id = Arr::get($discussion, 'id');
+            $title = Arr::get($discussion, 'attributes.title');
+            $slug = Arr::get($discussion, 'attributes.slug');
+            $createdAt = Arr::get($discussion, 'attributes.createdAt');
+
+            // Skip any discussion missing the fields we require to render a card.
+            if (! $id || ! $title || ! $slug || ! $createdAt) {
+                continue;
+            }
+
+            $firstPostId = Arr::get($discussion, 'relationships.firstPost.data.id');
+            $firstPost = $firstPostId ? ($posts[$firstPostId] ?? null) : null;
+
+            $userId = Arr::get($discussion, 'relationships.user.data.id');
+            $user = $userId ? ($users[$userId] ?? null) : null;
+
+            $items[] = [
+                'id' => $id,
+                'title' => $title,
+                'slug' => $slug,
+                'commentCount' => Arr::get($discussion, 'attributes.commentCount', 0),
+                'createdAt' => $createdAt,
+                'isSticky' => (bool) Arr::get($discussion, 'attributes.isSticky', false),
+                'url' => 'https://discuss.flarum.org/d/'.$slug,
+                'excerpt' => $this->makeExcerpt(Arr::get($firstPost, 'attributes.contentHtml', '')),
+                'authorName' => Arr::get($user, 'attributes.displayName'),
+                'avatarUrl' => Arr::get($user, 'attributes.avatarUrl'),
+            ];
+        }
+
+        usort($items, fn (array $a, array $b) => $b['isSticky'] <=> $a['isSticky']);
+
+        return array_slice($items, 0, self::LIMIT);
+    }
+
+    private function makeExcerpt(string $html): string
+    {
+        $plain = strip_tags($html);
+        $plain = trim(preg_replace('/\s+/', ' ', $plain));
+
+        return mb_strimwidth($plain, 0, self::EXCERPT_LENGTH, '…');
+    }
+}

--- a/framework/core/src/Announcements/AnnouncementsServiceProvider.php
+++ b/framework/core/src/Announcements/AnnouncementsServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements;
+
+use Flarum\Announcements\Console\RefreshAnnouncementsCommand;
+use Flarum\Announcements\Console\WeeklySchedule;
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
+use Illuminate\Contracts\Container\Container;
+
+class AnnouncementsServiceProvider extends AbstractServiceProvider
+{
+    public function boot(Container $container, Config $config): void
+    {
+        if ($config['flarum_announcements.disabled'] ?? false) {
+            return;
+        }
+
+        $container->extend('flarum.console.commands', function (array $commands) {
+            $commands[] = RefreshAnnouncementsCommand::class;
+
+            return $commands;
+        });
+
+        $container->extend('flarum.console.scheduled', function (array $scheduled) {
+            $scheduled[] = [
+                'command' => RefreshAnnouncementsCommand::class,
+                'args' => [],
+                'callback' => new WeeklySchedule(),
+            ];
+
+            return $scheduled;
+        });
+    }
+}

--- a/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
+++ b/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
@@ -16,7 +16,7 @@ use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
 class RefreshAnnouncementsCommand extends Command
 {
-    protected $signature = 'flarum:refresh-announcements';
+    protected $signature = 'announcements:refresh';
     protected $description = 'Fetch and cache the latest announcements from discuss.flarum.org.';
 
     public function handle(CacheRepository $cache, AnnouncementsFetcher $fetcher)

--- a/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
+++ b/framework/core/src/Announcements/Console/RefreshAnnouncementsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements\Console;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Api\Controller\ListAnnouncementsController;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class RefreshAnnouncementsCommand extends Command
+{
+    protected $signature = 'flarum:refresh-announcements';
+    protected $description = 'Fetch and cache the latest announcements from discuss.flarum.org.';
+
+    public function handle(CacheRepository $cache, AnnouncementsFetcher $fetcher)
+    {
+        $this->info('Fetching announcements from discuss.flarum.org...');
+
+        try {
+            $announcements = $fetcher->fetch();
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $cache->put(ListAnnouncementsController::CACHE_KEY, $announcements, ListAnnouncementsController::CACHE_TTL);
+
+        $this->info('Cached '.count($announcements).' announcements.');
+
+        return self::SUCCESS;
+    }
+}

--- a/framework/core/src/Announcements/Console/WeeklySchedule.php
+++ b/framework/core/src/Announcements/Console/WeeklySchedule.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Announcements\Console;
+
+use Illuminate\Console\Scheduling\Event;
+
+class WeeklySchedule
+{
+    public function __invoke(Event $event): void
+    {
+        $event->weekly()->withoutOverlapping();
+    }
+}

--- a/framework/core/src/Api/Controller/ListAnnouncementsController.php
+++ b/framework/core/src/Api/Controller/ListAnnouncementsController.php
@@ -22,10 +22,20 @@ class ListAnnouncementsController implements RequestHandlerInterface
     public const CACHE_KEY = 'flarum.announcements';
     public const CACHE_TTL = 14 * 24 * 3600; // 14 days
 
-    public function __construct(
-        protected CacheRepository $cache,
-        protected AnnouncementsFetcher $fetcher
-    ) {
+    /**
+     * @var CacheRepository
+     */
+    protected $cache;
+
+    /**
+     * @var AnnouncementsFetcher
+     */
+    protected $fetcher;
+
+    public function __construct(CacheRepository $cache, AnnouncementsFetcher $fetcher)
+    {
+        $this->cache = $cache;
+        $this->fetcher = $fetcher;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -36,7 +46,7 @@ class ListAnnouncementsController implements RequestHandlerInterface
             try {
                 $announcements = $this->fetcher->fetch();
                 $this->cache->put(self::CACHE_KEY, $announcements, self::CACHE_TTL);
-            } catch (\RuntimeException) {
+            } catch (\RuntimeException $_e) {
                 $announcements = $this->cache->get(self::CACHE_KEY, []);
             }
 
@@ -49,7 +59,7 @@ class ListAnnouncementsController implements RequestHandlerInterface
             function () {
                 try {
                     return $this->fetcher->fetch();
-                } catch (\RuntimeException) {
+                } catch (\RuntimeException $_e) {
                     return null; // keep existing cached value
                 }
             }

--- a/framework/core/src/Api/Controller/ListAnnouncementsController.php
+++ b/framework/core/src/Api/Controller/ListAnnouncementsController.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Announcements\AnnouncementsFetcher;
+use Flarum\Http\RequestUtil;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ListAnnouncementsController implements RequestHandlerInterface
+{
+    public const CACHE_KEY = 'flarum.announcements';
+    public const CACHE_TTL = 14 * 24 * 3600; // 14 days
+
+    public function __construct(
+        protected CacheRepository $cache,
+        protected AnnouncementsFetcher $fetcher
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        if ($request->getQueryParams()['bust'] ?? false) {
+            try {
+                $announcements = $this->fetcher->fetch();
+                $this->cache->put(self::CACHE_KEY, $announcements, self::CACHE_TTL);
+            } catch (\RuntimeException) {
+                $announcements = $this->cache->get(self::CACHE_KEY, []);
+            }
+
+            return new JsonResponse($announcements);
+        }
+
+        $announcements = $this->cache->remember(
+            self::CACHE_KEY,
+            self::CACHE_TTL,
+            function () {
+                try {
+                    return $this->fetcher->fetch();
+                } catch (\RuntimeException) {
+                    return null; // keep existing cached value
+                }
+            }
+        ) ?? [];
+
+        return new JsonResponse($announcements);
+    }
+}

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -376,4 +376,11 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         'mailTest',
         $route->toController(Controller\SendTestMailController::class)
     );
+
+    // List Flarum community announcements from discuss.flarum.org
+    $map->get(
+        '/flarum/announcements',
+        'announcements.list',
+        $route->toController(Controller\ListAnnouncementsController::class)
+    );
 };

--- a/framework/core/src/Foundation/InstalledSite.php
+++ b/framework/core/src/Foundation/InstalledSite.php
@@ -10,6 +10,7 @@
 namespace Flarum\Foundation;
 
 use Flarum\Admin\AdminServiceProvider;
+use Flarum\Announcements\AnnouncementsServiceProvider;
 use Flarum\Api\ApiServiceProvider;
 use Flarum\Bus\BusServiceProvider;
 use Flarum\Console\ConsoleServiceProvider;
@@ -111,6 +112,7 @@ class InstalledSite implements SiteInterface
         $this->registerCache($container);
 
         $laravel->register(AdminServiceProvider::class);
+        $laravel->register(AnnouncementsServiceProvider::class);
         $laravel->register(ApiServiceProvider::class);
         $laravel->register(BusServiceProvider::class);
         $laravel->register(ConsoleServiceProvider::class);


### PR DESCRIPTION
Backport of #4471 for Flarum 1.x.

Adds an Announcements widget to the admin dashboard that fetches and displays the latest posts from discuss.flarum.org. Results are cached for 14 days with manual cache-busting support. The widget can be hidden (persisted in localStorage) or disabled entirely via `flarum_announcements.disabled` in `config.php`.

> **Note:** The 2.x version uses `cache->flexible()` (Laravel 13). This backport uses `cache->remember()` since Flarum 1.x runs on Laravel 8.

## Components

**Backend**
- `AnnouncementsFetcher` — fetches discussions from discuss.flarum.org with enriched User-Agent
- `ListAnnouncementsController` — admin-only `GET /api/flarum/announcements`, supports `?bust=1` for forced refresh
- `RefreshAnnouncementsCommand` + `WeeklySchedule` — weekly scheduled cache warming
- `AnnouncementsServiceProvider` — conditionally registers console command and scheduler
- Route registered in `Api/routes.php`
- `AdminPayload` injects `announcementsDisabled` flag

**Frontend**
- `AnnouncementsWidget` — dashboard widget with refresh/hide/show controls
- `AnnouncementList` — handles loading, error, and empty states
- `AnnouncementItem` — individual announcement card
- Hide state persisted in `localStorage`