### PR TITLE
[2.x] fix: send transactional emails in recipient's preferred locale

### DIFF
--- a/framework/core/src/Api/Controller/SendTestMailController.php
+++ b/framework/core/src/Api/Controller/SendTestMailController.php
@@ -35,16 +35,25 @@ class SendTestMailController implements RequestHandlerInterface
         $actor = RequestUtil::getActor($request);
         $actor->assertAdmin();
 
-        $this->queue->connection('sync')->push(
-            new SendInformationalEmailJob(
-                email: $actor->email,
-                displayName: $actor->display_name,
-                subject: $this->translator->trans('core.email.send_test.subject'),
-                body: $this->translator->trans('core.email.send_test.body'),
-                forumTitle: $this->settings->get('forum_title'),
-                bodyTitle: $this->translator->trans('core.email.send_test.subject')
-            )
-        );
+        $locale = $actor->getPreference('locale') ?? $this->settings->get('default_locale');
+        $previousLocale = $this->translator->getLocale();
+        $this->translator->setLocale($locale);
+
+        try {
+            $this->queue->connection('sync')->push(
+                new SendInformationalEmailJob(
+                    email: $actor->email,
+                    displayName: $actor->display_name,
+                    subject: $this->translator->trans('core.email.send_test.subject'),
+                    body: $this->translator->trans('core.email.send_test.body'),
+                    forumTitle: $this->settings->get('forum_title'),
+                    bodyTitle: $this->translator->trans('core.email.send_test.subject'),
+                    locale: $locale,
+                )
+            );
+        } finally {
+            $this->translator->setLocale($previousLocale);
+        }
 
         return new EmptyResponse();
     }

--- a/framework/core/src/Extension/AbandonedExtensionsFetcher.php
+++ b/framework/core/src/Extension/AbandonedExtensionsFetcher.php
@@ -11,6 +11,7 @@ namespace Flarum\Extension;
 
 use Flarum\Foundation\Application;
 use Flarum\Group\Group;
+use Flarum\Locale\TranslatorInterface;
 use Flarum\Mail\Job\SendAbandonedExtensionsEmailJob;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
@@ -18,7 +19,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Contracts\Queue\Queue;
 use RuntimeException;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AbandonedExtensionsFetcher
 {
@@ -113,25 +113,36 @@ class AbandonedExtensionsFetcher
             $q->where('id', Group::ADMINISTRATOR_ID);
         })->get();
 
-        $lines = array_map(function (string $package) use ($map) {
-            $replacement = $map[$package]['replacement'] ?? null;
-
-            return $replacement
-                ? $this->translator->trans('core.email.abandoned_extensions.line_with_replacement', compact('package', 'replacement'))
-                : $this->translator->trans('core.email.abandoned_extensions.line_no_replacement', compact('package'));
-        }, $newPackages);
-
-        $subject = $this->translator->trans('core.email.abandoned_extensions.subject');
         $forumTitle = $this->settings->get('forum_title', '');
+        $defaultLocale = $this->settings->get('default_locale');
+        $previousLocale = $this->translator->getLocale();
 
-        foreach ($admins as $admin) {
-            $this->queue->push(new SendAbandonedExtensionsEmailJob(
-                email: $admin->email,
-                username: $admin->display_name,
-                subject: $subject,
-                extensionLines: $lines,
-                forumTitle: $forumTitle,
-            ));
+        try {
+            foreach ($admins as $admin) {
+                $locale = $admin->getPreference('locale') ?? $defaultLocale;
+                $this->translator->setLocale($locale);
+
+                $lines = array_map(function (string $package) use ($map) {
+                    $replacement = $map[$package]['replacement'] ?? null;
+
+                    return $replacement
+                        ? $this->translator->trans('core.email.abandoned_extensions.line_with_replacement', compact('package', 'replacement'))
+                        : $this->translator->trans('core.email.abandoned_extensions.line_no_replacement', compact('package'));
+                }, $newPackages);
+
+                $subject = $this->translator->trans('core.email.abandoned_extensions.subject');
+
+                $this->queue->push(new SendAbandonedExtensionsEmailJob(
+                    email: $admin->email,
+                    username: $admin->display_name,
+                    subject: $subject,
+                    extensionLines: $lines,
+                    forumTitle: $forumTitle,
+                    locale: $locale,
+                ));
+            }
+        } finally {
+            $this->translator->setLocale($previousLocale);
         }
     }
 

--- a/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
+++ b/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Mail\Job;
 
+use Flarum\Locale\TranslatorInterface;
 use Flarum\Queue\AbstractJob;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
@@ -22,11 +23,16 @@ class SendAbandonedExtensionsEmailJob extends AbstractJob
         private readonly string $subject,
         private readonly array $extensionLines,
         private readonly string $forumTitle,
+        private readonly ?string $locale = null,
     ) {
     }
 
-    public function handle(Mailer $mailer, Factory $view): void
+    public function handle(Mailer $mailer, Factory $view, TranslatorInterface $translator): void
     {
+        if ($this->locale !== null) {
+            $translator->setLocale($this->locale);
+        }
+
         $username = $this->username;
         $forumTitle = $this->forumTitle;
         $userEmail = $this->email;

--- a/framework/core/src/Mail/Job/SendInformationalEmailJob.php
+++ b/framework/core/src/Mail/Job/SendInformationalEmailJob.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Mail\Job;
 
+use Flarum\Locale\TranslatorInterface;
 use Flarum\Queue\AbstractJob;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
@@ -26,12 +27,17 @@ class SendInformationalEmailJob extends AbstractJob
         protected array $views = [
             'text' => 'mail::plain.information.generic',
             'html' => 'mail::html.information.generic'
-        ]
+        ],
+        private readonly ?string $locale = null,
     ) {
     }
 
-    public function handle(Mailer $mailer, Factory $view): void
+    public function handle(Mailer $mailer, Factory $view, TranslatorInterface $translator): void
     {
+        if ($this->locale !== null) {
+            $translator->setLocale($this->locale);
+        }
+
         $forumTitle = $this->forumTitle;
         $infoContent = $this->body;
         $userEmail = $this->email;

--- a/framework/core/src/User/AccountActivationMailerTrait.php
+++ b/framework/core/src/User/AccountActivationMailerTrait.php
@@ -36,15 +36,24 @@ trait AccountActivationMailerTrait
 
     protected function sendConfirmationEmail(User $user, array $data): void
     {
-        $body = $this->translator->trans('core.email.activate_account.body', $data);
-        $subject = $this->translator->trans('core.email.activate_account.subject');
+        $locale = $user->getPreference('locale') ?? $this->settings->get('default_locale');
+        $previousLocale = $this->translator->getLocale();
+        $this->translator->setLocale($locale);
+
+        try {
+            $body = $this->translator->trans('core.email.activate_account.body', $data);
+            $subject = $this->translator->trans('core.email.activate_account.subject');
+        } finally {
+            $this->translator->setLocale($previousLocale);
+        }
 
         $this->queue->push(new SendInformationalEmailJob(
             email: $user->email,
             displayName: Arr::get($data, 'username'),
             subject: $subject,
             body: $body,
-            forumTitle: Arr::get($data, 'forum')
+            forumTitle: Arr::get($data, 'forum'),
+            locale: $locale,
         ));
     }
 }

--- a/framework/core/src/User/EmailConfirmationMailer.php
+++ b/framework/core/src/User/EmailConfirmationMailer.php
@@ -32,15 +32,24 @@ class EmailConfirmationMailer
         $email = $event->email;
         $data = $this->getEmailData($event->user, $email);
 
-        $body = $this->translator->trans('core.email.confirm_email.body', $data);
-        $subject = $this->translator->trans('core.email.confirm_email.subject');
+        $locale = $event->user->getPreference('locale') ?? $this->settings->get('default_locale');
+        $previousLocale = $this->translator->getLocale();
+        $this->translator->setLocale($locale);
+
+        try {
+            $body = $this->translator->trans('core.email.confirm_email.body', $data);
+            $subject = $this->translator->trans('core.email.confirm_email.subject');
+        } finally {
+            $this->translator->setLocale($previousLocale);
+        }
 
         $this->queue->push(new SendInformationalEmailJob(
             email: $email,
             displayName: Arr::get($data, 'username'),
             subject: $subject,
             body: $body,
-            forumTitle: Arr::get($data, 'forum')
+            forumTitle: Arr::get($data, 'forum'),
+            locale: $locale,
         ));
     }
 

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -50,8 +50,16 @@ class RequestPasswordResetJob extends AbstractJob
             'forum' => $settings->get('forum_title'),
         ];
 
-        $body = $translator->trans('core.email.reset_password.body', $data);
-        $subject = $translator->trans('core.email.reset_password.subject');
+        $locale = $user->getPreference('locale') ?? $settings->get('default_locale');
+        $previousLocale = $translator->getLocale();
+        $translator->setLocale($locale);
+
+        try {
+            $body = $translator->trans('core.email.reset_password.body', $data);
+            $subject = $translator->trans('core.email.reset_password.subject');
+        } finally {
+            $translator->setLocale($previousLocale);
+        }
 
         $queue->push(new SendInformationalEmailJob(
             email: $user->email,
@@ -59,7 +67,8 @@ class RequestPasswordResetJob extends AbstractJob
             subject: $subject,
             body: $body,
             forumTitle: Arr::get($data, 'forum'),
-            bodyTitle: $subject
+            bodyTitle: $subject,
+            locale: $locale,
         ));
     }
 }


### PR DESCRIPTION
## Summary

- Translates email subject/body under the **recipient's** preferred locale (`User::getPreference('locale')`), falling back to the forum's `default_locale`.
- Carries the per-recipient locale through to `SendInformationalEmailJob` and `SendAbandonedExtensionsEmailJob` so the wrapper template's `greeting` / `signoff` strings render in the same language as subject/body — fixing the mixed-language output described in #4626.
- Moves abandoned-extensions translation **inside** the per-admin loop so each admin receives the email in their own locale (was previously translated once outside the loop, so all admins got the same language).
- Mirrors the existing pattern in `NotificationMailer::send()`.

Fixes #4626

## Changes

- `Mail/Job/SendInformationalEmailJob` — adds optional `?string $locale` (after `$views` to preserve positional BC); injects `TranslatorInterface` into `handle()` and applies locale before send.
- `Mail/Job/SendAbandonedExtensionsEmailJob` — same shape.
- `Api/Controller/SendTestMailController` — switches to actor's locale, translates, restores previous locale in `finally`.
- `User/Job/RequestPasswordResetJob` — same pattern, recipient = looked-up user.
- `User/EmailConfirmationMailer` — same pattern.
- `User/AccountActivationMailerTrait` — same pattern (already had `User $user` in scope).
- `Extension/AbandonedExtensionsFetcher::notifyAdmins()` — moves translation inside loop, switches to Flarum's `Locale\TranslatorInterface` (Symfony's contract doesn't expose `setLocale()`), wraps loop in `try/finally`.

## Test plan

- [ ] Forum default locale = German (`de`), admin user preference = English (`en`). Trigger **Send test mail** — full email renders in English.
- [ ] Same setup, request a password reset for the admin — full email renders in English.
- [ ] User with no locale preference set — email renders in the forum default locale (German).
- [ ] Two admins with different locale preferences (e.g. one English, one German). Trigger an abandoned-extensions notification — each admin receives the email in their own locale.
- [ ] Verify subscription / reply notification mails (handled by `NotificationMailer`) are unchanged.
- [ ] PHPUnit suite passes.

## Notes

- Backward compatibility: the new `locale` parameter on both jobs is **optional and trailing**, so existing third-party callers (positional or named) continue to work unchanged. When `null`, behavior is identical to today.
- All changes target a single bug class — no unrelated cleanup.