### PR TITLE
[2.x] Emoji: Update to Emoji/Unicode 17

### DIFF
--- a/extensions/emoji/extend.php
+++ b/extensions/emoji/extend.php
@@ -36,5 +36,5 @@ return [
 
     (new Extend\Settings)
         ->serializeToForum('flarum-emoji.cdn', 'flarum-emoji.cdn')
-        ->default('flarum-emoji.cdn', 'https://cdn.jsdelivr.net/gh/twitter/twemoji@[version]/assets/'),
+        ->default('flarum-emoji.cdn', 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@[version]/assets/'),
 ];

--- a/extensions/emoji/js/@types/shims.d.ts
+++ b/extensions/emoji/js/@types/shims.d.ts
@@ -1,2 +1,1 @@
 declare module 'simple-emoji-map';
-declare module 'twemoji';

--- a/extensions/emoji/js/package.json
+++ b/extensions/emoji/js/package.json
@@ -4,8 +4,9 @@
     "version": "0.0.0",
     "prettier": "@flarum/prettier-config",
     "dependencies": {
-        "simple-emoji-map": "^0.5.1",
-        "twemoji": "^14.0.2"
+        "@twemoji/api": "17",
+        "emojibase-data": "17",
+        "simple-emoji-map": "^1.0.0"
     },
     "devDependencies": {
         "@flarum/prettier-config": "^1.0.0",
@@ -27,6 +28,7 @@
         "build-typings": "yarn run clean-typings && ([ -e src/@types ] && cp -r src/@types dist-typings/@types || true) && tsc && yarn run post-build-typings",
         "post-build-typings": "find dist-typings -type f -name '*.d.ts' -print0 | xargs -0 sed -i 's,../src/@types,@types,g'",
         "check-typings": "tsc --noEmit --emitDeclarationOnly false",
-        "check-typings-coverage": "typescript-coverage-report"
+        "check-typings-coverage": "typescript-coverage-report",
+        "postinstall": "yarn run simple-emoji-map"
     }
 }

--- a/extensions/emoji/js/src/common/cdn.ts
+++ b/extensions/emoji/js/src/common/cdn.ts
@@ -1,6 +1,7 @@
-import twemoji from 'twemoji';
+import app from 'flarum/common/app';
+import twemoji from '@twemoji/api';
 
-export const version = /([0-9]+)\.[0-9]+\.[0-9]+/g.exec((twemoji as any).base)![1];
+export const version = /([0-9]+)\.[0-9]+\.[0-9]+/g.exec(twemoji.base)![1];
 
 export default function (): string {
   return app.forum.attribute<string>('flarum-emoji.cdn').replace('[version]', version);

--- a/extensions/emoji/js/src/forum/helpers/getEmojiIconCode.ts
+++ b/extensions/emoji/js/src/forum/helpers/getEmojiIconCode.ts
@@ -2,7 +2,7 @@
   https://github.com/twitter/twemoji/blob/gh-pages/LICENSE
 */
 
-import twemoji from 'twemoji';
+import twemoji from '@twemoji/api';
 
 // avoid using a string literal like '\u200D' here because minifiers expand it inline
 const U200D = String.fromCharCode(0x200d);
@@ -19,5 +19,5 @@ const UFE0Fg = /\uFE0F/g;
  * @return  string    the code point
  */
 export default function getEmojiIconCode(emoji: string): string {
-  return (twemoji as any).convert.toCodePoint(emoji.indexOf(U200D) < 0 ? emoji.replace(UFE0Fg, '') : emoji);
+  return twemoji.convert.toCodePoint(emoji.indexOf(U200D) < 0 ? emoji.replace(UFE0Fg, '') : emoji);
 }

--- a/extensions/emoji/js/src/forum/renderEmoji.ts
+++ b/extensions/emoji/js/src/forum/renderEmoji.ts
@@ -1,4 +1,4 @@
-import twemoji from 'twemoji';
+import twemoji from '@twemoji/api';
 
 import { override } from 'flarum/common/extend';
 import Post from 'flarum/common/models/Post';
@@ -44,7 +44,7 @@ export default function renderEmoji(): void {
       // element. This gets stripped below.
       //
       // See https://github.com/flarum/core/issues/2958
-      const emojifiedDom = (twemoji as any).parse(parseHTML(contentHtml), options());
+      const emojifiedDom = twemoji.parse(parseHTML(contentHtml), options());
 
       // Steal the HTML string inside the emojified DOM `<body>` tag.
       this.emojifiedContentHtml = emojifiedDom.innerHTML;

--- a/extensions/emoji/locale/en.yml
+++ b/extensions/emoji/locale/en.yml
@@ -10,7 +10,7 @@ flarum-emoji:
     # These translations are used in the Settings page of the admin interface.
     settings:
       cdn_label: CDN mirror address
-      cdn_help: "e.g. https://cdn.jsdelivr.net/gh/twitter/twemoji@[version]/assets/, The current version is: {version}"
+      cdn_help: "e.g. https://cdn.jsdelivr.net/gh/jdecked/twemoji@[version]/assets/, The current version is: {version}"
 
   # Translations in this namespace are used by the forum user interface.
   forum:

--- a/extensions/emoji/migrations/2026_03_22_000000_remove_old_emoji_cdn_setting.php
+++ b/extensions/emoji/migrations/2026_03_22_000000_remove_old_emoji_cdn_setting.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 use Illuminate\Database\Schema\Builder;
 
 return [

--- a/extensions/emoji/migrations/2026_03_22_000000_remove_old_emoji_cdn_setting.php
+++ b/extensions/emoji/migrations/2026_03_22_000000_remove_old_emoji_cdn_setting.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => static function (Builder $schema) {
+        $connection = $schema->getConnection();
+
+        // Delete any stored CDN settings that reference the old default CDN URL
+        $connection->table('settings')
+            ->where('key', 'flarum-emoji.cdn')
+            ->where('value', 'like', 'https://cdn.jsdelivr.net/gh/twitter/twemoji%')
+            ->delete();
+    },
+
+    'down' => function (Builder $schema) {
+        // noop
+    }
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,21 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@twemoji/api@17", "@twemoji/api@^17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@twemoji/api/-/api-17.0.2.tgz#cd1bf3d74c494fa48733382904cefe81f60e63d0"
+  integrity sha512-5xIdBcFLpRW4goXNdNNz497TzMHF2a76yElEaqISxVPj+KpJB82KuXHczfjhhTCsPaP1lAhM3qPtvAhMG7e71A==
+  dependencies:
+    "@twemoji/parser" "17.0.1"
+    fs-extra "^8.0.1"
+    jsonfile "^5.0.0"
+    universalify "^0.1.2"
+
+"@twemoji/parser@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@twemoji/parser/-/parser-17.0.1.tgz#5f55fa94fcd5111af55b980b8d6adf724405966f"
+  integrity sha512-Uiq5sq1Wx91Y6C0DczMlu4Gj4nC/0z8UIhT7S53hi/JATaS1oLM5jXygjot7STtyVoIagfnpsBCWaNy3ayfyFw==
+
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -1554,11 +1569,6 @@
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
-
-"@types/parse-json@^4.0.0":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
-  integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
 "@types/punycode@^2.1.0":
   version "2.1.4"
@@ -2352,16 +2362,15 @@ core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   dependencies:
     browserslist "^4.23.3"
 
-cosmiconfig@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
-  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+cosmiconfig@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.1.tgz#df110631a8547b5d1a98915271986f06e3011379"
+  integrity sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==
   dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
 
 create-jest@^29.7.0:
   version "29.7.0"
@@ -2558,10 +2567,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emojibase-data@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-7.0.1.tgz#a81d7fcd12247f7d94a96dcbdb143e6b6dd5c328"
-  integrity sha512-BLZpOdwyFpZ7lzBWyDtnxmKVm/SJMYgAfp1if3o6n1TVUMSXAf0nikONXl90LZuJ/m3XWPBkkubgCet2BsCGGQ==
+emojibase-data@17:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-17.0.0.tgz#5816fba6395da6b567fbd54b029ca6b5de2d9255"
+  integrity sha512-Yvgb5AWoHViHV/gq1qr5ZAarcBip+B27/ZLRsUJkbgAEaLlZ/fof9g882LTpmEpyhBNEC0m2SEmItljHsTygjA==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -2580,6 +2589,11 @@ entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+env-paths@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.7.3:
   version "7.14.0"
@@ -3155,10 +3169,10 @@ iframe-resizer@^4.3.2:
   resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.4.5.tgz#f5048636e7f2fb5d9a09cc2ae78eb2da55ad555c"
   integrity sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==
 
-import-fresh@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
-  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+import-fresh@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -3755,7 +3769,7 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.1:
+js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
@@ -4270,11 +4284,6 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-type@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
-  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -4756,15 +4765,14 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-simple-emoji-map@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/simple-emoji-map/-/simple-emoji-map-0.5.1.tgz#d42ceeec8f0dcda574587a62e59adfd087dc91d4"
-  integrity sha512-IBi769OaG3BjXCu0WnweB50OcRgQ18HJMZ1bFdzWits8lepmbgGgCdKF+preHiIAqa+wQyff1nAVVydOXrIhng==
+simple-emoji-map@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-emoji-map/-/simple-emoji-map-1.0.0.tgz#c8cfae6adf5fa5fe1620b0de4431b77884329309"
+  integrity sha512-bSKgEgtxIG/+086mloIx6xA1xeZOLsTWkRX1vShVJaFeWOVnaBrpgh9BU8tNovTnYtThr9mF0sqAYHeBPWPGTg==
   dependencies:
+    "@twemoji/api" "^17.0.2"
     chalk "^4.1.2"
-    cosmiconfig "^7.0.1"
-    emojibase-data "^7.0.1"
-    twemoji "^14.0.2"
+    cosmiconfig "^9.0.1"
 
 sirv@^2.0.3:
   version "2.0.4"
@@ -5051,21 +5059,6 @@ tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
-
-twemoji-parser@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-14.0.0.tgz#13dabcb6d3a261d9efbf58a1666b182033bf2b62"
-  integrity sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA==
-
-twemoji@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.2.tgz#c53adb01dab22bf4870f648ca8cc347ce99ee37e"
-  integrity sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==
-  dependencies:
-    fs-extra "^8.0.1"
-    jsonfile "^5.0.0"
-    twemoji-parser "14.0.0"
-    universalify "^0.1.2"
 
 type-coverage-core@^2.17.2:
   version "2.29.7"
@@ -5455,11 +5448,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION

**Changes proposed in this pull request:**
- Update to Emoji/Unicode 17 for new emojis (from 14)
- Replace `twemoji` package with `@twemoji/api`
- Add migration to delete CDN if it starts with old jsdelivr 

**Reviewers should focus on:**
I don't love the CDN url being set by default in the backend, as a user can go in and modify it and save such that it may be equal to the default, but now has a value in their DB and so it's technically a custom CDN. Though this shouldn't come up very often. I'd rather have it as a constant in the common JS and pass that when missing a setting (and to the locale -- should not be in the translation text imo).

Also, regarding CDN: For fof/reactions (see https://github.com/FriendsOfFlarum/reactions/pull/100/changes/d0d60a6bd9ff4a1d93f4eba048f6421300de60b8), I used Emoji/Unicode 16 since the CDN we use (cloudflare's cdnjs) does not have the latest version (see https://github.com/cdnjs/cdnjs/issues/14263). We use jsdelivr as a default here, but it may cause issues with those that use a custom one to avoid geoblocking?

**Screenshot**
<img width="516" height="265" alt="image" src="https://github.com/user-attachments/assets/46ce3b75-15ce-45c5-8a01-d2c914c57a4c" />
<img width="709" height="139" alt="image" src="https://github.com/user-attachments/assets/fba18ec5-c93a-48e0-aea4-8148d45fc96b" />


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- ~~For core PRs, does this need to be in core, or could it be in an extension?~~
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- Tests have been added, or are not appropriate here.
