### PR TITLE
[2.x] fix: lower SMTP ping threshold to 20s to survive idle-disconnect from relays

### DIFF
--- a/framework/core/src/Mail/SmtpDriver.php
+++ b/framework/core/src/Mail/SmtpDriver.php
@@ -13,6 +13,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\MessageBag;
 use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
 use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
@@ -80,7 +81,7 @@ class SmtpDriver implements DriverInterface
             $options['verify_peer'] = 'false';
         }
 
-        return $this->factory->create(new Dsn(
+        $transport = $this->factory->create(new Dsn(
             $scheme,
             $settings->get('mail_host'),
             $settings->get('mail_username'),
@@ -88,5 +89,18 @@ class SmtpDriver implements DriverInterface
             $settings->get('mail_port'),
             $options
         ));
+
+        // Symfony's default ping threshold of 100s is longer than the idle
+        // timeout used by some SMTP relays (notably AWS SES, which has been
+        // observed closing connections in the 30–90s range). Without a NOOP
+        // probe, the transport writes the next message into a dead socket and
+        // the relay returns "451 4.4.2 Timeout waiting for data from client".
+        // 20s is well under any reasonable relay idle timeout while keeping
+        // NOOP overhead negligible.
+        if ($transport instanceof SmtpTransport) {
+            $transport->setPingThreshold(20);
+        }
+
+        return $transport;
     }
 }


### PR DESCRIPTION
## Summary

Symfony's `SmtpTransport` reuses the SMTP connection across sends within a process and only NOOPs the connection when the inter-message gap exceeds `pingThreshold` (default **100s**). AWS SES has been observed closing idle connections in the **30–90s** range, so messages spaced 30–100s apart get written into a dead socket and the relay responds with:

```
451 4.4.2 Timeout waiting for data from client
```

The reporter's data (failures clustered late in the lifetime of each long-lived queue worker, never near the start) clearly fingerprints connection-age dependence.

Set `pingThreshold` to 20s on the Symfony transport in `SmtpDriver::buildTransport()` — well under any reasonable relay idle timeout, with negligible NOOP overhead.

Fixes #4614

## Changes

- [`framework/core/src/Mail/SmtpDriver.php`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Mail/SmtpDriver.php) — after building the transport via the factory, call `$transport->setPingThreshold(20)` (guarded by `instanceof SmtpTransport` so the cast is safe even though `EsmtpTransportFactory` always produces SMTP transports).

## Test plan

- [ ] Manual: configure SMTP against AWS SES; run a long-lived `queue:work` with a moderate trickle of email-bound notifications; confirm the `451 4.4.2 Timeout` errors no longer appear in `storage/logs/flarum-*.log`.
- [ ] Existing mailer integration tests pass.

No automated test for this — the bug only manifests with a real long-lived SMTP connection against a remote server with idle-disconnect behavior. Reproducing in a unit test would require simulating the transport's connection lifecycle, which is heavyweight relative to the fix.

## Notes

- 20s was chosen as a balance: well below any observed relay idle timeout (SES's lower bound is ~30s in the field), but high enough that NOOP overhead is rare. Could be made configurable via a `mail_smtp_ping_threshold` setting in a future PR if any operator runs into a relay needing different tuning, but the fixed default handles the common cases (SES, Mailgun, Postmark, Gmail SMTP) without ceremony.