### PR TITLE
[2.x] fix(realtime): guard against undefined app.data.settings in NotificationToastState

### DIFF
--- a/extensions/realtime/js/src/forum/states/NotificationToastState.ts
+++ b/extensions/realtime/js/src/forum/states/NotificationToastState.ts
@@ -20,8 +20,8 @@ export default class NotificationToastState {
   }
 
   push(notification: NotificationModel): void {
-    const settings = app.data.settings as unknown as Record<string, number>;
-    const dismissAfterS = settings['flarum-realtime.notification-toast-dismiss-after'];
+    const settings = (app.data?.settings ?? {}) as unknown as Record<string, number>;
+    const dismissAfterS = settings['flarum-realtime.notification-toast-dismiss-after'] ?? 10;
 
     if (dismissAfterS === 0) return;
 


### PR DESCRIPTION
## Summary

- `app.data` is not yet populated when `Application.mount` runs during boot, causing `app.data.settings` to throw
- Guard with optional chaining (`app.data?.settings ?? {}`) so early Pusher events don't crash
- Fall back to `10` (matching the PHP-registered default) when the setting key is absent, so toasts still display

Fixes the `TypeError: can't access property "flarum-realtime.notification-toast-dismiss-after", e().data.settings is undefined` error seen on boot.