### PR TITLE
[2.x] fix: remove hardcoded radio input name in `FormGroup`

### DIFF
--- a/framework/core/js/src/admin/components/BasicsPage.tsx
+++ b/framework/core/js/src/admin/components/BasicsPage.tsx
@@ -174,6 +174,7 @@ export default class BasicsPage<CustomAttrs extends IPageAttrs = IPageAttrs> ext
       .registerSetting({
         type: 'radio',
         setting: 'default_route',
+        name: 'homePage',
         options: BasicsPage.homePageItems()
           .toArray()
           .map((item: HomePageItem) => ({

--- a/framework/core/js/src/common/components/FormGroup.tsx
+++ b/framework/core/js/src/common/components/FormGroup.tsx
@@ -221,13 +221,13 @@ export default class FormGroup<CustomAttrs extends IFormGroupAttrs = IFormGroupA
         <Tag id={inputId} aria-describedby={helpTextId} value={value ?? defaultValue} options={options} onchange={stream} {...otherAttrs} />
       );
     } else if ((RadioSettingTypes as readonly string[]).includes(type)) {
-      const { default: defaultValue, options, multiple, ...otherAttrs } = attrs;
+      const { default: defaultValue, options, multiple, name, ...otherAttrs } = attrs;
 
       settingElement = (
         <FieldSet {...otherAttrs}>
           {options.map(({ value, label }: { value: string; label: string }) => (
             <label className="checkbox">
-              <input type="radio" name="homePage" value={value} bidi={stream} />
+              <input type="radio" name={name || inputId} value={value} bidi={stream} />
               {label}
             </label>
           ))}


### PR DESCRIPTION
**Changes proposed in this pull request:**

`FormGroup` hardcodes `name="homePage"` for all radio inputs. This breaks extensions trying to use multiple radio groups on the same page, as they all share the same name and overwrite each other.


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.