### PR TITLE
[2.x] feat: sync abandoned extensions list from flarum/abandoned-extensions

### DIFF
--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -6,6 +6,8 @@ import type { IPageAttrs } from '../../common/components/Page';
 import type Mithril from 'mithril';
 import Form from '../../common/components/Form';
 import extractText from '../../common/utils/extractText';
+import Button from '../../common/components/Button';
+import Link from '../../common/components/Link';
 
 export type HomePageItem = { path: string; label: Mithril.Children };
 export type DriverLocale = {
@@ -112,6 +114,32 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
       });
     });
 
+    let abandonedSyncing = false;
+    let abandonedSyncMessage: Mithril.Children = null;
+
+    function syncAbandoned() {
+      if (abandonedSyncing) return;
+
+      abandonedSyncing = true;
+      abandonedSyncMessage = null;
+
+      app
+        .request<{ count: number }>({
+          method: 'POST',
+          url: app.forum.attribute('apiUrl') + '/extensions/abandoned/sync',
+        })
+        .then((response) => {
+          abandonedSyncing = false;
+          abandonedSyncMessage = app.translator.trans('core.admin.basics.abandoned_extensions_sync_success', { count: response.count });
+          m.redraw();
+        })
+        .catch(() => {
+          abandonedSyncing = false;
+          abandonedSyncMessage = app.translator.trans('core.admin.basics.abandoned_extensions_sync_error');
+          m.redraw();
+        });
+    }
+
     app.registry.for('core-basics');
 
     app.registry
@@ -203,5 +231,34 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
         });
       }
     });
+
+    app.registry.registerSetting(
+      function (this: AdminPage) {
+        return (
+          <div className="Form-group">
+            <label>{app.translator.trans('core.admin.basics.abandoned_extensions_heading')}</label>
+            <div className="helpText">
+              {app.translator.trans('core.admin.basics.abandoned_extensions_text', {
+                a: <Link href="https://github.com/flarum/abandoned-extensions" target="_blank" external={true} />,
+              })}
+            </div>
+            <div className="Form-row">
+              <Button className="Button" onclick={syncAbandoned} loading={abandonedSyncing} disabled={abandonedSyncing}>
+                {app.translator.trans('core.admin.basics.abandoned_extensions_sync_button')}
+              </Button>
+              {abandonedSyncMessage && <span className="helpText">{abandonedSyncMessage}</span>}
+            </div>
+            <br />
+            {this.buildSettingComponent({
+              type: 'switch',
+              setting: 'flarum-core.notify_admins_on_abandoned',
+              label: app.translator.trans('core.admin.basics.abandoned_extensions_notify_admins_label'),
+            })}
+          </div>
+        );
+      },
+      -10,
+      'abandoned-extensions'
+    );
   }
 }

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -1141,16 +1141,10 @@ core:
     # These translations are used in emails sent to admins when abandoned extensions are detected
     abandoned_extensions:
       subject: "Action required: abandoned extension(s) detected"
-      body: |
-        Hi {username},
-
-        The following installed extension(s) have been flagged as abandoned:
-
-        {extensions}
-
-        Please review these extensions and consider migrating to alternatives where available.
-      line_with_replacement: "- {package} (suggested replacement: {replacement})"
-      line_no_replacement: "- {package} (no replacement available)"
+      body_intro: "Hi {username}, the following installed extension(s) have been flagged as abandoned:"
+      body_outro: "Please review these extensions and consider migrating to alternatives where available."
+      line_with_replacement: "{package} (suggested replacement: {replacement})"
+      line_no_replacement: "{package} (no replacement available)"
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -1141,7 +1141,7 @@ core:
     # These translations are used in emails sent to admins when abandoned extensions are detected
     abandoned_extensions:
       subject: "Action required: abandoned extension(s) detected"
-      body_intro: "Hi {username}, the following installed extension(s) have been flagged as abandoned:"
+      body_intro: "The following installed extension(s) have been flagged as abandoned:"
       body_outro: "Please review these extensions and consider migrating to alternatives where available."
       line_with_replacement: "{package} (suggested replacement: {replacement})"
       line_no_replacement: "{package} (no replacement available)"

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -159,6 +159,12 @@ core:
       title: Basics
       welcome_banner_heading: Welcome Banner
       welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
+      abandoned_extensions_heading: Abandoned Extensions
+      abandoned_extensions_text: "Flarum maintains a <a>community list of abandoned extensions</a>. When an installed extension appears on the list, it will be flagged in the admin panel."
+      abandoned_extensions_sync_button: Check Now
+      abandoned_extensions_sync_success: "Abandoned extensions list updated. {count} matching installed extension(s) found."
+      abandoned_extensions_sync_error: Failed to fetch the abandoned extensions list. Please try again later.
+      abandoned_extensions_notify_admins_label: Email admins when a newly abandoned extension is detected during the weekly check
 
     # These translations are used in the Create User modal.
     create_user:
@@ -1131,6 +1137,20 @@ core:
         If this was you, this email means that your configuration works!
 
         If this was not you, please ignore this email.
+
+    # These translations are used in emails sent to admins when abandoned extensions are detected
+    abandoned_extensions:
+      subject: "Action required: abandoned extension(s) detected"
+      body: |
+        Hi {username},
+
+        The following installed extension(s) have been flagged as abandoned:
+
+        {extensions}
+
+        Please review these extensions and consider migrating to alternatives where available.
+      line_with_replacement: "- {package} (suggested replacement: {replacement})"
+      line_no_replacement: "- {package} (no replacement available)"
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!

--- a/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
+++ b/framework/core/src/Api/Controller/SyncAbandonedExtensionsController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Http\RequestUtil;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SyncAbandonedExtensionsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected AbandonedExtensionsFetcher $fetcher,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        try {
+            $result = $this->fetcher->sync(true, true);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 500);
+        }
+
+        return new JsonResponse(['count' => $result['count'], 'new' => $result['new']]);
+    }
+}

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -204,6 +204,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\SendTestMailController::class)
     );
 
+    // Trigger a sync of the abandoned extensions list
+    $map->post(
+        '/extensions/abandoned/sync',
+        'extensions.abandoned.sync',
+        $route->toController(Controller\SyncAbandonedExtensionsController::class)
+    );
+
     // List Flarum community announcements from discuss.flarum.org
     $map->get(
         '/flarum/announcements',

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -11,7 +11,7 @@ namespace Flarum\Extension;
 
 use Flarum\Foundation\Application;
 use Flarum\Group\Group;
-use Flarum\Mail\Job\SendInformationalEmailJob;
+use Flarum\Mail\Job\SendAbandonedExtensionsEmailJob;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use GuzzleHttp\Client;
@@ -125,16 +125,11 @@ class AbandonedExtensionsFetcher
         $forumTitle = $this->settings->get('forum_title', '');
 
         foreach ($admins as $admin) {
-            $body = $this->translator->trans('core.email.abandoned_extensions.body', [
-                'username' => $admin->display_name,
-                'extensions' => implode("\n", $lines),
-            ]);
-
-            $this->queue->push(new SendInformationalEmailJob(
+            $this->queue->push(new SendAbandonedExtensionsEmailJob(
                 email: $admin->email,
-                displayName: $admin->display_name,
+                username: $admin->display_name,
                 subject: $subject,
-                body: $body,
+                extensionLines: $lines,
                 forumTitle: $forumTitle,
             ));
         }

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension;
+
+use Flarum\Foundation\Application;
+use Flarum\Group\Group;
+use Flarum\Mail\Job\SendInformationalEmailJob;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Contracts\Queue\Queue;
+use RuntimeException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class AbandonedExtensionsFetcher
+{
+    public const SETTINGS_KEY = 'flarum-core.abandoned_extensions_map';
+    public const NOTIFY_ADMINS_SETTING = 'flarum-core.notify_admins_on_abandoned';
+
+    protected const SOURCE_URL = 'https://raw.githubusercontent.com/flarum/abandoned-extensions/main/abandoned.json';
+
+    public function __construct(
+        protected ExtensionManager $extensions,
+        protected SettingsRepositoryInterface $settings,
+        protected Client $client,
+        protected Queue $queue,
+        protected TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * Fetch the upstream abandoned extensions list, filter to installed packages,
+     * persist the result to settings, and optionally notify admins.
+     *
+     * When $notify is true and the notify-admins setting is enabled:
+     * - On a scheduled (automatic) run: only notifies about packages newly flagged
+     *   since the last sync, to avoid repeating the same email every week.
+     * - On a manual run ($manual = true): notifies about all currently installed
+     *   abandoned extensions, since the admin explicitly requested the check.
+     *
+     * @throws RuntimeException
+     * @return array{count: int, new: string[]}
+     */
+    public function sync(bool $notify = false, bool $manual = false): array
+    {
+        $map = $this->fetch();
+        $installed = $this->installedPackageNames();
+
+        $filtered = array_filter(
+            $map,
+            function (string $name) use ($installed) {
+                return isset($installed[$name]);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $previous = static::getCachedMap($this->settings);
+        $new = array_keys(array_diff_key($filtered, $previous));
+
+        $this->settings->set(self::SETTINGS_KEY, json_encode($filtered));
+
+        if ($notify && $this->settings->get(self::NOTIFY_ADMINS_SETTING)) {
+            // Manual trigger: notify about all installed abandoned extensions.
+            // Scheduled trigger: only notify about newly detected ones.
+            $toNotify = $manual ? array_keys($filtered) : $new;
+
+            if ($toNotify) {
+                $this->notifyAdmins($toNotify, $filtered);
+            }
+        }
+
+        return ['count' => count($filtered), 'new' => $new];
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    protected function fetch(): array
+    {
+        try {
+            $response = $this->client->get(self::SOURCE_URL, [
+                'allow_redirects' => false,
+                'timeout' => 10,
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Flarum/'.Application::VERSION,
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('Could not fetch abandoned extensions list: '.$e->getMessage(), 0, $e);
+        }
+
+        $data = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($data)) {
+            throw new RuntimeException('Abandoned extensions list returned invalid JSON.');
+        }
+
+        return $data;
+    }
+
+    protected function notifyAdmins(array $newPackages, array $map): void
+    {
+        $admins = User::whereHas('groups', function ($q) {
+            $q->where('id', Group::ADMINISTRATOR_ID);
+        })->get();
+
+        $lines = array_map(function (string $package) use ($map) {
+            $replacement = $map[$package]['replacement'] ?? null;
+
+            return $replacement
+                ? $this->translator->trans('core.email.abandoned_extensions.line_with_replacement', compact('package', 'replacement'))
+                : $this->translator->trans('core.email.abandoned_extensions.line_no_replacement', compact('package'));
+        }, $newPackages);
+
+        $subject = $this->translator->trans('core.email.abandoned_extensions.subject');
+        $forumTitle = $this->settings->get('forum_title', '');
+
+        foreach ($admins as $admin) {
+            $body = $this->translator->trans('core.email.abandoned_extensions.body', [
+                'username' => $admin->display_name,
+                'extensions' => implode("\n", $lines),
+            ]);
+
+            $this->queue->push(new SendInformationalEmailJob(
+                email: $admin->email,
+                displayName: $admin->display_name,
+                subject: $subject,
+                body: $body,
+                forumTitle: $forumTitle,
+            ));
+        }
+    }
+
+    /**
+     * Returns an associative array of composer package name => true for all
+     * installed Flarum extensions.
+     */
+    protected function installedPackageNames(): array
+    {
+        $names = [];
+
+        foreach ($this->extensions->getExtensions() as $extension) {
+            $names[$extension->name] = true;
+        }
+
+        return $names;
+    }
+
+    /**
+     * Return the cached map from settings, or an empty array if not yet fetched.
+     *
+     * @return array<string, array{replacement?: string}>
+     */
+    public static function getCachedMap(SettingsRepositoryInterface $settings): array
+    {
+        $raw = $settings->get(self::SETTINGS_KEY);
+
+        if (! $raw) {
+            return [];
+        }
+
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+}

--- a/framework/core/src/Extension/Console/SyncAbandonedExtensionsCommand.php
+++ b/framework/core/src/Extension/Console/SyncAbandonedExtensionsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Console;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Illuminate\Console\Command;
+
+class SyncAbandonedExtensionsCommand extends Command
+{
+    protected $signature = 'extensions:sync-abandoned {--notify : Email admins if newly abandoned extensions are found}';
+    protected $description = 'Sync the list of abandoned extensions from flarum/abandoned-extensions.';
+
+    public function handle(AbandonedExtensionsFetcher $fetcher): int
+    {
+        $this->info('Fetching abandoned extensions list...');
+
+        try {
+            $result = $fetcher->sync($this->option('notify'));
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Stored {$result['count']} abandoned extension(s) matching installed packages.");
+
+        if ($result['new']) {
+            $this->info('Newly flagged: '.implode(', ', $result['new']));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/framework/core/src/Extension/Console/WeeklySchedule.php
+++ b/framework/core/src/Extension/Console/WeeklySchedule.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Extension\Console;
+
+use Illuminate\Console\Scheduling\Event;
+
+class WeeklySchedule
+{
+    public function __invoke(Event $event): void
+    {
+        $event->weekly()->withoutOverlapping();
+    }
+}

--- a/framework/core/src/Extension/ExtensionManager.php
+++ b/framework/core/src/Extension/ExtensionManager.php
@@ -520,21 +520,31 @@ class ExtensionManager
         $extension->setInstalled(true);
         $extension->setVersion(Arr::get($package, 'version', '0.0'));
 
-        // Set abandoned status if the package is marked as abandoned in composer
-        // The abandoned field can be either true (no replacement) or a string (replacement package name)
-        $abandoned = Arr::get($package, 'abandoned');
-        if (is_string($abandoned) && ! empty($abandoned)) {
-            // Always set abandoned status if a replacement package is specified
-            $extension->setAbandoned($abandoned);
-        } elseif ($abandoned === true) {
-            // If abandoned is just true (no replacement), check the package source
-            // Packages from flarum.org/composer may have unreliable abandoned flags
-            $distUrl = Arr::get($package, 'dist.url', '');
-            $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
+        $packageName = Arr::get($package, 'name');
 
-            // Only set abandoned if NOT from flarum.org/composer
-            if (! $isFromFlarumComposer) {
+        // The flarum/abandoned-extensions list takes precedence over composer's abandoned field,
+        // allowing us to flag extensions that haven't been marked on Packagist.
+        $abandonedMap = AbandonedExtensionsFetcher::getCachedMap($this->config);
+        if (isset($abandonedMap[$packageName])) {
+            $replacement = Arr::get($abandonedMap[$packageName], 'replacement', true);
+            $extension->setAbandoned($replacement);
+        } else {
+            // Set abandoned status if the package is marked as abandoned in composer.
+            // The abandoned field can be either true (no replacement) or a string (replacement package name).
+            $abandoned = Arr::get($package, 'abandoned');
+            if (is_string($abandoned) && ! empty($abandoned)) {
+                // Always set abandoned status if a replacement package is specified.
                 $extension->setAbandoned($abandoned);
+            } elseif ($abandoned === true) {
+                // If abandoned is just true (no replacement), check the package source.
+                // Packages from flarum.org/composer may have unreliable abandoned flags.
+                $distUrl = Arr::get($package, 'dist.url', '');
+                $isFromFlarumComposer = str_contains($distUrl, 'flarum.org/composer');
+
+                // Only set abandoned if NOT from flarum.org/composer.
+                if (! $isFromFlarumComposer) {
+                    $extension->setAbandoned($abandoned);
+                }
             }
         }
 

--- a/framework/core/src/Extension/ExtensionServiceProvider.php
+++ b/framework/core/src/Extension/ExtensionServiceProvider.php
@@ -9,11 +9,16 @@
 
 namespace Flarum\Extension;
 
+use Flarum\Extension\Console\SyncAbandonedExtensionsCommand;
+use Flarum\Extension\Console\WeeklySchedule;
 use Flarum\Extension\Event\Disabling;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Settings\SettingsRepositoryInterface;
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Queue;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ExtensionServiceProvider extends AbstractServiceProvider
 {
@@ -21,6 +26,16 @@ class ExtensionServiceProvider extends AbstractServiceProvider
     {
         $this->container->singleton(ExtensionManager::class);
         $this->container->alias(ExtensionManager::class, 'flarum.extensions');
+
+        $this->container->singleton(AbandonedExtensionsFetcher::class, function ($container) {
+            return new AbandonedExtensionsFetcher(
+                $container->make(ExtensionManager::class),
+                $container->make('flarum.settings'),
+                new Client(),
+                $container->make(Queue::class),
+                $container->make(TranslatorInterface::class)
+            );
+        });
 
         // Boot extensions when the app is booting. This must be done as a boot
         // listener on the app rather than in the service provider's boot method
@@ -42,5 +57,21 @@ class ExtensionServiceProvider extends AbstractServiceProvider
             Disabling::class,
             DefaultLanguagePackGuard::class
         );
+
+        $this->container->extend('flarum.console.commands', function (array $commands) {
+            $commands[] = SyncAbandonedExtensionsCommand::class;
+
+            return $commands;
+        });
+
+        $this->container->extend('flarum.console.scheduled', function (array $scheduled) {
+            $scheduled[] = [
+                'command' => SyncAbandonedExtensionsCommand::class,
+                'args' => ['--notify'],
+                'callback' => new WeeklySchedule(),
+            ];
+
+            return $scheduled;
+        });
     }
 }

--- a/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
+++ b/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
@@ -39,7 +39,7 @@ class SendAbandonedExtensionsEmailJob extends AbstractJob
                 'html' => 'mail::html.abandoned_extensions.notify',
                 'text' => 'mail::plain.abandoned_extensions.notify',
             ],
-            compact('extensionLines', 'username'),
+            compact('extensionLines'),
             function (Message $message) {
                 $message->to($this->email);
                 $message->subject($this->subject);

--- a/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
+++ b/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail\Job;
+
+use Flarum\Queue\AbstractJob;
+use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Message;
+
+class SendAbandonedExtensionsEmailJob extends AbstractJob
+{
+    public function __construct(
+        private readonly string $email,
+        private readonly string $username,
+        private readonly string $subject,
+        private readonly array $extensionLines,
+        private readonly string $forumTitle,
+    ) {
+    }
+
+    public function handle(Mailer $mailer, Factory $view): void
+    {
+        $username = $this->username;
+        $forumTitle = $this->forumTitle;
+        $userEmail = $this->email;
+        $extensionLines = $this->extensionLines;
+
+        $view->share(compact('forumTitle', 'userEmail', 'username'));
+
+        $mailer->send(
+            [
+                'html' => 'mail::html.abandoned_extensions.notify',
+                'text' => 'mail::plain.abandoned_extensions.notify',
+            ],
+            compact('extensionLines', 'username'),
+            function (Message $message) {
+                $message->to($this->email);
+                $message->subject($this->subject);
+            }
+        );
+    }
+}

--- a/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
+++ b/framework/core/tests/integration/api/extensions/SyncAbandonedExtensionsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\extensions;
+
+use Flarum\Extend;
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class SyncAbandonedExtensionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Replace the real fetcher with a stub so tests never make real HTTP requests.
+        $this->extend(
+            (new Extend\ServiceProvider())->register(StubAbandonedExtensionsProvider::class)
+        );
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    #[Test]
+    public function guest_cannot_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync')
+                ->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normal_user_cannot_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_trigger_sync(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/extensions/abandoned/sync', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('count', $body);
+        $this->assertIsInt($body['count']);
+    }
+}
+
+class StubAbandonedExtensionsFetcher extends AbandonedExtensionsFetcher
+{
+    public function __construct()
+    {
+    }
+
+    public function sync(bool $notify = false, bool $manual = false): array
+    {
+        return ['count' => 2, 'new' => ['vendor/pkg-a']];
+    }
+}
+
+class StubAbandonedExtensionsProvider extends AbstractServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->instance(AbandonedExtensionsFetcher::class, new StubAbandonedExtensionsFetcher());
+    }
+}

--- a/framework/core/tests/unit/Extension/AbandonedExtensionsFetcherTest.php
+++ b/framework/core/tests/unit/Extension/AbandonedExtensionsFetcherTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Extension;
+
+use Flarum\Extension\AbandonedExtensionsFetcher;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AbandonedExtensionsFetcherTest extends TestCase
+{
+    private function settingsWithMap(?string $json): SettingsRepositoryInterface
+    {
+        $settings = $this->createMock(SettingsRepositoryInterface::class);
+        $settings->method('get')
+            ->with(AbandonedExtensionsFetcher::SETTINGS_KEY)
+            ->willReturn($json);
+
+        return $settings;
+    }
+
+    #[Test]
+    public function returns_empty_array_when_no_cached_map(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(null));
+
+        $this->assertSame([], $map);
+    }
+
+    #[Test]
+    public function returns_empty_array_when_cached_value_is_invalid_json(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap('not-valid-json'));
+
+        $this->assertSame([], $map);
+    }
+
+    #[Test]
+    public function returns_abandoned_entry_without_replacement(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/old-package' => [],
+        ])));
+
+        $this->assertArrayHasKey('vendor/old-package', $map);
+        $this->assertSame([], $map['vendor/old-package']);
+    }
+
+    #[Test]
+    public function returns_abandoned_entry_with_replacement(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/old-package' => ['replacement' => 'vendor/new-package'],
+        ])));
+
+        $this->assertSame('vendor/new-package', $map['vendor/old-package']['replacement']);
+    }
+
+    #[Test]
+    public function returns_multiple_entries(): void
+    {
+        $map = AbandonedExtensionsFetcher::getCachedMap($this->settingsWithMap(json_encode([
+            'vendor/pkg-a' => ['replacement' => 'vendor/pkg-b'],
+            'vendor/pkg-c' => [],
+        ])));
+
+        $this->assertCount(2, $map);
+        $this->assertArrayHasKey('vendor/pkg-a', $map);
+        $this->assertArrayHasKey('vendor/pkg-c', $map);
+    }
+}

--- a/framework/core/views/email/html/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/html/abandoned_extensions/notify.blade.php
@@ -1,6 +1,6 @@
 <x-mail::html.information>
     <x-slot:content>
-        <p>{{ $translator->trans('core.email.abandoned_extensions.body_intro', ['username' => $username]) }}</p>
+        <p>{{ $translator->trans('core.email.abandoned_extensions.body_intro') }}</p>
         <ul>
             @foreach ($extensionLines as $line)
                 <li>{{ $line }}</li>

--- a/framework/core/views/email/html/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/html/abandoned_extensions/notify.blade.php
@@ -1,0 +1,11 @@
+<x-mail::html.information>
+    <x-slot:content>
+        <p>{{ $translator->trans('core.email.abandoned_extensions.body_intro', ['username' => $username]) }}</p>
+        <ul>
+            @foreach ($extensionLines as $line)
+                <li>{{ $line }}</li>
+            @endforeach
+        </ul>
+        <p>{{ $translator->trans('core.email.abandoned_extensions.body_outro') }}</p>
+    </x-slot:content>
+</x-mail::html.information>

--- a/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
@@ -1,0 +1,11 @@
+<x-mail::plain.information>
+<x-slot:content>
+{{ $translator->trans('core.email.abandoned_extensions.body_intro', ['username' => $username]) }}
+
+@foreach ($extensionLines as $line)
+{{ $line }}
+@endforeach
+
+{{ $translator->trans('core.email.abandoned_extensions.body_outro') }}
+</x-slot:content>
+</x-mail::plain.information>

--- a/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
@@ -1,6 +1,6 @@
 <x-mail::plain.information>
 <x-slot:content>
-{{ $translator->trans('core.email.abandoned_extensions.body_intro', ['username' => $username]) }}
+{{ $translator->trans('core.email.abandoned_extensions.body_intro') }}
 
 @foreach ($extensionLines as $line)
 {{ $line }}


### PR DESCRIPTION
Ports #4559 to 2.x.

Adds a weekly scheduled task that fetches the community-maintained [flarum/abandoned-extensions](https://github.com/flarum/abandoned-extensions) list, filters it to installed packages, and surfaces the results in the admin panel.

**What's included:**
- `AbandonedExtensionsFetcher` — fetches, filters, diffs, and stores the list; optionally emails admins
- `SyncAbandonedExtensionsCommand` — CLI command with `--notify` flag, scheduled weekly
- `POST /api/extensions/abandoned/sync` — manual trigger for admins
- **Basics page** — "Check Now" button and a toggle to email admins when newly abandoned extensions are detected during the weekly check
- `ExtensionManager` — applies abandoned status from the stored map in `extensionFromJson()`, taking precedence over composer's own `abandoned` field

**2.x adaptations:**
- `SendRawEmailJob` → `SendInformationalEmailJob` (with named constructor args)
- Abandoned map applied in `extensionFromJson()` rather than inline in `getExtensions()`
- `ExtensionServiceProvider` uses constructor property promotion style
- `BasicsPage` uses the registry callback pattern (`registerSetting()` with a function) rather than overriding `contentItems()`
- Integration tests use `Extend\ServiceProvider` stub pattern; `#[Test]` attributes (PHPUnit 11)