### PR TITLE
[2.x] misc: small correctness and accessibility fixes

### DIFF
--- a/framework/core/js/src/common/components/Checkbox.tsx
+++ b/framework/core/js/src/common/components/Checkbox.tsx
@@ -10,6 +10,8 @@ export interface ICheckboxAttrs extends ComponentAttrs {
   loading?: boolean;
   disabled?: boolean;
   onchange: (checked: boolean, component: Checkbox<this>) => void;
+  /** Extra attributes to spread onto the inner `<input>` element. */
+  inputAttrs?: Mithril.Attributes;
 }
 
 /**
@@ -36,7 +38,13 @@ export default class Checkbox<CustomAttrs extends ICheckboxAttrs = ICheckboxAttr
 
     return (
       <label className={className}>
-        <input type="checkbox" checked={this.attrs.state} disabled={this.attrs.disabled} onchange={withAttr('checked', this.onchange.bind(this))} />
+        <input
+          type="checkbox"
+          checked={this.attrs.state}
+          disabled={this.attrs.disabled}
+          onchange={withAttr('checked', this.onchange.bind(this))}
+          {...(this.attrs.inputAttrs ?? {})}
+        />
         <div className="Checkbox-display" aria-hidden="true">
           {this.getDisplay()}
         </div>

--- a/framework/core/js/src/common/components/FormGroup.tsx
+++ b/framework/core/js/src/common/components/FormGroup.tsx
@@ -193,14 +193,23 @@ export default class FormGroup<CustomAttrs extends IFormGroupAttrs = IFormGroupA
     // Typescript being Typescript
     // https://github.com/microsoft/TypeScript/issues/14520
     if ((BooleanSettingTypes as readonly string[]).includes(type)) {
+      const switchHelpTextId = help ? generateElementId() : undefined;
+
       return (
-        // TODO: Add aria-describedby for switch help text.
-        //? Requires changes to Checkbox component to allow providing attrs directly for the element(s).
         <div className={classList('Form-group', containerClassName)}>
-          <Switch state={!!value && value !== '0'} onchange={stream} {...attrs}>
+          <Switch
+            state={!!value && value !== '0'}
+            onchange={stream}
+            inputAttrs={switchHelpTextId ? { 'aria-describedby': switchHelpTextId } : undefined}
+            {...attrs}
+          >
             {label}
           </Switch>
-          {help ? <div className="helpText">{help}</div> : null}
+          {help ? (
+            <div id={switchHelpTextId} className="helpText">
+              {help}
+            </div>
+          ) : null}
         </div>
       );
     } else if ((SelectSettingTypes as readonly string[]).includes(type)) {

--- a/framework/core/js/tests/integration/common/components/Checkbox.test.ts
+++ b/framework/core/js/tests/integration/common/components/Checkbox.test.ts
@@ -30,4 +30,16 @@ describe('Checkbox displays as expected', () => {
     checkbox.trigger('input', 'change', { target: new EventTarget() });
     expect(onchange).toHaveBeenCalled();
   });
+
+  it('passes inputAttrs onto the inner input element', () => {
+    const checkbox = mq(
+      m(Checkbox, {
+        state: false,
+        onchange: jest.fn(),
+        inputAttrs: { 'aria-describedby': 'help-123' },
+      })
+    );
+
+    expect(checkbox).toHaveElementAttr('input[type="checkbox"]', 'aria-describedby', 'help-123');
+  });
 });

--- a/framework/core/js/tests/integration/common/components/FormGroup.test.ts
+++ b/framework/core/js/tests/integration/common/components/FormGroup.test.ts
@@ -1,0 +1,48 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import FormGroup from '../../../../src/common/components/FormGroup';
+import m from 'mithril';
+import mq from 'mithril-query';
+import Stream from '../../../../src/common/utils/Stream';
+
+beforeAll(() => bootstrapForum());
+
+describe('FormGroup boolean/switch type', () => {
+  it('renders a Switch component', () => {
+    const stream = Stream(false);
+    const group = mq(m(FormGroup, { type: 'bool', label: 'Enable feature', stream }));
+
+    expect(group).toHaveElement('.Form-group');
+    expect(group).toHaveElement('.Checkbox--switch');
+  });
+
+  it('renders help text when provided', () => {
+    const stream = Stream(false);
+    const group = mq(m(FormGroup, { type: 'bool', label: 'Enable feature', help: 'This helps you.', stream }));
+
+    expect(group).toHaveElement('.helpText');
+    expect(group).toContainRaw('This helps you.');
+  });
+
+  it('passes aria-describedby to the switch input when help text is provided', () => {
+    const stream = Stream(false);
+    const group = mq(m(FormGroup, { type: 'bool', label: 'Enable feature', help: 'This helps you.', stream }));
+
+    const helpEl = group.first('.helpText') as HTMLElement;
+    expect(helpEl).not.toBeNull();
+
+    const helpId = helpEl.id;
+    expect(helpId).toBeTruthy();
+
+    expect(group).toHaveElementAttr('input[type="checkbox"]', 'aria-describedby', helpId);
+  });
+
+  it('does not add aria-describedby when no help text', () => {
+    const stream = Stream(false);
+    const group = mq(m(FormGroup, { type: 'bool', label: 'Enable feature', stream }));
+
+    expect(group).not.toHaveElement('.helpText');
+    // Input should not have aria-describedby (or it should be absent/empty)
+    const inputEl = group.first('input[type="checkbox"]');
+    expect(inputEl?.attrs?.['aria-describedby']).toBeFalsy();
+  });
+});

--- a/framework/core/src/Api/Serializer.php
+++ b/framework/core/src/Api/Serializer.php
@@ -101,8 +101,11 @@ class Serializer extends \Tobyz\JsonApiServer\Serializer
             }, $field instanceof Relationship);
         }
 
-        // TODO: cache
         foreach ($resource->meta() as $field) {
+            if (isset($this->map[$key]['meta'][$field->name])) {
+                continue;
+            }
+
             if (! $field->isVisible($context)) {
                 continue;
             }

--- a/framework/core/src/Queue/ExceptionHandler.php
+++ b/framework/core/src/Queue/ExceptionHandler.php
@@ -11,6 +11,7 @@ namespace Flarum\Queue;
 
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandling;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 readonly class ExceptionHandler implements ExceptionHandling
@@ -33,23 +34,21 @@ readonly class ExceptionHandler implements ExceptionHandling
     /**
      * Render an exception into an HTTP response.
      *
-     * @param  \Illuminate\Http\Request $request
-     * @return void
+     * Not applicable in a queue context — re-throw so the worker can handle it.
      */
-    public function render($request, Throwable $e) /** @phpstan-ignore-line */
+    public function render($request, Throwable $e): never
     {
-        // TODO: Implement render() method.
+        throw $e;
     }
 
     /**
      * Render an exception to the console.
      *
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @param OutputInterface $output
      */
-    public function renderForConsole($output, Throwable $e)
+    public function renderForConsole($output, Throwable $e): void
     {
-        // TODO: Implement renderForConsole() method.
+        $output->writeln((string) $e);
     }
 
     /**

--- a/framework/core/tests/unit/Queue/ExceptionHandlerTest.php
+++ b/framework/core/tests/unit/Queue/ExceptionHandlerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Queue;
+
+use Flarum\Queue\ExceptionHandler;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExceptionHandlerTest extends TestCase
+{
+    private ExceptionHandler $handler;
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->handler = new ExceptionHandler($this->logger);
+    }
+
+    #[Test]
+    public function report_logs_exception_as_error(): void
+    {
+        $e = new RuntimeException('Something went wrong');
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with((string) $e);
+
+        $this->handler->report($e);
+    }
+
+    #[Test]
+    public function render_rethrows_the_exception(): void
+    {
+        $e = new RuntimeException('Queue job failed');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Queue job failed');
+
+        $this->handler->render(null, $e);
+    }
+
+    #[Test]
+    public function render_for_console_writes_exception_to_output(): void
+    {
+        $e = new RuntimeException('Something went wrong');
+        $output = $this->createMock(OutputInterface::class);
+
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with((string) $e);
+
+        $this->handler->renderForConsole($output, $e);
+    }
+
+    #[Test]
+    public function should_report_always_returns_true(): void
+    {
+        $this->assertTrue($this->handler->shouldReport(new RuntimeException()));
+    }
+}

--- a/framework/core/views/layouts/basic.blade.php
+++ b/framework/core/views/layouts/basic.blade.php
@@ -6,8 +6,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    {{-- TODO: Change below to @hasSection when Laravel is upgraded --}}
-    <title>@if ($__env->hasSection('title')) @yield('title') - @endif{{ $settings->get('forum_title') }}</title>
+    <title>@hasSection('title') @yield('title') - @endif{{ $settings->get('forum_title') }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>


### PR DESCRIPTION
## Summary

- **`Serializer.php`** — skip meta fields already computed for a resource, matching the existing attribute/relationship caching behaviour
- **`ExceptionHandler.php`** — implement `render()` (re-throws — no HTTP cycle in a queue) and `renderForConsole()` properly; add unit tests (`ExceptionHandlerTest.php`)
- **`basic.blade.php`** — replace `$__env->hasSection()` workaround with the `@hasSection` directive (available since Laravel 9, now required in Laravel 13)
- **`Checkbox.tsx`** — add optional `inputAttrs` prop, spread onto the inner `<input>` element
- **`FormGroup.tsx`** — in the boolean/switch branch, generate a stable id for the help text div and pass `aria-describedby` to the Switch via the new `inputAttrs` prop, removing the long-standing TODO comment