### PR TITLE
[2.x] fix(realtime): order users by joined_at in realtime:info

### DIFF
--- a/extensions/realtime/src/Websocket/Console/InfoCommand.php
+++ b/extensions/realtime/src/Websocket/Console/InfoCommand.php
@@ -48,7 +48,7 @@ class InfoCommand extends Command
         $promise->wait();
         $this->info('Triggered an async test event.');
 
-        $queue->push(new SendTriggerJob('test', User::query()->oldest()->first()));
+        $queue->push(new SendTriggerJob('test', User::query()->oldest('joined_at')->first()));
         $this->info('Triggered a test event dispatched to the queue.');
     }
 }


### PR DESCRIPTION
## Summary

`php flarum realtime:info` failed with `Unknown column 'created_at' in 'order clause'` because the command used Eloquent's `oldest()` without arguments — which defaults to a `created_at` column that Flarum's `users` table doesn't have. Flarum uses `joined_at` instead.

Fixes #4617

## Changes

- [`extensions/realtime/src/Websocket/Console/InfoCommand.php`](https://github.com/flarum/framework/blob/2.x/extensions/realtime/src/Websocket/Console/InfoCommand.php) — pass `'joined_at'` to `oldest()` explicitly.

This is the only place in the framework that hits this pattern (verified via `grep`).

## Why not override `CREATED_AT` on `User` or `AbstractModel`

- `AbstractModel` is the base for every Flarum model — most use `created_at`, only `User` uses `joined_at`. There's no single column name that fits all.
- Setting `const CREATED_AT = 'joined_at'` on `User` would help future callers but makes the model look like it has Eloquent-style timestamps when it doesn't (`$timestamps = false`). Risk of confusing third-party code that introspects the model.
- The targeted fix at the call site is clearer about what the code wants (oldest user by join date) and matches Flarum's existing convention everywhere else.

## Test plan

- [x] Manually verified `php flarum realtime:info` runs to completion in the dev container.
- No automated test added — the command depends on a live Pusher connection, so writing one would require heavy mocking for a one-line fix.