### PR TITLE
fix: preserve array values in Attribute::serializeValue

### DIFF
--- a/framework/core/src/Api/Schema/Attribute.php
+++ b/framework/core/src/Api/Schema/Attribute.php
@@ -19,8 +19,8 @@ class Attribute extends BaseAttribute
 
     public function serializeValue(mixed $value, Context $context): mixed
     {
-        if ($value === null) {
-            return null;
+        if ($value === null || is_array($value)) {
+            return $value;
         }
 
         return parent::serializeValue($value, $context);


### PR DESCRIPTION
Regression fix for #4530.

After #4530 began correctly calling `serializeValue` for attribute fields, extensions that register forum attributes typed as `Str` but whose getters return arrays started throwing `Array to string conversion` errors in `Str::serialize()`.

Pass array values through without type serialization, restoring the previous behaviour for extensions with mismatched field types while keeping the boolean/string fix intact.