### PR TITLE
[2.x] fix(core): strip trailing slash from URI before route dispatch

### DIFF
--- a/framework/core/src/Http/Middleware/ResolveRoute.php
+++ b/framework/core/src/Http/Middleware/ResolveRoute.php
@@ -38,6 +38,11 @@ class ResolveRoute implements Middleware
         $method = $request->getMethod();
         $uri = $request->getUri()->getPath() ?: '/';
 
+        // Strip trailing slash so that e.g. /d/123-slug/ resolves the same as /d/123-slug.
+        if ($uri !== '/' && str_ends_with($uri, '/')) {
+            $uri = rtrim($uri, '/');
+        }
+
         $routeInfo = $this->getDispatcher()->dispatch($method, $uri);
 
         switch ($routeInfo[0]) {


### PR DESCRIPTION
Fixes flarum/framework#4504.

## Problem

Discussion URLs (and any other route) with a trailing slash — e.g. `/d/123-slug/` — were not matched by FastRoute because the route patterns do not include an optional trailing slash. FastRoute returned `NOT_FOUND`, which caused a `RouteNotFoundException` and the user was redirected to the home page.

## Fix

Strip any trailing slash from the URI (except `/`) in `ResolveRoute::process()` before dispatching to FastRoute. This is the standard approach — one central fix that covers all routes without modifying every route pattern.

```php
if ($uri !== '/' && str_ends_with($uri, '/')) {
    $uri = rtrim($uri, '/');
}
```