### PR TITLE
[2.x] fix: avoid duplicate ModelNotFoundException logs on orphaned queued jobs

### DIFF
--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -19,4 +19,16 @@ class AbstractJob implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+
+    /**
+     * If a serialized model on this job has been deleted between dispatch and
+     * worker pickup, treat the job as a no-op and remove it from the queue
+     * rather than calling failed(), which re-deserializes the payload and
+     * throws ModelNotFoundException a second time — producing duplicate error
+     * log entries for what is in fact a handled-correctly race.
+     *
+     * Subclasses that should be retried or marked failed in this scenario can
+     * override with `public bool $deleteWhenMissingModels = false;`.
+     */
+    public bool $deleteWhenMissingModels = true;
 }


### PR DESCRIPTION
## Summary

When a queued job's serialized model is deleted between dispatch and worker pickup (a common race for notification fan-out — mentions, subscriptions, FoF byobu/follow-tags, etc.), the worker logs **two** `ModelNotFoundException` entries even though the race is handled correctly.

The flow ([`CallQueuedHandler`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/CallQueuedHandler.php#L305-L316)):

1. Worker `unserialize()`s payload → `firstOrFail()` throws `ModelNotFoundException` (caught silently).
2. `handleModelNotFound()` runs. With `deleteWhenMissingModels` unset (default `false`), it falls through to `$job->fail($e)`.
3. `fail()` calls `getCommand()` → `unserialize()` **again** → `ModelNotFoundException` (this time not caught, gets logged).

Setting `public bool $deleteWhenMissingModels = true;` on `AbstractJob` makes the handler `$job->delete()` the job instead, skipping the noisy second-deserialize path. The job is already off the queue and any unique-job lock has already been released.

Fixes #4615

## Why apply at the AbstractJob level

All current `AbstractJob` subclasses (12 across core + bundled extensions) follow the same pattern: notify-X-about-Y, send-mail-about-Y, index-Y-for-search, run-composer-command, gdpr-export-for-user, etc. **None** of them does anything useful if the subject model has been deleted — there's no meaningful retry path.

Subclasses that genuinely want the failed-and-retry behavior can opt out with `public bool $deleteWhenMissingModels = false;`.

## Changes

- [`framework/core/src/Queue/AbstractJob.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Queue/AbstractJob.php) — set `public bool $deleteWhenMissingModels = true;` with a docblock explaining the override path.

## Test plan

- [ ] Manual: dispatch a queued job whose model is then deleted before the worker reaches it (post a reply that triggers a notification, immediately delete the post). Confirm only the original `ModelNotFoundException` is logged once at INFO/DEBUG level (Laravel's caught-and-handled path), not twice at ERROR.
- [ ] Existing queue test suite passes.

## Notes

- Pairs with #4633 (`getHidden()` stub fix) — once that's merged, this PR removes the remaining log noise from the same orphaned-job scenario.
- This is a behavior change for any third-party extension whose `AbstractJob` subclass *was* relying on `failed()` being called on missing models. That should be vanishingly rare given Flarum's job patterns, and the override is one line. Worth calling out in upgrade notes.