### PR TITLE
[2.x] fix: scope UserResource groups relationship to viewable groups

### DIFF
--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -310,6 +310,11 @@ class UserResource extends AbstractDatabaseResource
                 }),
 
             Schema\Relationship\ToMany::make('groups')
+                ->get(function (User $user, Context $context) {
+                    return $context->getActor()->can('viewHiddenGroups')
+                        ? $user->groups()->get()->all()
+                        : $user->visibleGroups()->get()->all();
+                })
                 ->writable(fn (User $user, Context $context) => $context->updating() && $context->getActor()->can('editGroups', $user))
                 ->includable()
                 ->set(function (User $user, $value, Context $context) {

--- a/framework/core/tests/integration/api/users/ShowGroupsRelationshipTest.php
+++ b/framework/core/tests/integration/api/users/ShowGroupsRelationshipTest.php
@@ -109,5 +109,4 @@ class ShowGroupsRelationshipTest extends TestCase
         $this->assertEqualsCanonicalizing(['10', '11'], $this->groupRelationshipIds($body));
         $this->assertEqualsCanonicalizing(['10', '11'], $this->includedGroupIds($body));
     }
-
 }

--- a/framework/core/tests/integration/api/users/ShowGroupsRelationshipTest.php
+++ b/framework/core/tests/integration/api/users/ShowGroupsRelationshipTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\users;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\Test;
+
+class ShowGroupsRelationshipTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Group::class => [
+                [
+                    'id' => 10,
+                    'name_singular' => 'Public',
+                    'name_plural' => 'Public',
+                    'is_hidden' => 0,
+                ],
+                [
+                    'id' => 11,
+                    'name_singular' => 'Hidden',
+                    'name_plural' => 'Hidden',
+                    'is_hidden' => 1,
+                ],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 10],
+                ['user_id' => 2, 'group_id' => 11],
+            ],
+        ]);
+    }
+
+    private function groupRelationshipIds(array $body): array
+    {
+        return Arr::pluck($body['data']['relationships']['groups']['data'] ?? [], 'id');
+    }
+
+    private function includedGroupIds(array $body): array
+    {
+        $included = $body['included'] ?? [];
+
+        $groups = array_filter($included, fn (array $resource) => ($resource['type'] ?? null) === 'groups');
+
+        return array_values(Arr::pluck($groups, 'id'));
+    }
+
+    #[Test]
+    public function guest_does_not_see_hidden_groups_in_user_groups_relationship()
+    {
+        $response = $this->send($this->request('GET', '/api/users/2'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEqualsCanonicalizing(['10'], $this->groupRelationshipIds($body));
+        $this->assertNotContains('11', $this->includedGroupIds($body));
+    }
+
+    #[Test]
+    public function normal_user_does_not_see_hidden_groups_in_user_groups_relationship()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEqualsCanonicalizing(['10'], $this->groupRelationshipIds($body));
+        $this->assertNotContains('11', $this->includedGroupIds($body));
+    }
+
+    #[Test]
+    public function admin_sees_hidden_groups_in_user_groups_relationship()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEqualsCanonicalizing(['10', '11'], $this->groupRelationshipIds($body));
+        $this->assertEqualsCanonicalizing(['10', '11'], $this->includedGroupIds($body));
+    }
+
+}


### PR DESCRIPTION
## Summary

`GET /api/users/{id}` was including hidden group IDs in `data.relationships.groups.data` for actors without the `viewHiddenGroups` permission.

The `groups` `ToMany` relationship on `UserResource` resolved against the unfiltered `User::groups()` Eloquent relation, so linkage leaked hidden group IDs even though `GroupResource::scope()` correctly filtered the hidden groups themselves out of the `included` resources. The frontend store (and `User.badges()` rendering) therefore received hidden group references it shouldn't have known about.

Adds a `get()` callback on the relationship that returns `User::visibleGroups()` (which already excludes `is_hidden = 1`) for actors without `viewHiddenGroups`, mirroring the visibility check in `Group\Access\ScopeGroupVisibility`.

Fixes #4618

## Changes

- [`framework/core/src/Api/Resource/UserResource.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/UserResource.php) — add `->get(...)` to the `groups` relationship that branches on `$context->getActor()->can('viewHiddenGroups')`.
- New test file `framework/core/tests/integration/api/users/ShowGroupsRelationshipTest.php` covering guest, normal user, and admin actors against `/api/users/{id}`.

## Test plan

- [x] New `ShowGroupsRelationshipTest` passes (3 tests, 9 assertions).
- [x] All existing user + group API integration tests still pass (123 tests, 274 assertions).
- [ ] Manual: assign a hidden group to a user, request `/api/users/{id}` as guest / non-privileged member — confirm `relationships.groups.data` only contains visible group IDs.
- [ ] Manual: same request as admin — confirm both visible and hidden group IDs appear.

## Notes

- Backward compatible — third-party consumers reading `relationships.groups.data` were already broken on the hidden-groups case (the included resources weren't there); now the linkage matches the included resources.
- The same field declaration is reused for `Update` and `Index` endpoints (both `defaultInclude(['groups'])`), so the fix applies there too.