### PR TITLE
ux: move PostUser group badges inline after username

### DIFF
--- a/framework/core/js/src/forum/components/PostUser.tsx
+++ b/framework/core/js/src/forum/components/PostUser.tsx
@@ -54,8 +54,6 @@ export default class PostUser<CustomAttrs extends IPostUserAttrs = IPostUserAttr
       100
     );
 
-    items.add('postUser-badges', <ul className="PostUser-badges badges badges--packed">{listItems(user.badges().toArray())}</ul>, 90);
-
     return items;
   }
 
@@ -70,6 +68,8 @@ export default class PostUser<CustomAttrs extends IPostUserAttrs = IPostUserAttr
     }
 
     items.add('username', username(user), 80);
+
+    items.add('badges', <ul className="PostUser-badges badges">{listItems(user.badges().toArray())}</ul>, 70);
 
     return items;
   }

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -81,9 +81,22 @@
   }
 }
 .PostUser-badges {
-  text-align: right;
+  display: inline-flex;
+  align-items: center;
   white-space: nowrap;
   pointer-events: none;
+  margin-left: 6px;
+  vertical-align: middle;
+  gap: 2px;
+
+  > li {
+    display: flex;
+    align-items: center;
+  }
+
+  .Badge {
+    .Badge--size(16px);
+  }
 }
 
 .Post-body {
@@ -375,17 +388,6 @@
       display: none;
     }
   }
-  .PostUser-badges {
-    position: absolute;
-    top: -12px;
-    left: 6px;
-    width: 32px;
-
-    .Badge {
-      .Badge--size(20px);
-      margin-left: -13px;
-    }
-  }
   .EventPost {
     padding-left: 50px;
   }
@@ -412,13 +414,6 @@
   }
   .Post-header .Post-avatar {
     display: none;
-  }
-  .PostUser-badges {
-    float: left;
-    position: relative;
-    margin-left: calc(~"5px - var(--avatar-column-width)");
-    margin-top: -3px;
-    width: 64px;
   }
   .EventPost-icon {
     text-align: right;


### PR DESCRIPTION
## Summary

- Group badges in post headers were overlaid on the avatar via float/absolute positioning, causing overflow when a user belongs to many groups (visible at all viewport widths)
- Badges are now rendered inline after the username and online indicator, using `inline-flex` alignment so they sit flush with the text
- Old avatar-column positioning rules removed; badges display at 16px with a small gap between each

## Test plan

- [ ] User with 1 group badge — renders cleanly inline after username
- [ ] User with many group badges — no overflow, badges wrap or extend naturally
- [ ] Online indicator still shows correctly before username
- [ ] Timestamp still appears after badges without layout breakage
- [ ] Check on mobile and desktop viewports