### PR TITLE
[1.x] fix: enforce expiry check on password reset token submission

### DIFF
--- a/framework/core/src/Forum/Controller/SavePasswordController.php
+++ b/framework/core/src/Forum/Controller/SavePasswordController.php
@@ -72,7 +72,8 @@ class SavePasswordController implements RequestHandlerInterface
     {
         $input = $request->getParsedBody();
 
-        $token = PasswordToken::findOrFail(Arr::get($input, 'passwordToken'));
+        /** @var PasswordToken $token */
+        $token = PasswordToken::validOrFail(Arr::get($input, 'passwordToken'));
 
         $password = Arr::get($input, 'password');
 

--- a/framework/core/src/User/PasswordToken.php
+++ b/framework/core/src/User/PasswordToken.php
@@ -11,12 +11,14 @@ namespace Flarum\User;
 
 use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
+use Flarum\User\Exception\InvalidConfirmationTokenException;
 use Illuminate\Support\Str;
 
 /**
  * @property string $token
  * @property \Carbon\Carbon $created_at
  * @property int $user_id
+ * @method static self validOrFail(string $token)
  */
 class PasswordToken extends AbstractModel
 {
@@ -52,6 +54,26 @@ class PasswordToken extends AbstractModel
         $token->token = Str::random(40);
         $token->user_id = $userId;
         $token->created_at = Carbon::now();
+
+        return $token;
+    }
+
+    /**
+     * Find the token with the given ID, and assert that it has not expired.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $id
+     * @return static
+     * @throws InvalidConfirmationTokenException
+     */
+    public function scopeValidOrFail($query, $id)
+    {
+        /** @var static|null $token */
+        $token = $query->find($id);
+
+        if (! $token || $token->created_at->diffInDays() >= 1) {
+            throw new InvalidConfirmationTokenException;
+        }
 
         return $token;
     }


### PR DESCRIPTION
## Summary

- `POST /reset` accepted any token present in the database without checking expiry, while `GET /reset/{token}` correctly enforced the 24-hour window
- An attacker with a stale token (e.g. from a leaked email or DB backup) could use it indefinitely to take over the account
- Adds a `validOrFail` scope to `PasswordToken` matching the existing pattern on `EmailToken`, and updates `SavePasswordController` to use it

## Test plan

- [ ] `PasswordTokenExpiryTest::expired_password_token_is_rejected_by_post_reset` — fails before fix, passes after
- [ ] `PasswordTokenExpiryTest::valid_password_token_is_accepted_by_post_reset` — passes throughout
- [ ] Existing `PasswordEmailTokensTest` suite — no regressions