### PR TITLE
[2.x] [Tags] Drop legacy unused background columns from tags table

### DIFF
--- a/extensions/tags/js/src/common/models/Tag.ts
+++ b/extensions/tags/js/src/common/models/Tag.ts
@@ -16,12 +16,6 @@ export default class Tag extends Model {
   color() {
     return Model.attribute<string | null>('color').call(this);
   }
-  backgroundUrl() {
-    return Model.attribute<string | null>('backgroundUrl').call(this);
-  }
-  backgroundMode() {
-    return Model.attribute<string | null>('backgroundMode').call(this);
-  }
   icon() {
     return Model.attribute<string | null>('icon').call(this);
   }

--- a/extensions/tags/migrations/2026_04_07_000000_drop_legacy_background_columns_from_tags.php
+++ b/extensions/tags/migrations/2026_04_07_000000_drop_legacy_background_columns_from_tags.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        if (! $schema->hasTable('tags')) {
+            return;
+        }
+
+        if ($schema->hasColumn('tags', 'background_path')) {
+            $schema->table('tags', function (Blueprint $table) {
+                $table->dropColumn('background_path');
+            });
+        }
+
+        if ($schema->hasColumn('tags', 'background_mode')) {
+            $schema->table('tags', function (Blueprint $table) {
+                $table->dropColumn('background_mode');
+            });
+        }
+    },
+    'down' => function (Builder $schema) {
+        if (! $schema->hasTable('tags')) {
+            return;
+        }
+
+        if (! $schema->hasColumn('tags', 'background_path')) {
+            $schema->table('tags', function (Blueprint $table) {
+                $table->string('background_path', 100)->nullable()->after('color');
+            });
+        }
+
+        if (! $schema->hasColumn('tags', 'background_mode')) {
+            $afterColumn = $schema->hasColumn('tags', 'background_path') ? 'background_path' : 'color';
+
+            $schema->table('tags', function (Blueprint $table) use ($afterColumn) {
+                $table->string('background_mode', 100)->nullable()->after($afterColumn);
+            });
+        }
+    }
+];

--- a/extensions/tags/migrations/2026_04_07_000000_drop_legacy_background_columns_from_tags.php
+++ b/extensions/tags/migrations/2026_04_07_000000_drop_legacy_background_columns_from_tags.php
@@ -7,44 +7,9 @@
  * LICENSE file that was distributed with this source code.
  */
 
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Schema\Builder;
+use Flarum\Database\Migration;
 
-return [
-    'up' => function (Builder $schema) {
-        if (! $schema->hasTable('tags')) {
-            return;
-        }
-
-        if ($schema->hasColumn('tags', 'background_path')) {
-            $schema->table('tags', function (Blueprint $table) {
-                $table->dropColumn('background_path');
-            });
-        }
-
-        if ($schema->hasColumn('tags', 'background_mode')) {
-            $schema->table('tags', function (Blueprint $table) {
-                $table->dropColumn('background_mode');
-            });
-        }
-    },
-    'down' => function (Builder $schema) {
-        if (! $schema->hasTable('tags')) {
-            return;
-        }
-
-        if (! $schema->hasColumn('tags', 'background_path')) {
-            $schema->table('tags', function (Blueprint $table) {
-                $table->string('background_path', 100)->nullable()->after('color');
-            });
-        }
-
-        if (! $schema->hasColumn('tags', 'background_mode')) {
-            $afterColumn = $schema->hasColumn('tags', 'background_path') ? 'background_path' : 'color';
-
-            $schema->table('tags', function (Blueprint $table) use ($afterColumn) {
-                $table->string('background_mode', 100)->nullable()->after($afterColumn);
-            });
-        }
-    }
-];
+return Migration::dropColumns('tags', [
+    'background_path' => ['string', 'length' => 100, 'nullable' => true],
+    'background_mode' => ['string', 'length' => 100, 'nullable' => true],
+]);

--- a/extensions/tags/src/Api/Resource/TagResource.php
+++ b/extensions/tags/src/Api/Resource/TagResource.php
@@ -112,10 +112,6 @@ class TagResource extends AbstractDatabaseResource
             Schema\Boolean::make('isRestricted')
                 ->writableOnUpdate()
                 ->visible(fn (Tag $tag, FlarumContext $context) => $context->getActor()->isAdmin()),
-            Schema\Str::make('backgroundUrl')
-                ->get(fn (Tag $tag) => $tag->getAttribute('background_path')),
-            Schema\Str::make('backgroundMode')
-                ->get(fn (Tag $tag) => $tag->getAttribute('background_mode')),
             Schema\Integer::make('discussionCount'),
             Schema\Integer::make('position')
                 ->nullable(),

--- a/extensions/tags/src/Api/Resource/TagResource.php
+++ b/extensions/tags/src/Api/Resource/TagResource.php
@@ -113,8 +113,9 @@ class TagResource extends AbstractDatabaseResource
                 ->writableOnUpdate()
                 ->visible(fn (Tag $tag, FlarumContext $context) => $context->getActor()->isAdmin()),
             Schema\Str::make('backgroundUrl')
-                ->get(fn (Tag $tag) => $tag->background_path),
-            Schema\Str::make('backgroundMode'),
+                ->get(fn (Tag $tag) => $tag->getAttribute('background_path')),
+            Schema\Str::make('backgroundMode')
+                ->get(fn (Tag $tag) => $tag->getAttribute('background_mode')),
             Schema\Integer::make('discussionCount'),
             Schema\Integer::make('position')
                 ->nullable(),

--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -28,8 +28,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property string $slug
  * @property string $description
  * @property string $color
- * @property string $background_path
- * @property string $background_mode
  * @property bool $is_primary
  * @property int $position
  * @property int $parent_id

--- a/extensions/tags/src/TagFactory.php
+++ b/extensions/tags/src/TagFactory.php
@@ -21,8 +21,6 @@ class TagFactory extends Factory
             'slug' => $this->faker->slug,
             'description' => $this->faker->sentence,
             'color' => $this->faker->hexColor,
-            'background_path' => null,
-            'background_mode' => null,
             'position' => 0,
             'parent_id' => null,
             'default_sort' => null,

--- a/extensions/tags/tests/integration/api/tags/SchemaTest.php
+++ b/extensions/tags/tests/integration/api/tags/SchemaTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\api\tags;
+
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Database\Schema\Builder;
+use PHPUnit\Framework\Attributes\Test;
+
+class SchemaTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+    }
+
+    #[Test]
+    public function legacy_background_columns_are_not_present_on_tags_table()
+    {
+        $schema = $this->app()->getContainer()->make(Builder::class);
+
+        $this->assertFalse($schema->hasColumn('tags', 'background_path'));
+        $this->assertFalse($schema->hasColumn('tags', 'background_mode'));
+    }
+}


### PR DESCRIPTION
## Summary
This PR removes two legacy columns from the `tags` table that are no longer used by current tags flows:
- `background_path`
- `background_mode`

Fixes #4527.

## What changed
- Added migration using `Migration::dropColumns()` to remove both legacy columns.
- Removed `backgroundUrl` and `backgroundMode` from the tags API resource.
- Removed stale background accessors from the frontend `Tag` model.
- Removed stale references from the tag factory and model docblocks.
- Added an integration schema test asserting those columns are absent after migrations.

## Backward compatibility
- This is an intentional clean break for 2.x pre-stable, aligned with review feedback.
- Existing data in removed columns is dropped as part of schema cleanup.

## Scope note
An unrelated local change in `extensions/tags/js/tsconfig.json` was intentionally excluded from this PR to keep the fix focused.

## Testing
- Added: `extensions/tags/tests/integration/api/tags/SchemaTest.php`
- Local test execution in this environment is blocked because `phpunit` is not available (`sh: 1: phpunit: not found`).
