### PR TITLE
[2.x] fix(admin): avatar driver default value and abandoned sync message padding

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -175,7 +175,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
 
     const { setting, json, refreshAfterSaving, ...attrs } = entry;
 
-    const originalBidi: (value?: string) => any = this.setting(setting);
+    const originalBidi: (value?: string) => any = this.setting(setting, (entry as any).default ?? '');
     let bidi: (value?: string) => any;
 
     if (json) {

--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -211,6 +211,7 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
       app.registry.registerSetting({
         type: 'select',
         setting: 'avatar_driver',
+        default: 'default',
         options: avatarDriverOptions,
         label: app.translator.trans('core.admin.basics.avatar_driver_heading'),
         help: app.translator.trans('core.admin.basics.avatar_driver_text'),
@@ -246,7 +247,7 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
               <Button className="Button" onclick={syncAbandoned} loading={abandonedSyncing} disabled={abandonedSyncing}>
                 {app.translator.trans('core.admin.basics.abandoned_extensions_sync_button')}
               </Button>
-              {abandonedSyncMessage && <span className="helpText">{abandonedSyncMessage}</span>}
+              {abandonedSyncMessage && <span className="helpText BasicsPage-abandonedSyncMessage">{abandonedSyncMessage}</span>}
             </div>
             <br />
             {this.buildSettingComponent({

--- a/framework/core/less/admin/BasicsPage.less
+++ b/framework/core/less/admin/BasicsPage.less
@@ -15,6 +15,10 @@
   }
 }
 
+.BasicsPage-abandonedSyncMessage {
+  margin-left: 0.75rem;
+}
+
 .BasicsPage-welcomeBanner-input {
   .StackedFormControl > :first-child {
     font-weight: bold;

--- a/framework/core/src/Install/Steps/WriteSettings.php
+++ b/framework/core/src/Install/Steps/WriteSettings.php
@@ -47,6 +47,7 @@ readonly class WriteSettings implements Step
     {
         return [
             'allow_hide_own_posts' => 'reply',
+            'avatar_driver' => 'default',
             'allow_post_editing' => 'reply',
             'allow_renaming' => '10',
             'allow_sign_up' => '1',


### PR DESCRIPTION
## Summary

- The avatar driver select on the admin basics page showed blank when the setting had no stored value. Fixed by passing the setting's `default` property as a fallback to `this.setting()` in `AdminPage.buildSettingComponent`, and pre-seeding `avatar_driver = 'default'` in install defaults.
- Added a small left margin to the status message that appears next to the "Check Now" button in the Abandoned Extensions section.