### PR TITLE
[1.x] fix(tags): exclude bypassTagCounts from DiscussionPolicy catch-all

### DIFF
--- a/extensions/tags/src/Access/DiscussionPolicy.php
+++ b/extensions/tags/src/Access/DiscussionPolicy.php
@@ -38,6 +38,13 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function can(User $actor, $ability, Discussion $discussion)
     {
+        // Meta-permissions that govern tag validation logic (not tag-scoped
+        // access) must not be intercepted by this catch-all. They have no
+        // per-tag variant and will always deny for non-admins if left in.
+        if ($ability === 'bypassTagCounts') {
+            return;
+        }
+
         // Wrap all discussion permission checks with some logic pertaining to
         // the discussion's tags. If the discussion has a tag that has been
         // restricted, the user must have the permission for that tag.

--- a/extensions/tags/tests/integration/api/discussions/CreateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/CreateTest.php
@@ -325,5 +325,4 @@ class CreateTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode());
     }
-
 }

--- a/extensions/tags/tests/integration/api/discussions/CreateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/CreateTest.php
@@ -325,4 +325,5 @@ class CreateTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode());
     }
+
 }

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -298,4 +298,51 @@ class UpdateTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode());
     }
+
+    /**
+     * @test
+     * Non-admin with bypassTagCounts cannot exceed the primary tag limit when
+     * the discussion is in a restricted tag. The DiscussionPolicy catch-all
+     * must not intercept the bypassTagCounts meta-permission check.
+     */
+    public function user_with_bypass_permission_can_exceed_primary_tag_limit_in_restricted_tag()
+    {
+        $this->setting('allow_tag_change', '-1');
+
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'bypassTagCounts'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.viewForum'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.startDiscussion'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.discussion.tag'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.viewForum'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.startDiscussion'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.discussion.tag'],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 6],
+            ],
+        ]);
+
+        // max_primary_tags defaults to 1; the user sets 2 restricted primary tags
+        $response = $this->send(
+            $this->request('PATCH', '/api/discussions/1', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'relationships' => [
+                            'tags' => [
+                                'data' => [
+                                    ['type' => 'tags', 'id' => 6],
+                                    ['type' => 'tags', 'id' => 12],
+                                ]
+                            ]
+                        ]
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Fixes #4537

The catch-all `can()` method in `DiscussionPolicy` intercepted every discussion ability and checked for a per-tag variant (e.g. `tag6.discussion.bypassTagCounts`) that never exists. This caused `bypassTagCounts` to always deny non-admin users when the discussion was in a restricted tag.

The fix returns early from the catch-all when `$ability === 'bypassTagCounts'`, letting the normal global permission check handle it instead.