### PR TITLE
[1.x] feat: add 'forum-widget' extension category

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -51,6 +51,7 @@ export default class AdminApplication extends Application {
   extensionCategories = {
     feature: 30,
     theme: 20,
+    'forum-widget': 15,
     language: 10,
   };
 

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -215,6 +215,7 @@ core:
         discussion: Discussion
         feature: Features
         formatting: Formatting
+        forum-widget: Forum Widgets
         language: Languages
         moderation: Moderation
         other: Other Extensions


### PR DESCRIPTION
Adds a new `forum-widget` extension category, ordered between `theme` (20) and `language` (10) with a weight of 15.