### PR TITLE
[2.x] fix: invalidate active sessions when password is changed

### DIFF
--- a/framework/core/src/User/TokensClearer.php
+++ b/framework/core/src/User/TokensClearer.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\User;
 
+use Flarum\Http\AccessToken;
 use Flarum\User\Event\EmailChanged;
 use Flarum\User\Event\PasswordChanged;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -19,6 +20,7 @@ class TokensClearer
     {
         $events->listen([PasswordChanged::class, EmailChanged::class], $this->clearPasswordTokens(...));
         $events->listen(PasswordChanged::class, $this->clearEmailTokens(...));
+        $events->listen(PasswordChanged::class, $this->clearAccessTokens(...));
     }
 
     public function clearPasswordTokens(EmailChanged|PasswordChanged $event): void
@@ -29,5 +31,10 @@ class TokensClearer
     public function clearEmailTokens(PasswordChanged $event): void
     {
         $event->user->emailTokens()->delete();
+    }
+
+    public function clearAccessTokens(PasswordChanged $event): void
+    {
+        AccessToken::query()->where('user_id', $event->user->id)->delete();
     }
 }

--- a/framework/core/tests/integration/api/users/PasswordChangeSessionInvalidationTest.php
+++ b/framework/core/tests/integration/api/users/PasswordChangeSessionInvalidationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Flarum\Http\AccessToken;
+use Flarum\Http\DeveloperAccessToken;
+use Flarum\Http\RememberAccessToken;
+use Flarum\Http\SessionAccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\PasswordToken;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class PasswordChangeSessionInvalidationTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function active_sessions_are_invalidated_when_password_is_changed(): void
+    {
+        $this->app();
+
+        // Create existing access tokens of all types for the user
+        SessionAccessToken::generate(2);
+        RememberAccessToken::generate(2);
+        DeveloperAccessToken::generate(2);
+
+        $this->assertEquals(3, AccessToken::query()->where('user_id', 2)->count());
+
+        // Generate a password reset token and use it as an unauthenticated user
+        $passwordToken = PasswordToken::generate(2);
+        $passwordToken->save();
+
+        $response = $this->send(
+            $this->requestWithCsrfToken(
+                $this->request('POST', '/reset')->withParsedBody([
+                    'passwordToken' => $passwordToken->token,
+                    'password' => 'new-password',
+                    'password_confirmation' => 'new-password',
+                ])
+            )
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+
+        // After password reset, all old access tokens should be gone.
+        // Only the new session token created by the reset flow should remain.
+        $remainingTokens = AccessToken::query()->where('user_id', 2)->count();
+
+        // Currently fails: old tokens are NOT cleared — only the new session token from the reset should remain
+        $this->assertEquals(1, $remainingTokens);
+    }
+}


### PR DESCRIPTION
Fixes a security issue where existing access tokens (session, remember, developer) remained valid after a password reset. Adds `TokensClearer::clearAccessTokens()` as a listener on `PasswordChanged`, deleting all access tokens for the user. The new session token created by the reset flow is saved afterwards and is unaffected.

Ref: #4546