### PR TITLE
[1.x] feat: add setting to disable sticky pinning on All Discussions page

### DIFF
--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -49,6 +49,9 @@ return [
 
     new Extend\Locales(__DIR__.'/locale'),
 
+    (new Extend\Settings())
+        ->default('flarum-sticky.pin_sticky_on_all_discussions', true),
+
     (new Extend\Event())
         ->listen(Saving::class, SaveStickyToDatabase::class)
         ->listen(DiscussionWasStickied::class, [Listener\CreatePostWhenDiscussionIsStickied::class, 'whenDiscussionWasStickied'])

--- a/extensions/sticky/js/src/admin/index.js
+++ b/extensions/sticky/js/src/admin/index.js
@@ -1,13 +1,21 @@
 import app from 'flarum/admin/app';
 
 app.initializers.add('flarum-sticky', () => {
-  app.extensionData.for('flarum-sticky').registerPermission(
-    {
-      icon: 'fas fa-thumbtack',
-      label: app.translator.trans('flarum-sticky.admin.permissions.sticky_discussions_label'),
-      permission: 'discussion.sticky',
-    },
-    'moderate',
-    95
-  );
+  app.extensionData
+    .for('flarum-sticky')
+    .registerSetting({
+      setting: 'flarum-sticky.pin_sticky_on_all_discussions',
+      label: app.translator.trans('flarum-sticky.admin.settings.pin_sticky_on_all_discussions_label'),
+      help: app.translator.trans('flarum-sticky.admin.settings.pin_sticky_on_all_discussions_help'),
+      type: 'boolean',
+    })
+    .registerPermission(
+      {
+        icon: 'fas fa-thumbtack',
+        label: app.translator.trans('flarum-sticky.admin.permissions.sticky_discussions_label'),
+        permission: 'discussion.sticky',
+      },
+      'moderate',
+      95
+    );
 });

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -11,6 +11,11 @@ flarum-sticky:
     permissions:
       sticky_discussions_label: Sticky discussions
 
+    # These translations are used in the Settings page of the admin interface.
+    settings:
+      pin_sticky_on_all_discussions_label: Pin stickied discussions on the All Discussions page
+      pin_sticky_on_all_discussions_help: When enabled (default), unread stickied discussions are pinned to the top of the All Discussions page. When disabled, stickied discussions appear at their natural position by latest activity. Tag pages always pin stickied discussions to the top regardless of this setting.
+
   # Translations in this namespace are used by the forum user interface.
   forum:
 

--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -11,10 +11,21 @@ namespace Flarum\Sticky;
 
 use Flarum\Filter\FilterState;
 use Flarum\Query\QueryCriteria;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Query\TagFilterGambit;
 
 class PinStickiedDiscussionsToTop
 {
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
     public function __invoke(FilterState $filterState, QueryCriteria $criteria)
     {
         if ($criteria->sortIsDefault) {
@@ -33,6 +44,13 @@ class PinStickiedDiscussionsToTop
                     array_unshift($query->orders, ['column' => 'is_sticky', 'direction' => 'desc']);
                 }
 
+                return;
+            }
+
+            // On "all discussions", admins can disable sticky pinning entirely.
+            // When disabled, stickied discussions appear at their natural
+            // last_posted_at position rather than being floated to the top.
+            if (! $this->settings->get('flarum-sticky.pin_sticky_on_all_discussions', true)) {
                 return;
             }
 

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -117,4 +117,60 @@ class ListDiscussionsTest extends TestCase
 
         $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
     }
+
+    /** @test */
+    public function list_discussions_does_not_pin_sticky_on_all_when_setting_disabled_as_guest()
+    {
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', '0');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    /** @test */
+    public function list_discussions_does_not_pin_unread_sticky_on_all_when_setting_disabled_as_user()
+    {
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', '0');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 2
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    /** @test */
+    public function list_discussions_pins_sticky_on_a_tag_when_setting_disabled()
+    {
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', '0');
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])->withQueryParams([
+                'filter' => [
+                    'tag' => 'general'
+                ]
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds an admin setting `flarum-sticky.pin_sticky_on_all_discussions` (default: `true`) that controls whether stickied discussions get pinned to the top of the All Discussions page. Tag pages are unaffected.

## Motivation

Today, on `/all`, unread sticky discussions are floated to the top via a UNION query. For communities with long-lived sticky announcements (rules, FAQs, sticky welcome threads), this can push fresh activity down and make `/all` feel stale — once a user has read the sticky, it returns to its natural position, but a forum with many users will always have *some* user with an unread sticky, so the pinning is effectively permanent for new visitors.

This adds an opt-out so admins can decide that `/all` is purely "latest activity," while still relying on sticky pinning inside individual tag pages where it remains useful.

## Behavior matrix

| Page | Setting `true` (default) | Setting `false` |
|---|---|---|
| `/all` | Unread sticky pinned to top (existing behavior) | Sticky at natural `last_posted_at` position |
| Tag page | All sticky pinned to top | All sticky pinned to top (unchanged) |
| Other filters | No pinning | No pinning |

## Changes

- `extend.php` — register the setting with a default of `true`.
- `src/PinStickiedDiscussionsToTop.php` — inject `SettingsRepositoryInterface`; before the UNION block, return early when the setting is `false`.
- `locale/en.yml` — add `admin.settings.pin_sticky_on_all_discussions_{label,help}`.
- `js/src/admin/index.js` — add a boolean toggle in the extension's admin settings tab.

## Backwards compatibility

The default value matches existing behavior, so this is a no-op on upgrade. No migration is needed.

## Testing

- [ ] Admin toggle appears in the extension settings tab and persists across reloads.
- [ ] With setting `true`: `/all` shows unread sticky at the top, read sticky at natural position (existing behavior).
- [ ] With setting `false`: `/all` shows all sticky at their natural position; no sticky-induced reordering.
- [ ] Tag pages pin sticky to the top in both states.
- [ ] Sticky badge, row highlight, and first-post excerpt remain visible regardless of the setting.

## Related

This setting is also honored by `fof/discussion-language`'s replacement of `PinStickiedDiscussionsToTop`, so the toggle takes effect on language-filtered `/all` views as well.