### PR TITLE
[2.x] fix(js): capture extension name by value in initializer error closure

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -315,12 +315,11 @@ export default class Application {
       try {
         initializer(this);
       } catch (e) {
+        const extension = this.currentInitializerExtension;
         caughtInitializationErrors.push(() =>
           fireApplicationError(
-            extractText(
-              app.translator.trans('core.lib.error.extension_initialiation_failed_message', { extension: this.currentInitializerExtension })
-            ),
-            `${this.currentInitializerExtension} failed to initialize`,
+            extractText(app.translator.trans('core.lib.error.extension_initialiation_failed_message', { extension })),
+            `${extension} failed to initialize`,
             e
           )
         );

--- a/framework/core/js/tests/integration/admin/Application.test.ts
+++ b/framework/core/js/tests/integration/admin/Application.test.ts
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
+import { app } from '../../../src/admin';
+
+beforeAll(() => bootstrapAdmin());
+
+describe('Application.initialize()', () => {
+  test('error closure captures the throwing extension name, not the last initializer name', () => {
+    // Register two initializers: the first throws, the second succeeds.
+    app.initializers.add('flarum/bad-ext', () => {
+      throw new Error('intentional failure');
+    });
+    app.initializers.add('flarum/good-ext', () => {});
+
+    const errors: CallableFunction[] = (app as any).initialize();
+
+    // One error should have been caught.
+    expect(errors).toHaveLength(1);
+
+    // The closure should reference 'bad-ext', not 'good-ext' (which ran last).
+    // fireApplicationError calls console.group with the consoleTitle.
+    const consoleSpy = jest.spyOn(console, 'group').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
+
+    errors[0]();
+
+    // console.group is called as: console.group('%c<title>', '<css>')
+    // The first argument contains both the format specifier and the extension name.
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('bad-ext'),
+      expect.any(String)
+    );
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('good-ext'),
+      expect.any(String)
+    );
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4293.

When an initializer throws, the error is deferred into a `caughtInitializationErrors` closure and fired after `mount()` completes. The closure was reading `this.currentInitializerExtension` at call time — by which point the property holds the *last* initializer's name, not the one that threw. So every error message incorrectly blamed the final extension in the boot sequence.

The fix is a one-liner: capture `this.currentInitializerExtension` into a local `const` inside the `catch` block before creating the closure, so each closure closes over its own immutable value.

`extend.ts` already does this correctly (`const extension = app.currentInitializerExtension` at line ~34). The `catch` block was just not updated to match when `currentInitializerExtension` was introduced in #4134.

## Test plan

- [ ] New integration test: registers two initializers where the first throws, calls `initialize()`, and asserts the error closure names `bad-ext` (the throwing extension), not `good-ext` (the last one to run)
- [ ] Run `yarn test` in `framework/core/js/`