### PR TITLE
fix: show avatar and badges in reply placeholder composing state on mobile

### DIFF
--- a/framework/core/js/src/forum/components/ReplyPlaceholder.tsx
+++ b/framework/core/js/src/forum/components/ReplyPlaceholder.tsx
@@ -30,12 +30,12 @@ export default class ReplyPlaceholder<CustomAttrs extends IReplyPlaceholderAttrs
           <div className="Post-container">
             <div className="Post-side">
               <Avatar user={app.session.user} className="Post-avatar" />
+              <ul className="PostUser-badges badges badges--packed">{listItems(app.session.user!.badges().toArray())}</ul>
             </div>
             <div className="Post-main">
               <header className="Post-header">
                 <div className="PostUser">
                   <h3 className="PostUser-name">{username(app.session.user)}</h3>
-                  <ul className="PostUser-badges badges badges--packed">{listItems(app.session.user!.badges().toArray())}</ul>
                 </div>
               </header>
               <div className="Post-body">

--- a/framework/core/less/forum/Post.less
+++ b/framework/core/less/forum/Post.less
@@ -386,6 +386,26 @@
       margin-left: -13px;
     }
   }
+  .CommentPost.editing {
+    .Post-side {
+      position: relative;
+      width: 32px;
+      .Post-avatar {
+        display: block;
+        .Avatar--size(32px);
+      }
+    }
+    .Post-container {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 10px;
+    }
+    .Post-side .PostUser-badges {
+      top: -4px;
+      left: 6px;
+      width: 32px;
+    }
+  }
   .EventPost {
     padding-left: 50px;
   }


### PR DESCRIPTION
Fixes #4513.

On mobile, the `.Post-side .Post-avatar` is hidden globally. The composing state of `ReplyPlaceholder` (rendered as `article.CommentPost.editing`) only places the avatar in `Post-side`, so it was invisible on mobile.

- Un-hide the avatar in `Post-side` for `.CommentPost.editing` on mobile
- Add `display: grid` to `Post-container` so side/main render side by side
- Move badges into `Post-side` in `ReplyPlaceholder.tsx` and position them to overlap the avatar, matching the regular post appearance