### PR TITLE
[2.x] fix: re-sort extension order during migrate

### DIFF
--- a/framework/core/src/Database/Console/MigrateCommand.php
+++ b/framework/core/src/Database/Console/MigrateCommand.php
@@ -61,6 +61,10 @@ class MigrateCommand extends AbstractCommand
         $extensions = $this->container->make(ExtensionManager::class);
         $extensions->getMigrator()->setOutput($this->output);
 
+        // Re-sort and persist the enabled extension order so that any optional-dependencies
+        // added or changed since the last enable/disable cycle take effect immediately.
+        $extensions->syncExtensionOrder();
+
         foreach ($extensions->getEnabledExtensions() as $name => $extension) {
             if ($extension->hasMigrations()) {
                 $this->info('Migrating extension: '.$name);

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -349,6 +349,18 @@ class ExtensionManager
     }
 
     /**
+     * Re-sort and persist the enabled extension order based on current composer.json dependency
+     * declarations. Call this after a composer update so that any new or changed
+     * optional-dependencies are reflected without requiring a manual enable/disable cycle.
+     *
+     * @throws CircularDependenciesException
+     */
+    public function syncExtensionOrder(): void
+    {
+        $this->setEnabledExtensions($this->getEnabledExtensions());
+    }
+
+    /**
      * Persist the currently enabled extensions.
      *
      * @param Extension[] $enabledExtensions


### PR DESCRIPTION
## Summary

When an extension update adds or changes `optional-dependencies` in its `composer.json`, the stored boot order in `extensions_enabled` is not updated until an extension is manually disabled and re-enabled. This means the new dependency ordering is silently ignored until that manual cycle happens.

**Root cause:** `setEnabledExtensions()` — which re-sorts and persists the order — is only called during enable/disable. The `migrate` command reads the stored order via `getEnabledExtensions()` but never re-sorts it.

**Fix:** Add a `syncExtensionOrder()` public method to `ExtensionManager` that re-sorts and persists the current enabled extension list, and call it at the start of `MigrateCommand::upgrade()`. Since `php flarum migrate` is the standard step after any `composer update`, this ensures the order is always up to date.

## Test plan

- Run `php flarum migrate` after adding an `optional-dependencies` entry to an extension's `composer.json` — the boot order in `extensions_enabled` should be updated without needing to toggle the extension.
- Existing `ExtensionDependencyResolutionTest` passes unchanged.