### PR TITLE
fix: improve StatusWidget mobile layout on admin dashboard

### DIFF
--- a/framework/core/less/admin/DashboardPage.less
+++ b/framework/core/less/admin/DashboardPage.less
@@ -43,6 +43,35 @@
       }
     }
   }
+
+  @media @phone {
+    > ul {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px 0;
+
+      > li {
+        flex: 0 0 50%;
+        margin-right: 0;
+        vertical-align: unset;
+
+        &[class^="item-version-"] {
+          max-width: none;
+        }
+
+        &.item-tools {
+          float: none;
+          flex: 0 0 100%;
+          display: flex;
+          justify-content: flex-end;
+
+          .Dropdown-toggle .Button-label {
+            display: none;
+          }
+        }
+      }
+    }
+  }
 }
 
 .StatusWidgetItem {


### PR DESCRIPTION
Fixes #4525.

On mobile, the admin dashboard StatusWidget items were rendering as `inline-block` with the tools dropdown `float: right`, causing it to escape normal flow and stack incorrectly.

At the `@phone` breakpoint:
- Switch the list to a flex row that wraps into a 2-column grid
- Remove the float on the tools button; make it full-width and right-aligned
- Hide the "Tools" label text — the cog icon alone is sufficient on mobile