### PR TITLE
[2.x] fix: resolve email logo URL via flarum-assets disk

### DIFF
--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -14,8 +14,10 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
@@ -99,8 +101,18 @@ class MailServiceProvider extends AbstractServiceProvider
         });
     }
 
-    public function boot(Dispatcher $events): void
-    {
+    public function boot(
+        Dispatcher $events,
+        ViewFactory $views,
+        FilesystemFactory $filesystemFactory,
+        SettingsRepositoryInterface $settings,
+    ): void {
         $events->listen(MessageSending::class, MutateEmail::class);
+
+        // Resolve the logo URL via the flarum-assets disk so it stays correct on
+        // installs whose assets are served from a remote bucket / CDN — same path
+        // ForumResource::getLogoUrl() uses for the frontend.
+        $logoPath = $settings->get('logo_path');
+        $views->share('logoUrl', $logoPath ? $filesystemFactory->disk('flarum-assets')->url($logoPath) : null);
     }
 }

--- a/framework/core/views/email/html.blade.php
+++ b/framework/core/views/email/html.blade.php
@@ -50,8 +50,8 @@
 <div class="header">
     <div class="Header-title">
         <a href="{{ $url->to('forum')->base() }}" id="home-link">
-            @if ($settings->get('logo_path'))
-                <img src="{{ $url->to('forum')->base() . '/assets/' . $settings->get('logo_path') }}" alt="{{ $settings->get('forum_title') }}" class="Header-logo">
+            @if ($logoUrl)
+                <img src="{{ $logoUrl }}" alt="{{ $settings->get('forum_title') }}" class="Header-logo">
             @else
                 {{ $settings->get('forum_title') }}
             @endif


### PR DESCRIPTION
## Summary

The HTML email layout built the logo `<img src>` as:

```php
$url->to('forum')->base() . '/assets/' . $settings->get('logo_path')
```

On installs serving assets from a remote bucket or CDN, the actual logo file lives at the `flarum-assets` disk's resolved URL — *not* under `forum-base/assets/`. Every email those installs rendered showed a broken logo.

Resolve the logo URL via the same `flarum-assets` disk that [`ForumResource::getLogoUrl()`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/ForumResource.php#L154-L159) uses for the frontend, and share it to email views as a precomputed `$logoUrl`.

Fixes #4604

## Changes

- [`framework/core/src/Mail/MailServiceProvider.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Mail/MailServiceProvider.php) — `boot()` now resolves `logo_path` against the `flarum-assets` disk and shares the result as `logoUrl` to all views (computed once per request boot, cheap).
- [`framework/core/views/email/html.blade.php`](https://github.com/flarum/framework/blob/2.x/framework/core/views/email/html.blade.php) — read the precomputed `$logoUrl` instead of the broken concatenation; no `@inject` added.

## Compatibility

- **Local-disk installs (default):** the `flarum-assets` disk's `url()` returns `https://forum.example.com/assets/<path>` — same URL the old concatenation produced. No observable change.
- **S3 / CDN installs:** the disk now returns the actual asset URL. Logos render where the file is.
- **Third-party extensions** that already pass their own `$logoUrl` to an email render via `->with('logoUrl', ...)` still win — Laravel's local `with()` overrides global `share()`.

## Test plan

- [x] Existing mailer-related integration tests pass (7/7).
- [ ] Manual: send a test email on a local-disk install — logo renders unchanged.
- [ ] Manual on S3-backed install: send a test email — logo loads from the bucket/CDN URL.

## Notes

- No automated test for the rendered HTML body — would need to capture mailer output and inspect the `<img src>` attribute, which is heavyweight relative to the size of this change. The fix mirrors a pattern already exercised everywhere else in core that resolves asset URLs.
- The plain-text email template doesn't include the logo, so no change there.
- Dark-mode logo handling in emails is out of scope — most mail clients can't reliably swap images per dark mode anyway.