### PR TITLE
[2.x] feat(realtime): add extension hook to authorize presence channels

### DIFF
--- a/extensions/realtime/src/Extend/Realtime.php
+++ b/extensions/realtime/src/Extend/Realtime.php
@@ -14,6 +14,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Extend\ExtenderInterface;
 use Flarum\Extension\Extension;
 use Flarum\Realtime\Push\RealtimeRegistry;
+use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
 use Flarum\Realtime\Websocket\Settings;
 use Flarum\User\User;
 use Illuminate\Contracts\Container\Container;
@@ -43,10 +44,23 @@ class Realtime implements ExtenderInterface
      */
     protected array $modelEndpoints = [];
 
+    /**
+     * @var array<string, callable[]>
+     */
+    protected array $presenceChannelGuards = [];
+
     public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->afterResolving(Settings::class, function (Settings $settings) {
             $settings->use($this->configuration);
+        });
+
+        $container->afterResolving(PresenceChannelAuthorizer::class, function (PresenceChannelAuthorizer $authorizer) {
+            foreach ($this->presenceChannelGuards as $channel => $callbacks) {
+                foreach ($callbacks as $callback) {
+                    $authorizer->add($channel, $callback);
+                }
+            }
         });
 
         $container->afterResolving(RealtimeRegistry::class, function (RealtimeRegistry $registry) {
@@ -264,6 +278,41 @@ class Realtime implements ExtenderInterface
     public function registerModelEndpoint(string $modelClass, string $endpoint): self
     {
         $this->modelEndpoints[$modelClass] = $endpoint;
+
+        return $this;
+    }
+
+    // -------------------------------------------------------------------------
+    // Presence channel authorization
+    // -------------------------------------------------------------------------
+
+    /**
+     * Register a callback to authorize access to a presence channel.
+     *
+     * The callback receives the actor and the channel subject name (the part
+     * after `presence-`, e.g. `'online'` for `presence-online`). Return
+     * `false` to deny; any other return value (including `null`) is treated as
+     * a pass. All registered callbacks for the channel must pass before the
+     * authentication response is issued.
+     *
+     * The actor is guaranteed to be a logged-in user — guests are rejected
+     * before callbacks are invoked.
+     *
+     * Example (in an extension's extend.php):
+     *
+     *   (new Extend\Conditional())
+     *       ->whenExtensionEnabled('flarum-realtime', fn () => [
+     *           (new \Flarum\Realtime\Extend\Realtime())
+     *               ->authorizePresenceChannel('online',
+     *                   fn (User $actor) => $actor->hasPermission('viewOnlineUsersWidget')),
+     *       ]),
+     *
+     * @param string $channel  Channel subject name, e.g. 'online'.
+     * @param callable(User $actor, string $channel): bool $callback
+     */
+    public function authorizePresenceChannel(string $channel, callable $callback): self
+    {
+        $this->presenceChannelGuards[$channel][] = $callback;
 
         return $this;
     }

--- a/extensions/realtime/src/Websocket/Api/AuthController.php
+++ b/extensions/realtime/src/Websocket/Api/AuthController.php
@@ -27,7 +27,8 @@ class AuthController implements RequestHandlerInterface
 
     public function __construct(
         protected Pusher $pusher,
-        protected Generator $generator
+        protected Generator $generator,
+        protected PresenceChannelAuthorizer $presenceAuthorizer
     ) {
     }
 
@@ -50,7 +51,9 @@ class AuthController implements RequestHandlerInterface
         }
 
         if (preg_match('~^presence-(?<subject>[a-z-]+)$~', $channel, $m)) {
-            if (! $this->actor->isGuest() && method_exists($this, $m['subject'])) {
+            if (! $this->actor->isGuest() && method_exists($this, $m['subject'])
+                && $this->presenceAuthorizer->authorize($m['subject'], $this->actor)
+            ) {
                 $payload = call_user_func([$this, $m['subject']], $this->actor);
 
                 // Only if the method returns anything, will we allow authentication.

--- a/extensions/realtime/src/Websocket/Api/PresenceChannelAuthorizer.php
+++ b/extensions/realtime/src/Websocket/Api/PresenceChannelAuthorizer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Websocket\Api;
+
+use Flarum\User\User;
+
+class PresenceChannelAuthorizer
+{
+    /** @var array<string, callable[]> */
+    private array $guards = [];
+
+    public function add(string $channel, callable $callback): void
+    {
+        $this->guards[$channel][] = $callback;
+    }
+
+    /**
+     * Run all registered guards for the given channel.
+     * Returns false if any guard explicitly returns false; true otherwise.
+     */
+    public function authorize(string $channel, User $actor): bool
+    {
+        foreach ($this->guards[$channel] ?? [] as $guard) {
+            if ($guard($actor, $channel) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/extensions/realtime/src/WebsocketProvider.php
+++ b/extensions/realtime/src/WebsocketProvider.php
@@ -12,6 +12,7 @@ namespace Flarum\Realtime;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Config;
 use Flarum\Realtime\Push\RealtimeRegistry;
+use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
 use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\Settings;
 use Illuminate\Contracts\Container\Container;
@@ -24,6 +25,7 @@ class WebsocketProvider extends AbstractServiceProvider
     {
         $this->container->singleton(RealtimeRegistry::class);
         $this->container->singleton(Manager::class);
+        $this->container->singleton(PresenceChannelAuthorizer::class);
 
         $this->container->singleton(Pusher::class, function (Container $container) {
             /** @var Settings $settings */


### PR DESCRIPTION
## Summary

- Adds `PresenceChannelAuthorizer` — a singleton bag that holds per-channel guard callbacks registered by extensions
- Adds `Realtime::authorizePresenceChannel(string $channel, callable $callback)` to the `Realtime` extender so extensions can gate access to specific presence channels
- `AuthController` now runs registered guards before issuing a presence channel auth response; any callback returning `false` results in a 403

Enables extensions like `fof/online-users-widget` to enforce permission checks at the WebSocket authentication layer.

Closes #4572.