### PR TITLE
[2.x] fix: add missing getHidden() to Log\Context\Repository stub

### DIFF
--- a/framework/core/src/Log/Context/Repository.php
+++ b/framework/core/src/Log/Context/Repository.php
@@ -81,6 +81,14 @@ class Repository
     }
 
     /**
+     * Get a hidden context value.
+     */
+    public function getHidden(string $key, mixed $default = null): mixed
+    {
+        return $this->hidden[$key] ?? $default;
+    }
+
+    /**
      * Add a hidden context value.
      */
     public function addHidden(string|array $key, mixed $value = null): self

--- a/framework/core/tests/unit/Log/Context/RepositoryTest.php
+++ b/framework/core/tests/unit/Log/Context/RepositoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Log\Context;
+
+use Flarum\Log\Context\Repository;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class RepositoryTest extends TestCase
+{
+    #[Test]
+    public function get_hidden_returns_stored_value()
+    {
+        $repository = new Repository();
+        $repository->addHidden('foo', 'bar');
+
+        $this->assertSame('bar', $repository->getHidden('foo'));
+    }
+
+    #[Test]
+    public function get_hidden_returns_default_when_key_missing()
+    {
+        $repository = new Repository();
+
+        $this->assertNull($repository->getHidden('missing'));
+        $this->assertSame('fallback', $repository->getHidden('missing', 'fallback'));
+    }
+
+    #[Test]
+    public function add_get_forget_hidden_round_trip()
+    {
+        $repository = new Repository();
+        $repository->addHidden(['a' => 1, 'b' => 2]);
+
+        $this->assertSame(1, $repository->getHidden('a'));
+        $this->assertSame(['a' => 1, 'b' => 2], $repository->allHidden());
+
+        $repository->forgetHidden('a');
+
+        $this->assertNull($repository->getHidden('a'));
+        $this->assertSame(['b' => 2], $repository->allHidden());
+    }
+
+    #[Test]
+    public function hidden_data_is_isolated_from_public_data()
+    {
+        $repository = new Repository();
+        $repository->add('foo', 'public');
+        $repository->addHidden('foo', 'hidden');
+
+        $this->assertSame('public', $repository->get('foo'));
+        $this->assertSame('hidden', $repository->getHidden('foo'));
+    }
+}


### PR DESCRIPTION
## Summary

Laravel 13's queue handler calls `getHidden()` on the log context repository when releasing unique-job locks after a `ModelNotFoundException` ([`CallQueuedHandler::ensureUniqueJobLockIsReleasedViaContext`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/CallQueuedHandler.php#L325-L345)).

Flarum's stub at `framework/core/src/Log/Context/Repository.php` implemented `addHidden`, `forgetHidden`, and `allHidden` but not `getHidden`. So any queued job whose subject (post, discussion, etc.) was deleted between dispatch and execution turned a benign `ModelNotFoundException` into a cluster of fatal `Error: Call to undefined method Flarum\Log\Context\Repository::getHidden()` — one per pending job for that subject.

Add `getHidden()` mirroring `get()` for the hidden array. With nothing writing to the hidden context in a fresh worker, the call returns `null` and Laravel's handler silently skips lock cleanup — the intended no-op-on-empty path.

Fixes #4611

## Changes

- [`framework/core/src/Log/Context/Repository.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Log/Context/Repository.php) — add `getHidden(string $key, mixed $default = null): mixed`.
- New `framework/core/tests/unit/Log/Context/RepositoryTest.php` — 4 unit tests covering `getHidden` return value, default fallback, add/get/forget round-trip, and isolation between public and hidden arrays.

## Test plan

- [x] Unit tests pass (4 tests, 9 assertions).
- [x] Verified the new tests catch the original bug — reverting the fix produces 4× `Call to undefined method` errors, exactly the runtime error users hit.
- [ ] Manual: dispatch a queued job that touches a soon-to-be-deleted model (e.g. mention a user, then delete the post immediately); confirm the worker logs the `ModelNotFoundException` quietly without the fatal cascade.

## Notes

- The stub still doesn't implement many other Laravel `Repository` methods (`pullHidden`, `hasHidden`, `pushHidden`, …) — adding those is out of scope here. This PR fixes the specific path that's currently fataling in production.