### PR TITLE
[3.x] Migrate to Intervention Image v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
         "illuminate/support": "^13.0",
         "illuminate/validation": "^13.0",
         "illuminate/view": "^13.0",
-        "intervention/image": "^3.2",
+        "intervention/image": "^4.0",
         "jenssegers/agent": "^2.6",
         "laminas/laminas-diactoros": "^3.0",
         "laminas/laminas-httphandlerrunner": "^2.6",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -60,7 +60,7 @@
         "illuminate/support": "^13.0",
         "illuminate/validation": "^13.0",
         "illuminate/view": "^13.0",
-        "intervention/image": "^3.2",
+        "intervention/image": "^4.0",
         "jenssegers/agent": "^2.6.4",
         "laminas/laminas-diactoros": "^3.0",
         "laminas/laminas-httphandlerrunner": "^2.6.1",

--- a/framework/core/src/Api/Controller/UploadFaviconController.php
+++ b/framework/core/src/Api/Controller/UploadFaviconController.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Api\Controller;
 
+use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -26,9 +27,9 @@ class UploadFaviconController extends UploadImageController
             return $file->getStream();
         }
 
-        $encodedImage = $this->imageManager->read($file->getStream()->getMetadata('uri'))
+        $encodedImage = $this->imageManager->decode($file->getStream()->getMetadata('uri'))
             ->scale(64, 64)
-            ->toPng();
+            ->encodeUsingFormat(Format::PNG);
 
         $this->fileExtension = 'png';
 

--- a/framework/core/src/Api/Controller/UploadFaviconController.php
+++ b/framework/core/src/Api/Controller/UploadFaviconController.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Api\Controller;
 
-use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -27,11 +26,11 @@ class UploadFaviconController extends UploadImageController
             return $file->getStream();
         }
 
+        $this->fileExtension = 'png';
+
         $encodedImage = $this->imageManager->decode($file->getStream()->getMetadata('uri'))
             ->scale(64, 64)
-            ->encodeUsingFormat(Format::PNG);
-
-        $this->fileExtension = 'png';
+            ->encodeUsingFileExtension($this->fileExtension);
 
         return $encodedImage;
     }

--- a/framework/core/src/Api/Controller/UploadLogoController.php
+++ b/framework/core/src/Api/Controller/UploadLogoController.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Api\Controller;
 
+use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -21,18 +22,18 @@ class UploadLogoController extends UploadImageController
 
     protected function makeImage(UploadedFileInterface $file): EncodedImageInterface
     {
-        $image = $this->imageManager->read($file->getStream()->getMetadata('uri'))
+        $image = $this->imageManager->decode($file->getStream()->getMetadata('uri'))
             ->scale(height: 60);
 
         if ($image->isAnimated()) {
             $this->resolvedExtension = 'gif';
 
-            return $image->toGif();
+            return $image->encodeUsingFormat(Format::GIF);
         }
 
         $this->resolvedExtension = 'webp';
 
-        return $image->toWebp();
+        return $image->encodeUsingFormat(Format::WEBP);
     }
 
     protected function fileExtension(ServerRequestInterface $request, UploadedFileInterface $file): string

--- a/framework/core/src/Api/Controller/UploadLogoController.php
+++ b/framework/core/src/Api/Controller/UploadLogoController.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Api\Controller;
 
-use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -25,15 +24,9 @@ class UploadLogoController extends UploadImageController
         $image = $this->imageManager->decode($file->getStream()->getMetadata('uri'))
             ->scale(height: 60);
 
-        if ($image->isAnimated()) {
-            $this->resolvedExtension = 'gif';
+        $this->resolvedExtension = $image->isAnimated() ? 'gif' : 'webp';
 
-            return $image->encodeUsingFormat(Format::GIF);
-        }
-
-        $this->resolvedExtension = 'webp';
-
-        return $image->encodeUsingFormat(Format::WEBP);
+        return $image->encodeUsingFileExtension($this->resolvedExtension);
     }
 
     protected function fileExtension(ServerRequestInterface $request, UploadedFileInterface $file): string

--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -424,7 +424,7 @@ class UserResource extends AbstractDatabaseResource
         $urlContents = $this->retrieveAvatarFromUrl($url);
 
         if ($urlContents !== null) {
-            $image = $this->imageManager->read($urlContents);
+            $image = $this->imageManager->decodeBinary($urlContents);
 
             $this->avatarUploader->upload($user, $image);
         }

--- a/framework/core/src/User/AvatarUploader.php
+++ b/framework/core/src/User/AvatarUploader.php
@@ -12,6 +12,7 @@ namespace Flarum\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use Intervention\Image\Format;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class AvatarUploader
@@ -29,10 +30,10 @@ class AvatarUploader
         $avatarPath = Str::random();
 
         if ($image->isAnimated()) {
-            $encodedImage = $image->toGif();
+            $encodedImage = $image->encodeUsingFormat(Format::GIF);
             $avatarPath .= '.gif';
         } else {
-            $encodedImage = $image->toWebp();
+            $encodedImage = $image->encodeUsingFormat(Format::WEBP);
             $avatarPath .= '.webp';
         }
 

--- a/framework/core/src/User/AvatarUploader.php
+++ b/framework/core/src/User/AvatarUploader.php
@@ -12,7 +12,6 @@ namespace Flarum\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Str;
-use Intervention\Image\Format;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class AvatarUploader
@@ -30,12 +29,12 @@ class AvatarUploader
         $avatarPath = Str::random();
 
         if ($image->isAnimated()) {
-            $encodedImage = $image->encodeUsingFormat(Format::GIF);
             $avatarPath .= '.gif';
         } else {
-            $encodedImage = $image->encodeUsingFormat(Format::WEBP);
             $avatarPath .= '.webp';
         }
+
+        $encodedImage = $image->encodeUsingPath($avatarPath);
 
         $this->removeFileAfterSave($user);
         $user->changeAvatarPath($avatarPath);

--- a/framework/core/src/User/AvatarValidator.php
+++ b/framework/core/src/User/AvatarValidator.php
@@ -13,8 +13,7 @@ use Flarum\Foundation\AbstractValidator;
 use Flarum\Foundation\ValidationException;
 use Flarum\Locale\TranslatorInterface;
 use Illuminate\Validation\Factory;
-use Intervention\Gif\Exceptions\DecoderException as GifDecoderException;
-use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\Exceptions\ImageException;
 use Intervention\Image\ImageManager;
 use Psr\Http\Message\UploadedFileInterface;
 use Symfony\Component\Mime\MimeTypes;
@@ -74,8 +73,8 @@ class AvatarValidator extends AbstractValidator
         }
 
         try {
-            $this->imageManager->read($file->getStream()->getMetadata('uri'));
-        } catch (DecoderException|GifDecoderException) {
+            $this->imageManager->decode($file->getStream()->getMetadata('uri'));
+        } catch (ImageException) {
             $this->raise('image');
         }
     }

--- a/framework/core/src/User/Command/UploadAvatarHandler.php
+++ b/framework/core/src/User/Command/UploadAvatarHandler.php
@@ -43,7 +43,7 @@ class UploadAvatarHandler
 
         $this->validator->assertValid(['avatar' => $command->file]);
 
-        $image = $this->imageManager->read($command->file->getStream()->getMetadata('uri'));
+        $image = $this->imageManager->decode($command->file->getStream()->getMetadata('uri'));
 
         $this->events->dispatch(
             new AvatarSaving($user, $actor, $image)

--- a/framework/core/src/User/Console/ConvertAvatarsToWebpCommand.php
+++ b/framework/core/src/User/Console/ConvertAvatarsToWebpCommand.php
@@ -13,6 +13,7 @@ use Flarum\Console\AbstractCommand;
 use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Intervention\Image\Format;
 use Intervention\Image\ImageManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -73,7 +74,7 @@ class ConvertAvatarsToWebpCommand extends AbstractCommand
 
                 try {
                     $contents = $this->uploadDir->get($oldPath);
-                    $webpContents = $this->imageManager->read($contents)->toWebp();
+                    $webpContents = $this->imageManager->decodeBinary($contents)->encodeUsingFormat(Format::WEBP);
 
                     $newPath = pathinfo($oldPath, PATHINFO_FILENAME).'.webp';
 

--- a/framework/core/src/User/Console/ConvertAvatarsToWebpCommand.php
+++ b/framework/core/src/User/Console/ConvertAvatarsToWebpCommand.php
@@ -13,7 +13,6 @@ use Flarum\Console\AbstractCommand;
 use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Intervention\Image\Format;
 use Intervention\Image\ImageManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -74,9 +73,9 @@ class ConvertAvatarsToWebpCommand extends AbstractCommand
 
                 try {
                     $contents = $this->uploadDir->get($oldPath);
-                    $webpContents = $this->imageManager->decodeBinary($contents)->encodeUsingFormat(Format::WEBP);
-
                     $newPath = pathinfo($oldPath, PATHINFO_FILENAME).'.webp';
+
+                    $webpContents = $this->imageManager->decodeBinary($contents)->encodeUsingPath($newPath);
 
                     $this->uploadDir->put($newPath, $webpContents);
 

--- a/framework/core/tests/unit/User/AvatarUploaderTest.php
+++ b/framework/core/tests/unit/User/AvatarUploaderTest.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
+use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 use Mockery as m;
 
@@ -93,7 +94,7 @@ class AvatarUploaderTest extends TestCase
         $user->changeAvatarPath('ABCDEFGHabcdefgh.png');
         $user->syncOriginal();
 
-        $this->uploader->upload($user, ImageManager::gd()->create(50, 50));
+        $this->uploader->upload($user, ImageManager::usingDriver(Driver::class)->createImage(50, 50));
 
         // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {
@@ -111,7 +112,7 @@ class AvatarUploaderTest extends TestCase
 
         $user = new User();
 
-        $this->uploader->upload($user, ImageManager::gd()->create(50, 50));
+        $this->uploader->upload($user, ImageManager::usingDriver(Driver::class)->createImage(50, 50));
 
         // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {


### PR DESCRIPTION
This PR makes the necessary changes to migrate to the just released [Intervention Image Version 4](https://github.com/Intervention/image/releases/tag/4.0.0).

Please note that the new version requires at least PHP 8.3.

I recommend a thorough review. However, I think this is a good start and takes care of most of the work for the update. 

If you have any questions, feel free to reach out to me.

PS: For your reference, here is the [upgrade guide](https://image.intervention.io/v4/getting-started/upgrade)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Necessity**

- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
