### PR TITLE
[2.x] feat: add reset settings button to extension admin pages

### DIFF
--- a/extensions/mentions/js/src/forum/mentionables/TagMention.tsx
+++ b/extensions/mentions/js/src/forum/mentionables/TagMention.tsx
@@ -45,11 +45,7 @@ export default class TagMention extends MentionableModel<Tag, HashMentionFormat>
   }
 
   suggestion(model: Tag, typed: string): Mithril.Children {
-    let tagName: Mithril.Children = model.name();
-
-    if (typed) {
-      tagName = highlight(tagName, typed);
-    }
+    let tagName: Mithril.Children = typed ? highlight(model.name(), typed) : model.name();
 
     return (
       <>

--- a/extensions/mentions/js/tsconfig.json
+++ b/extensions/mentions/js/tsconfig.json
@@ -10,7 +10,7 @@
     "declarationDir": "./dist-typings",
     "paths": {
       "flarum/*": ["../../../framework/core/js/dist-typings/*"],
-      "ext:flarum/tags/*": ["../../tags/js/dist-typings/*"]
+      "ext:flarum/tags/*": ["../../tags/js/src/*", "../../tags/js/dist-typings/*"]
     }
   }
 }

--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -61,11 +61,14 @@ export default class TagsPage extends ExtensionPage {
       return <LoadingIndicator />;
     }
 
-    const minPrimaryTags = this.setting('flarum-tags.min_primary_tags', 0);
-    const maxPrimaryTags = this.setting('flarum-tags.max_primary_tags', 0);
+    const primaryLabel = app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading');
+    const secondaryLabel = app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading');
 
-    const minSecondaryTags = this.setting('flarum-tags.min_secondary_tags', 0);
-    const maxSecondaryTags = this.setting('flarum-tags.max_secondary_tags', 0);
+    const minPrimaryTags = this.setting('flarum-tags.min_primary_tags', 0, primaryLabel);
+    const maxPrimaryTags = this.setting('flarum-tags.max_primary_tags', 0, primaryLabel);
+
+    const minSecondaryTags = this.setting('flarum-tags.min_secondary_tags', 0, secondaryLabel);
+    const maxSecondaryTags = this.setting('flarum-tags.max_secondary_tags', 0, secondaryLabel);
 
     const tags = sortTags(app.store.all('tags').filter((tag) => !tag.parent()));
 
@@ -125,7 +128,10 @@ export default class TagsPage extends ExtensionPage {
                       <input className="FormControl" type="number" min={minSecondaryTags()} bidi={maxSecondaryTags} />
                     </div>
                   </div>
-                  <div className="Form-group Form-controls">{this.submitButton()}</div>
+                  <div className="Form-group Form-controls">
+                    {this.submitButton()}
+                    {this.resetButton()}
+                  </div>
                 </Form>
               </FormSection>
             </FormSectionGroup>

--- a/extensions/tags/js/src/admin/extend.tsx
+++ b/extensions/tags/js/src/admin/extend.tsx
@@ -2,6 +2,7 @@ import Extend from 'flarum/common/extenders';
 import commonExtend from '../common/extend';
 import app from 'flarum/admin/app';
 import TagsPage from './components/TagsPage';
+import extractText from 'flarum/common/utils/extractText';
 
 export default [
   ...commonExtend,
@@ -25,5 +26,27 @@ export default [
       }),
       'start',
       89
-    ),
+    )
+    .generalIndexItems('settings', () => [
+      {
+        id: 'flarum-tags.min_primary_tags',
+        label: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading')),
+        help: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_primary_text')),
+      },
+      {
+        id: 'flarum-tags.max_primary_tags',
+        label: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading')),
+        help: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_primary_text')),
+      },
+      {
+        id: 'flarum-tags.min_secondary_tags',
+        label: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading')),
+        help: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_text')),
+      },
+      {
+        id: 'flarum-tags.max_secondary_tags',
+        label: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading')),
+        help: extractText(app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_text')),
+      },
+    ]),
 ];

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -41,6 +41,7 @@ export type SaveSubmitEvent = SubmitEvent & { redraw: boolean };
 
 export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends Page<CustomAttrs> {
   settings: MutableSettings = {};
+  settingLabels: Record<string, Mithril.Children> = {};
   refreshAfterSaving: string[] = [];
   loading: boolean = false;
 
@@ -75,6 +76,24 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
         disabled={!this.isChanged()}
       >
         {app.translator.trans('core.admin.settings.submit_button')}
+      </Button>
+    );
+  }
+
+  /**
+   * Returns a button that opens a confirmation modal to delete all settings
+   * tracked by this page from the database, reverting them to their PHP-side defaults.
+   *
+   * Calls can pass an explicit list of setting keys to reset; otherwise all keys
+   * currently tracked in `this.settings` are used.
+   */
+  resetButton(settings: import('./ResetExtensionSettingsModal').ResetSettingItem[] = Object.keys(this.settings).map((key) => ({ key, label: this.settingLabels[key] })), title?: string, extensionId?: string): Mithril.Children {
+    return (
+      <Button
+        className="Button Button--danger"
+        onclick={() => app.modal.show(() => import('./ResetExtensionSettingsModal'), { settings, title, extensionId })}
+      >
+        {app.translator.trans('core.admin.extension.reset_settings.button')}
       </Button>
     );
   }
@@ -195,9 +214,16 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
 
   /**
    * Returns a function that fetches the setting from the `app` global.
+   *
+   * An optional `label` can be provided to associate a human-readable label
+   * with the setting key, which is used by `resetButton()` in the reset modal.
    */
-  setting(key: string, fallback: string = ''): Stream<string> {
+  setting(key: string, fallback: string = '', label?: Mithril.Children): Stream<string> {
     this.settings[key] = this.settings[key] || Stream<string>(app.data.settings[key] || fallback);
+
+    if (label !== undefined) {
+      this.settingLabels[key] = label;
+    }
 
     return this.settings[key];
   }

--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -87,7 +87,14 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
    * Calls can pass an explicit list of setting keys to reset; otherwise all keys
    * currently tracked in `this.settings` are used.
    */
-  resetButton(settings: import('./ResetExtensionSettingsModal').ResetSettingItem[] = Object.keys(this.settings).map((key) => ({ key, label: this.settingLabels[key] })), title?: string, extensionId?: string): Mithril.Children {
+  resetButton(
+    settings: import('./ResetExtensionSettingsModal').ResetSettingItem[] = Object.keys(this.settings).map((key) => ({
+      key,
+      label: this.settingLabels[key],
+    })),
+    title?: string,
+    extensionId?: string
+  ): Mithril.Children {
     return (
       <Button
         className="Button Button--danger"

--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -184,7 +184,18 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
           {settings ? (
             <Form>
               {settings.map(this.buildSettingComponent.bind(this))}
-              <div className="Form-group Form-controls">{this.submitButton()}</div>
+              <div className="Form-group Form-controls">
+                {this.submitButton()}
+                {this.resetButton(
+                  settings
+                    .filter((e): e is Exclude<typeof e, () => Mithril.Children> => typeof e !== 'function')
+                    .map((e) => ({ key: e.setting, label: e.label })),
+                  app.translator.trans('core.admin.extension.reset_settings.title_extension', {
+                    extensionTitle: this.extension.extra['flarum-extension'].title,
+                  }, true),
+                  this.extension.id
+                )}
+              </div>
             </Form>
           ) : (
             <h3 className="ExtensionPage-subHeader">{app.translator.trans('core.admin.extension.no_settings')}</h3>

--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -190,9 +190,13 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
                   settings
                     .filter((e): e is Exclude<typeof e, () => Mithril.Children> => typeof e !== 'function')
                     .map((e) => ({ key: e.setting, label: e.label })),
-                  app.translator.trans('core.admin.extension.reset_settings.title_extension', {
-                    extensionTitle: this.extension.extra['flarum-extension'].title,
-                  }, true),
+                  app.translator.trans(
+                    'core.admin.extension.reset_settings.title_extension',
+                    {
+                      extensionTitle: this.extension.extra['flarum-extension'].title,
+                    },
+                    true
+                  ),
                   this.extension.id
                 )}
               </div>

--- a/framework/core/js/src/admin/components/ResetExtensionSettingsModal.tsx
+++ b/framework/core/js/src/admin/components/ResetExtensionSettingsModal.tsx
@@ -1,0 +1,78 @@
+import app from '../../admin/app';
+import Modal, { IInternalModalAttrs } from '../../common/components/Modal';
+import Button from '../../common/components/Button';
+import Tooltip from '../../common/components/Tooltip';
+import Alert from '../../common/components/Alert';
+import LoadingModal from './LoadingModal';
+import extractText from '../../common/utils/extractText';
+import type Mithril from 'mithril';
+
+export interface ResetSettingItem {
+  key: string;
+  label?: Mithril.Children;
+}
+
+export interface IResetExtensionSettingsModalAttrs extends IInternalModalAttrs {
+  settings: ResetSettingItem[];
+  extensionId?: string;
+  title?: string;
+}
+
+export default class ResetExtensionSettingsModal<CustomAttrs extends IResetExtensionSettingsModalAttrs = IResetExtensionSettingsModalAttrs> extends Modal<CustomAttrs> {
+  protected loading = false;
+
+  className() {
+    return 'ResetExtensionSettingsModal Modal--medium';
+  }
+
+  title() {
+    return this.attrs.title ?? app.translator.trans('core.admin.extension.reset_settings.title');
+  }
+
+  content() {
+    return (
+      <div className="Modal-body">
+        <Alert type="warning" dismissible={false}>
+          {app.translator.trans('core.admin.extension.reset_settings.warning')}
+        </Alert>
+        <ul className="ResetExtensionSettingsModal-keys">
+          {this.attrs.settings.map(({ key, label }) => (
+            <li>
+              <Tooltip text={key} position="right">
+                <span>{label ? extractText(label) : key}</span>
+              </Tooltip>
+            </li>
+          ))}
+        </ul>
+        <div className="Form-group Form-controls">
+          <Button className="Button Button--danger" loading={this.loading} onclick={this.confirm.bind(this)}>
+            {app.translator.trans('core.admin.extension.reset_settings.confirm_button')}
+          </Button>
+          <Button className="Button" onclick={() => this.hide()}>
+            {app.translator.trans('core.admin.extension.reset_settings.cancel_button')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  async confirm() {
+    this.loading = true;
+    m.redraw();
+
+    try {
+      await app.request({
+        method: 'DELETE',
+        url: app.forum.attribute('apiUrl') + '/settings',
+        body: { keys: this.attrs.settings.map(({ key }) => key), extensionId: this.attrs.extensionId ?? '' },
+      });
+
+      this.hide();
+      app.modal.show(LoadingModal);
+      window.location.reload();
+    } catch (e) {
+      this.loading = false;
+      m.redraw();
+    }
+  }
+}

--- a/framework/core/js/src/admin/components/ResetExtensionSettingsModal.tsx
+++ b/framework/core/js/src/admin/components/ResetExtensionSettingsModal.tsx
@@ -18,7 +18,9 @@ export interface IResetExtensionSettingsModalAttrs extends IInternalModalAttrs {
   title?: string;
 }
 
-export default class ResetExtensionSettingsModal<CustomAttrs extends IResetExtensionSettingsModalAttrs = IResetExtensionSettingsModalAttrs> extends Modal<CustomAttrs> {
+export default class ResetExtensionSettingsModal<
+  CustomAttrs extends IResetExtensionSettingsModalAttrs = IResetExtensionSettingsModalAttrs
+> extends Modal<CustomAttrs> {
   protected loading = false;
 
   className() {

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -14,6 +14,7 @@
 @import "admin/ExtensionPage";
 @import "admin/ExtensionWidget";
 @import "admin/InfoModal";
+@import "admin/ResetExtensionSettingsModal";
 @import "admin/AppearancePage";
 @import "admin/MailPage";
 @import "admin/NoJs";

--- a/framework/core/less/admin/ResetExtensionSettingsModal.less
+++ b/framework/core/less/admin/ResetExtensionSettingsModal.less
@@ -1,0 +1,9 @@
+.ResetExtensionSettingsModal {
+  .Alert {
+    margin-bottom: 15px;
+  }
+
+  .ResetExtensionSettingsModal-keys {
+    margin-bottom: 15px;
+  }
+}

--- a/framework/core/less/common/Tooltip.less
+++ b/framework/core/less/common/Tooltip.less
@@ -30,6 +30,7 @@
   text-decoration: none;
   background-color: var(--tooltip-bg);
   border-radius: var(--border-radius);
+  overflow-wrap: break-word;
 }
 
 // Arrows

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -335,6 +335,13 @@ core:
         no_readme: This extension does not appear to have a README file
         title: "{extName} documentation"
       replaced: Replaced
+      reset_settings:
+        button: Reset Settings
+        cancel_button: Cancel
+        confirm_button: Reset
+        warning: "This action is irreversible. The settings below will be permanently deleted from the database and revert to their defaults. This extension's data will not be affected."
+        title: Reset Settings
+        title_extension: "Reset {extensionTitle} Settings"
       safe_mode_warning: Safe mode is currently enabled. Extensions are not booted and their settings are therefore inaccessible.
 
     # These translations are used in the secondary header.

--- a/framework/core/src/Api/Controller/DeleteSettingsController.php
+++ b/framework/core/src/Api/Controller/DeleteSettingsController.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Settings\Event\Reset;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class DeleteSettingsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected SettingsRepositoryInterface $settings,
+        protected Dispatcher $dispatcher
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $actor = RequestUtil::getActor($request);
+        $actor->assertAdmin();
+
+        $body = $request->getParsedBody();
+        $keys = Arr::wrap(Arr::get($body, 'keys', []));
+        $extensionId = (string) Arr::get($body, 'extensionId', '');
+
+        foreach ($keys as $key) {
+            $this->settings->delete($key);
+        }
+
+        $this->dispatcher->dispatch(new Reset($actor, $extensionId, $keys));
+
+        return new EmptyResponse(204);
+    }
+}

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -127,6 +127,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\SetSettingsController::class)
     );
 
+    // Delete settings (reset to defaults)
+    $map->delete(
+        '/settings',
+        'settings.delete',
+        $route->toController(Controller\DeleteSettingsController::class)
+    );
+
     // Update a permission
     $map->post(
         '/permission',

--- a/framework/core/src/Settings/Event/Reset.php
+++ b/framework/core/src/Settings/Event/Reset.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Settings\Event;
+
+use Flarum\User\User;
+
+class Reset
+{
+    /**
+     * @param User $actor The admin user who triggered the reset.
+     * @param string $extensionId The extension ID whose settings were reset (e.g. 'flarum-tags').
+     * @param string[] $keys The setting keys that were deleted.
+     */
+    public function __construct(
+        public readonly User $actor,
+        public readonly string $extensionId,
+        public readonly array $keys
+    ) {
+    }
+}

--- a/framework/core/tests/integration/api/settings/DeleteTest.php
+++ b/framework/core/tests/integration/api/settings/DeleteTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\settings;
+
+use Flarum\Settings\Event\Reset;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+class DeleteTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            'settings' => [
+                ['key' => 'foo', 'value' => 'bar'],
+                ['key' => 'baz', 'value' => 'qux'],
+                ['key' => 'keep_me', 'value' => 'untouched'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function guest_cannot_delete_settings()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'json' => ['keys' => ['foo']],
+            ])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function user_cannot_delete_settings()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 2,
+                'json' => ['keys' => ['foo']],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+
+        $this->assertEquals('bar', $this->database()->table('settings')->where('key', 'foo')->value('value'));
+    }
+
+    #[Test]
+    public function admin_can_delete_a_setting()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => ['foo']],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertNull($this->database()->table('settings')->where('key', 'foo')->value('value'));
+    }
+
+    #[Test]
+    public function admin_can_delete_multiple_settings()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => ['foo', 'baz']],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertNull($this->database()->table('settings')->where('key', 'foo')->value('value'));
+        $this->assertNull($this->database()->table('settings')->where('key', 'baz')->value('value'));
+    }
+
+    #[Test]
+    public function deleting_settings_does_not_affect_other_settings()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => ['foo']],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertEquals('untouched', $this->database()->table('settings')->where('key', 'keep_me')->value('value'));
+    }
+
+    #[Test]
+    public function deleting_a_nonexistent_setting_is_successful()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => ['does_not_exist']],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function deleting_with_empty_keys_is_successful()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => []],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function settings_reset_event_is_dispatched_with_extension_id_and_keys()
+    {
+        /** @var Reset|null $firedEvent */
+        $firedEvent = null;
+
+        $this->app()->getContainer()->make(Dispatcher::class)->listen(Reset::class, function (Reset $event) use (&$firedEvent) {
+            $firedEvent = $event;
+        });
+
+        $this->send(
+            $this->request('DELETE', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['keys' => ['foo', 'baz'], 'extensionId' => 'acme-test'],
+            ])
+        );
+
+        $this->assertNotNull($firedEvent);
+        $this->assertEquals(1, $firedEvent->actor->id);
+        $this->assertEquals('acme-test', $firedEvent->extensionId);
+        $this->assertEquals(['foo', 'baz'], $firedEvent->keys);
+    }
+}

--- a/js-packages/prettier-config/README.md
+++ b/js-packages/prettier-config/README.md
@@ -20,7 +20,7 @@ yarn add -D @flarum/prettier-config
 {
   "name": "my-cool-package",
   "version": "1.0.0",
-  "prettier": "@flarum/prettier-config"
+  "prettier": "@flarum/prettier-config",
   // ...
 }
 ```

--- a/js-packages/prettier-config/package.json
+++ b/js-packages/prettier-config/package.json
@@ -1,35 +1,35 @@
 {
-    "name": "@flarum/prettier-config",
-    "version": "1.0.0",
-    "description": "Flarum's configuration for the Prettier code formatter.",
-    "main": "prettierrc.json",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "dev": "echo 'skipping..'",
-        "build": "echo 'skipping..'",
-        "analyze": "echo 'skipping..'",
-        "format": "prettier --write .",
-        "format-check": "prettier --check .",
-        "clean-typings": "echo 'skipping..'",
-        "build-typings": "echo 'skipping..'",
-        "post-build-typings": "echo 'skipping..'",
-        "check-typings": "echo 'skipping..'",
-        "check-typings-coverage": "echo 'skipping..'"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/flarum/prettier-config.git"
-    },
-    "keywords": [
-        "flarum"
-    ],
-    "author": "Flarum Team",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/flarum/prettier-config/issues"
-    },
-    "homepage": "https://github.com/flarum/prettier-config#readme",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@flarum/prettier-config",
+  "version": "1.0.0",
+  "description": "Flarum's configuration for the Prettier code formatter.",
+  "main": "prettierrc.json",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "echo 'skipping..'",
+    "build": "echo 'skipping..'",
+    "analyze": "echo 'skipping..'",
+    "format": "prettier --write .",
+    "format-check": "prettier --check .",
+    "clean-typings": "echo 'skipping..'",
+    "build-typings": "echo 'skipping..'",
+    "post-build-typings": "echo 'skipping..'",
+    "check-typings": "echo 'skipping..'",
+    "check-typings-coverage": "echo 'skipping..'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/flarum/prettier-config.git"
+  },
+  "keywords": [
+    "flarum"
+  ],
+  "author": "Flarum Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/flarum/prettier-config/issues"
+  },
+  "homepage": "https://github.com/flarum/prettier-config#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js-packages/tsconfig/README.md
+++ b/js-packages/tsconfig/README.md
@@ -27,9 +27,9 @@ A baseline `tsconfig.json` is provided below that you can modify as needed. This
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
     "paths": {
-      "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"]
-    }
-  }
+      "flarum/*": ["../vendor/flarum/core/js/dist-typings/*"],
+    },
+  },
 }
 ```
 

--- a/js-packages/tsconfig/package.json
+++ b/js-packages/tsconfig/package.json
@@ -1,27 +1,27 @@
 {
-    "name": "flarum-tsconfig",
-    "version": "2.0.0",
-    "description": "Flarum's official Typescript config file",
-    "main": "tsconfig.json",
-    "repository": "https://github.com/flarum/flarum-tsconfig",
-    "author": "Flarum Team",
-    "license": "MIT",
-    "dependencies": {
-        "@types/jquery": "^3.5.5",
-        "@types/mithril": "^2.0.7",
-        "@types/throttle-debounce": "^2.1.0",
-        "dayjs": "^1.10.4"
-    },
-    "scripts": {
-        "dev": "echo 'skipping..'",
-        "build": "echo 'skipping..'",
-        "analyze": "echo 'skipping..'",
-        "format": "prettier --write .",
-        "format-check": "prettier --check .",
-        "clean-typings": "echo 'skipping..'",
-        "build-typings": "echo 'skipping..'",
-        "post-build-typings": "echo 'skipping..'",
-        "check-typings": "echo 'skipping..'",
-        "check-typings-coverage": "echo 'skipping..'"
-    }
+  "name": "flarum-tsconfig",
+  "version": "2.0.0",
+  "description": "Flarum's official Typescript config file",
+  "main": "tsconfig.json",
+  "repository": "https://github.com/flarum/flarum-tsconfig",
+  "author": "Flarum Team",
+  "license": "MIT",
+  "dependencies": {
+    "@types/jquery": "^3.5.5",
+    "@types/mithril": "^2.0.7",
+    "@types/throttle-debounce": "^2.1.0",
+    "dayjs": "^1.10.4"
+  },
+  "scripts": {
+    "dev": "echo 'skipping..'",
+    "build": "echo 'skipping..'",
+    "analyze": "echo 'skipping..'",
+    "format": "prettier --write .",
+    "format-check": "prettier --check .",
+    "clean-typings": "echo 'skipping..'",
+    "build-typings": "echo 'skipping..'",
+    "post-build-typings": "echo 'skipping..'",
+    "check-typings": "echo 'skipping..'",
+    "check-typings-coverage": "echo 'skipping..'"
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a **Reset Settings** button alongside the Save button on extension admin pages
- Clicking opens a confirmation modal listing the settings to be deleted (with human-readable labels and raw-key tooltips)
- A `DELETE /api/settings` endpoint handles deletion and dispatches a `Flarum\Settings\Event\Reset` event with `$actor`, `$extensionId`, and `$keys`
- `AdminPage::resetButton()` is available for custom page authors to call manually
- Tags extension integrated as a real-world example
- Integration tests added for `DeleteSettingsController`

Docs: https://github.com/flarum/docs/pull/521