### PR TITLE
[2.x] fix(UserCard): restore controls icon for mobile visibility

### DIFF
--- a/framework/core/js/src/forum/components/UserCard.js
+++ b/framework/core/js/src/forum/components/UserCard.js
@@ -129,7 +129,7 @@ export default class UserCard extends Component {
           buttonClassName={this.attrs.controlsButtonClassName}
           label={app.translator.trans('core.forum.user_controls.button')}
           accessibleToggleLabel={app.translator.trans('core.forum.user_controls.toggle_dropdown_accessible_label')}
-          icon={this.attrs.controlsButtonClassName?.includes('Button--icon') ? 'fas fa-ellipsis-v' : undefined}
+          icon="fas fa-ellipsis-v"
         >
           {controls}
         </Dropdown>,


### PR DESCRIPTION
Regression from bf6b90795 (#4409), which conditionally removed the `icon` prop from the UserHero controls Dropdown to prevent it rendering alongside the label on desktop.

`UserPage.less` already has a rule hiding `.Button-icon` inside the UserHero on desktop, and the `@media @phone` `.App-primaryControl` rules override it with `display: block !important` on mobile. The icon must always be rendered for this CSS to work — without it, the controls button on mobile has no visible content (label is hidden, no icon element exists).

Reverts the conditional and always passes `icon="fas fa-ellipsis-v"`.