### PR TITLE
[2.x] chore(messages): change wording of select recipients modal title

### DIFF
--- a/extensions/messages/locale/en.yml
+++ b/extensions/messages/locale/en.yml
@@ -64,7 +64,7 @@ flarum-messages:
       title: Messages
 
     recipient_selection_modal:
-      title: Select the recipients of this message
+      title: Select the recipient of this message
 
     settings:
       notify_message_received_label: Someone sends me a message


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
At least right now we can just select one recipient. This makes the singular form recipient better fitting than the plural form

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
