### PR TITLE
[2.x] fix: enforce expiry check on password reset token submission

### DIFF
--- a/framework/core/src/Forum/Controller/SavePasswordController.php
+++ b/framework/core/src/Forum/Controller/SavePasswordController.php
@@ -42,7 +42,7 @@ class SavePasswordController implements RequestHandlerInterface
     {
         $input = $request->getParsedBody();
 
-        $token = PasswordToken::findOrFail(Arr::get($input, 'passwordToken'));
+        $token = PasswordToken::validOrFail(Arr::get($input, 'passwordToken'));
 
         $password = Arr::get($input, 'password');
 

--- a/framework/core/src/User/PasswordToken.php
+++ b/framework/core/src/User/PasswordToken.php
@@ -12,7 +12,6 @@ namespace Flarum\User;
 use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
 use Flarum\User\Exception\InvalidConfirmationTokenException;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 
@@ -20,8 +19,6 @@ use Illuminate\Support\Str;
  * @property string $token
  * @property \Carbon\Carbon $created_at
  * @property int $user_id
- *
- * @method static self validOrFail(string $token)
  */
 class PasswordToken extends AbstractModel
 {
@@ -53,10 +50,10 @@ class PasswordToken extends AbstractModel
      *
      * @throws InvalidConfirmationTokenException
      */
-    public function scopeValidOrFail(Builder $query, string $id): static
+    public static function validOrFail(string $id): static
     {
         /** @var static|null $token */
-        $token = $query->find($id);
+        $token = static::find($id);
 
         if (! $token || $token->created_at->diffInDays(null, true) >= 1) {
             throw new InvalidConfirmationTokenException;

--- a/framework/core/src/User/PasswordToken.php
+++ b/framework/core/src/User/PasswordToken.php
@@ -20,6 +20,8 @@ use Illuminate\Support\Str;
  * @property string $token
  * @property \Carbon\Carbon $created_at
  * @property int $user_id
+ *
+ * @method static self validOrFail(string $token)
  */
 class PasswordToken extends AbstractModel
 {

--- a/framework/core/src/User/PasswordToken.php
+++ b/framework/core/src/User/PasswordToken.php
@@ -11,6 +11,8 @@ namespace Flarum\User;
 
 use Carbon\Carbon;
 use Flarum\Database\AbstractModel;
+use Flarum\User\Exception\InvalidConfirmationTokenException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 
@@ -40,6 +42,23 @@ class PasswordToken extends AbstractModel
         $token->token = Str::random(40);
         $token->user_id = $userId;
         $token->created_at = Carbon::now();
+
+        return $token;
+    }
+
+    /**
+     * Find the token with the given ID, and assert that it has not expired.
+     *
+     * @throws InvalidConfirmationTokenException
+     */
+    public function scopeValidOrFail(Builder $query, string $id): static
+    {
+        /** @var static|null $token */
+        $token = $query->find($id);
+
+        if (! $token || $token->created_at->diffInDays(null, true) >= 1) {
+            throw new InvalidConfirmationTokenException;
+        }
 
         return $token;
     }

--- a/framework/core/tests/integration/api/users/PasswordTokenExpiryTest.php
+++ b/framework/core/tests/integration/api/users/PasswordTokenExpiryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\PasswordToken;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class PasswordTokenExpiryTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function valid_password_reset_token_is_accepted(): void
+    {
+        $this->app();
+
+        $token = PasswordToken::generate(2);
+        $token->save();
+
+        $response = $this->send(
+            $this->requestWithCsrfToken(
+                $this->request('POST', '/reset')->withParsedBody([
+                    'passwordToken' => $token->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function expired_password_reset_token_is_rejected(): void
+    {
+        $this->app();
+
+        $token = PasswordToken::generate(2);
+        $token->created_at = Carbon::now()->subDays(2);
+        $token->save();
+
+        $response = $this->send(
+            $this->requestWithCsrfToken(
+                $this->request('POST', '/reset')->withParsedBody([
+                    'passwordToken' => $token->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        // Should be rejected — currently findOrFail accepts expired tokens
+        $this->assertNotEquals(302, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Fixes a security issue where expired password reset tokens were accepted by the `POST /reset` endpoint. Adds `PasswordToken::validOrFail()` (mirroring the existing `EmailToken` implementation) and switches `SavePasswordController` to use it.

Ref: #4545