### PR TITLE
[2.x] fix(tags): use forum description for meta description on tags homepage

### DIFF
--- a/extensions/tags/src/Content/Tags.php
+++ b/extensions/tags/src/Content/Tags.php
@@ -48,7 +48,8 @@ class Tags
 
         $defaultRoute = $this->settings->get('default_route');
         $document->title = $this->translator->trans('flarum-tags.forum.all_tags.meta_title_text');
-        $document->meta['description'] = $this->translator->trans('flarum-tags.forum.all_tags.meta_description_text');
+        $document->meta['description'] = $this->settings->get('forum_description')
+            ?: $this->translator->trans('flarum-tags.forum.all_tags.meta_description_text');
         $document->content = $this->view->make('tags::frontend.content.tags', compact('primaryTags', 'secondaryTags', 'children'));
         $document->canonicalUrl = $this->url->to('forum')->base().($defaultRoute === '/tags' ? '' : $request->getUri()->getPath());
         $document->payload['apiDocument'] = $apiDocument;


### PR DESCRIPTION
Fixes #3973.

When the homepage is set to "Tags", the meta description was hardcoded to the "All Tags" translation string, ignoring the forum description set in admin settings. Fall back to the translation only when no forum description is configured.