### PR TITLE
[2.x] fix: restore text-overflow: ellipsis on long button labels

### DIFF
--- a/framework/core/less/common/Button.less
+++ b/framework/core/less/common/Button.less
@@ -272,10 +272,13 @@
 }
 .Button-label {
   line-height: inherit;
-  overflow: hidden;
-  text-overflow: ellipsis;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+}
+.Button-labelText {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .Button-helperText {
   font-size: 0.73rem;

--- a/framework/core/less/common/Dropdown.less
+++ b/framework/core/less/common/Dropdown.less
@@ -119,6 +119,10 @@
 
 
 .Dropdown--split {
+  .SplitDropdown-button {
+    min-width: 0;
+    flex-shrink: 1;
+  }
   .Dropdown-toggle .Button-icon {
     display: none;
   }


### PR DESCRIPTION
## Summary

Restores `text-overflow: ellipsis` on long button labels — regressed in #4174 when `display: flex; flex-direction: column;` was added to `.Button-label` to stack helper text below the label.

Flex containers don't honor `text-overflow: ellipsis` on themselves, so labels stopped truncating and started overflowing their containers.

Fixes #4621

## Changes

**`Button.less`** — moved truncation to the inner span:
- Removed `overflow: hidden; text-overflow: ellipsis;` from `.Button-label`.
- Added the same rules to a new `.Button-labelText` block — that's the `<span>` already rendered inside every `.Button-label` ([Button.tsx:122](https://github.com/flarum/framework/blob/2.x/framework/core/js/src/common/components/Button.tsx#L122)).
- Added `min-width: 0;` to `.Button-label` so the flex chain can shrink below content size when its parent applies shrink force.

**`Dropdown.less`** — fix for the SplitDropdown case shown in the issue:
- The main-action button (`.SplitDropdown-button`) sits inside a `.ButtonGroup`, where `.ButtonGroup > .Button { flex-shrink: 0 }` prevents shrinking. Without overriding that, the button would still grow past the group's `max-width: 100%`.
- Added `.SplitDropdown-button { min-width: 0; flex-shrink: 1; }` scoped under `.Dropdown--split`, leaving every other ButtonGroup user (post controls, admin permission grids, `ExtensionNavButton`) unchanged.

## Test plan

- [ ] Discussion controls SplitDropdown with a long Reply label (e.g. Polish language pack as a guest, or `Reply, but much longer` as in the issue) — main button truncates with `…`, dropdown toggle stays at fixed width.
- [ ] SplitDropdown with a short label — appearance unchanged.
- [ ] `ExtensionNavButton` (admin extension list with long extension name) — still truncates correctly via its existing `white-space: nowrap` rule.
- [ ] Other ButtonGroup uses (post controls, permission grids) — appearance unchanged.
- [ ] Subscription notification email button row, header dropdowns — sanity check no regressions.

## Notes

- No JS changes; the markup `<span class="Button-label"><span class="Button-labelText">…</span>…</span>` already exists.
- Backward compatible — third-party themes that target `.Button-label` for text styling still work; only the overflow behavior moves to `.Button-labelText`.