### PR TITLE
[2.x] perf: skip mime detection in JsDirectoryCompiler when extension matches

### DIFF
--- a/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
+++ b/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
@@ -109,9 +109,11 @@ class JsDirectoryCompiler implements CompilerInterface
         foreach ($filesystem->allFiles() as $relativeFilePath) {
             // Check both file extension and MIME type to identify JS files.
             // We require at least one of these checks to pass, as MIME type detection
-            // can be unreliable for minified/bundled JS files.
+            // can be unreliable for minified/bundled JS files. Only run mime
+            // detection (which calls finfo_file and is expensive) when the cheap
+            // extension check has already failed.
             $hasJsExtension = str_ends_with($relativeFilePath, '.js');
-            $mimeType = $filesystem->mimeType($relativeFilePath);
+            $mimeType = $hasJsExtension ? null : $filesystem->mimeType($relativeFilePath);
             $hasJsMimeType = $mimeType === 'application/javascript' || $mimeType === 'text/javascript';
 
             if (! $hasJsExtension && ! $hasJsMimeType) {


### PR DESCRIPTION
## Summary

`JsDirectoryCompiler::eachFile()` called `Filesystem::mimeType()` for **every** file in **every** per-extension JS bundle directory, on **every** request — `finfo_file()` is ~1ms per call, and a typical install with ~40 extensions paid **60–80ms of TTFB** to this single loop on every page.

The mime check was only ever intended as a fallback for cases where the `.js` extension check fails (e.g. minified bundles served without the extension, see #4329). Short-circuit when the cheap extension check has already matched.

Behavior is identical: every file processed before is still processed, every file skipped is still skipped. Only timing changes.

Fixes #4616

## Changes

- [`framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php) — only call `$filesystem->mimeType()` when `$hasJsExtension` is false.

## Reporter's verified improvement (production install, 10-sample TTFB medians)

| URL | Before | After | Δ |
|---|---|---|---|
| `/u/<user>` | 240 ms | 210 ms | **−30 ms (−12%)** |
| `/` (forum index, ~50 discussions) | 1354 ms | 1262 ms | **−92 ms (−7%)** |
| `/d/<id>` (small discussion) | 540 ms | 483 ms | **−57 ms (−11%)** |

## Test plan

- [ ] Forum and admin frontends load and execute normally; lazy-loaded JS bundles for all installed extensions still work.
- [ ] Run `php flarum cache:clear` and `php flarum assets:publish`, confirm bundles still compile and serve.
- [ ] If any extension publishes JS files without `.js` extensions (the original case #4329 was added to handle), verify they're still picked up — the mime fallback is unchanged for those, only its timing is gated.

The patch is the same one the reporter verified live in production for 24h with no regressions.