### PR TITLE
[1.x] fix: re-sort extension order during migrate

### DIFF
--- a/framework/core/src/Database/Console/MigrateCommand.php
+++ b/framework/core/src/Database/Console/MigrateCommand.php
@@ -79,6 +79,8 @@ class MigrateCommand extends AbstractCommand
         $extensions = $this->container->make(ExtensionManager::class);
         $extensions->getMigrator()->setOutput($this->output);
 
+        $extensions->syncExtensionOrder();
+
         foreach ($extensions->getEnabledExtensions() as $name => $extension) {
             if ($extension->hasMigrations()) {
                 $this->info('Migrating extension: '.$name);

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -445,6 +445,19 @@ class ExtensionManager
     }
 
     /**
+     * Re-sort and persist the enabled extension order based on current
+     * composer.json dependency declarations. Call this after a composer
+     * update so that any new or changed optional-dependencies are reflected
+     * without requiring a manual enable/disable cycle.
+     *
+     * @throws CircularDependenciesException
+     */
+    public function syncExtensionOrder(): void
+    {
+        $this->setEnabledExtensions($this->getEnabledExtensions());
+    }
+
+    /**
      * Whether the extension is enabled.
      *
      * @param $extension


### PR DESCRIPTION
Backport of #4493 to 1.x. Fixes #4494.

When an extension update adds or changes `optional-dependencies` in its `composer.json`, the stored boot order in `extensions_enabled` is not updated until an extension is manually disabled and re-enabled.

**Root cause:** `setEnabledExtensions()` — which re-sorts and persists the order — is only called during enable/disable. The `migrate` command reads the stored order via `getEnabledExtensions()` but never re-sorts it.

**Fix:** Add a `syncExtensionOrder()` public method to `ExtensionManager` that re-sorts and persists the current enabled extension list, and call it at the start of `MigrateCommand::upgrade()`.