### PR TITLE
[2.x] fix: resolve VersionerInterface from container; cache rev-manifest reads

### DIFF
--- a/framework/core/src/Frontend/Compiler/FileVersioner.php
+++ b/framework/core/src/Frontend/Compiler/FileVersioner.php
@@ -10,11 +10,12 @@
 namespace Flarum\Frontend\Compiler;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Support\Arr;
 
 class FileVersioner implements VersionerInterface
 {
     public const REV_MANIFEST = 'rev-manifest.json';
+
+    private ?array $cachedManifest = null;
 
     public function __construct(
         protected Filesystem $filesystem
@@ -23,11 +24,7 @@ class FileVersioner implements VersionerInterface
 
     public function putRevision(string $file, ?string $revision): void
     {
-        if ($this->filesystem->exists(static::REV_MANIFEST)) {
-            $manifest = json_decode($this->filesystem->get(static::REV_MANIFEST), true);
-        } else {
-            $manifest = [];
-        }
+        $manifest = $this->readManifest();
 
         if ($revision) {
             $manifest[$file] = $revision;
@@ -36,25 +33,38 @@ class FileVersioner implements VersionerInterface
         }
 
         $this->filesystem->put(static::REV_MANIFEST, json_encode($manifest));
+        $this->cachedManifest = $manifest;
     }
 
     public function getRevision(string $file): ?string
     {
-        if ($this->filesystem->exists(static::REV_MANIFEST)) {
-            $manifest = json_decode($this->filesystem->get(static::REV_MANIFEST), true);
-
-            return Arr::get($manifest, $file);
-        }
-
-        return null;
+        return $this->readManifest()[$file] ?? null;
     }
 
     public function allRevisions(): array
     {
-        if ($contents = $this->filesystem->get(static::REV_MANIFEST)) {
-            return json_decode($contents, true);
+        return $this->readManifest();
+    }
+
+    /**
+     * Read the manifest, caching the parsed array for the lifetime of this
+     * instance. Frontend rendering constructs ~6 compilers per request, all
+     * sharing the same VersionerInterface singleton — without this cache the
+     * manifest is read and JSON-decoded once per compiler.
+     */
+    private function readManifest(): array
+    {
+        if ($this->cachedManifest !== null) {
+            return $this->cachedManifest;
         }
 
-        return [];
+        if (! $this->filesystem->exists(static::REV_MANIFEST)) {
+            return $this->cachedManifest = [];
+        }
+
+        $contents = $this->filesystem->get(static::REV_MANIFEST);
+        $manifest = json_decode($contents, true);
+
+        return $this->cachedManifest = is_array($manifest) ? $manifest : [];
     }
 }

--- a/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
+++ b/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php
@@ -25,13 +25,11 @@ class JsDirectoryCompiler implements CompilerInterface
 {
     use HasSources;
 
-    protected VersionerInterface $versioner;
-
     public function __construct(
         protected Cloud $assetsDir,
-        protected string $destinationPath
+        protected string $destinationPath,
+        protected VersionerInterface $versioner,
     ) {
-        $this->versioner = new FileVersioner($assetsDir);
     }
 
     public function getFilename(): ?string

--- a/framework/core/src/Frontend/Compiler/RevisionCompiler.php
+++ b/framework/core/src/Frontend/Compiler/RevisionCompiler.php
@@ -25,14 +25,12 @@ class RevisionCompiler implements CompilerInterface
 
     public const EMPTY_REVISION = 'empty';
 
-    protected VersionerInterface $versioner;
-
     public function __construct(
         protected Cloud $assetsDir,
         protected string $filename,
-        protected SettingsRepositoryInterface $settings
+        protected SettingsRepositoryInterface $settings,
+        protected VersionerInterface $versioner,
     ) {
-        $this->versioner = new FileVersioner($assetsDir);
     }
 
     public function getFilename(): string

--- a/framework/core/src/Frontend/Document.php
+++ b/framework/core/src/Frontend/Document.php
@@ -10,10 +10,8 @@
 namespace Flarum\Frontend;
 
 use Flarum\Foundation\Config;
-use Flarum\Frontend\Compiler\FileVersioner;
 use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\Driver\TitleDriverInterface;
-use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -150,22 +148,17 @@ class Document implements Renderable
         'class' => [],
     ];
 
-    /**
-     * We need the versioner to get the revisions of split chunks.
-     */
-    protected VersionerInterface $versioner;
-
     public function __construct(
         protected Factory $view,
         protected array $forumApiDocument,
         protected Request $request,
         protected TitleDriverInterface $titleDriver,
         protected Config $config,
-        FilesystemFactory $filesystem
+        /**
+         * We need the versioner to get the revisions of split chunks.
+         */
+        protected VersionerInterface $versioner,
     ) {
-        $this->versioner = new FileVersioner(
-            $filesystem->disk('flarum-assets')
-        );
     }
 
     public function render(): string

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -15,7 +15,9 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\FontAwesome;
 use Flarum\Foundation\Paths;
+use Flarum\Frontend\Compiler\FileVersioner;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Frontend\Driver\BasicTitleDriver;
 use Flarum\Frontend\Driver\TitleDriverInterface;
 use Flarum\Http\RequestUtil;
@@ -32,6 +34,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
 {
     public function register(): void
     {
+        $this->container->singleton(VersionerInterface::class, function (Container $container) {
+            return new FileVersioner(
+                $container->make('filesystem')->disk('flarum-assets')
+            );
+        });
+
         $this->container->singleton('flarum.assets', function (Container $container) {
             return new AssetManager($container, $container->make(LocaleManager::class));
         });

--- a/framework/core/tests/unit/Frontend/Compiler/FileVersionerTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/FileVersionerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Compiler;
+
+use Flarum\Frontend\Compiler\FileVersioner;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+class FileVersionerTest extends TestCase
+{
+    #[Test]
+    public function it_reads_the_manifest_from_disk_only_once_per_instance()
+    {
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->once()->andReturn(true);
+        $filesystem->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)->once()
+            ->andReturn(json_encode(['foo.js' => 'abc123', 'bar.css' => 'def456']));
+
+        $versioner = new FileVersioner($filesystem);
+
+        // Three calls — should only hit the filesystem once.
+        $this->assertSame('abc123', $versioner->getRevision('foo.js'));
+        $this->assertSame('def456', $versioner->getRevision('bar.css'));
+        $this->assertSame(['foo.js' => 'abc123', 'bar.css' => 'def456'], $versioner->allRevisions());
+    }
+
+    #[Test]
+    public function it_returns_null_for_missing_keys()
+    {
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->andReturn(true);
+        $filesystem->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)
+            ->andReturn(json_encode(['foo.js' => 'abc123']));
+
+        $versioner = new FileVersioner($filesystem);
+
+        $this->assertNull($versioner->getRevision('missing.js'));
+    }
+
+    #[Test]
+    public function it_returns_empty_array_when_manifest_does_not_exist()
+    {
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->once()->andReturn(false);
+        $filesystem->shouldNotReceive('get');
+
+        $versioner = new FileVersioner($filesystem);
+
+        $this->assertNull($versioner->getRevision('foo.js'));
+        $this->assertSame([], $versioner->allRevisions());
+    }
+
+    #[Test]
+    public function put_revision_writes_through_and_updates_in_memory_cache()
+    {
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->once()->andReturn(true);
+        $filesystem->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)->once()
+            ->andReturn(json_encode(['foo.js' => 'old']));
+        $filesystem->shouldReceive('put')->with(FileVersioner::REV_MANIFEST, json_encode(['foo.js' => 'new']))->once();
+
+        $versioner = new FileVersioner($filesystem);
+        $versioner->putRevision('foo.js', 'new');
+
+        // Subsequent reads should NOT hit the filesystem again — the in-memory
+        // cache must reflect the write-through.
+        $this->assertSame('new', $versioner->getRevision('foo.js'));
+    }
+
+    #[Test]
+    public function put_revision_with_null_removes_the_entry()
+    {
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->andReturn(true);
+        $filesystem->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)
+            ->andReturn(json_encode(['foo.js' => 'abc', 'bar.css' => 'def']));
+        $filesystem->shouldReceive('put')->with(FileVersioner::REV_MANIFEST, json_encode(['bar.css' => 'def']))->once();
+
+        $versioner = new FileVersioner($filesystem);
+        $versioner->putRevision('foo.js', null);
+
+        $this->assertNull($versioner->getRevision('foo.js'));
+        $this->assertSame('def', $versioner->getRevision('bar.css'));
+    }
+}


### PR DESCRIPTION
## Summary

`RevisionCompiler`, `JsDirectoryCompiler`, and `Document` declared a `VersionerInterface` property but instantiated `FileVersioner` directly in their constructors. The interface contract was unenforceable — `$container->bind(VersionerInterface::class, MyVersioner::class)` had no effect on these classes.

This PR:

1. **Binds `VersionerInterface`** in `FrontendServiceProvider` (defaulting to `FileVersioner` against the `flarum-assets` disk) and resolves it via the container in all three call sites. Local-disk installs are unchanged (same default binding); installs on remote storage can now bind a faster implementation and have it take effect everywhere.
2. **Caches the parsed manifest in-memory** on `FileVersioner`. With the binding now a singleton, all ~6 compilers + `Document` per request share one `VersionerInterface` instance — previously each read and JSON-decoded `rev-manifest.json` independently. On S3-backed installs this was **~12 round-trips per request** just for asset URL resolution; now it's one.

Fixes #4637

## Changes

- [`framework/core/src/Frontend/FrontendServiceProvider.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/FrontendServiceProvider.php) — bind `VersionerInterface` to a `FileVersioner` singleton scoped to the `flarum-assets` filesystem.
- [`framework/core/src/Frontend/Compiler/RevisionCompiler.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/Compiler/RevisionCompiler.php) and [`JsDirectoryCompiler.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/Compiler/JsDirectoryCompiler.php) — drop the inline `new FileVersioner(...)`, accept `VersionerInterface` via constructor (autowired). Both classes are `@internal` and resolved through the container by `Frontend\Assets`, so no caller needs updating.
- [`framework/core/src/Frontend/Document.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/Document.php) — replace the `FilesystemFactory $filesystem` constructor parameter with `VersionerInterface $versioner`. Resolved via `$container->makeWith()` from `Frontend.php` — autowiring picks up the new arg.
- [`framework/core/src/Frontend/Compiler/FileVersioner.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Frontend/Compiler/FileVersioner.php) — per-instance manifest cache with write-through. `putRevision()` updates both disk and the cache; `getRevision()` and `allRevisions()` read from the cache. The CLI compile path constructs fresh containers, so per-instance lifetime is correct (no stale-manifest worries across processes).
- New `framework/core/tests/unit/Frontend/Compiler/FileVersionerTest.php` — 5 tests pinning down read-once-per-instance, missing keys, missing manifest, write-through cache update, and key removal via `null` revision.

## Backward compatibility

- **`Document::__construct` signature change** is the only break. The sixth parameter `FilesystemFactory $filesystem` is now `VersionerInterface $versioner`. Subclasses that call `parent::__construct(...)` with positional arguments will need to update; named arguments are forward-compatible. Most extensions don't subclass `Document` and aren't affected. Worth a note in the 2.0 dev upgrade guide.
- `RevisionCompiler` and `JsDirectoryCompiler` are `@internal` and only resolved through the container; the new constructor parameter is autowired from the binding.

## Test plan

- [x] Unit tests: 5/5 pass (`FileVersionerTest`).
- [x] Frontend integration tests: 10/10 pass (full document rendering exercises all three resolved instantiation paths).
- [x] Admin integration tests: 2/2 pass.
- [ ] Manual: confirm forum/admin pages render normally on a local-disk install.
- [ ] Manual: confirm `php flarum assets:publish` and `php flarum cache:clear` still write a valid `rev-manifest.json` and bundles serve correctly.
- [ ] Manual on S3 install (if available): confirm filesystem call count for asset URL resolution drops from ~12 to 1 per request.

## Related

- #4635 — same shape (Flysystem `exists()` calls in a per-request hot path) on the avatar `srcsetFor` accessor; outside scope of this PR.