### PR TITLE
fix: admin nav dropdown flickers on mobile, fixes #4577

### DIFF
--- a/framework/core/js/src/admin/components/ExtensionLinkButton.js
+++ b/framework/core/js/src/admin/components/ExtensionLinkButton.js
@@ -1,23 +1,10 @@
 import app from '../../admin/app';
 import isExtensionEnabled from '../utils/isExtensionEnabled';
 import LinkButton from '../../common/components/LinkButton';
-import Tooltip from '../../common/components/Tooltip';
 import ItemList from '../../common/utils/ItemList';
 import Icon from '../../common/components/Icon';
 
 export default class ExtensionLinkButton extends LinkButton {
-  view(vnode) {
-    const extension = app.data.extensions[this.attrs.extensionId];
-    const title = extension?.extra?.['flarum-extension']?.title || this.attrs.extensionId;
-    const tooltipText = extension?.version ? `${title}<br>${extension.version}` : title;
-
-    return (
-      <Tooltip text={tooltipText} position="right" container="body" html={true}>
-        {super.view(vnode)}
-      </Tooltip>
-    );
-  }
-
   getButtonContent(children) {
     const content = super.getButtonContent(children);
     const extension = app.data.extensions[this.attrs.extensionId];


### PR DESCRIPTION
Admin navigation flickers on mobile due to the button being encapsulated inside a Tooltip component. There are two options, but one impacts a dependency:

---
Line 271: this.childDomNode.setAttribute('title', realText);

  Tooltip.createTooltip() sets a title attribute directly on the child DOM node to power Bootstrap's jQuery tooltip. The child here is the <a> element rendered by super.view(vnode) (the LinkButton).

  Why this breaks SelectDropdown: SelectDropdown reads the title attribute of its children's DOM nodes to label its button (it picks the label from the active item). When Tooltip injects title onto the <a>, SelectDropdown picks up that Bootstrap tooltip string — including the <br> and version number from
  tooltipText — and renders it as the dropdown button label. Every Mithril redraw calls onupdate → recreateTooltip → re-sets the title → triggers another redraw → flickering loop.

  Why passing title to <Tooltip> doesn't fix it: The title prop on the Tooltip component itself (line 138) just triggers a console warning. It never prevents createTooltip() from writing its own title onto the child DOM node at line 271.

  The real fix is either:
  1. Remove the Tooltip wrapper in ExtensionLinkButton (what you already found works), or
  2. In createTooltip(), use data-original-title instead of title — Bootstrap 3 tooltips actually store/read from data-original-title after initialization, so the live title attribute doesn't need to stay set. Or use aria-label only and configure Bootstrap with title: () => realText.
---

For now disabled the tooltip as on mobile tooltips don't work anyway, and version information/description is available on detail pages anyway.