### PR TITLE
fix: attribute fields bypassed serializeValue in Flarum Serializer

### DIFF
--- a/framework/core/src/Api/Schema/Attribute.php
+++ b/framework/core/src/Api/Schema/Attribute.php
@@ -10,9 +10,19 @@
 namespace Flarum\Api\Schema;
 
 use Flarum\Api\Schema\Concerns\FlarumField;
+use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Schema\Field\Attribute as BaseAttribute;
 
 class Attribute extends BaseAttribute
 {
     use FlarumField;
+
+    public function serializeValue(mixed $value, Context $context): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return parent::serializeValue($value, $context);
+    }
 }

--- a/framework/core/src/Api/Schema/Type/Arr.php
+++ b/framework/core/src/Api/Schema/Type/Arr.php
@@ -20,6 +20,10 @@ class Arr implements Type
 
     public function serialize(mixed $value): array
     {
+        if ($value instanceof \JsonSerializable) {
+            return (array) $value->jsonSerialize();
+        }
+
         return (array) $value;
     }
 

--- a/framework/core/src/Api/Serializer.php
+++ b/framework/core/src/Api/Serializer.php
@@ -93,8 +93,8 @@ class Serializer extends \Tobyz\JsonApiServer\Serializer
 
             $this->whenResolved($value, function (mixed $value) use ($key, $field, $context) {
                 if (
-                    ! $field instanceof Relationship ||
-                    ($value = $field->serializeValue($value, $context))
+                    ($value = $field->serializeValue($value, $context)) ||
+                    ! $field instanceof Relationship
                 ) {
                     set_value($this->map[$key], $field, $value);
                 }

--- a/framework/core/tests/integration/api/forum/ShowTest.php
+++ b/framework/core/tests/integration/api/forum/ShowTest.php
@@ -88,4 +88,21 @@ class ShowTest extends TestCase
         $this->assertEquals('http://localhost/api', Arr::get($json, 'data.attributes.apiUrl'));
         $this->assertEquals('http://localhost/admin', Arr::get($json, 'data.attributes.adminUrl'));
     }
+
+    #[Test]
+    public function allow_sign_up_is_serialized_as_boolean()
+    {
+        /** @var \Flarum\Settings\SettingsRepositoryInterface $settings */
+        $settings = $this->app()->getContainer()->make(\Flarum\Settings\SettingsRepositoryInterface::class);
+
+        $settings->set('allow_sign_up', '1');
+
+        $json = json_decode($this->send($this->request('GET', '/api'))->getBody()->getContents(), true);
+        $this->assertSame(true, Arr::get($json, 'data.attributes.allowSignUp'));
+
+        $settings->set('allow_sign_up', '0');
+
+        $json = json_decode($this->send($this->request('GET', '/api'))->getBody()->getContents(), true);
+        $this->assertSame(false, Arr::get($json, 'data.attributes.allowSignUp'));
+    }
 }


### PR DESCRIPTION
The condition in `Flarum\Api\Serializer::addToMap` was inverted — it only called `serializeValue` for `Relationship` fields, skipping it for `Attribute` fields entirely. Raw values from the getter (e.g. the string `'0'` from the settings repository) were written directly to the output, causing boolean fields like `allowSignUp` to be serialized as strings instead of booleans.

In JavaScript, `'0'` is truthy, so `app.forum.attribute('allowSignUp')` returned `'0'` even when sign-up was closed, keeping the sign-up button visible.

Also fixes `Flarum\Api\Schema\Type\Arr::serialize()` to respect `JsonSerializable` objects (e.g. `MessageBag`) rather than casting with `(array)`, which bypasses `JsonSerializable` and produces mangled property keys.

Closes #4528