### PR TITLE
[2.x] fix(core): suppress PHP warning when extension name lacks vendor/package format

### DIFF
--- a/framework/core/src/Extension/Extension.php
+++ b/framework/core/src/Extension/Extension.php
@@ -94,7 +94,9 @@ class Extension implements Arrayable
 
     public static function nameToId(string $name): string
     {
-        [$vendor, $package] = explode('/', $name);
+        $parts = explode('/', $name, 2);
+        $vendor = $parts[0];
+        $package = $parts[1] ?? $name;
         $package = str_replace(['flarum-ext-', 'flarum-'], '', $package);
 
         return "$vendor-$package";

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -71,7 +71,7 @@ class ExtensionManager
                     ? $this->paths->vendor.'/composer/'.$package['install-path']
                     : $this->paths->vendor.'/'.$name;
 
-                if (Arr::get($package, 'type') === 'flarum-extension') {
+                if (Arr::get($package, 'type') === 'flarum-extension' && str_contains($name, '/')) {
                     $composerJsonConfs[$packagePath] = $package;
                 }
 
@@ -553,7 +553,7 @@ class ExtensionManager
             $subPackagePath = "$packagePath/$subExtPath";
             $conf = json_decode($this->filesystem->get("$subPackagePath/composer.json"), true);
 
-            if (Arr::get($conf, 'type') === 'flarum-extension') {
+            if (Arr::get($conf, 'type') === 'flarum-extension' && str_contains((string) Arr::get($conf, 'name', ''), '/')) {
                 $subExtConfs[$subPackagePath] = $conf;
             }
         }


### PR DESCRIPTION
## Problem

`Extension::nameToId()` uses array destructuring on `explode('/', $name)`:

```php
[$vendor, $package] = explode('/', $name);
```

If `$name` contains no `/` (e.g. a package with a malformed or missing name), PHP emits:

```
PHP Warning: Undefined array key 1 in Extension.php on line 97
```

This was observed during `php flarum migrate` in certain environments.

## Fix

- `ExtensionManager::getExtensions()` — skip `flarum-extension` packages from `installed.json` whose name has no `/`
- `ExtensionManager::subExtensionConfsFromJson()` — skip sub-extensions whose name has no `/`  
- `Extension::nameToId()` — made robust against a missing slash so any name that does slip through no longer triggers the warning