### PR TITLE
[2.x] fix: various styling fixes

### DIFF
--- a/framework/core/js/src/forum/components/HeaderDropdown.tsx
+++ b/framework/core/js/src/forum/components/HeaderDropdown.tsx
@@ -43,7 +43,11 @@ export default abstract class HeaderDropdown<CustomAttrs extends IHeaderDropdown
 
     return [
       this.attrs.icon ? <Icon name={this.attrs.icon} className="Button-icon" /> : null,
-      unread !== 0 && <span className="Bubble HeaderDropdownBubble">{unread}</span>,
+      unread > 0 && (
+        <span className="Bubble HeaderDropdownBubble" data-digits={String(unread).length}>
+          {unread}
+        </span>
+      ),
       <span className="Button-label">
         <span className="Button-labelText">{this.attrs.label}</span>
       </span>,

--- a/framework/core/js/src/forum/components/Notification.tsx
+++ b/framework/core/js/src/forum/components/Notification.tsx
@@ -17,7 +17,7 @@ export interface INotificationAttrs extends ComponentAttrs {
  * Subclasses should implement the `icon`, `href`, and `content` methods.
  */
 export default abstract class Notification<CustomAttrs extends INotificationAttrs = INotificationAttrs> extends Component<CustomAttrs> {
-  view(vnode: Mithril.Vnode<CustomAttrs, this>) {
+  view(_vnode: Mithril.Vnode<CustomAttrs, this>) {
     const notification = this.attrs.notification;
     const href = this.href() ?? '';
     const fromUser = notification.fromUser();
@@ -87,7 +87,7 @@ export default abstract class Notification<CustomAttrs extends INotificationAttr
   markAsRead() {
     if (this.attrs.notification.isRead()) return;
 
-    app.session.user?.pushAttributes({ unreadNotificationCount: (app.session.user.unreadNotificationCount() ?? 1) - 1 });
+    app.session.user?.pushAttributes({ unreadNotificationCount: Math.max(0, (app.session.user.unreadNotificationCount() ?? 0) - 1) });
 
     this.attrs.notification.save({ isRead: true });
   }

--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -70,7 +70,12 @@
   --discussion-title-color:        mix(@@heading-color, @@body-bg, 55%);
 
   .Button--color-vars(@@control-color, @@control-bg, 'button');
-  .Button--color-vars(if(luma(@primary-color) > 50%, @text-on-light, @text-on-dark), @primary-color, 'button-primary');
+  // Use the YIQ formula (matching the JS isDark utility) rather than luma() to determine
+  // button text colour. luma() uses W3C relative luminance which disagrees with YIQ for
+  // warm/mid-range colours (e.g. orange reads as dark by luma but bright by YIQ).
+  // Pre-compute into a variable to avoid nested parentheses in if(); threshold is 128*1000.
+  @primary-button-yiq: red(@primary-color) * 299 + green(@primary-color) * 587 + blue(@primary-color) * 114;
+  .Button--color-vars(if(@primary-button-yiq >= 128000, @text-on-light, @text-on-dark), @primary-color, 'button-primary');
   .Button--color-vars(@@control-danger-color, @@control-danger-bg, 'control-danger');
   .Button--color-vars(@@muted-more-color, fade(@@muted-more-color, 30%), 'muted-more');
   .Button--color-vars(@@control-color, @@body-bg, 'button-inverted');

--- a/framework/core/less/forum/HeaderDropdown.less
+++ b/framework/core/less/forum/HeaderDropdown.less
@@ -26,6 +26,14 @@
   color: var(--header-color);
 }
 
+@media @tablet-up {
+  .HeaderDropdownBubble[data-digits="3"],
+  .HeaderDropdownBubble[data-digits="4"] {
+    left: auto;
+    right: 2px;
+  }
+}
+
 .HeaderDropdownBubble {
   --bubble-bg: var(--header-control-color);
   --bubble-color: var(--header-bg);

--- a/framework/core/less/forum/HeaderList.less
+++ b/framework/core/less/forum/HeaderList.less
@@ -182,13 +182,14 @@
 
   &.unread {
     background: var(--control-bg);
+    box-shadow: inset 3px 0 0 var(--primary-color);
   }
 
   &:hover,
   &:focus,
   &:focus-within {
     text-decoration: none;
-    background: var(--control-bg);
+    background: var(--control-bg-shaded);
   }
 
   .Avatar {

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -368,8 +368,7 @@
 
 @media @phone {
   .Post {
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-right: 0;
   }
   .Post-side {
     .Post-avatar {

--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -108,10 +108,12 @@ class NotificationResource extends AbstractDatabaseResource
             Schema\Boolean::make('isRead')
                 ->writable()
                 ->get(fn (Notification $notification) => (bool) $notification->read_at)
-                ->set(function (Notification $notification, bool $value, Context $context) {
+                ->set(function (Notification $notification, bool $_value, Context $context) {
                     $this->bus->dispatch(
                         new ReadNotification($notification->id, $context->getActor())
                     );
+
+                    $notification->refresh();
                 }),
 
             Schema\Relationship\ToOne::make('user')


### PR DESCRIPTION
## Summary

- **Mobile post padding**: Remove asymmetric right padding on `.Post` for mobile. The base style has `padding-right: 20px` but `padding-left: 0` (the avatar column provides left balance on desktop). On mobile with no avatar column, this caused visual asymmetry. The container already provides 15px symmetrically, so the extra post-level right padding is zeroed out.
- **Unread notification contrast**: Add a primary-colour left border (`box-shadow: inset 3px 0`) to unread `HeaderListItem`s for clear visual distinction in dark mode, where background contrast alone was insufficient. Also use `--control-bg-shaded` on hover so hovered items are distinct from the unread background.
- **Stale unread notification state**: Fix PATCH `/api/notifications/:id` returning `isRead: false` after marking as read. The `isRead` set handler dispatched a `ReadNotification` command that updated the database but left the in-memory `Notification` model with `read_at = null`. The serialised response therefore returned `isRead: false`, causing the JS store to overwrite the optimistic local update. Calling `$notification->refresh()` reloads the model from the now-updated DB before serialisation.
- **Notification bubble overlapping avatar at 3+ digits**: For 3+ digit unread counts, anchor the bubble to the right side of the icon button (`right: 2px`) so it grows leftward over the bell icon rather than rightward into the adjacent avatar. Uses a `data-digits` attribute on the bubble span, targeted by CSS attribute selectors at `@tablet-up`. Also prevents the unread count going negative on optimistic decrement, and guards the bubble against non-positive values.
- **Primary button text colour (YIQ vs luma)**: The previous luma-based fix (#4451) used LESS `luma()` (W3C relative luminance) which disagrees with the JS `isDark` utility's YIQ formula for warm/mid-range colours — e.g. orange (#FF8C00) has luma ~40% (white text) but YIQ ~158 (dark text, correct). Switch to the same YIQ formula used by `isDark`: `r×299 + g×587 + b×114`, threshold 128. The original fix for dark primaries (#064635) is preserved.

## Test plan

- [ ] Mobile: Post content has equal spacing on left and right edges
- [ ] Notifications dropdown: unread items show a left accent border; hover is visually distinct from unread background
- [ ] Click a notification, navigate to its destination, reopen the dropdown — the clicked notification shows as read
- [ ] With 3+ digit unread count, the bubble does not overlap the user avatar
- [ ] Set primary colour to an orange/warm mid-range value — primary buttons should show dark text
- [ ] Set primary colour to a dark value (e.g. `#064635`) — primary buttons should show white text