### PR TITLE
[2.x] fix(sticky): qualify ambiguous `id` column in is_unread_sticky subquery

### DIFF
--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -65,7 +65,7 @@ class PinStickiedDiscussionsToTop
                 $read = $q->newQuery()
                     ->selectRaw('1')
                     ->from('discussion_user as sticky')
-                    ->whereColumn('sticky.discussion_id', 'id')
+                    ->whereColumn('sticky.discussion_id', 'discussions.id')
                     ->where('sticky.user_id', '=', $state->getActor()->id)
                     ->whereColumn('sticky.last_read_post_number', '>=', 'last_post_number');
 


### PR DESCRIPTION
Fixes #4519.

The correlated subquery that builds the `is_unread_sticky` computed column used a bare `id` reference:

```sql
where `sticky`.`discussion_id` = `id`
```

When the outer `discussions` query is joined by another extension (e.g. byobu adding `LEFT JOIN recipients`), MySQL raises *Column 'id' in where clause is ambiguous*. Qualifying it as `discussions.id` resolves this regardless of what JOINs are present.