### PR TITLE
fix: harden avatar-from-URL Guzzle client (disable redirects, add timeout and size limit)

### DIFF
--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -19,6 +19,7 @@ use Flarum\Http\SlugManager;
 use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\AvatarUploader;
+use Flarum\User\AvatarValidator;
 use Flarum\User\Command\DeleteAvatar;
 use Flarum\User\Command\UploadAvatar;
 use Flarum\User\Event\Deleting;
@@ -46,6 +47,7 @@ class UserResource extends AbstractDatabaseResource
         protected SettingsRepositoryInterface $settings,
         protected ImageManager $imageManager,
         protected AvatarUploader $avatarUploader,
+        protected AvatarValidator $avatarValidator,
         protected Dispatcher $bus,
     ) {
     }
@@ -432,7 +434,12 @@ class UserResource extends AbstractDatabaseResource
 
     private function retrieveAvatarFromUrl(string $url): ?string
     {
-        $client = new Client();
+        $maxSizeBytes = $this->avatarValidator->getMaxSize() * 1024;
+
+        $client = new Client([
+            'allow_redirects' => false,
+            'timeout'         => 5,
+        ]);
 
         try {
             $response = $client->get($url);
@@ -441,6 +448,12 @@ class UserResource extends AbstractDatabaseResource
         }
 
         if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $contentLength = $response->getHeaderLine('Content-Length');
+
+        if ($contentLength !== '' && (int) $contentLength > $maxSizeBytes) {
             return null;
         }
 

--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -438,7 +438,7 @@ class UserResource extends AbstractDatabaseResource
 
         $client = new Client([
             'allow_redirects' => false,
-            'timeout'         => 5,
+            'timeout' => 5,
         ]);
 
         try {

--- a/framework/core/src/User/AvatarValidator.php
+++ b/framework/core/src/User/AvatarValidator.php
@@ -105,7 +105,7 @@ class AvatarValidator extends AbstractValidator
         throw new ValidationException(['avatar' => $message]);
     }
 
-    protected function getMaxSize(): int
+    public function getMaxSize(): int
     {
         return 2048;
     }


### PR DESCRIPTION
Closes #4548

- Sets `allow_redirects => false` to prevent redirect-based SSRF
- Sets a 5s `timeout` to prevent worker hangs on slow hosts
- Checks `Content-Length` before reading the body and rejects responses exceeding `AvatarValidator::getMaxSize()` (2 MB)
- Makes `AvatarValidator::getMaxSize()` public so it can be used at the fetch layer