### PR TITLE
[2.x] fix: delete avatar file from disk when user account is deleted

### DIFF
--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -151,6 +151,16 @@ class User extends AbstractModel
             if ($user->id == 1) {
                 throw new DomainException('Cannot delete the root admin');
             }
+
+            $avatarPath = $user->getRawOriginal('avatar_url');
+
+            if ($avatarPath) {
+                $disk = resolve(Factory::class)->disk('flarum-avatars');
+
+                if ($disk->exists($avatarPath)) {
+                    $disk->delete($avatarPath);
+                }
+            }
         });
 
         static::deleted(function (self $user) {


### PR DESCRIPTION
## Summary

Closes #4459.

When a user account was deleted, their avatar file was never cleaned up from the `flarum-avatars` disk. `AvatarUploader::remove()` was only called via the explicit avatar delete flow — not during user account deletion. Over time this accumulates orphaned files with no recovery path.

## Fix

Hook into the existing `deleting` observer in `User::boot()` (pre-delete, so `avatar_url` is still readable) and delete the file directly from the filesystem using the same `resolve(Factory::class)->disk('flarum-avatars')` pattern already used in the model.

Using `deleting` rather than `deleted` is intentional — by the time `deleted` fires the model attributes may no longer reflect the original DB state. `getRawOriginal('avatar_url')` reads the stored path rather than going through the accessor (which would return a full URL).

## Test plan

- [ ] Upload an avatar for a user, note the filename in `flarum-avatars` storage
- [ ] Delete the user account
- [ ] Confirm the avatar file is no longer present on disk
- [ ] Confirm deleting a user with no avatar does not error
- [ ] Confirm root admin (id=1) still cannot be deleted