### PR TITLE
[2.x] perf(core): add composite index on notifications to fix slow unread count queries

### DIFF
--- a/framework/core/migrations/2026_03_25_000000_add_notifications_composite_index.php
+++ b/framework/core/migrations/2026_03_25_000000_add_notifications_composite_index.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('notifications', function (Blueprint $table) {
+            // Composite index to support the unread/new notification count queries
+            // issued on every page load. Without this, MySQL abandons the single-
+            // column user_id index when one user owns a large fraction of the table
+            // (common in active communities) and falls back to a full table scan.
+            //
+            // Column order rationale:
+            //   1. user_id   — equality prefix, mandatory filter on all count queries
+            //   2. is_deleted — equality (always 0 for visible notifications)
+            //   3. read_at   — IS NULL filter for unread; narrows to a small fraction
+            //   4. type      — IN (...) filter; included so the index covers the query
+            //
+            // With this index, the count query can be satisfied with an index range
+            // scan on (user_id, is_deleted=0, read_at IS NULL) without touching the
+            // table rows, regardless of how many notifications a user has in total.
+            $table->index(['user_id', 'is_deleted', 'read_at', 'type'], 'notifications_user_unread_type_index');
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('notifications', function (Blueprint $table) {
+            $table->dropIndex('notifications_user_unread_type_index');
+        });
+    }
+];


### PR DESCRIPTION
Mirrors flarum/framework#4507 (merged on 1.x) to the 2.x branch.

## Problem

On forums with large notification tables, the unread/new notification count queries are slow. These counts are serialized on every page load via `CurrentUserSerializer`. MySQL abandons the single-column `user_id` index when one user owns a significant fraction of the table — common on active forums — and falls back to a full table scan.

## Fix

Add a composite index `(user_id, is_deleted, read_at, type)`. With this index, MySQL uses a range scan on `(user_id=?, is_deleted=0, read_at IS NULL)` and satisfies the entire count query from the index without scanning table rows.

## Upgrade safety

The migration filename is identical to the one in 1.x (`2026_03_25_000000_add_notifications_composite_index.php`). When a site upgrades from 1.x to 2.x, the migration will already be recorded in the `migrations` table and will be skipped — the index will already exist.

Fixes flarum/framework#3952.