### PR TITLE
fix: use value comparison in PaginatedListState::paramsChanged() for object params

### DIFF
--- a/framework/core/js/src/common/states/PaginatedListState.ts
+++ b/framework/core/js/src/common/states/PaginatedListState.ts
@@ -320,7 +320,18 @@ export default abstract class PaginatedListState<T extends Model, P extends Pagi
   }
 
   protected paramsChanged(newParams: P): boolean {
-    return Object.keys(newParams).some((key) => this.getParams()[key] !== newParams[key]);
+    return Object.keys(newParams).some((key) => {
+      const oldVal = this.getParams()[key];
+      const newVal = newParams[key];
+
+      if (oldVal === newVal) return false;
+
+      if (typeof oldVal === 'object' && oldVal !== null && typeof newVal === 'object' && newVal !== null) {
+        return JSON.stringify(oldVal) !== JSON.stringify(newVal);
+      }
+
+      return true;
+    });
   }
 
   protected getAllItems(): T[] {

--- a/framework/core/js/tests/unit/common/states/PaginatedListState.test.ts
+++ b/framework/core/js/tests/unit/common/states/PaginatedListState.test.ts
@@ -1,0 +1,85 @@
+import PaginatedListState, { PaginatedListParams } from '../../../../src/common/states/PaginatedListState';
+import Model from '../../../../src/common/Model';
+
+interface TestParams extends PaginatedListParams {
+  sort?: string;
+  filter?: Record<string, string>;
+}
+
+class TestState extends PaginatedListState<Model, TestParams> {
+  get type() {
+    return 'test';
+  }
+
+  requestParams() {
+    return {};
+  }
+
+  // Expose for spying
+  public refreshCount = 0;
+
+  public refresh(page = 1): Promise<void> {
+    this.refreshCount++;
+    // Simulate a loaded page with items so isEmpty() returns false after first refresh
+    this.pages = [{ number: page, items: [{}] as any }];
+    this.initialLoading = false;
+    return Promise.resolve();
+  }
+}
+
+describe('PaginatedListState', () => {
+  describe('paramsChanged', () => {
+    test('does not reload when called again with semantically identical primitive params', async () => {
+      const state = new TestState({ sort: 'latest' });
+
+      await state.refreshParams({ sort: 'latest' }, 1);
+      expect(state.refreshCount).toBe(1);
+
+      await state.refreshParams({ sort: 'latest' }, 1);
+      expect(state.refreshCount).toBe(1);
+    });
+
+    test('reloads when primitive param value changes', async () => {
+      const state = new TestState({ sort: 'latest' });
+
+      await state.refreshParams({ sort: 'latest' }, 1);
+      expect(state.refreshCount).toBe(1);
+
+      await state.refreshParams({ sort: 'oldest' }, 1);
+      expect(state.refreshCount).toBe(2);
+    });
+
+    test('does not reload when called again with semantically identical object params', async () => {
+      // This is the bug: filter is a new {} on every call (from stickyParams), so
+      // paramsChanged() sees {} !== {} and triggers a reload every time.
+      const state = new TestState({ filter: {} });
+
+      await state.refreshParams({ filter: {} }, 1);
+      expect(state.refreshCount).toBe(1);
+
+      // Second call with a new {} object — same value, different reference
+      await state.refreshParams({ filter: {} }, 1);
+      expect(state.refreshCount).toBe(1); // fails before fix: refreshCount is 2
+    });
+
+    test('does not reload when called again with semantically identical non-empty filter', async () => {
+      const state = new TestState({ filter: { tag: 'foo' } });
+
+      await state.refreshParams({ filter: { tag: 'foo' } }, 1);
+      expect(state.refreshCount).toBe(1);
+
+      await state.refreshParams({ filter: { tag: 'foo' } }, 1);
+      expect(state.refreshCount).toBe(1); // fails before fix
+    });
+
+    test('reloads when filter value changes', async () => {
+      const state = new TestState({ filter: { tag: 'foo' } });
+
+      await state.refreshParams({ filter: { tag: 'foo' } }, 1);
+      expect(state.refreshCount).toBe(1);
+
+      await state.refreshParams({ filter: { tag: 'bar' } }, 1);
+      expect(state.refreshCount).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4526.

`paramsChanged()` used strict reference equality (`!==`) to compare params. In Flarum 2.x, `GlobalSearchState.stickyParams()` always creates a new `filter` object via `Object.assign({}, m.route.param('filter'))`, so `{} !== {}` was always `true` — causing `refreshParams()` to call `refresh()` on every back-navigation, clearing all loaded pages and scroll position.

The fix uses `JSON.stringify` for deep value comparison when both sides are objects, matching the same pattern already used in route-param cache keys throughout the codebase (see `DefaultResolver`, `UserPageResolver`, `DiscussionPageResolver`).