### PR TITLE
[2.x] fix(sticky): sticky discussions in hidden tags appear on all-discussions page

### DIFF
--- a/extensions/sticky/composer.json
+++ b/extensions/sticky/composer.json
@@ -33,6 +33,9 @@
         "flarum-extension": {
             "title": "Sticky",
             "category": "feature",
+            "optional-dependencies": [
+                "flarum-tags"
+            ],
             "icon": {
                 "name": "fas fa-thumbtack",
                 "backgroundColor": "#D13E32",

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -39,20 +39,24 @@ class ListDiscussionsTest extends TestCase
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(2), 'last_posted_at' => Carbon::now()->addMinutes(5), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => false, 'last_post_number' => 1],
                 ['id' => 3, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(3), 'last_posted_at' => Carbon::now()->addMinute(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => true, 'last_post_number' => 1],
                 ['id' => 4, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(4), 'last_posted_at' => Carbon::now()->addMinutes(2), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => false, 'last_post_number' => 1],
+                // Sticky discussion in a hidden tag — must not appear on the all-discussions page.
+                ['id' => 5, 'title' => __CLASS__, 'created_at' => Carbon::now()->addMinutes(10), 'last_posted_at' => Carbon::now()->addMinutes(10), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => true, 'last_post_number' => 1],
             ],
             'discussion_user' => [
                 ['discussion_id' => 1, 'user_id' => 3, 'last_read_post_number' => 1],
                 ['discussion_id' => 3, 'user_id' => 3, 'last_read_post_number' => 1],
             ],
             Tag::class => [
-                ['id' => 1, 'slug' => 'general', 'position' => 0, 'parent_id' => null]
+                ['id' => 1, 'slug' => 'general', 'position' => 0, 'parent_id' => null],
+                ['id' => 2, 'slug' => 'hidden', 'position' => 1, 'parent_id' => null, 'is_hidden' => true],
             ],
             'discussion_tag' => [
                 ['discussion_id' => 1, 'tag_id' => 1],
                 ['discussion_id' => 2, 'tag_id' => 1],
                 ['discussion_id' => 3, 'tag_id' => 1],
                 ['discussion_id' => 4, 'tag_id' => 1],
-            ]
+                ['discussion_id' => 5, 'tag_id' => 2],
+            ],
         ]);
     }
 
@@ -136,6 +140,36 @@ class ListDiscussionsTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true);
 
         $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    #[Test]
+    public function sticky_discussion_in_hidden_tag_excluded_from_all_discussions_as_guest()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $body = $response->getBody()->getContents());
+
+        $ids = Arr::pluck(json_decode($body, true)['data'], 'id');
+
+        $this->assertNotContains('5', $ids);
+    }
+
+    #[Test]
+    public function sticky_discussion_in_hidden_tag_excluded_from_all_discussions_with_only_unread_on()
+    {
+        $this->setting('flarum-sticky.only_sticky_unread_discussions', true);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $body = $response->getBody()->getContents());
+
+        $ids = Arr::pluck(json_decode($body, true)['data'], 'id');
+
+        $this->assertNotContains('5', $ids);
     }
 
     #[Test]

--- a/extensions/tags/src/Search/HideHiddenTagsFromAllDiscussionsPage.php
+++ b/extensions/tags/src/Search/HideHiddenTagsFromAllDiscussionsPage.php
@@ -21,10 +21,23 @@ class HideHiddenTagsFromAllDiscussionsPage
             return;
         }
 
-        $state->getQuery()->whereNotIn('discussions.id', function ($query) {
-            return $query->select('discussion_id')
-            ->from('discussion_tag')
-            ->whereIn('tag_id', Tag::where('is_hidden', 1)->pluck('id'));
-        });
+        $hiddenTagIds = Tag::where('is_hidden', 1)->pluck('id');
+
+        $applyFilter = function ($query) use ($hiddenTagIds) {
+            $query->whereNotIn('discussions.id', function ($q) use ($hiddenTagIds) {
+                return $q->select('discussion_id')
+                    ->from('discussion_tag')
+                    ->whereIn('tag_id', $hiddenTagIds);
+            });
+        };
+
+        $eloquentQuery = $state->getQuery();
+        $applyFilter($eloquentQuery);
+
+        // Also apply to any existing union queries (e.g. from PinStickiedDiscussionsToTop)
+        // in case that mutator ran before this one.
+        foreach ($eloquentQuery->getQuery()->unions ?? [] as $union) {
+            $applyFilter($union['query']);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Sticky discussions tagged with a hidden tag were incorrectly appearing on the "All Discussions" page — a regression from 1.x behaviour.

**Root cause:** `PinStickiedDiscussionsToTop` clones the raw query builder (`$sticky = clone $query`) to construct a UNION for the unread-sticky sort path. If `HideHiddenTagsFromAllDiscussionsPage` ran *after* that clone, the `whereNotIn` exclusion was never applied to the `$sticky` subquery, so hidden-tag discussions leaked through the UNION.

## Fix

Two complementary changes:

- **`sticky/composer.json`** — declares `flarum-tags` as an optional dependency so tags always boots (and registers its mutator) before sticky, ensuring the `whereNotIn` is on the builder before the clone happens.
- **`HideHiddenTagsFromAllDiscussionsPage`** — defensive belt-and-suspenders: after applying the filter to the main query, also applies it to any union queries already present on the builder, covering any future ordering edge cases.

## Tests

- Added a hidden tag (`is_hidden = true`) and a sticky discussion in that tag to the existing `ListDiscussionsTest` fixture.
- Two new test cases: guest request and authenticated request with `only_sticky_unread_discussions` enabled (the UNION path).

Closes #4487