### PR TITLE
[2.x] chore: bump phpunit/phpunit to ^12.5.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -180,7 +180,7 @@
         "larastan/larastan": "^3.8",
         "mockery/mockery": "^1.5",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^12.5.22",
         "symfony/var-dumper": "^7.0"
     },
     "config": {

--- a/php-packages/testing/composer.json
+++ b/php-packages/testing/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "ext-json": "*",
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^12.5.22"
     },
     "require-dev": {
         "flarum/core": "*@dev",


### PR DESCRIPTION
## Summary
- Bumps `phpunit/phpunit` from `^11.0` to `^12.5.22` in `php-packages/testing` and root `composer.json`.
- Unblocks `composer install` on every repo consuming `flarum/testing` (directly or via `flarum/phpstan`).

## Why

As of 2026-04-18, `composer install` fails with:

> phpunit/phpunit[11.0.0, ..., 11.5.55] ... are affected by security advisories (\"PKSA-5jz8-6tcw-pbk4\", \"PKSA-z3gr-8qht-p93v\").

Two advisories apply to PHPUnit 11.x:

- **PKSA-z3gr-8qht-p93v** (CVE-2026-24765) — fixed in 11.5.50.
- **PKSA-5jz8-6tcw-pbk4** (GHSA-qrr6-mg7r-m243) — fixed in 12.5.22 / 13.1.6. **No 11.x backport**, so every 11.x release is filtered out by Composer's resolver-level advisory check.

Bumping to `^12.5.22` is the minimum to restore a resolvable dependency graph.

## Compatibility

- PHPUnit 12 requires PHP 8.3+, matching the Flarum 2.x floor (`^8.3`).
- Flarum's own test suites already use PHP 8 attributes (`#[Test]`, `#[DataProvider]`). No `@test` / `@dataProvider` annotations remain in-tree.
- Core unit suite runs green on PHPUnit 12.5.23 locally (277 tests, 473 assertions, 24 advisory-only `AllowMockObjectsWithoutExpectations` notices — out of scope here).

## Downstream impact

Third-party extensions still using docblock annotations (`@test`, `@dataProvider`, `@depends`, `@before`, `@after`, `@group`, `@covers`, `@runInSeparateProcess`) will need to migrate to PHP 8 attributes. Release notes for the next 2.x release should link the [PHPUnit annotations-to-attributes migration guide](https://docs.phpunit.de/en/12.5/annotations.html).

Also note: `flarum/phpstan` pins `flarum/testing ^2.0` — a coordinated `flarum/phpstan` release will likely be needed after `flarum/testing` is tagged to actually unblock downstream `composer install`.

## Test plan

- [x] `composer update phpunit/phpunit -W` resolves cleanly against current tree.
- [x] `composer audit` no longer reports PHPUnit advisories.
- [x] `framework/core` unit suite passes under PHPUnit 12.5.23.
- [x] `framework/core` integration suite loads test cases without error.
- [x] CI runs the full extension matrix on PHPUnit 12.

Closes #4584