### PR TITLE
[2.x] feat: support opcache flushing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,7 @@
         "flarum/suspend": "self.version",
         "flarum/tags": "self.version",
         "flarum/messages": "self.version",
+        "flarum/composer-plugin": "self.version",
         "flarum/phpstan": "self.version",
         "flarum/testing": "self.version"
     },
@@ -122,6 +123,7 @@
         "doctrine/dbal": "^3.6.2",
         "dragonmantank/cron-expression": "^3.3",
         "fakerphp/faker": "^1.9.1",
+        "flarum/composer-plugin": "2.x-dev",
         "flarum/json-api-server": "^0.1.0",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "*",

--- a/extensions/package-manager/src/ExtensionManagerServiceProvider.php
+++ b/extensions/package-manager/src/ExtensionManagerServiceProvider.php
@@ -15,8 +15,11 @@ use Composer\Util\Platform;
 use Flarum\Extension\ExtensionManager;
 use Flarum\ExtensionManager\Composer\ComposerAdapter;
 use Flarum\ExtensionManager\Event\FlarumUpdated;
+use Flarum\ExtensionManager\Extension\Event\Installed;
+use Flarum\ExtensionManager\Extension\Event\Removed;
 use Flarum\ExtensionManager\Extension\Event\Updated;
 use Flarum\ExtensionManager\Listener\ClearCacheAfterUpdate;
+use Flarum\ExtensionManager\Listener\ClearOPCacheAfterUpdate;
 use Flarum\ExtensionManager\Listener\ReCheckForUpdates;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Paths;
@@ -100,5 +103,6 @@ class ExtensionManagerServiceProvider extends AbstractServiceProvider
 
         $events->listen(FlarumUpdated::class, ClearCacheAfterUpdate::class);
         $events->listen([FlarumUpdated::class, Updated::class], ReCheckForUpdates::class);
+        $events->listen([Installed::class, Updated::class, Removed::class, FlarumUpdated::class], ClearOPCacheAfterUpdate::class);
     }
 }

--- a/extensions/package-manager/src/Listener/ClearOPCacheAfterUpdate.php
+++ b/extensions/package-manager/src/Listener/ClearOPCacheAfterUpdate.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flarum\ExtensionManager\Listener;
+
+use Flarum\Foundation\Paths;
+use Flarum\Http\Middleware\ClearOPCache;
+
+readonly class ClearOPCacheAfterUpdate
+{
+    public function __construct(private readonly Paths $paths)
+    {
+    }
+
+    public function handle(): void
+    {
+        $path = $this->paths->storage . ClearOPCache::PATH;
+
+        if (file_exists($path) || ! function_exists('opcache_reset')) {
+            return;
+        }
+
+        @file_put_contents($path, (string) time());
+    }
+}

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -42,6 +42,7 @@
         "doctrine/dbal": "^3.6",
         "dragonmantank/cron-expression": "*",
         "fakerphp/faker": "^1.9.1",
+        "flarum/composer-plugin": "2.x-dev",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "^7.7",
         "illuminate/bus": "^13.0",

--- a/framework/core/src/Admin/AdminServiceProvider.php
+++ b/framework/core/src/Admin/AdminServiceProvider.php
@@ -50,6 +50,7 @@ class AdminServiceProvider extends AbstractServiceProvider
 
         $this->container->singleton('flarum.admin.middleware', function () {
             return [
+                HttpMiddleware\ClearOPCache::class,
                 HttpMiddleware\InjectActorReference::class,
                 'flarum.admin.error_handler',
                 HttpMiddleware\ParseJsonBody::class,

--- a/framework/core/src/Api/ApiServiceProvider.php
+++ b/framework/core/src/Api/ApiServiceProvider.php
@@ -86,6 +86,7 @@ class ApiServiceProvider extends AbstractServiceProvider
 
         $this->container->singleton('flarum.api.middleware', function () {
             return [
+                HttpMiddleware\ClearOPCache::class,
                 HttpMiddleware\InjectActorReference::class,
                 'flarum.api.error_handler',
                 HttpMiddleware\ParseJsonBody::class,

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -61,6 +61,7 @@ class ForumServiceProvider extends AbstractServiceProvider
 
         $this->container->singleton('flarum.forum.middleware', function () {
             return [
+                HttpMiddleware\ClearOPCache::class,
                 HttpMiddleware\InjectActorReference::class,
                 'flarum.forum.error_handler',
                 HttpMiddleware\ParseJsonBody::class,

--- a/framework/core/src/Http/Middleware/ClearOPCache.php
+++ b/framework/core/src/Http/Middleware/ClearOPCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flarum\Http\Middleware;
 
 use Flarum\Foundation\Paths;
+use Illuminate\Contracts\Container\Container;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
@@ -14,7 +15,7 @@ class ClearOPCache implements Middleware
 {
     const PATH = '/cache/clear-opcache';
 
-    public function __construct(private readonly Paths $paths)
+    public function __construct(private readonly Container $container)
     {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -32,6 +33,20 @@ class ClearOPCache implements Middleware
 
     public function path(): string
     {
-        return $this->paths->storage . static::PATH;
+        if ($this->container->bound(Paths::class)) {
+            return $this->container->make(Paths::class)->storage . static::PATH;
+        }
+
+        // Fallback when Paths is not available during installation.
+        $path = dirname(__DIR__, 3);
+
+        while(true) {
+            if ($path === '.') throw new \Exception('Could not find storage directory');
+
+            if (is_dir("$path/storage")) break;
+            $path = dirname($path);
+        }
+
+        return "$path/storage" . static::PATH;
     }
 }

--- a/framework/core/src/Http/Middleware/ClearOPCache.php
+++ b/framework/core/src/Http/Middleware/ClearOPCache.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flarum\Http\Middleware;
+
+use Flarum\Foundation\Paths;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ClearOPCache implements Middleware
+{
+    const PATH = '/cache/clear-opcache';
+
+    public function __construct(private readonly Paths $paths)
+    {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (! file_exists($this->path()) || ! function_exists('opcache_reset')) {
+            return $handler->handle($request);
+        }
+
+        opcache_reset();
+
+        @unlink($this->path());
+
+        return $handler->handle($request);
+    }
+
+    public function path(): string
+    {
+        return $this->paths->storage . static::PATH;
+    }
+}

--- a/framework/core/src/Http/Middleware/ClearOPCache.php
+++ b/framework/core/src/Http/Middleware/ClearOPCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flarum\Http\Middleware;
 
+use Exception;
 use Flarum\Foundation\Paths;
 use Illuminate\Contracts\Container\Container;
 use Psr\Http\Message\ResponseInterface;
@@ -20,7 +21,7 @@ class ClearOPCache implements Middleware
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (! file_exists($this->path()) || ! function_exists('opcache_reset')) {
+        if (! function_exists('opcache_reset') || ! file_exists($this->path())) {
             return $handler->handle($request);
         }
 
@@ -39,9 +40,11 @@ class ClearOPCache implements Middleware
 
         // Fallback when Paths is not available during installation.
         $path = dirname(__DIR__, 3);
+        $upTo = dirname(__DIR__, 6);
 
         while(true) {
-            if ($path === '.') throw new \Exception('Could not find storage directory');
+            if ($path === $upTo) throw new Exception('Could not find storage directory');
+            if ($path === '.') throw new Exception('Could not find storage directory');
 
             if (is_dir("$path/storage")) break;
             $path = dirname($path);

--- a/framework/core/src/Install/Installer.php
+++ b/framework/core/src/Install/Installer.php
@@ -34,6 +34,7 @@ class Installer implements AppInterface
     public function getRequestHandler(): RequestHandlerInterface
     {
         $pipe = new MiddlewarePipe;
+        $pipe->pipe(new HttpMiddleware\ClearOPCache($this->getContainer()));
         $pipe->pipe(new HttpMiddleware\HandleErrors(
             $this->container->make(Registry::class),
             $this->container->make(WhoopsFormatter::class),

--- a/php-packages/composer-plugin/composer.json
+++ b/php-packages/composer-plugin/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "flarum/composer-plugin",
+    "description": "Assists Flarum with Composer",
+    "type": "composer-plugin",
+    "license": "MIT",
+    "require": {
+        "composer-plugin-api": "^2.0"
+    },
+    "require-dev": {
+        "composer/composer": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Flarum\\Composer\\Plugin\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
+        "class": "Flarum\\Composer\\Plugin\\ComposerPlugin"
+    }
+}

--- a/php-packages/composer-plugin/src/ComposerPlugin.php
+++ b/php-packages/composer-plugin/src/ComposerPlugin.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flarum\Composer\Plugin;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Flarum\Http\Middleware\ClearOPCache;
+
+class ComposerPlugin implements PluginInterface, EventSubscriberInterface
+{
+    private Composer $composer;
+
+    public function activate(Composer $composer, IOInterface $io): void
+    {
+        $this->composer = $composer;
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io): void {}
+    public function uninstall(Composer $composer, IOInterface $io): void {}
+
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'post-autoload-dump' => 'flag',
+        ];
+    }
+
+    public function flag(): void
+    {
+        $path = class_exists(ClearOPCache::class) ? ClearOPCache::PATH : '/storage/cache/clear-opcache';
+
+        $vendorDir  = $this->composer->getConfig()->get('vendor-dir');
+        $flagFile   = dirname($vendorDir) . $path;
+
+        if (is_dir(dirname($flagFile)) && ! file_exists($flagFile)) {
+            @file_put_contents($flagFile, (string) time());
+        }
+    }
+}


### PR DESCRIPTION
### Why

PHP's OPcache compiles and caches bytecode for every file it loads. When Composer installs, updates, or removes packages — whether triggered through the Flarum admin UI or directly from the CLI — the files in vendor/ change on disk. PHP-FPM workers, however, keep serving the stale cached bytecode for those paths until they are recycled. This causes class-not-found errors, method signature mismatches, or silently running old code immediately after a package operation.

### How it is solved

The fix uses a flag file (storage/cache/clear-opcache) as a signal between the process that ran Composer (CLI or queue worker) and the PHP-FPM workers that serve HTTP requests. The reason we need to push this towards HTTP is because cli has no access to the opcache. The flag is written after any Composer operation and consumed on the next incoming request.

Three components work together:

  1. flarum/composer-plugin (new package in php-packages/composer-plugin/)

  A Composer plugin that subscribes to the post-autoload-dump event. This event fires after Composer regenerates the autoloader — the point at which the vendor directory is fully updated. When triggered, the plugin writes the flag file. This covers any Composer operation run directly from the CLI (composer
   require, composer update, composer remove).

  2. ClearOPCacheAfterUpdate listener (extension manager)

  The Flarum extension manager runs Composer in-process using a temporary vendor directory (temp-vendor), which means the plugin above is not loaded during those operations. To cover this path, the extension manager listens to its own events (Installed, Updated, Removed, FlarumUpdated) and writes the same 
  flag file from PHP when any of those fire.
                                                                                                                                                                                                                                                                                                                   
  3. ClearOPCache middleware (core)

  Added early in the forum middleware stack. On each incoming HTTP request it checks whether the flag file exists. If it does, it calls opcache_reset() to clear all cached bytecode in the current FPM worker, then deletes the flag file. Subsequent workers that receive requests after the file has been removed skip the reset.

---

There are some considerations to this PR. 

- Without the composer plugin opcache will not be properly cleared when composer commands are being executed. Using the plugin signals to Flarum to clear the opcache as soon as possible.
- The Middleware is placed in core, not in extension manager, because outside interaction from cli using composer will still affect the opcache.
- The extension manager is most likely the culprit to cause stale opcache. As such this extension receives its own listener to signal an opcache clear.
- Code has been written to exit early, to reduce performance hits.
- This solution will have zero effect on scalable environments, but then again I expect no one to be running extension manager or composer commands in those environments anyway.


_Code was written 100% by my hands, summary generated with the help of Claude._ Let me know if you have any questions or things need clarification.

