### PR TITLE
[2.x] fix: use SlugManager in AuthorFilter to support custom slug drivers

### DIFF
--- a/framework/core/src/Discussion/Search/Filter/AuthorFilter.php
+++ b/framework/core/src/Discussion/Search/Filter/AuthorFilter.php
@@ -9,12 +9,14 @@
 
 namespace Flarum\Discussion\Search\Filter;
 
+use Flarum\Http\SlugManager;
 use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\Search\ValidateFilterTrait;
-use Flarum\User\UserRepository;
+use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * @implements FilterInterface<DatabaseSearchState>
@@ -24,7 +26,7 @@ class AuthorFilter implements FilterInterface
     use ValidateFilterTrait;
 
     public function __construct(
-        protected UserRepository $users
+        protected SlugManager $slugManager
     ) {
     }
 
@@ -35,20 +37,20 @@ class AuthorFilter implements FilterInterface
 
     public function filter(SearchState $state, string|array $value, bool $negate): void
     {
-        $this->constrain($state->getQuery(), $value, $negate);
+        $this->constrain($state->getQuery(), $value, $state->getActor(), $negate);
     }
 
-    protected function constrain(Builder $query, string|array $rawUsernames, bool $negate): void
+    protected function constrain(Builder $query, string|array $rawSlugs, User $actor, bool $negate): void
     {
-        $usernames = $this->asStringArray($rawUsernames);
+        $slugDriver = $this->slugManager->forResource(User::class);
+        $ids = [];
 
-        $ids = $this->users->getIdsForUsernames($usernames);
-
-        // To be able to also use IDs.
-        $actualIds = array_diff(array_map('strval', $usernames), array_map('strval', array_keys($ids)));
-
-        if (! empty($actualIds)) {
-            $ids = array_merge($ids, $actualIds);
+        foreach ($this->asStringArray($rawSlugs) as $slug) {
+            try {
+                $ids[] = $slugDriver->fromSlug($slug, $actor)->id;
+            } catch (ModelNotFoundException) {
+                // Slug does not match any user; skip it.
+            }
         }
 
         $query->whereIn('discussions.user_id', $ids, 'and', $negate);

--- a/framework/core/src/Post/Filter/AuthorFilter.php
+++ b/framework/core/src/Post/Filter/AuthorFilter.php
@@ -9,11 +9,13 @@
 
 namespace Flarum\Post\Filter;
 
+use Flarum\Http\SlugManager;
 use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\Search\ValidateFilterTrait;
-use Flarum\User\UserRepository;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * @implements FilterInterface<DatabaseSearchState>
@@ -23,7 +25,7 @@ class AuthorFilter implements FilterInterface
     use ValidateFilterTrait;
 
     public function __construct(
-        protected UserRepository $users
+        protected SlugManager $slugManager
     ) {
     }
 
@@ -34,15 +36,15 @@ class AuthorFilter implements FilterInterface
 
     public function filter(SearchState $state, string|array $value, bool $negate): void
     {
-        $usernames = $this->asStringArray($value);
+        $slugDriver = $this->slugManager->forResource(User::class);
+        $ids = [];
 
-        $ids = $this->users->getIdsForUsernames($usernames);
-
-        // To be able to also use IDs.
-        $actualIds = array_diff(array_map('strval', $usernames), array_map('strval', array_keys($ids)));
-
-        if (! empty($actualIds)) {
-            $ids = array_merge($ids, $actualIds);
+        foreach ($this->asStringArray($value) as $slug) {
+            try {
+                $ids[] = $slugDriver->fromSlug($slug, $state->getActor())->id;
+            } catch (ModelNotFoundException) {
+                // Slug does not match any user; skip it.
+            }
         }
 
         $state->getQuery()->whereIn('posts.user_id', $ids, 'and', $negate);

--- a/framework/core/tests/integration/api/discussions/ListTest.php
+++ b/framework/core/tests/integration/api/discussions/ListTest.php
@@ -16,6 +16,7 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class ListTest extends TestCase
@@ -106,6 +107,53 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
 
         // Order-independent comparison
+        $this->assertEquals(['1'], Arr::pluck($data, 'id'), 'IDs do not match');
+    }
+
+    public static function slugDriverProvider(): array
+    {
+        return [
+            'username driver (default)' => ['username', 'normal', ['2', '3']],
+            'id driver' => ['id', '2', ['2', '3']],
+            'id_with_display_name driver' => ['id_with_display_name', '2-normal', ['2', '3']],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('slugDriverProvider')]
+    public function author_filter_works_with_slug_driver(string $driver, string $slug, array $expectedIds): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', $driver);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+            ->withQueryParams([
+                'filter' => ['author' => $slug],
+                'include' => 'mostRelevantPost',
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $data = json_decode($body, true)['data'];
+        $this->assertEqualsCanonicalizing($expectedIds, Arr::pluck($data, 'id'), 'IDs do not match');
+    }
+
+    #[Test]
+    public function author_filter_negation_works_with_id_slug_driver(): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', 'id');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+            ->withQueryParams([
+                'filter' => ['-author' => '2'],
+                'include' => 'mostRelevantPost',
+            ])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
         $this->assertEquals(['1'], Arr::pluck($data, 'id'), 'IDs do not match');
     }
 

--- a/framework/core/tests/integration/api/posts/ListTest.php
+++ b/framework/core/tests/integration/api/posts/ListTest.php
@@ -16,6 +16,7 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class ListTest extends TestCase
@@ -109,6 +110,54 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true);
 
         $this->assertEqualsCanonicalizing(['1', '2', '3', '4', '5'], Arr::pluck($data['data'], 'id'));
+    }
+
+    public static function slugDriverProvider(): array
+    {
+        return [
+            'username driver (default)' => ['username', 'normal', ['3', '4', '5']],
+            'id driver' => ['id', '2', ['3', '4', '5']],
+            'id_with_display_name driver' => ['id_with_display_name', '2-normal', ['3', '4', '5']],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('slugDriverProvider')]
+    public function author_filter_works_with_slug_driver(string $driver, string $slug, array $expectedIds): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', $driver);
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 1])
+                ->withQueryParams([
+                    'filter' => ['author' => $slug],
+                ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $data = json_decode($body, true)['data'];
+        $this->assertEqualsCanonicalizing($expectedIds, Arr::pluck($data, 'id'), 'IDs do not match');
+    }
+
+    #[Test]
+    public function author_filter_negation_works_with_id_slug_driver(): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', 'id');
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 1])
+                ->withQueryParams([
+                    'filter' => ['-author' => '2'],
+                ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $data = json_decode($body, true)['data'];
+        $this->assertEqualsCanonicalizing(['1', '2'], Arr::pluck($data, 'id'), 'IDs do not match');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Fixes #4360
- `AuthorFilter` (discussions and posts) previously resolved users via `UserRepository::getIdsForUsernames()`, which only queries by the `username` column — ignoring the active user slug driver
- Users with `id` or `id_with_display_name` slug drivers configured could not filter by author using the expected slug format
- Both filters now use `SlugManager::forResource(User::class)->fromSlug()` so the active driver is respected; unresolvable slugs are silently skipped

## Test plan

- [ ] Existing `author_filter_works` and `author_filter_works_negated` tests still pass (username driver)
- [ ] New `author_filter_works_with_slug_driver` data-provider tests cover `username`, `id`, and `id_with_display_name` drivers for both discussions and posts
- [ ] New `author_filter_negation_works_with_id_slug_driver` tests cover negation with `id` driver for both discussions and posts
- [ ] Manual: switch slug driver in admin, filter discussions/posts by author using the appropriate slug format