### PR TITLE
[2.x] fix(tags): use hasPermission for bypassTagCounts to avoid restricted-tag policy interference

### DIFF
--- a/extensions/tags/src/Api/DiscussionResourceFields.php
+++ b/extensions/tags/src/Api/DiscussionResourceFields.php
@@ -37,7 +37,7 @@ class DiscussionResourceFields
             Schema\Relationship\ToMany::make('tags')
                 ->includable()
                 ->writable()
-                ->required(fn (Context $context, Discussion $discussion) => $context->creating() && ! $context->getActor()->can('bypassTagCounts', $discussion))
+                ->required(fn (Context $context, Discussion $discussion) => $context->creating() && ! $context->getActor()->hasPermission('bypassTagCounts'))
                 ->set(function (Discussion $discussion, array $newTags, Context $context) {
                     $actor = $context->getActor();
 
@@ -83,7 +83,7 @@ class DiscussionResourceFields
                         throw new PermissionDeniedException;
                     }
 
-                    if (! $actor->can('bypassTagCounts', $discussion)) {
+                    if (! $actor->hasPermission('bypassTagCounts')) {
                         $this->validateTagCount('primary', $primaryParentCount);
                         $this->validateTagCount('secondary', $secondaryOrPrimaryChildCount);
                     }

--- a/extensions/tags/tests/integration/api/discussions/UpdateTest.php
+++ b/extensions/tags/tests/integration/api/discussions/UpdateTest.php
@@ -287,4 +287,46 @@ class UpdateTest extends TestCase
 
         $this->assertEquals(422, $response->getStatusCode());
     }
+
+    #[Test]
+    public function user_with_bypass_permission_can_exceed_primary_tag_limit_in_restricted_tag()
+    {
+        $this->setting('allow_tag_change', '-1');
+
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'bypassTagCounts'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.viewForum'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.startDiscussion'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag6.discussion.tag'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.viewForum'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.startDiscussion'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'tag12.discussion.tag'],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 6],
+            ],
+        ]);
+
+        // max_primary_tags defaults to 1; the user sets 2 restricted primary tags
+        $response = $this->send(
+            $this->request('PATCH', '/api/discussions/1', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'relationships' => [
+                            'tags' => [
+                                'data' => [
+                                    ['type' => 'tags', 'id' => 6],
+                                    ['type' => 'tags', 'id' => 12],
+                                ]
+                            ]
+                        ]
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
## Problem

Non-admin users granted the `bypassTagCounts` permission could not exceed tag count limits when a discussion was in a restricted tag.

`bypassTagCounts` is a global permission, not a discussion-scoped ability. Both uses in `DiscussionResourceFields` were calling `$actor->can('bypassTagCounts', $discussion)`, which routes through `DiscussionPolicy::can()`. That catch-all checks for a per-tag variant (`tag{id}.discussion.bypassTagCounts`) on every restricted tag — a permission that doesn't exist. Non-admin users always failed the check, while admins bypassed it via the short-circuit in the permission system.

## Fix

Replace both calls with `$actor->hasPermission('bypassTagCounts')`, which evaluates the global permission directly and skips the discussion policy chain entirely.

Fixes #4538