### PR TITLE
[1.x] fix: invalidate active sessions when password is changed

### DIFF
--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\User;
 
+use Flarum\Http\AccessToken;
 use Flarum\User\Event\EmailChanged;
 use Flarum\User\Event\PasswordChanged;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -19,6 +20,7 @@ class TokensClearer
     {
         $events->listen([PasswordChanged::class, EmailChanged::class], [$this, 'clearPasswordTokens']);
         $events->listen(PasswordChanged::class, [$this, 'clearEmailTokens']);
+        $events->listen(PasswordChanged::class, [$this, 'clearAccessTokens']);
     }
 
     /**
@@ -35,5 +37,13 @@ class TokensClearer
     public function clearEmailTokens($event): void
     {
         $event->user->emailTokens()->delete();
+    }
+
+    /**
+     * @param PasswordChanged $event
+     */
+    public function clearAccessTokens($event): void
+    {
+        AccessToken::query()->where('user_id', $event->user->id)->delete();
     }
 }

--- a/framework/core/tests/integration/api/users/PasswordChangeSessionInvalidationTest.php
+++ b/framework/core/tests/integration/api/users/PasswordChangeSessionInvalidationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\PasswordToken;
+
+class PasswordChangeSessionInvalidationTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+            'access_tokens' => [
+                ['id' => 1, 'token' => 'tok_a', 'user_id' => 2, 'last_activity_at' => Carbon::now(), 'type' => 'session'],
+                ['id' => 2, 'token' => 'tok_b', 'user_id' => 2, 'last_activity_at' => Carbon::now(), 'type' => 'session_remember'],
+                ['id' => 3, 'token' => 'tok_c', 'user_id' => 2, 'last_activity_at' => Carbon::now(), 'type' => 'developer'],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function active_sessions_are_invalidated_when_password_is_changed()
+    {
+        $this->app();
+
+        $token = PasswordToken::generate(2);
+        $token->save();
+
+        // User has existing active sessions before the reset
+        $this->assertEquals(3, AccessToken::query()->where('user_id', 2)->count());
+
+        $response = $this->send(
+            $this->requestWithCsrfToken(
+                $this->request('POST', '/reset')->withParsedBody([
+                    'passwordToken' => $token->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+
+        // All prior access tokens should be gone; only the new session token from the reset remains
+        $remainingTokens = AccessToken::query()->where('user_id', 2)->get();
+        $this->assertEquals(1, $remainingTokens->count());
+        $this->assertNotContains('tok_a', $remainingTokens->pluck('token')->all());
+        $this->assertNotContains('tok_b', $remainingTokens->pluck('token')->all());
+        $this->assertNotContains('tok_c', $remainingTokens->pluck('token')->all());
+    }
+}


### PR DESCRIPTION
## Summary

- Active access tokens (session, remember, developer) were not cleared when a user's password changed
- Sessions established before a password reset — or during an account takeover — remained valid indefinitely
- Adds `clearAccessTokens` to `TokensClearer`, fired on `PasswordChanged`, deleting all access tokens for the user

## Test plan

- [ ] `PasswordChangeSessionInvalidationTest::active_sessions_are_invalidated_when_password_is_changed` — fails before fix, passes after
- [ ] Existing `PasswordEmailTokensTest` suite — no regressions