### PR TITLE
[2.x] feat(install): support queue configuration in installer file

### DIFF
--- a/framework/core/src/Install/Console/FileDataProvider.php
+++ b/framework/core/src/Install/Console/FileDataProvider.php
@@ -25,6 +25,7 @@ class FileDataProvider implements DataProviderInterface
     protected array $adminUser = [];
     protected array $settings = [];
     protected ?array $extensions = null;
+    protected array $queue = ['driver' => 'sync'];
 
     public function __construct(InputInterface $input)
     {
@@ -50,6 +51,7 @@ class FileDataProvider implements DataProviderInterface
             $this->adminUser = (array) ($configuration['adminUser'] ?? []);
             $this->settings = (array) ($configuration['settings'] ?? []);
             $this->extensions = isset($configuration['extensions']) ? explode(',', (string) $configuration['extensions']) : null;
+            $this->queue = (array) ($configuration['queue'] ?? ['driver' => 'sync']);
         } else {
             throw new Exception('Configuration file does not exist.');
         }
@@ -63,7 +65,8 @@ class FileDataProvider implements DataProviderInterface
             ->databaseConfig($this->getDatabaseConfiguration())
             ->adminUser($this->getAdminUser())
             ->settings($this->settings)
-            ->extensions($this->extensions);
+            ->extensions($this->extensions)
+            ->queueConfig($this->queue);
     }
 
     private function getDatabaseConfiguration(): DatabaseConfig

--- a/framework/core/src/Install/Installation.php
+++ b/framework/core/src/Install/Installation.php
@@ -22,6 +22,7 @@ class Installation
     private DatabaseConfig $dbConfig;
     private AdminUser $adminUser;
     private ?string $accessToken = null;
+    private array $queueConfig = ['driver' => 'sync'];
 
     // A few instance variables to persist objects between steps.
     // Could also be local variables in build(), but this way
@@ -64,6 +65,13 @@ class Installation
     public function settings(array $settings): self
     {
         $this->customSettings = $settings;
+
+        return $this;
+    }
+
+    public function queueConfig(array $queue): self
+    {
+        $this->queueConfig = $queue;
 
         return $this;
     }
@@ -133,7 +141,8 @@ class Installation
                 $this->debug,
                 $this->dbConfig,
                 $this->baseUrl,
-                $this->getConfigPath()
+                $this->getConfigPath(),
+                $this->queueConfig
             );
         });
 

--- a/framework/core/src/Install/Steps/StoreConfig.php
+++ b/framework/core/src/Install/Steps/StoreConfig.php
@@ -19,7 +19,8 @@ readonly class StoreConfig implements ReversibleStep
         private bool $debugMode,
         private DatabaseConfig $dbConfig,
         private BaseUrl $baseUrl,
-        private string $configFile
+        private string $configFile,
+        private array $queueConfig = ['driver' => 'sync']
     ) {
     }
 
@@ -52,9 +53,7 @@ readonly class StoreConfig implements ReversibleStep
                 'poweredByHeader' => true,
                 'referrerPolicy' => 'same-origin',
             ],
-            'queue' => [
-                'driver' => 'sync'
-            ]
+            'queue' => $this->queueConfig
         ];
     }
 


### PR DESCRIPTION
## Summary

Closes #4469.

`FileDataProvider` now reads a `queue` key from the JSON/YAML installer config file and passes it through to `StoreConfig` via `Installation`. Previously the queue config in `config.php` was always hardcoded to `['driver' => 'sync']`, requiring a manual post-install edit for any other driver.

## Usage

```json
{
  "baseUrl": "https://example.com",
  "databaseConfiguration": { "..." },
  "queue": {
    "driver": "database"
  }
}
```

Omitting the `queue` key defaults to `['driver' => 'sync']`, preserving existing behaviour.

## Changes

- `FileDataProvider` — reads `queue` from config, defaults to `['driver' => 'sync']`
- `Installation` — adds `queueConfig(array $queue): self` fluent method
- `StoreConfig` — accepts queue config as constructor param (default `['driver' => 'sync']`), uses it in `buildConfig()` instead of hardcoded value

## Test plan

- [ ] Install with a config file containing `"queue": {"driver": "database"}` and verify `config.php` contains the correct queue config
- [ ] Install without a `queue` key and verify `config.php` still defaults to `sync`