### PR TITLE
[1.x] feat: sync abandoned extensions list from flarum/abandoned-extensions

### DIFF
--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -1,9 +1,11 @@
 import app from '../../admin/app';
 import FieldSet from '../../common/components/FieldSet';
+import Button from '../../common/components/Button';
 import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { IPageAttrs } from '../../common/components/Page';
 import Mithril from 'mithril';
+import Link from '../../common/components/Link';
 
 export type HomePageItem = { path: string; label: Mithril.Children };
 
@@ -11,6 +13,8 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
   localeOptions: Record<string, string> = {};
   displayNameOptions: Record<string, string> = {};
   slugDriverOptions: Record<string, Record<string, string>> = {};
+  abandonedSyncing = false;
+  abandonedSyncMessage: Mithril.Children = null;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
@@ -63,6 +67,29 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
     });
 
     return items;
+  }
+
+  syncAbandoned() {
+    if (this.abandonedSyncing) return;
+
+    this.abandonedSyncing = true;
+    this.abandonedSyncMessage = null;
+
+    app
+      .request<{ count: number }>({
+        method: 'POST',
+        url: app.forum.attribute('apiUrl') + '/extensions/abandoned/sync',
+      })
+      .then((response) => {
+        this.abandonedSyncing = false;
+        this.abandonedSyncMessage = app.translator.trans('core.admin.basics.abandoned_extensions_sync_success', { count: response.count });
+        m.redraw();
+      })
+      .catch(() => {
+        this.abandonedSyncing = false;
+        this.abandonedSyncMessage = app.translator.trans('core.admin.basics.abandoned_extensions_sync_error');
+        m.redraw();
+      });
   }
 
   contentItems(): ItemList<Mithril.Children> {
@@ -167,6 +194,31 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
         return null;
       }),
       40
+    );
+
+    items.add(
+      'abandoned-extensions',
+      <div className="Form-group">
+        <label>{app.translator.trans('core.admin.basics.abandoned_extensions_heading')}</label>
+        <div className="helpText">
+          {app.translator.trans('core.admin.basics.abandoned_extensions_text', {
+            a: <Link href="https://github.com/flarum/abandoned-extensions" target="_blank" external={true} />,
+          })}
+        </div>
+        <div className="Form-row">
+          <Button className="Button" onclick={this.syncAbandoned.bind(this)} loading={this.abandonedSyncing} disabled={this.abandonedSyncing}>
+            {app.translator.trans('core.admin.basics.abandoned_extensions_sync_button')}
+          </Button>
+          {this.abandonedSyncMessage && <span className="helpText">{this.abandonedSyncMessage}</span>}
+        </div>
+        <br />
+        {this.buildSettingComponent({
+          type: 'switch',
+          setting: 'flarum-core.notify_admins_on_abandoned',
+          label: app.translator.trans('core.admin.basics.abandoned_extensions_notify_admins_label'),
+        })}
+      </div>,
+      30
     );
 
     return items;

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -51,6 +51,12 @@ core:
       title: Basics
       welcome_banner_heading: Welcome Banner
       welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
+      abandoned_extensions_heading: Abandoned Extensions
+      abandoned_extensions_text: "Flarum maintains a <a>community list of abandoned extensions</a>. When an installed extension appears on the list, it will be flagged in the admin panel."
+      abandoned_extensions_sync_button: Check Now
+      abandoned_extensions_sync_success: "Abandoned extensions list updated. {count} matching installed extension(s) found."
+      abandoned_extensions_sync_error: Failed to fetch the abandoned extensions list. Please try again later.
+      abandoned_extensions_notify_admins_label: Email admins when a newly abandoned extension is detected during the weekly check
 
     # These translations are used in the Create User modal.
     create_user:
@@ -824,6 +830,20 @@ core:
         If this was you, this email means that your configuration works!
 
         If this was not you, please ignore this email.
+
+    # These translations are used in emails sent to admins when abandoned extensions are detected
+    abandoned_extensions:
+      subject: "Action required: abandoned extension(s) detected"
+      body: |
+        Hi {username},
+
+        The following installed extension(s) have been flagged as abandoned:
+
+        {extensions}
+
+        Please review these extensions and consider migrating to alternatives where available.
+      line_with_replacement: "- {package} (suggested replacement: {replacement})"
+      line_no_replacement: "- {package} (no replacement available)"
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!

--- a/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
+++ b/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
@@ -11,7 +11,6 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Extension\AbandonedExtensionsFetcher;
 use Flarum\Http\RequestUtil;
-use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
+++ b/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Http\RequestUtil;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SyncAbandonedExtensionsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected AbandonedExtensionsFetcher $fetcher
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        try {
+            $result = $this->fetcher->sync(notify: true, manual: true);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 500);
+        }
+
+        return new JsonResponse(['count' => $result['count'], 'new' => $result['new']]);
+    }
+}

--- a/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
+++ b/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
@@ -18,9 +18,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SyncAbandonedExtensionsController implements RequestHandlerInterface
 {
-    public function __construct(
-        protected AbandonedExtensionsFetcher $fetcher
-    ) {
+    /**
+     * @var AbandonedExtensionsFetcher
+     */
+    protected $fetcher;
+
+    public function __construct(AbandonedExtensionsFetcher $fetcher)
+    {
+        $this->fetcher = $fetcher;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -28,7 +33,7 @@ class SyncAbandonedExtensionsController implements RequestHandlerInterface
         RequestUtil::getActor($request)->assertAdmin();
 
         try {
-            $result = $this->fetcher->sync(notify: true, manual: true);
+            $result = $this->fetcher->sync(true, true);
         } catch (\RuntimeException $e) {
             return new JsonResponse(['error' => $e->getMessage()], 500);
         }

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -377,6 +377,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\SendTestMailController::class)
     );
 
+    // Trigger a sync of the abandoned extensions list
+    $map->post(
+        '/extensions/abandoned/sync',
+        'extensions.abandoned.sync',
+        $route->toController(Controller\SyncAbandonedExtensionsController::class)
+    );
+
     // List Flarum community announcements from discuss.flarum.org
     $map->get(
         '/flarum/announcements',

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -27,13 +27,43 @@ class AbandonedExtensionsFetcher
 
     protected const SOURCE_URL = 'https://raw.githubusercontent.com/flarum/abandoned-extensions/main/abandoned.json';
 
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensions;
+
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var Queue
+     */
+    protected $queue;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
     public function __construct(
-        protected ExtensionManager $extensions,
-        protected SettingsRepositoryInterface $settings,
-        protected Client $client,
-        protected Queue $queue,
-        protected TranslatorInterface $translator
+        ExtensionManager $extensions,
+        SettingsRepositoryInterface $settings,
+        Client $client,
+        Queue $queue,
+        TranslatorInterface $translator
     ) {
+        $this->extensions = $extensions;
+        $this->settings = $settings;
+        $this->client = $client;
+        $this->queue = $queue;
+        $this->translator = $translator;
     }
 
     /**
@@ -56,7 +86,9 @@ class AbandonedExtensionsFetcher
 
         $filtered = array_filter(
             $map,
-            fn (string $name) => isset($installed[$name]),
+            function (string $name) use ($installed) {
+                return isset($installed[$name]);
+            },
             ARRAY_FILTER_USE_KEY
         );
 
@@ -107,7 +139,9 @@ class AbandonedExtensionsFetcher
 
     protected function notifyAdmins(array $newPackages, array $map): void
     {
-        $admins = User::whereHas('groups', fn ($q) => $q->where('id', Group::ADMINISTRATOR_ID))->get();
+        $admins = User::whereHas('groups', function ($q) {
+            $q->where('id', Group::ADMINISTRATOR_ID);
+        })->get();
 
         $lines = array_map(function (string $package) use ($map) {
             $replacement = $map[$package]['replacement'] ?? null;

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension;
+
+use Flarum\Foundation\Application;
+use Flarum\Group\Group;
+use Flarum\Mail\Job\SendRawEmailJob;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Contracts\Queue\Queue;
+use RuntimeException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class AbandonedExtensionsFetcher
+{
+    public const SETTINGS_KEY = 'flarum-core.abandoned_extensions_map';
+    public const NOTIFY_ADMINS_SETTING = 'flarum-core.notify_admins_on_abandoned';
+
+    protected const SOURCE_URL = 'https://raw.githubusercontent.com/flarum/abandoned-extensions/main/abandoned.json';
+
+    public function __construct(
+        protected ExtensionManager $extensions,
+        protected SettingsRepositoryInterface $settings,
+        protected Client $client,
+        protected Queue $queue,
+        protected TranslatorInterface $translator
+    ) {
+    }
+
+    /**
+     * Fetch the upstream abandoned extensions list, filter to installed packages,
+     * persist the result to settings, and optionally notify admins.
+     *
+     * When $notify is true and the notify-admins setting is enabled:
+     * - On a scheduled (automatic) run: only notifies about packages newly flagged
+     *   since the last sync, to avoid repeating the same email every week.
+     * - On a manual run ($manual = true): notifies about all currently installed
+     *   abandoned extensions, since the admin explicitly requested the check.
+     *
+     * @throws RuntimeException
+     * @return array{count: int, new: string[]}
+     */
+    public function sync(bool $notify = false, bool $manual = false): array
+    {
+        $map = $this->fetch();
+        $installed = $this->installedPackageNames();
+
+        $filtered = array_filter(
+            $map,
+            fn (string $name) => isset($installed[$name]),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $previous = static::getCachedMap($this->settings);
+        $new = array_keys(array_diff_key($filtered, $previous));
+
+        $this->settings->set(self::SETTINGS_KEY, json_encode($filtered));
+
+        if ($notify && $this->settings->get(self::NOTIFY_ADMINS_SETTING)) {
+            // Manual trigger: notify about all installed abandoned extensions.
+            // Scheduled trigger: only notify about newly detected ones.
+            $toNotify = $manual ? array_keys($filtered) : $new;
+
+            if ($toNotify) {
+                $this->notifyAdmins($toNotify, $filtered);
+            }
+        }
+
+        return ['count' => count($filtered), 'new' => $new];
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    protected function fetch(): array
+    {
+        try {
+            $response = $this->client->get(self::SOURCE_URL, [
+                'allow_redirects' => false,
+                'timeout'         => 10,
+                'headers'         => [
+                    'Accept'     => 'application/json',
+                    'User-Agent' => 'Flarum/'.Application::VERSION,
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('Could not fetch abandoned extensions list: '.$e->getMessage(), 0, $e);
+        }
+
+        $data = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($data)) {
+            throw new RuntimeException('Abandoned extensions list returned invalid JSON.');
+        }
+
+        return $data;
+    }
+
+    protected function notifyAdmins(array $newPackages, array $map): void
+    {
+        $admins = User::whereHas('groups', fn ($q) => $q->where('id', Group::ADMINISTRATOR_ID))->get();
+
+        $lines = array_map(function (string $package) use ($map) {
+            $replacement = $map[$package]['replacement'] ?? null;
+
+            return $replacement
+                ? $this->translator->trans('core.email.abandoned_extensions.line_with_replacement', compact('package', 'replacement'))
+                : $this->translator->trans('core.email.abandoned_extensions.line_no_replacement', compact('package'));
+        }, $newPackages);
+
+        $subject = $this->translator->trans('core.email.abandoned_extensions.subject');
+
+        foreach ($admins as $admin) {
+            $body = $this->translator->trans('core.email.abandoned_extensions.body', [
+                'username'   => $admin->display_name,
+                'extensions' => implode("\n", $lines),
+            ]);
+
+            $this->queue->push(new SendRawEmailJob($admin->email, $subject, $body));
+        }
+    }
+
+    /**
+     * Returns an associative array of composer package name => true for all
+     * installed Flarum extensions.
+     */
+    protected function installedPackageNames(): array
+    {
+        $names = [];
+
+        foreach ($this->extensions->getExtensions() as $extension) {
+            $names[$extension->name] = true;
+        }
+
+        return $names;
+    }
+
+    /**
+     * Return the cached map from settings, or an empty array if not yet fetched.
+     *
+     * @return array<string, array{replacement?: string}>
+     */
+    public static function getCachedMap(SettingsRepositoryInterface $settings): array
+    {
+        $raw = $settings->get(self::SETTINGS_KEY);
+
+        if (! $raw) {
+            return [];
+        }
+
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+}

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -86,9 +86,9 @@ class AbandonedExtensionsFetcher
         try {
             $response = $this->client->get(self::SOURCE_URL, [
                 'allow_redirects' => false,
-                'timeout'         => 10,
-                'headers'         => [
-                    'Accept'     => 'application/json',
+                'timeout' => 10,
+                'headers' => [
+                    'Accept' => 'application/json',
                     'User-Agent' => 'Flarum/'.Application::VERSION,
                 ],
             ]);
@@ -121,7 +121,7 @@ class AbandonedExtensionsFetcher
 
         foreach ($admins as $admin) {
             $body = $this->translator->trans('core.email.abandoned_extensions.body', [
-                'username'   => $admin->display_name,
+                'username' => $admin->display_name,
                 'extensions' => implode("\n", $lines),
             ]);
 

--- a/framework/core/src/Extension/Console/SyncAbandonedExtensionsCommand.php
+++ b/framework/core/src/Extension/Console/SyncAbandonedExtensionsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Console;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Illuminate\Console\Command;
+
+class SyncAbandonedExtensionsCommand extends Command
+{
+    protected $signature = 'extensions:sync-abandoned {--notify : Email admins if newly abandoned extensions are found}';
+    protected $description = 'Sync the list of abandoned extensions from flarum/abandoned-extensions.';
+
+    public function handle(AbandonedExtensionsFetcher $fetcher): int
+    {
+        $this->info('Fetching abandoned extensions list...');
+
+        try {
+            $result = $fetcher->sync($this->option('notify'));
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Stored {$result['count']} abandoned extension(s) matching installed packages.");
+
+        if ($result['new']) {
+            $this->info('Newly flagged: '.implode(', ', $result['new']));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/framework/core/src/Extension/Console/WeeklySchedule.php
+++ b/framework/core/src/Extension/Console/WeeklySchedule.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Console;
+
+use Illuminate\Console\Scheduling\Event;
+
+class WeeklySchedule
+{
+    public function __invoke(Event $event): void
+    {
+        $event->weekly()->withoutOverlapping();
+    }
+}

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -118,6 +118,8 @@ class ExtensionManager
                 }
             }
 
+            $abandonedMap = AbandonedExtensionsFetcher::getCachedMap($this->config);
+
             foreach ($composerJsonConfs as $path => $package) {
                 $installedSet[Arr::get($package, 'name')] = true;
 
@@ -128,21 +130,30 @@ class ExtensionManager
                 $extension->setInstalled(true);
                 $extension->setVersion(Arr::get($package, 'version'));
 
-                // Set abandoned status if the package is marked as abandoned in composer
-                // The abandoned field can be either true (no replacement) or a string (replacement package name)
-                $abandoned = Arr::get($package, 'abandoned');
-                if (is_string($abandoned) && ! empty($abandoned)) {
-                    // Always set abandoned status if a replacement package is specified
-                    $extension->setAbandoned($abandoned);
-                } elseif ($abandoned === true) {
-                    // If abandoned is just true (no replacement), check the package source
-                    // Packages from flarum.org/composer may have unreliable abandoned flags
-                    $distUrl = Arr::get($package, 'dist.url', '');
-                    $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
+                $packageName = Arr::get($package, 'name');
 
-                    // Only set abandoned if NOT from flarum.org/composer
-                    if (! $isFromFlarumComposer) {
+                // The flarum/abandoned-extensions list takes precedence over composer's abandoned field,
+                // allowing us to flag extensions that haven't been marked on Packagist.
+                if (isset($abandonedMap[$packageName])) {
+                    $replacement = Arr::get($abandonedMap[$packageName], 'replacement', true);
+                    $extension->setAbandoned($replacement);
+                } else {
+                    // Set abandoned status if the package is marked as abandoned in composer.
+                    // The abandoned field can be either true (no replacement) or a string (replacement package name).
+                    $abandoned = Arr::get($package, 'abandoned');
+                    if (is_string($abandoned) && ! empty($abandoned)) {
+                        // Always set abandoned status if a replacement package is specified.
                         $extension->setAbandoned($abandoned);
+                    } elseif ($abandoned === true) {
+                        // If abandoned is just true (no replacement), check the package source.
+                        // Packages from flarum.org/composer may have unreliable abandoned flags.
+                        $distUrl = Arr::get($package, 'dist.url', '');
+                        $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
+
+                        // Only set abandoned if NOT from flarum.org/composer.
+                        if (! $isFromFlarumComposer) {
+                            $extension->setAbandoned($abandoned);
+                        }
                     }
                 }
 

--- a/framework/core/src/Extension/ExtensionServiceProvider.php
+++ b/framework/core/src/Extension/ExtensionServiceProvider.php
@@ -9,9 +9,14 @@
 
 namespace Flarum\Extension;
 
+use Flarum\Extension\Console\SyncAbandonedExtensionsCommand;
+use Flarum\Extension\Console\WeeklySchedule;
 use Flarum\Extension\Event\Disabling;
 use Flarum\Foundation\AbstractServiceProvider;
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Queue;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ExtensionServiceProvider extends AbstractServiceProvider
 {
@@ -22,6 +27,16 @@ class ExtensionServiceProvider extends AbstractServiceProvider
     {
         $this->container->singleton(ExtensionManager::class);
         $this->container->alias(ExtensionManager::class, 'flarum.extensions');
+
+        $this->container->singleton(AbandonedExtensionsFetcher::class, function ($container) {
+            return new AbandonedExtensionsFetcher(
+                $container->make(ExtensionManager::class),
+                $container->make('flarum.settings'),
+                new Client(),
+                $container->make(Queue::class),
+                $container->make(TranslatorInterface::class)
+            );
+        });
 
         // Boot extensions when the app is booting. This must be done as a boot
         // listener on the app rather than in the service provider's boot method
@@ -41,5 +56,21 @@ class ExtensionServiceProvider extends AbstractServiceProvider
             Disabling::class,
             DefaultLanguagePackGuard::class
         );
+
+        $this->container->extend('flarum.console.commands', function (array $commands) {
+            $commands[] = SyncAbandonedExtensionsCommand::class;
+
+            return $commands;
+        });
+
+        $this->container->extend('flarum.console.scheduled', function (array $scheduled) {
+            $scheduled[] = [
+                'command'  => SyncAbandonedExtensionsCommand::class,
+                'args'     => ['--notify'],
+                'callback' => new WeeklySchedule(),
+            ];
+
+            return $scheduled;
+        });
     }
 }

--- a/framework/core/src/Extension/ExtensionServiceProvider.php
+++ b/framework/core/src/Extension/ExtensionServiceProvider.php
@@ -65,8 +65,8 @@ class ExtensionServiceProvider extends AbstractServiceProvider
 
         $this->container->extend('flarum.console.scheduled', function (array $scheduled) {
             $scheduled[] = [
-                'command'  => SyncAbandonedExtensionsCommand::class,
-                'args'     => ['--notify'],
+                'command' => SyncAbandonedExtensionsCommand::class,
+                'args' => ['--notify'],
                 'callback' => new WeeklySchedule(),
             ];
 

--- a/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
+++ b/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
@@ -31,7 +31,9 @@ class SyncAbandonedExtensionsTest extends TestCase
         $this->app()->getContainer()->instance(
             AbandonedExtensionsFetcher::class,
             new class extends AbandonedExtensionsFetcher {
-                public function __construct() {}
+                public function __construct()
+                {
+                }
 
                 public function sync(bool $notify = false): array
                 {

--- a/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
+++ b/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
@@ -35,7 +35,7 @@ class SyncAbandonedExtensionsTest extends TestCase
                 {
                 }
 
-                public function sync(bool $notify = false): array
+                public function sync(bool $notify = false, bool $manual = false): array
                 {
                     return ['count' => 2, 'new' => ['vendor/pkg-a']];
                 }

--- a/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
+++ b/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\extensions;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class SyncAbandonedExtensionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+
+        // Bind a fake fetcher that doesn't make real HTTP requests.
+        $this->app()->getContainer()->instance(
+            AbandonedExtensionsFetcher::class,
+            new class extends AbandonedExtensionsFetcher {
+                public function __construct() {}
+
+                public function sync(bool $notify = false): array
+                {
+                    return ['count' => 2, 'new' => ['vendor/pkg-a']];
+                }
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function guest_cannot_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync')
+                ->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function normal_user_cannot_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function admin_can_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('count', $body);
+        $this->assertIsInt($body['count']);
+    }
+}

--- a/framework/core/tests/unit/Extension/AbandonedExtensionsFetcherTest.php
+++ b/framework/core/tests/unit/Extension/AbandonedExtensionsFetcherTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Extension;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+
+class AbandonedExtensionsFetcherTest extends TestCase
+{
+    private function settingsWithMap(?string $json): SettingsRepositoryInterface
+    {
+        $settings = $this->createMock(SettingsRepositoryInterface::class);
+        $settings->method('get')
+            ->with(AbandonedExtensionsFetcher::SETTINGS_KEY)
+            ->willReturn($json);
+
+        return $settings;
+    }
+
+    /** @test */
+    public function returns_empty_array_when_no_cached_map(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(null));
+
+        $this->assertSame([], $map);
+    }
+
+    /** @test */
+    public function returns_empty_array_when_cached_value_is_invalid_json(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap('not-valid-json'));
+
+        $this->assertSame([], $map);
+    }
+
+    /** @test */
+    public function returns_abandoned_entry_without_replacement(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/old-package' => [],
+        ])));
+
+        $this->assertArrayHasKey('vendor/old-package', $map);
+        $this->assertSame([], $map['vendor/old-package']);
+    }
+
+    /** @test */
+    public function returns_abandoned_entry_with_replacement(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/old-package' => ['replacement' => 'vendor/new-package'],
+        ])));
+
+        $this->assertSame('vendor/new-package', $map['vendor/old-package']['replacement']);
+    }
+
+    /** @test */
+    public function returns_multiple_entries(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/pkg-a' => ['replacement' => 'vendor/pkg-b'],
+            'vendor/pkg-c' => [],
+        ])));
+
+        $this->assertCount(2, $map);
+        $this->assertArrayHasKey('vendor/pkg-a', $map);
+        $this->assertArrayHasKey('vendor/pkg-c', $map);
+    }
+}


### PR DESCRIPTION
Adds a weekly scheduled task that fetches the community-maintained [flarum/abandoned-extensions](https://github.com/flarum/abandoned-extensions) list, filters it to installed packages, and surfaces the results in the admin panel.

## What's included

- `AbandonedExtensionsFetcher` — fetches, filters, diffs, and stores the list; optionally emails admins
- `SyncAbandonedExtensionsCommand` — CLI command with `--notify` flag, scheduled weekly
- `POST /api/extensions/abandoned/sync` — manual trigger for admins
- **Basics page** — "Check Now" button and a toggle to email admins when newly abandoned extensions are detected during the weekly check
- `ExtensionManager` — applies abandoned status from the stored map, taking precedence over composer's own `abandoned` field

## Behaviour

- The weekly scheduled run only notifies about *newly* flagged extensions (diff against previous map) to avoid repeat emails
- The manual "Check Now" button always notifies about all currently installed abandoned extensions
- The notify-admins setting defaults to off