### PR TITLE
[2.x] fix: prevent FA Kit from overriding display on hidden icon elements

### DIFF
--- a/extensions/tags/less/common/TagSelectionModal.less
+++ b/extensions/tags/less/common/TagSelectionModal.less
@@ -53,15 +53,6 @@
   }
 }
 
-.SelectTagListItem-checkIcon {
-  position: absolute;
-  inset: 0;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
-}
-
 .SelectTagList {
   padding: 0;
   margin: 0;
@@ -80,6 +71,17 @@
     cursor: pointer;
     display: flex;
     align-items: center;
+
+    // Nesting under `> li` bumps specificity to (0,2,1) so this beats a
+    // FontAwesome Kit's late-arriving `.fas { display:… }` at (0,1,0).
+    .SelectTagListItem-checkIcon {
+      position: absolute;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background-color: transparent;
+    }
 
     &.pinned:not(.child) {
       padding-top: 10px;

--- a/framework/core/js/src/common/components/DetailedDropdownItem.tsx
+++ b/framework/core/js/src/common/components/DetailedDropdownItem.tsx
@@ -22,7 +22,7 @@ export default class DetailedDropdownItem<
   view() {
     return (
       <button type="button" className="DetailedDropdownItem hasIcon" onclick={this.attrs.onclick}>
-        <Icon name={this.attrs.active ? 'fas fa-check' : 'fas'} className="Button-icon" />
+        <span className="DetailedDropdownItem-checkIcon">{this.attrs.active && <Icon name="fas fa-check" className="Button-icon" />}</span>
         <span className="DetailedDropdownItem-content">
           <Icon name={this.attrs.icon} className="Button-icon" />
           <span className="DetailedDropdownItem-label">

--- a/framework/core/less/common/DetailedDropdownItem.less
+++ b/framework/core/less/common/DetailedDropdownItem.less
@@ -8,6 +8,14 @@
   }
 }
 
+.DetailedDropdownItem-checkIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  flex-shrink: 0;
+}
+
 .DetailedDropdownItem-content {
   display: grid;
   grid-template-columns: 25px 1fr;

--- a/framework/core/less/common/Iconography.less
+++ b/framework/core/less/common/Iconography.less
@@ -2,3 +2,23 @@
 @import (inline) "brands.css";
 @import (inline) "regular.css";
 @import (inline) "solid.css";
+
+// FontAwesome 7 (and its Kit JS) sets `display: var(--fa-display, inline-block)` on
+// .fas/.far/.fab etc. When a Kit is loaded its dynamically-injected stylesheet lands
+// *after* our compiled CSS, so a Kit `.fas { display:… }` declaration at specificity
+// (0,1,0) beats any application rule that also targets (0,1,0) — purely by source order.
+//
+// Fix: pin `--fa-display` on every icon element so the Kit's :root-level variable
+// cannot flip all icons to `display:block`. Application rules that need to hide an
+// FA-classed element must use specificity > (0,1,0) — e.g. nest under a parent class —
+// to beat the Kit's late-arriving `.fas { display:… }` declaration.
+.fa-solid,
+.fa-regular,
+.fa-brands,
+.fa-classic,
+.fas,
+.far,
+.fab,
+.fa {
+  --fa-display: inline-block;
+}


### PR DESCRIPTION
## Problem

Font Awesome 7's Kit JS dynamically injects a stylesheet **after** the compiled `forum.css`. The Kit's `.fas { display: var(--fa-display, inline-block) }` declaration at specificity `(0,1,0)` wins the cascade over any application `display: none` rule at the same specificity — purely by source order.

This causes FA-classed elements that should be hidden (via `display: none`) to remain visible when a Kit is active. Two known affected components:

1. **Tag selection modal** — the `fas fa-check` overlay icon (`.SelectTagListItem-checkIcon`) is always visible instead of only appearing on selected tags.
2. **Subscription dropdown** (`DetailedDropdownItem`) — the inactive check-icon spacer uses a bare `fas` class, which FA 7 / Kit styles with `display: inline-block`, `width: 1.25em`, and font metrics — creating a visible artifact.

Reported at https://discuss.flarum.org/d/39058

## Fix

Three layers:

### Root mitigation — `Iconography.less`

Pins `--fa-display: inline-block` on every FA icon element (`.fas`, `.far`, `.fab`, etc.) so the Kit's `:root`-level `--fa-display` variable cannot flip all icons to `display: block`. This neutralises the CSS-variable override path. Application rules that need to hide an FA-classed element must use specificity > `(0,1,0)` to beat the Kit's late-arriving stylesheet.

### Tag selection modal — `TagSelectionModal.less`

Moved `.SelectTagListItem-checkIcon { display: none }` from a standalone rule at `(0,1,0)` into `.SelectTagList > li .SelectTagListItem-checkIcon` at `(0,2,1)`, which reliably beats the Kit's `(0,1,0)`.

### Subscription dropdown — `DetailedDropdownItem.tsx` / `.less`

Replaced the bare `<Icon name="fas" />` spacer with a plain `<span class="DetailedDropdownItem-checkIcon">` wrapper. The check icon is only rendered inside it when the item is active. A new CSS class provides the fixed-width layout slot without any FA class interference.