### PR TITLE
feat(sticky): add setting to disable sticky pinning on All Discussions page

### DIFF
--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -32,8 +32,11 @@ return [
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Settings())
+        ->default('flarum-sticky.enable_display_excerpt', true)
+        ->default('flarum-sticky.only_sticky_unread_discussions', true)
+        ->default('flarum-sticky.pin_sticky_on_all_discussions', true)
         ->serializeToForum('excerptDisplayEnabled', 'flarum-sticky.enable_display_excerpt', 'boolval')
-        ->default('flarum-sticky.enable_display_excerpt', true),
+        ->serializeToForum('onlyStickyUnreadDiscussions', 'flarum-sticky.only_sticky_unread_discussions', 'boolval'),
 
     (new Extend\Model(Discussion::class))
         ->cast('is_sticky', 'bool'),
@@ -54,8 +57,4 @@ return [
     (new Extend\SearchDriver(DatabaseSearchDriver::class))
         ->addFilter(DiscussionSearcher::class, StickyFilter::class)
         ->addMutator(DiscussionSearcher::class, PinStickiedDiscussionsToTop::class),
-
-    (new Extend\Settings())
-        ->default('flarum-sticky.only_sticky_unread_discussions', true)
-        ->serializeToForum('onlyStickyUnreadDiscussions', 'flarum-sticky.only_sticky_unread_discussions', 'boolval'),
 ];

--- a/extensions/sticky/js/src/admin/extend.tsx
+++ b/extensions/sticky/js/src/admin/extend.tsx
@@ -17,11 +17,23 @@ export default [
     )
     .setting(
       () => ({
+        setting: 'flarum-sticky.pin_sticky_on_all_discussions',
+        name: 'pinStickyOnAllDiscussions',
+        type: 'boolean',
+        label: app.translator.trans('flarum-sticky.admin.settings.pin_sticky_on_all_discussions_label'),
+        help: app.translator.trans('flarum-sticky.admin.settings.pin_sticky_on_all_discussions_help'),
+      }),
+      95
+    )
+    .setting(
+      () => ({
         setting: 'flarum-sticky.only_sticky_unread_discussions',
         name: 'onlyStickyUnreadDiscussions',
         type: 'boolean',
         label: app.translator.trans('flarum-sticky.admin.settings.only_sticky_unread_discussions_label'),
         help: app.translator.trans('flarum-sticky.admin.settings.only_sticky_unread_discussions_help'),
+        // Only meaningful when sticky pinning is enabled on the All Discussions page.
+        disabled: app.data.settings['flarum-sticky.pin_sticky_on_all_discussions'] === '0',
       }),
       90
     )

--- a/extensions/sticky/locale/en.yml
+++ b/extensions/sticky/locale/en.yml
@@ -10,6 +10,8 @@ flarum-sticky:
       enable_display_excerpt: Show an excerpt of the first post when a sticky discussion is unread
       only_sticky_unread_discussions_label: Only sticky unread discussions
       only_sticky_unread_discussions_help: On the All Discussions page, unread sticky discussions pin to the top, while read sticky discussions follow the regular order.
+      pin_sticky_on_all_discussions_label: Pin stickied discussions on the All Discussions page
+      pin_sticky_on_all_discussions_help: When enabled (default), stickied discussions are pinned at the top of the All Discussions page. When disabled, they appear at their natural position by latest activity. Tag pages always pin stickied discussions to the top regardless of this setting.
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/extensions/sticky/src/PinStickiedDiscussionsToTop.php
+++ b/extensions/sticky/src/PinStickiedDiscussionsToTop.php
@@ -27,18 +27,8 @@ class PinStickiedDiscussionsToTop
     {
         if ($criteria->sortIsDefault && ! $state->isFulltextSearch()) {
             $query = $state->getQuery()->getQuery();
-            $onlyStickyUnread = $this->settings->get('flarum-sticky.only_sticky_unread_discussions');
 
-            // If only sticky unread discussions is disabled, then pin all stickied
-            // discussions to the top whether they are read or not.
-            if (! $onlyStickyUnread) {
-                $this->pinStickiedToTop($query);
-
-                return;
-            }
-
-            // If we are viewing a specific tag, then pin all stickied
-            // discussions to the top no matter what.
+            // Tag pages always pin stickied discussions to the top.
             $filters = $state->getActiveFilters();
 
             if ($count = count($filters)) {
@@ -49,10 +39,27 @@ class PinStickiedDiscussionsToTop
                 return;
             }
 
-            // Otherwise, if we are viewing "all discussions", only pin stickied
-            // discussions to the top if they are unread. To do this in a
-            // performant way we create another query which will select all
-            // stickied discussions, marry them into the main query, and then
+            // The remainder of this method handles the All Discussions page only.
+
+            // Admins can disable sticky pinning on this page entirely. When disabled,
+            // stickied discussions appear at their natural last_posted_at position
+            // and the only_sticky_unread_discussions setting becomes a no-op (the
+            // distinction between read and unread sticky no longer matters).
+            if (! $this->settings->get('flarum-sticky.pin_sticky_on_all_discussions', true)) {
+                return;
+            }
+
+            // If unread-only floating is disabled, pin all stickied discussions to
+            // the top regardless of read state.
+            if (! $this->settings->get('flarum-sticky.only_sticky_unread_discussions')) {
+                $this->pinStickiedToTop($query);
+
+                return;
+            }
+
+            // Otherwise, only pin stickied discussions to the top if they are unread.
+            // To do this in a performant way we create another query which will select
+            // all stickied discussions, marry them into the main query, and then
             // reorder the unread ones up to the top.
             $sticky = clone $query;
             $sticky->where('is_sticky', true);

--- a/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/ListDiscussionsTest.php
@@ -193,4 +193,63 @@ class ListDiscussionsTest extends TestCase
 
         $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
     }
+
+    #[Test]
+    public function list_discussions_does_not_pin_sticky_on_all_when_pin_setting_disabled_as_guest()
+    {
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', false);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $body = $response->getBody()->getContents());
+
+        $data = json_decode($body, true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    #[Test]
+    public function list_discussions_pin_setting_disabled_overrides_only_unread_setting_on_all()
+    {
+        // pin_sticky_on_all_discussions is the master gate for /all and must
+        // override only_sticky_unread_discussions when both are flipped.
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', false);
+        $this->setting('flarum-sticky.only_sticky_unread_discussions', false);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 2
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $body = $response->getBody()->getContents());
+
+        $data = json_decode($body, true);
+
+        $this->assertEquals([2, 4, 3, 1], Arr::pluck($data['data'], 'id'));
+    }
+
+    #[Test]
+    public function list_discussions_pin_setting_disabled_does_not_affect_tag_pages()
+    {
+        $this->setting('flarum-sticky.pin_sticky_on_all_discussions', false);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 3
+            ])->withQueryParams([
+                'filter' => [
+                    'tag' => 'general'
+                ]
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $body = $response->getBody()->getContents());
+
+        $data = json_decode($body, true);
+
+        $this->assertEquals([3, 1, 2, 4], Arr::pluck($data['data'], 'id'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds an admin setting `flarum-sticky.pin_sticky_on_all_discussions` (default: `true`) that controls whether stickied discussions are pinned to the top of the All Discussions page. Tag pages are unaffected.

This is the 2.x counterpart of #4607 (1.x). It also restructures `PinStickiedDiscussionsToTop` so the new toggle is the master gate for `/all` and `only_sticky_unread_discussions` becomes subordinate to it.

## Motivation

The unread-only floating on `/all` (introduced via `only_sticky_unread_discussions`) helps until you have long-lived sticky announcements (rules, FAQs). For new visitors, those sticky are always unread, so they pin permanently and push fresh activity down. Some communities want the option to treat `/all` purely as latest activity, while keeping sticky pinning inside individual tag pages where it remains useful.

## Behavior matrix

`pin_on_all` = `flarum-sticky.pin_sticky_on_all_discussions`
`only_unread` = `flarum-sticky.only_sticky_unread_discussions`

| Page | `pin_on_all=true`, `only_unread=true` (default) | `pin_on_all=true`, `only_unread=false` | `pin_on_all=false` |
|---|---|---|---|
| `/all` | Unread sticky pinned (UNION) | All sticky pinned to top | No pinning — natural `last_posted_at` order |
| Tag page | All sticky pinned | All sticky pinned | All sticky pinned (setting irrelevant) |
| Other filters | No pinning | No pinning | No pinning |

When `pin_on_all=false`, the `only_unread` setting becomes a no-op — the admin UI greys it out (after save) since the read/unread distinction can't apply to discussions that aren't pinned.

## Changes

- `extend.php` — register `pin_sticky_on_all_discussions` (default `true`) and consolidate the three `Extend\Settings` declarations into a single block.
- `src/PinStickiedDiscussionsToTop.php` — reorder the `__invoke` flow so tag pages are handled first, then `pin_on_all` gates the `/all` path, then `only_unread` decides the pinning style. The new ordering keeps tag-page behavior unchanged.
- `js/src/admin/extend.tsx` — add a boolean toggle for `pin_on_all` directly above `only_unread`, and add a `disabled` predicate on `only_unread` that reflects the persisted `pin_on_all` value.
- `locale/en.yml` — add `admin.settings.pin_sticky_on_all_discussions_{label,help}`.
- `tests/integration/api/ListDiscussionsTest.php` — three new tests (see below).

## Backwards compatibility

The default value matches existing behavior, so this is a no-op on upgrade. No migration needed. Existing `only_sticky_unread_discussions` semantics are preserved when `pin_on_all` is `true` (the default).

## Tests added

- `list_discussions_does_not_pin_sticky_on_all_when_pin_setting_disabled_as_guest` — `pin_on_all=false` as guest, expects natural order on `/all`.
- `list_discussions_pin_setting_disabled_overrides_only_unread_setting_on_all` — both settings off, authenticated user with unread sticky, still expects natural order — proves master-gate precedence.
- `list_discussions_pin_setting_disabled_does_not_affect_tag_pages` — `pin_on_all=false` with a tag filter, expects all sticky pinned — proves the gate is `/all`-scoped.

All existing tests continue to pass unchanged.

## Notes

The admin disabled-state on `only_sticky_unread_discussions` reads `app.data.settings`, which reflects persisted values. So the disabled state updates after save. A fully reactive (no-save-needed) version would require a custom component subscribing to the in-progress form stream — left out as a polish item.

## Related

- 1.x counterpart: #4607