### PR TITLE
[2.x] feat: HiDPI avatar srcset (#4554)

### DIFF
--- a/framework/core/js/src/common/components/Avatar.tsx
+++ b/framework/core/js/src/common/components/Avatar.tsx
@@ -44,7 +44,9 @@ export default class Avatar<CustomAttrs extends IAvatarAttrs = IAvatarAttrs> ext
           (attrs as any).alt = username;
         }
 
-        return <img {...attrs} src={avatarUrl} />;
+        const srcset = user.avatarSrcset?.() ?? null;
+
+        return <img {...attrs} src={avatarUrl} srcSet={srcset ?? undefined} />;
       }
 
       content = username.charAt(0).toUpperCase();

--- a/framework/core/js/src/common/models/User.tsx
+++ b/framework/core/js/src/common/models/User.tsx
@@ -38,6 +38,10 @@ export default class User extends Model {
     return Model.attribute<string | null>('avatarUrl').call(this);
   }
 
+  avatarSrcset() {
+    return Model.attribute<string | null>('avatarSrcset').call(this);
+  }
+
   preferences() {
     return Model.attribute<Record<string, any> | null | undefined>('preferences').call(this);
   }

--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -245,6 +245,7 @@ class UserResource extends AbstractDatabaseResource
                 ->save(fn () => null),
             Schema\Str::make('displayName'),
             Schema\Str::make('avatarUrl'),
+            Schema\Str::make('avatarSrcset'),
             Schema\Boolean::make('hasUploadedAvatar'),
             Schema\Str::make('slug')
                 ->get(function (User $user) {
@@ -382,9 +383,18 @@ class UserResource extends AbstractDatabaseResource
 
     private function applyToken(User $user, #[\SensitiveParameter] RegistrationToken $token): void
     {
-        foreach ($token->user_attributes as $k => $v) {
+        $attributes = $token->user_attributes;
+
+        foreach ($attributes as $k => $v) {
             if ($k === 'avatar_url') {
-                $this->uploadAvatarFromUrl($user, $v);
+                $url2x = $attributes['avatar_url_2x'] ?? null;
+                $url3x = $attributes['avatar_url_3x'] ?? null;
+                $this->uploadAvatarFromUrl($user, $v, $url2x, $url3x);
+                continue;
+            }
+
+            // These are handled above alongside avatar_url.
+            if ($k === 'avatar_url_2x' || $k === 'avatar_url_3x') {
                 continue;
             }
 
@@ -403,7 +413,34 @@ class UserResource extends AbstractDatabaseResource
     /**
      * @throws InvalidArgumentException
      */
-    private function uploadAvatarFromUrl(User $user, string $url): void
+    private function uploadAvatarFromUrl(User $user, string $url, ?string $url2x = null, ?string $url3x = null): void
+    {
+        $this->assertValidAvatarUrl($url);
+
+        $urlContents = $this->retrieveAvatarFromUrl($url);
+
+        if ($urlContents === null) {
+            return;
+        }
+
+        // If the OAuth driver provided explicit HiDPI URLs, fetch and store them directly.
+        if ($url2x !== null || $url3x !== null) {
+            $image1x = $this->imageManager->read($urlContents);
+            $image2x = $url2x !== null ? $this->readAvatarFromUrl($url2x) : null;
+            $image3x = $url3x !== null ? $this->readAvatarFromUrl($url3x) : null;
+
+            $this->avatarUploader->uploadPresized($user, $image1x, $image2x, $image3x);
+        } else {
+            $image = $this->imageManager->read($urlContents);
+
+            $this->avatarUploader->upload($user, $image);
+        }
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function assertValidAvatarUrl(string $url): void
     {
         $urlValidator = $this->validation->make(compact('url'), [
             'url' => 'required|active_url',
@@ -422,14 +459,13 @@ class UserResource extends AbstractDatabaseResource
                 'avatar_url' => "Provided avatar URL must have scheme http or https. Scheme provided was $scheme.",
             ]);
         }
+    }
 
-        $urlContents = $this->retrieveAvatarFromUrl($url);
+    private function readAvatarFromUrl(string $url): ?\Intervention\Image\Interfaces\ImageInterface
+    {
+        $contents = $this->retrieveAvatarFromUrl($url);
 
-        if ($urlContents !== null) {
-            $image = $this->imageManager->read($urlContents);
-
-            $this->avatarUploader->upload($user, $image);
-        }
+        return $contents !== null ? $this->imageManager->read($contents) : null;
     }
 
     private function retrieveAvatarFromUrl(string $url): ?string

--- a/framework/core/src/Forum/Auth/Registration.php
+++ b/framework/core/src/Forum/Auth/Registration.php
@@ -47,6 +47,30 @@ class Registration
         return $this->provide('avatar_url', $url);
     }
 
+    /**
+     * Provide a 2× (200px) HiDPI avatar URL from the OAuth provider.
+     *
+     * Call this alongside provideAvatar() when the provider's CDN supports
+     * sized images (e.g. GitHub's ?s=200). Flarum will fetch and store this
+     * URL directly rather than upscaling the base avatar.
+     */
+    public function provideAvatar2x(string $url): self
+    {
+        return $this->provide('avatar_url_2x', $url);
+    }
+
+    /**
+     * Provide a 3× (300px) HiDPI avatar URL from the OAuth provider.
+     *
+     * Call this alongside provideAvatar() when the provider's CDN supports
+     * sized images (e.g. GitHub's ?s=300). Flarum will fetch and store this
+     * URL directly rather than upscaling the base avatar.
+     */
+    public function provideAvatar3x(string $url): self
+    {
+        return $this->provide('avatar_url_3x', $url);
+    }
+
     public function suggest(string $key, mixed $value): self
     {
         $this->suggested[$key] = $value;

--- a/framework/core/src/User/Avatar/DefaultDriver.php
+++ b/framework/core/src/User/Avatar/DefaultDriver.php
@@ -20,4 +20,9 @@ class DefaultDriver implements DriverInterface
     {
         return null;
     }
+
+    public function avatarSrcset(User $user): ?string
+    {
+        return null;
+    }
 }

--- a/framework/core/src/User/Avatar/DriverInterface.php
+++ b/framework/core/src/User/Avatar/DriverInterface.php
@@ -22,4 +22,14 @@ interface DriverInterface
      * Return an avatar URL for a user.
      */
     public function avatarUrl(User $user): ?string;
+
+    /**
+     * Return a srcset string for a user's avatar, or null if not supported.
+     *
+     * Example return value: "avatar.webp 1x, avatar@2x.webp 2x, avatar@3x.webp 3x"
+     *
+     * Third-party drivers may override this to construct srcset strings using
+     * their provider's own sizing capabilities (e.g. Gravatar's ?s= parameter).
+     */
+    public function avatarSrcset(User $user): ?string;
 }

--- a/framework/core/src/User/AvatarUploader.php
+++ b/framework/core/src/User/AvatarUploader.php
@@ -20,7 +20,7 @@ class AvatarUploader
 
     /** Sizes to generate: base (1×), @2x, @3x. */
     protected const SIZES = [
-        ''    => 100,
+        '' => 100,
         '@2x' => 200,
         '@3x' => 300,
     ];
@@ -44,7 +44,7 @@ class AvatarUploader
     {
         $avatarBase = Str::random();
         $extension = $image1x->isAnimated() ? 'gif' : 'webp';
-        $basePath = $avatarBase . '.' . $extension;
+        $basePath = $avatarBase.'.'.$extension;
 
         $this->removeFileAfterSave($user);
         $user->changeAvatarPath($basePath);
@@ -68,7 +68,7 @@ class AvatarUploader
         $avatarBase = Str::random();
         $isAnimated = $image->isAnimated();
         $extension = $isAnimated ? 'gif' : 'webp';
-        $basePath = $avatarBase . '.' . $extension;
+        $basePath = $avatarBase.'.'.$extension;
 
         // Read source dimensions before any cover() call, since cover() mutates the image in place.
         $sourceWidth = $image->width();
@@ -86,7 +86,7 @@ class AvatarUploader
             $resized = clone $image;
             $resized->cover($size, $size);
             $encoded = $isAnimated ? $resized->toGif() : $resized->toWebp();
-            $path = $avatarBase . $suffix . '.' . $extension;
+            $path = $avatarBase.$suffix.'.'.$extension;
 
             $this->uploadDir->put($path, $encoded);
         }
@@ -193,7 +193,7 @@ class AvatarUploader
         $dot = strrpos($basePath, '.');
 
         return $dot !== false
-            ? substr($basePath, 0, $dot) . $suffix . substr($basePath, $dot)
-            : $basePath . $suffix;
+            ? substr($basePath, 0, $dot).$suffix.substr($basePath, $dot)
+            : $basePath.$suffix;
     }
 }

--- a/framework/core/src/User/AvatarUploader.php
+++ b/framework/core/src/User/AvatarUploader.php
@@ -9,41 +9,91 @@
 
 namespace Flarum\User;
 
+use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class AvatarUploader
 {
-    protected Filesystem $uploadDir;
+    protected Cloud $uploadDir;
+
+    /** Sizes to generate: base (1×), @2x, @3x. */
+    protected const SIZES = [
+        ''    => 100,
+        '@2x' => 200,
+        '@3x' => 300,
+    ];
 
     public function __construct(Factory $filesystemFactory)
     {
         $this->uploadDir = $filesystemFactory->disk('flarum-avatars');
     }
 
-    public function upload(User $user, ImageInterface $image): void
+    /**
+     * Upload pre-sized avatar images provided by an OAuth driver.
+     *
+     * The caller is responsible for providing correctly sized images.
+     * Only the variants whose images are non-null are stored.
+     *
+     * @param ImageInterface      $image1x Base (1×) image
+     * @param ImageInterface|null $image2x 2× image (200px), or null to skip
+     * @param ImageInterface|null $image3x 3× image (300px), or null to skip
+     */
+    public function uploadPresized(User $user, ImageInterface $image1x, ?ImageInterface $image2x, ?ImageInterface $image3x): void
     {
-        $image = $image->cover(100, 100);
-        $avatarPath = Str::random();
-
-        if ($image->isAnimated()) {
-            $encodedImage = $image->toGif();
-            $avatarPath .= '.gif';
-        } else {
-            $encodedImage = $image->toWebp();
-            $avatarPath .= '.webp';
-        }
+        $avatarBase = Str::random();
+        $extension = $image1x->isAnimated() ? 'gif' : 'webp';
+        $basePath = $avatarBase . '.' . $extension;
 
         $this->removeFileAfterSave($user);
-        $user->changeAvatarPath($avatarPath);
+        $user->changeAvatarPath($basePath);
 
-        $this->uploadDir->put($avatarPath, $encodedImage);
+        $variants = ['' => $image1x, '@2x' => $image2x, '@3x' => $image3x];
+
+        foreach ($variants as $suffix => $image) {
+            if ($image === null) {
+                continue;
+            }
+
+            $encoded = $image->isAnimated() ? $image->toGif() : $image->toWebp();
+            $path = $this->variantPath($basePath, $suffix);
+
+            $this->uploadDir->put($path, $encoded);
+        }
+    }
+
+    public function upload(User $user, ImageInterface $image): void
+    {
+        $avatarBase = Str::random();
+        $isAnimated = $image->isAnimated();
+        $extension = $isAnimated ? 'gif' : 'webp';
+        $basePath = $avatarBase . '.' . $extension;
+
+        // Read source dimensions before any cover() call, since cover() mutates the image in place.
+        $sourceWidth = $image->width();
+        $sourceHeight = $image->height();
+
+        $this->removeFileAfterSave($user);
+        $user->changeAvatarPath($basePath);
+
+        foreach (self::SIZES as $suffix => $size) {
+            // Never upscale — skip this variant if the source is too small.
+            if ($sourceWidth < $size || $sourceHeight < $size) {
+                continue;
+            }
+
+            $resized = clone $image;
+            $resized->cover($size, $size);
+            $encoded = $isAnimated ? $resized->toGif() : $resized->toWebp();
+            $path = $avatarBase . $suffix . '.' . $extension;
+
+            $this->uploadDir->put($path, $encoded);
+        }
     }
 
     /**
-     * Handle the removal of the old avatar file after a successful user save
+     * Handle the removal of the old avatar file after a successful user save.
      * We don't place this in remove() because otherwise we would call changeAvatarPath 2 times when uploading.
      */
     protected function removeFileAfterSave(User $user): void
@@ -56,9 +106,7 @@ class AvatarUploader
         }
 
         $user->afterSave(function () use ($avatarPath) {
-            if ($this->uploadDir->exists($avatarPath)) {
-                $this->uploadDir->delete($avatarPath);
-            }
+            $this->deleteAllVariants($avatarPath);
         });
     }
 
@@ -67,5 +115,85 @@ class AvatarUploader
         $this->removeFileAfterSave($user);
 
         $user->changeAvatarPath(null);
+    }
+
+    /**
+     * Delete the base file and all HiDPI variants (@2x, @3x) for a given base path.
+     * Safe to call with external URLs — the filesystem exists() check guards against it.
+     */
+    public function deleteAllVariants(string $basePath): void
+    {
+        // Derive all variant paths from the base path (e.g. "abc.webp" → "abc@2x.webp")
+        $paths = $this->variantPaths($basePath);
+
+        foreach ($paths as $path) {
+            if ($this->uploadDir->exists($path)) {
+                $this->uploadDir->delete($path);
+            }
+        }
+    }
+
+    /**
+     * Return the srcset string for a given base path, including only variants that exist on disk.
+     * Returns null if only the base file exists (no HiDPI variants).
+     */
+    public function srcsetFor(string $basePath): ?string
+    {
+        // External URLs (e.g. from OAuth provider) — no local variants.
+        if (str_contains($basePath, '://')) {
+            return null;
+        }
+
+        // Collect which variant paths exist on disk first, without calling url().
+        $existing = [];
+
+        foreach (self::SIZES as $suffix => $size) {
+            $path = $this->variantPath($basePath, $suffix);
+
+            if ($this->uploadDir->exists($path)) {
+                $existing[$path] = $size / 100;
+            }
+        }
+
+        // Only meaningful if we have more than just the 1× base.
+        if (count($existing) <= 1) {
+            return null;
+        }
+
+        $entries = [];
+
+        foreach ($existing as $path => $multiplier) {
+            $url = $this->uploadDir->url($path);
+            $entries[] = "$url {$multiplier}x";
+        }
+
+        return implode(', ', $entries);
+    }
+
+    /**
+     * Return all variant paths (base + @2x + @3x) for a given base path.
+     */
+    protected function variantPaths(string $basePath): array
+    {
+        return array_map(
+            fn (string $suffix) => $this->variantPath($basePath, $suffix),
+            array_keys(self::SIZES)
+        );
+    }
+
+    /**
+     * Derive a variant path from the base path and a suffix (e.g. '' → 'abc.webp', '@2x' → 'abc@2x.webp').
+     */
+    protected function variantPath(string $basePath, string $suffix): string
+    {
+        if ($suffix === '') {
+            return $basePath;
+        }
+
+        $dot = strrpos($basePath, '.');
+
+        return $dot !== false
+            ? substr($basePath, 0, $dot) . $suffix . substr($basePath, $dot)
+            : $basePath . $suffix;
     }
 }

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -155,11 +155,7 @@ class User extends AbstractModel
             $avatarPath = $user->getRawOriginal('avatar_url');
 
             if ($avatarPath) {
-                $disk = resolve(Factory::class)->disk('flarum-avatars');
-
-                if ($disk->exists($avatarPath)) {
-                    $disk->delete($avatarPath);
-                }
+                resolve(AvatarUploader::class)->deleteAllVariants($avatarPath);
             }
         });
 
@@ -292,6 +288,17 @@ class User extends AbstractModel
         }
 
         return $value ?? static::$avatarDriver->avatarUrl($this);
+    }
+
+    public function getAvatarSrcsetAttribute(): ?string
+    {
+        $value = $this->getRawOriginal('avatar_url');
+
+        if ($value && ! str_contains($value, '://')) {
+            return resolve(AvatarUploader::class)->srcsetFor($value);
+        }
+
+        return static::$avatarDriver->avatarSrcset($this);
     }
 
     public function getDisplayNameAttribute(): string

--- a/framework/core/tests/integration/api/users/AvatarSrcsetTest.php
+++ b/framework/core/tests/integration/api/users/AvatarSrcsetTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class AvatarSrcsetTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                [
+                    'id' => 3,
+                    'username' => 'local_avatar_user',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email' => 'localavatar@machine.local',
+                    'is_email_confirmed' => 1,
+                    'avatar_url' => 'ABCDEFGHabcdefgh.webp',
+                ],
+                [
+                    'id' => 4,
+                    'username' => 'external_avatar_user',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email' => 'externalavatar@machine.local',
+                    'is_email_confirmed' => 1,
+                    'avatar_url' => 'https://example.com/avatar.png',
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function user_without_avatar_has_null_avatar_srcset(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('avatarSrcset', $data['data']['attributes']);
+        $this->assertNull($data['data']['attributes']['avatarSrcset']);
+    }
+
+    #[Test]
+    public function user_with_external_url_avatar_has_null_avatar_srcset(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('avatarSrcset', $data['data']['attributes']);
+        // External URLs never have locally stored HiDPI variants.
+        $this->assertNull($data['data']['attributes']['avatarSrcset']);
+    }
+
+    #[Test]
+    public function user_with_local_avatar_but_no_hidpi_variants_has_null_avatar_srcset(): void
+    {
+        // The flarum-avatars disk in integration tests is backed by local storage.
+        // No physical files are written, so exists() returns false for all variants —
+        // srcsetFor() returns null (only meaningful when HiDPI variants exist).
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('avatarSrcset', $data['data']['attributes']);
+        $this->assertNull($data['data']['attributes']['avatarSrcset']);
+    }
+
+    #[Test]
+    public function deleting_avatar_returns_null_avatar_srcset(): void
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/users/2/avatar', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('avatarSrcset', $data['data']['attributes']);
+        $this->assertNull($data['data']['attributes']['avatarSrcset']);
+    }
+}

--- a/framework/core/tests/integration/extenders/UserTest.php
+++ b/framework/core/tests/integration/extenders/UserTest.php
@@ -228,4 +228,9 @@ class CustomAvatarDriver implements AvatarDriverInterface
     {
         return 'https://example.com/avatar/'.$user->id;
     }
+
+    public function avatarSrcset(User $user): ?string
+    {
+        return null;
+    }
 }

--- a/framework/core/tests/unit/Forum/Auth/RegistrationTest.php
+++ b/framework/core/tests/unit/Forum/Auth/RegistrationTest.php
@@ -79,6 +79,38 @@ class RegistrationTest extends TestCase
     }
 
     #[Test]
+    public function provide_avatar_2x_stores_hidpi_url(): void
+    {
+        $this->registration->provideAvatar2x('https://example.com/avatar@2x.jpg');
+
+        $provided = $this->registration->getProvided();
+        $this->assertEquals('https://example.com/avatar@2x.jpg', $provided['avatar_url_2x']);
+    }
+
+    #[Test]
+    public function provide_avatar_3x_stores_hidpi_url(): void
+    {
+        $this->registration->provideAvatar3x('https://example.com/avatar@3x.jpg');
+
+        $provided = $this->registration->getProvided();
+        $this->assertEquals('https://example.com/avatar@3x.jpg', $provided['avatar_url_3x']);
+    }
+
+    #[Test]
+    public function all_avatar_variants_can_be_provided_together(): void
+    {
+        $this->registration
+            ->provideAvatar('https://example.com/avatar.jpg')
+            ->provideAvatar2x('https://example.com/avatar@2x.jpg')
+            ->provideAvatar3x('https://example.com/avatar@3x.jpg');
+
+        $provided = $this->registration->getProvided();
+        $this->assertEquals('https://example.com/avatar.jpg', $provided['avatar_url']);
+        $this->assertEquals('https://example.com/avatar@2x.jpg', $provided['avatar_url_2x']);
+        $this->assertEquals('https://example.com/avatar@3x.jpg', $provided['avatar_url_3x']);
+    }
+
+    #[Test]
     public function payload_is_stored_and_retrieved(): void
     {
         $payload = ['raw_data' => 'from_provider', 'extra' => 42];

--- a/framework/core/tests/unit/User/AvatarUploaderTest.php
+++ b/framework/core/tests/unit/User/AvatarUploaderTest.php
@@ -13,48 +13,47 @@ use Flarum\Testing\unit\TestCase;
 use Flarum\User\AvatarUploader;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
 use Intervention\Image\ImageManager;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 
 class AvatarUploaderTest extends TestCase
 {
     private $dispatcher;
     private $filesystem;
     private $filesystemFactory;
-    private $uploader;
+    private AvatarUploader $uploader;
 
-    /**
-     * @inheritDoc
-     */
     protected function setUp(): void
     {
         $this->dispatcher = m::mock(Dispatcher::class);
         $this->dispatcher->shouldIgnoreMissing();
         Model::setEventDispatcher($this->dispatcher);
 
-        $this->filesystem = m::mock(Filesystem::class);
+        $this->filesystem = m::mock(Cloud::class);
         $this->filesystemFactory = m::mock(Factory::class);
         $this->filesystemFactory->shouldReceive('disk')->with('flarum-avatars')->andReturn($this->filesystem);
         $this->uploader = new AvatarUploader($this->filesystemFactory);
     }
 
+    #[Test]
     public function test_removing_avatar_removes_file()
     {
         $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh.png')->andReturn(true);
         $this->filesystem->shouldReceive('delete')->with('ABCDEFGHabcdefgh.png')->once();
+        // @2x and @3x variants — don't exist
+        $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh@2x.png')->andReturn(false);
+        $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh@3x.png')->andReturn(false);
 
         $user = new User();
         $user->changeAvatarPath('ABCDEFGHabcdefgh.png');
-        // Necessary because AvatarUpload looks into the original attributes for the raw value,
-        // which isn't usually automatically updated without saving to the database
         $user->syncOriginal();
 
         $this->uploader->remove($user);
 
-        // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {
             $callback($user);
         }
@@ -63,9 +62,10 @@ class AvatarUploaderTest extends TestCase
         $this->assertEquals(null, $user->getRawOriginal('avatar_url'));
     }
 
+    #[Test]
     public function test_removing_url_avatar_removes_no_file()
     {
-        $this->filesystem->shouldReceive('exists')->with('https://example.com/avatar.png')->andReturn(false)->once();
+        $this->filesystem->shouldReceive('exists')->andReturn(false);
         $this->filesystem->shouldNotReceive('delete');
 
         $user = new User();
@@ -74,7 +74,6 @@ class AvatarUploaderTest extends TestCase
 
         $this->uploader->remove($user);
 
-        // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {
             $callback($user);
         }
@@ -83,19 +82,26 @@ class AvatarUploaderTest extends TestCase
         $this->assertEquals(null, $user->getRawOriginal('avatar_url'));
     }
 
-    public function test_changing_avatar_removes_file()
+    #[Test]
+    public function test_changing_avatar_removes_old_file_and_all_variants()
     {
-        $this->filesystem->shouldReceive('put')->once();
+        // Old base + variants exist
         $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh.png')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh@2x.png')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('ABCDEFGHabcdefgh@3x.png')->andReturn(true);
         $this->filesystem->shouldReceive('delete')->with('ABCDEFGHabcdefgh.png')->once();
+        $this->filesystem->shouldReceive('delete')->with('ABCDEFGHabcdefgh@2x.png')->once();
+        $this->filesystem->shouldReceive('delete')->with('ABCDEFGHabcdefgh@3x.png')->once();
+        // New files being stored
+        $this->filesystem->shouldReceive('put')->times(3); // 1x, 2x, 3x from a 300px source
 
         $user = new User();
         $user->changeAvatarPath('ABCDEFGHabcdefgh.png');
         $user->syncOriginal();
 
-        $this->uploader->upload($user, ImageManager::gd()->create(50, 50));
+        // 300px source — all three variants should be generated
+        $this->uploader->upload($user, ImageManager::gd()->create(300, 300));
 
-        // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {
             $callback($user);
         }
@@ -104,21 +110,131 @@ class AvatarUploaderTest extends TestCase
         $this->assertNotEquals('ABCDEFGHabcdefgh.png', $user->getRawOriginal('avatar_url'));
     }
 
+    #[Test]
     public function test_upload_stores_webp_for_static_images()
     {
-        $this->filesystem->shouldReceive('put')->once();
+        $this->filesystem->shouldReceive('put')->atLeast()->once();
         $this->filesystem->shouldIgnoreMissing();
 
         $user = new User();
 
-        $this->uploader->upload($user, ImageManager::gd()->create(50, 50));
+        $this->uploader->upload($user, ImageManager::gd()->create(300, 300));
 
-        // Simulate saving
         foreach ($user->releaseAfterSaveCallbacks() as $callback) {
             $callback($user);
         }
         $user->syncOriginal();
 
         $this->assertStringEndsWith('.webp', $user->getRawOriginal('avatar_url'));
+    }
+
+    #[Test]
+    public function test_upload_generates_all_three_variants_for_large_source()
+    {
+        $putPaths = [];
+        $this->filesystem->shouldReceive('put')->andReturnUsing(function (string $path) use (&$putPaths) {
+            $putPaths[] = $path;
+        });
+        $this->filesystem->shouldIgnoreMissing();
+
+        $user = new User();
+
+        // 300px source — should generate 1x, 2x, and 3x
+        $this->uploader->upload($user, ImageManager::gd()->create(300, 300));
+
+        $this->assertCount(3, $putPaths);
+        $this->assertStringNotContainsString('@', $putPaths[0]);
+        $this->assertStringContainsString('@2x', $putPaths[1]);
+        $this->assertStringContainsString('@3x', $putPaths[2]);
+    }
+
+    #[Test]
+    public function test_upload_skips_variants_that_would_require_upscaling()
+    {
+        $putPaths = [];
+        $this->filesystem->shouldReceive('put')->andReturnUsing(function (string $path) use (&$putPaths) {
+            $putPaths[] = $path;
+        });
+        $this->filesystem->shouldIgnoreMissing();
+
+        $user = new User();
+
+        // 150px source — should only generate 1x (100px). 2x (200px) and 3x (300px) would upscale.
+        $this->uploader->upload($user, ImageManager::gd()->create(150, 150));
+
+        $this->assertCount(1, $putPaths);
+        $this->assertStringNotContainsString('@', $putPaths[0]);
+    }
+
+    #[Test]
+    public function test_upload_generates_two_variants_for_mid_size_source()
+    {
+        $putPaths = [];
+        $this->filesystem->shouldReceive('put')->andReturnUsing(function (string $path) use (&$putPaths) {
+            $putPaths[] = $path;
+        });
+        $this->filesystem->shouldIgnoreMissing();
+
+        $user = new User();
+
+        // 200px source — should generate 1x and 2x, but not 3x (would upscale).
+        $this->uploader->upload($user, ImageManager::gd()->create(200, 200));
+
+        $this->assertCount(2, $putPaths);
+        $this->assertStringNotContainsString('@', $putPaths[0]);
+        $this->assertStringContainsString('@2x', $putPaths[1]);
+    }
+
+    #[Test]
+    public function test_srcset_for_returns_null_when_only_base_exists()
+    {
+        $this->filesystem->shouldReceive('exists')->with('abc.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('abc@2x.webp')->andReturn(false);
+        $this->filesystem->shouldReceive('exists')->with('abc@3x.webp')->andReturn(false);
+
+        $result = $this->uploader->srcsetFor('abc.webp');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function test_srcset_for_returns_string_when_hidpi_variants_exist()
+    {
+        $this->filesystem->shouldReceive('exists')->with('abc.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('abc@2x.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('abc@3x.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('url')->with('abc.webp')->andReturn('https://cdn.example.com/abc.webp');
+        $this->filesystem->shouldReceive('url')->with('abc@2x.webp')->andReturn('https://cdn.example.com/abc@2x.webp');
+        $this->filesystem->shouldReceive('url')->with('abc@3x.webp')->andReturn('https://cdn.example.com/abc@3x.webp');
+
+        $result = $this->uploader->srcsetFor('abc.webp');
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('1x', $result);
+        $this->assertStringContainsString('2x', $result);
+        $this->assertStringContainsString('3x', $result);
+    }
+
+    #[Test]
+    public function test_srcset_for_returns_null_for_external_url()
+    {
+        $this->filesystem->shouldNotReceive('exists');
+
+        $result = $this->uploader->srcsetFor('https://example.com/avatar.png');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function test_delete_all_variants_removes_all_existing_files()
+    {
+        $this->filesystem->shouldReceive('exists')->with('abc.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('abc@2x.webp')->andReturn(true);
+        $this->filesystem->shouldReceive('exists')->with('abc@3x.webp')->andReturn(false);
+        $this->filesystem->shouldReceive('delete')->with('abc.webp')->once();
+        $this->filesystem->shouldReceive('delete')->with('abc@2x.webp')->once();
+        $this->filesystem->shouldNotReceive('delete')->with('abc@3x.webp');
+
+        $this->uploader->deleteAllVariants('abc.webp');
     }
 }


### PR DESCRIPTION
Implements #4554.

Generates `@2x` (200 px) and `@3x` (300 px) avatar variants at upload time alongside the existing base `1×` (100 px) file. Upscaling is never performed — variants are skipped when the source image is too small. The `User` API resource exposes a new `avatarSrcset` field, and the `Avatar` component passes it through as the HTML `srcset` attribute.

**Changes:**
- `AvatarUploader`: generates up to three variants per upload using a `clone`+`cover()` pattern to avoid mutating the source image; `deleteAllVariants()` removes all three on avatar removal; `srcsetFor()` builds the srcset string only when HiDPI variants are present on disk
- `DriverInterface` / `DefaultDriver`: new `avatarSrcset()` method — custom drivers may override to return a srcset string
- `User`: `getAvatarSrcsetAttribute()` accessor; `deleting` hook updated to remove all variants via `AvatarUploader::deleteAllVariants()`
- `UserResource`: `avatarSrcset` schema field; `uploadAvatarFromUrl()` accepts optional `$url2x`/`$url3x` for pre-sized OAuth-provided images
- `Registration`: `provideAvatar2x()` / `provideAvatar3x()` for OAuth drivers
- `Avatar.tsx` / `User.tsx`: `avatarSrcset()` model method; `srcSet` prop on `<img>`