### PR TITLE
[2.x] fix(mentions): cast UserPageResolver to satisfy Routes.add() type constraint

### DIFF
--- a/extensions/mentions/js/src/forum/extend.ts
+++ b/extensions/mentions/js/src/forum/extend.ts
@@ -1,6 +1,7 @@
 import Extend from 'flarum/common/extenders';
 import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
+import DefaultResolver from 'flarum/common/resolvers/DefaultResolver';
 import UserPageResolver from 'flarum/forum/resolvers/UserPageResolver';
 import MentionsUserPage from './components/MentionsUserPage';
 import PostMentionedNotification from './components/PostMentionedNotification';
@@ -13,7 +14,7 @@ export default [
   ...commonExtend,
 
   new Extend.Routes() //
-    .add('user.mentions', '/u/:username/mentions', MentionsUserPage, UserPageResolver),
+    .add('user.mentions', '/u/:username/mentions', MentionsUserPage, UserPageResolver as typeof DefaultResolver),
 
   new Extend.Model(Post) //
     .hasMany<Post>('mentionedBy')


### PR DESCRIPTION
## Summary

- `typeof UserPageResolver` is not directly assignable to `typeof DefaultResolver` due to TypeScript's strict constructor signature checking — `UserPageResolver` specializes the generic `Comp` type to `UserPage`, which conflicts with the broader generic expected by `Routes.add()`
- Fix: import `DefaultResolver` and cast `UserPageResolver as typeof DefaultResolver` at the call site

## Test plan

- [ ] `yarn check-typings` passes in `extensions/mentions/js`