### PR TITLE
[2.x] perf: frontend performance improvements — preconnect hints, fetchpriority, FOUC fix, viewport

### DIFF
--- a/framework/core/src/Frontend/Content/Meta.php
+++ b/framework/core/src/Frontend/Content/Meta.php
@@ -35,7 +35,7 @@ readonly class Meta
         $forumApiDocument = $document->getForumApiDocument();
 
         return [
-            'viewport' => 'width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1',
+            'viewport' => 'width=device-width, initial-scale=1',
             'description' => Arr::get($forumApiDocument, 'data.attributes.description'),
             'theme-color' => Arr::get($forumApiDocument, 'data.attributes.themePrimaryColor')
         ];

--- a/framework/core/src/Frontend/Document.php
+++ b/framework/core/src/Frontend/Document.php
@@ -270,17 +270,63 @@ class Document implements Renderable
         }, '');
     }
 
+    protected function makePreconnects(): array
+    {
+        $forumOrigin = $this->config->url()->getScheme().'://'.$this->config->url()->getHost();
+
+        $urls = array_merge($this->css, $this->js, array_column($this->preloads, 'href'));
+
+        $seen = [];
+        $tags = [];
+
+        foreach ($urls as $url) {
+            if (empty($url)) {
+                continue;
+            }
+
+            $parts = parse_url($url);
+
+            if (empty($parts['host'])) {
+                continue;
+            }
+
+            $origin = $parts['scheme'].'://'.$parts['host'];
+
+            if ($origin === $forumOrigin || isset($seen[$origin])) {
+                continue;
+            }
+
+            $seen[$origin] = true;
+            $escaped = e($origin);
+            $tags[] = '<link rel="preconnect" href="'.$escaped.'" crossorigin>';
+            $tags[] = '<link rel="dns-prefetch" href="'.$escaped.'">';
+        }
+
+        return $tags;
+    }
+
     protected function makeHead(): string
     {
-        // Load stylesheets asynchronously to avoid render-blocking.
-        // The onload trick swaps rel from "preload" to "stylesheet" once the file
-        // is fetched. The <noscript> fallback serves JS-disabled browsers.
-        $head = array_map(function ($url) {
-            $escaped = e($url);
+        // On warm visits (CSS already cached), a tiny inline script injects blocking
+        // <link rel="stylesheet"> tags synchronously before first paint — no FOUC, no
+        // network round-trip. On cold visits the sessionStorage keys are absent so the
+        // script exits immediately and the async preload path below takes over.
+        // Versioned URLs act as natural cache-busters: a new deploy changes the URL,
+        // the old sessionStorage key doesn't match, and the async path runs once more.
+        $head = $this->makePreconnects();
 
-            return '<link rel="preload" href="'.$escaped.'" as="style" onload="this.onload=null;this.rel=\'stylesheet\'">'
+        if (! empty($this->css)) {
+            $cssJson = json_encode(array_values($this->css), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
+            $head[] = '<script>(function(){var s='.$cssJson.';if(s.every(function(h){return sessionStorage.getItem("css:"+h);})){s.forEach(function(h){var l=document.createElement("link");l.rel="stylesheet";l.href=h;document.head.appendChild(l);});}Object.keys(sessionStorage).forEach(function(k){if(k.indexOf("css:")===0&&s.indexOf(k.slice(4))===-1){sessionStorage.removeItem(k);}});})();</script>';
+        }
+
+        // Async preload path for cold visits. The onload updates sessionStorage so the
+        // next page load can take the fast synchronous path above.
+        foreach ($this->css as $url) {
+            $escaped = e($url);
+            $head[] = '<link rel="preload" href="'.$escaped.'" as="style" fetchpriority="high" onload="sessionStorage.setItem(\'css:\'+this.href,\'1\');this.onload=null;this.rel=\'stylesheet\'">'
                 .'<noscript><link rel="stylesheet" href="'.$escaped.'"></noscript>';
-        }, $this->css);
+        }
 
         if ($this->page) {
             if ($this->page > 1) {

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -86,7 +86,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     foreach ($document->js as $url) {
                         $js_preloads[] = [
                             'href' => $url,
-                            'as' => 'script'
+                            'as' => 'script',
+                            'fetchpriority' => 'low',
                         ];
                     }
 
@@ -103,6 +104,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     if ($fontAwesome->useCdn()) {
                         $cdnUrl = $fontAwesome->cdnUrl();
                         if (! empty($cdnUrl)) {
+                            $cdnParts = parse_url($cdnUrl);
+                            if (! empty($cdnParts['host'])) {
+                                $cdnOrigin = e($cdnParts['scheme'].'://'.$cdnParts['host']);
+                                $document->head[] = '<link rel="preconnect" href="'.$cdnOrigin.'" crossorigin>';
+                                $document->head[] = '<link rel="dns-prefetch" href="'.$cdnOrigin.'">';
+                            }
                             // Load asynchronously — FA icons are only rendered after JS boots the
                             // SPA, so there is no FOUC risk from deferring this stylesheet.
                             // The <noscript> fallback covers JS-disabled browsers.
@@ -113,6 +120,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     } elseif ($fontAwesome->useKit()) {
                         $kitUrl = $fontAwesome->kitUrl();
                         if (! empty($kitUrl)) {
+                            $kitParts = parse_url($kitUrl);
+                            if (! empty($kitParts['host'])) {
+                                $kitOrigin = e($kitParts['scheme'].'://'.$kitParts['host']);
+                                $document->head[] = '<link rel="preconnect" href="'.$kitOrigin.'" crossorigin>';
+                                $document->head[] = '<link rel="dns-prefetch" href="'.$kitOrigin.'">';
+                            }
                             // Defer Kit JS — it has no dependencies and nothing depends on it
                             // executing synchronously; defer keeps it out of the critical path
                             // while preserving execution order relative to other deferred scripts.

--- a/framework/core/views/frontend/admin.blade.php
+++ b/framework/core/views/frontend/admin.blade.php
@@ -12,9 +12,9 @@
                 <div class="Header-title">
                     <a href="{{ $forum['baseUrl'] }}">
                         @if ($forum['logoUrl'])
-                            <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo">
+                            <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo" loading="eager" fetchpriority="high" decoding="async">
                             @if($forum['logoDarkModeUrl'])
-                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode">
+                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode" loading="eager" fetchpriority="high" decoding="async">
                             @endif
                         @else
                             {{ $forum['title'] }}

--- a/framework/core/views/frontend/forum.blade.php
+++ b/framework/core/views/frontend/forum.blade.php
@@ -14,9 +14,9 @@
                 <div class="Header-title">
                     <a href="{{ $forum['baseUrl'] }}" id="home-link">
                         @if ($forum['logoUrl'])
-                            <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo">
+                            <img src="{{ $forum['logoUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo" loading="eager" fetchpriority="high" decoding="async">
                             @if($forum['logoDarkModeUrl'])
-                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode">
+                                <img src="{{ $forum['logoDarkModeUrl'] }}" alt="{{ $forum['title'] }}" class="Header-logo Header-logo--dark-mode" loading="eager" fetchpriority="high" decoding="async">
                             @endif
                         @else
                             {{ $forum['title'] }}

--- a/framework/core/views/install/app.php
+++ b/framework/core/views/install/app.php
@@ -2,9 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><?php echo $title; ?></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>
       @import url(//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,600);

--- a/framework/core/views/layouts/basic.blade.php
+++ b/framework/core/views/layouts/basic.blade.php
@@ -8,7 +8,7 @@
     <meta charset="utf-8">
     {{-- TODO: Change below to @hasSection when Laravel is upgraded --}}
     <title>@if ($__env->hasSection('title')) @yield('title') - @endif{{ $settings->get('forum_title') }}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>
       * {


### PR DESCRIPTION
## Summary

- **`fetchpriority` on preloads and logo images** — JS preload hints get `fetchpriority="low"` so they don't compete with CSS and fonts. Forum and admin logo `<img>` tags get `loading="eager" fetchpriority="high" decoding="async"` as they are typically the LCP element.

- **sessionStorage CSS loading (FOUC fix)** — On warm visits where CSS is already browser-cached, stylesheets are injected synchronously via JS before first paint, eliminating the flash of unstyled content. Cold visits use the existing async preload path and stamp sessionStorage keys on load. Stale keys from old CSS URLs are pruned automatically on each visit.

- **Automatic preconnect hints** — `Document::makePreconnects()` scans the page's CSS, JS, and preload URLs and emits `<link rel="preconnect" crossorigin>` + `<link rel="dns-prefetch">` for any cross-origin origins. Explicit hints for FontAwesome CDN and Kit URLs are also added in `FrontendServiceProvider`.

- **Viewport meta fix** — Removes `maximum-scale=1, minimum-scale=1` from the viewport meta tag in `Meta.php`, `basic.blade.php`, and `install/app.php`. These attributes prevent user zoom on mobile, which is an accessibility issue. The `initial-scale=1` is retained.

- **IE11 meta removed** — The `X-UA-Compatible` meta tag has been removed from the installer; IE11 has been end-of-life since June 2022.