### PR TITLE
[2.x] chore: seed initial dist-typings for likes and lock

### DIFF
--- a/extensions/likes/js/dist-typings/admin/extend.d.ts
+++ b/extensions/likes/js/dist-typings/admin/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: (import("flarum/common/extenders/Search").default | import("flarum/common/extenders/Admin").default)[];
+export default _default;

--- a/extensions/likes/js/dist-typings/admin/index.d.ts
+++ b/extensions/likes/js/dist-typings/admin/index.d.ts
@@ -1,0 +1,1 @@
+export { default as extend } from './extend';

--- a/extensions/likes/js/dist-typings/common/extend.d.ts
+++ b/extensions/likes/js/dist-typings/common/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("flarum/common/extenders/Search").default[];
+export default _default;

--- a/extensions/likes/js/dist-typings/common/query/posts/LikedByGambit.d.ts
+++ b/extensions/likes/js/dist-typings/common/query/posts/LikedByGambit.d.ts
@@ -1,0 +1,6 @@
+import { KeyValueGambit } from 'flarum/common/query/IGambit';
+export default class LikedByGambit extends KeyValueGambit {
+    key(): string;
+    hint(): string;
+    filterKey(): string;
+}

--- a/extensions/likes/js/dist-typings/forum/addLikeAction.d.ts
+++ b/extensions/likes/js/dist-typings/forum/addLikeAction.d.ts
@@ -1,0 +1,1 @@
+export default function _default(): void;

--- a/extensions/likes/js/dist-typings/forum/addLikesList.d.ts
+++ b/extensions/likes/js/dist-typings/forum/addLikesList.d.ts
@@ -1,0 +1,1 @@
+export default function _default(): void;

--- a/extensions/likes/js/dist-typings/forum/addLikesTabToUserProfile.d.ts
+++ b/extensions/likes/js/dist-typings/forum/addLikesTabToUserProfile.d.ts
@@ -1,0 +1,1 @@
+export default function addLikesTabToUserProfile(): void;

--- a/extensions/likes/js/dist-typings/forum/components/LikesUserPage.d.ts
+++ b/extensions/likes/js/dist-typings/forum/components/LikesUserPage.d.ts
@@ -1,0 +1,13 @@
+import PostsUserPage from 'flarum/forum/components/PostsUserPage';
+import type User from 'flarum/common/models/User';
+/**
+ * The `LikesUserPage` component shows posts which user the user liked.
+ */
+export default class LikesUserPage extends PostsUserPage {
+    params(user: User): {
+        filter: {
+            type: string;
+            likedBy: string | undefined;
+        };
+    };
+}

--- a/extensions/likes/js/dist-typings/forum/components/PostLikedNotification.d.ts
+++ b/extensions/likes/js/dist-typings/forum/components/PostLikedNotification.d.ts
@@ -1,0 +1,6 @@
+export default class PostLikedNotification extends Notification<import("flarum/forum/components/Notification").INotificationAttrs> {
+    constructor();
+    content(): any[];
+    excerpt(): string;
+}
+import Notification from "flarum/forum/components/Notification";

--- a/extensions/likes/js/dist-typings/forum/components/PostLikesModal.d.ts
+++ b/extensions/likes/js/dist-typings/forum/components/PostLikesModal.d.ts
@@ -1,0 +1,14 @@
+import Modal from 'flarum/common/components/Modal';
+import type { IInternalModalAttrs } from 'flarum/common/components/Modal';
+import type Post from 'flarum/common/models/Post';
+import type Mithril from 'mithril';
+import PostLikesModalState from '../states/PostLikesModalState';
+export interface IPostLikesModalAttrs extends IInternalModalAttrs {
+    post: Post;
+}
+export default class PostLikesModal<CustomAttrs extends IPostLikesModalAttrs = IPostLikesModalAttrs> extends Modal<CustomAttrs, PostLikesModalState> {
+    oninit(vnode: Mithril.VnodeDOM<CustomAttrs, this>): void;
+    className(): string;
+    title(): string | any[];
+    content(): JSX.Element;
+}

--- a/extensions/likes/js/dist-typings/forum/extend.d.ts
+++ b/extensions/likes/js/dist-typings/forum/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: (import("flarum/common/extenders/Search").default | import("flarum/common/extenders/Routes").default | import("flarum/common/extenders/Notification").default | import("flarum/common/extenders/Model").default)[];
+export default _default;

--- a/extensions/likes/js/dist-typings/forum/extendRealtime.d.ts
+++ b/extensions/likes/js/dist-typings/forum/extendRealtime.d.ts
@@ -1,0 +1,1 @@
+export default function extendRealtime(): void;

--- a/extensions/likes/js/dist-typings/forum/index.d.ts
+++ b/extensions/likes/js/dist-typings/forum/index.d.ts
@@ -1,0 +1,1 @@
+export { default as extend } from './extend';

--- a/extensions/likes/js/dist-typings/forum/states/PostLikesModalState.d.ts
+++ b/extensions/likes/js/dist-typings/forum/states/PostLikesModalState.d.ts
@@ -1,0 +1,15 @@
+import PaginatedListState, { PaginatedListParams } from 'flarum/common/states/PaginatedListState';
+import User from 'flarum/common/models/User';
+export interface PostLikesModalListParams extends PaginatedListParams {
+    filter: {
+        liked: string;
+    };
+    page?: {
+        offset?: number;
+        limit: number;
+    };
+}
+export default class PostLikesModalState<P extends PostLikesModalListParams = PostLikesModalListParams> extends PaginatedListState<User, P> {
+    constructor(params: P, page?: number);
+    get type(): string;
+}

--- a/extensions/lock/js/dist-typings/admin/extend.d.ts
+++ b/extensions/lock/js/dist-typings/admin/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: (import("flarum/common/extenders/Search").default | import("flarum/common/extenders/Admin").default)[];
+export default _default;

--- a/extensions/lock/js/dist-typings/admin/index.d.ts
+++ b/extensions/lock/js/dist-typings/admin/index.d.ts
@@ -1,0 +1,1 @@
+export { default as extend } from './extend';

--- a/extensions/lock/js/dist-typings/common/extend.d.ts
+++ b/extensions/lock/js/dist-typings/common/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("flarum/common/extenders/Search").default[];
+export default _default;

--- a/extensions/lock/js/dist-typings/common/query/discussions/LockedGambit.d.ts
+++ b/extensions/lock/js/dist-typings/common/query/discussions/LockedGambit.d.ts
@@ -1,0 +1,5 @@
+import { BooleanGambit } from 'flarum/common/query/IGambit';
+export default class LockedGambit extends BooleanGambit {
+    key(): string;
+    filterKey(): string;
+}

--- a/extensions/lock/js/dist-typings/forum/addLockBadge.d.ts
+++ b/extensions/lock/js/dist-typings/forum/addLockBadge.d.ts
@@ -1,0 +1,1 @@
+export default function addLockBadge(): void;

--- a/extensions/lock/js/dist-typings/forum/addLockControl.d.ts
+++ b/extensions/lock/js/dist-typings/forum/addLockControl.d.ts
@@ -1,0 +1,1 @@
+export default function addLockControl(): void;

--- a/extensions/lock/js/dist-typings/forum/components/DiscussionLockedNotification.d.ts
+++ b/extensions/lock/js/dist-typings/forum/components/DiscussionLockedNotification.d.ts
@@ -1,0 +1,6 @@
+export default class DiscussionLockedNotification extends Notification<import("flarum/forum/components/Notification").INotificationAttrs> {
+    constructor();
+    content(): any[];
+    excerpt(): null;
+}
+import Notification from "flarum/forum/components/Notification";

--- a/extensions/lock/js/dist-typings/forum/components/DiscussionLockedPost.d.ts
+++ b/extensions/lock/js/dist-typings/forum/components/DiscussionLockedPost.d.ts
@@ -1,0 +1,5 @@
+export default class DiscussionLockedPost extends EventPost {
+    icon(): "fas fa-lock" | "fas fa-unlock";
+    descriptionKey(): "flarum-lock.forum.post_stream.discussion_locked_text" | "flarum-lock.forum.post_stream.discussion_unlocked_text";
+}
+import EventPost from "flarum/forum/components/EventPost";

--- a/extensions/lock/js/dist-typings/forum/extend.d.ts
+++ b/extensions/lock/js/dist-typings/forum/extend.d.ts
@@ -1,0 +1,2 @@
+declare const _default: (import("flarum/common/extenders/Search").default | import("flarum/common/extenders/PostTypes").default | import("flarum/common/extenders/Notification").default | import("flarum/common/extenders/Model").default)[];
+export default _default;

--- a/extensions/lock/js/dist-typings/forum/extendRealtime.d.ts
+++ b/extensions/lock/js/dist-typings/forum/extendRealtime.d.ts
@@ -1,0 +1,1 @@
+export default function extendRealtime(): void;

--- a/extensions/lock/js/dist-typings/forum/index.d.ts
+++ b/extensions/lock/js/dist-typings/forum/index.d.ts
@@ -1,0 +1,1 @@
+export { default as extend } from './extend';


### PR DESCRIPTION
The build bot only updates already-tracked `dist-typings` files. This seeds the initial versions so future PRs will be bundled automatically.