### PR TITLE
[2.x] fix(gdpr): harden export download with audit trail, single-use, and active expiry check

### DIFF
--- a/extensions/gdpr/migrations/2026_05_07_000000_add_download_audit_to_gdpr_exports_table.php
+++ b/extensions/gdpr/migrations/2026_05_07_000000_add_download_audit_to_gdpr_exports_table.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('gdpr_exports', function (Blueprint $table) use ($schema) {
+            if (! $schema->hasColumn('gdpr_exports', 'downloaded_at')) {
+                $table->dateTime('downloaded_at')->nullable();
+            }
+            if (! $schema->hasColumn('gdpr_exports', 'downloaded_ip')) {
+                $table->string('downloaded_ip', 45)->nullable();
+            }
+            if (! $schema->hasColumn('gdpr_exports', 'downloaded_user_agent')) {
+                $table->string('downloaded_user_agent', 255)->nullable();
+            }
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('gdpr_exports', function (Blueprint $table) use ($schema) {
+            foreach (['downloaded_at', 'downloaded_ip', 'downloaded_user_agent'] as $column) {
+                if ($schema->hasColumn('gdpr_exports', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    },
+];

--- a/extensions/gdpr/src/Console/DestroyExportsCommand.php
+++ b/extensions/gdpr/src/Console/DestroyExportsCommand.php
@@ -22,7 +22,7 @@ class DestroyExportsCommand extends Command
     {
         Export::destroyable()
             ->each(function (Export $export) use ($exporter) {
-                $exporter->destroy($export);
+                $exporter->expire($export);
             });
     }
 }

--- a/extensions/gdpr/src/Exporter.php
+++ b/extensions/gdpr/src/Exporter.php
@@ -88,7 +88,7 @@ class Exporter
         return $export;
     }
 
-    public function destroy(Export $export): void
+    public function expire(Export $export): void
     {
         $this->storageManager->deleteStoredExport($export);
 
@@ -97,7 +97,8 @@ class Exporter
             ->where('subject_id', $export->id)
             ->update(['is_deleted' => true]);
 
-        $export->delete();
+        $export->file = null;
+        $export->save();
     }
 
     private function getTempDir(): string

--- a/extensions/gdpr/src/Http/Controller/ExportController.php
+++ b/extensions/gdpr/src/Http/Controller/ExportController.php
@@ -9,9 +9,10 @@
 
 namespace Flarum\Gdpr\Http\Controller;
 
+use Carbon\Carbon;
 use Flarum\Gdpr\Models\Export;
 use Flarum\Gdpr\StorageManager;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -30,18 +31,24 @@ class ExportController implements RequestHandlerInterface
 
         $export = Export::byFile($file);
 
-        if ($export) {
-            return new Response(
-                $this->storageManager->getStoredExport($export),
-                200,
-                [
-                    'Content-Type' => 'application/zip',
-                    'Content-Length' => (string) $this->storageManager->getStoredExportSize($export),
-                    'Content-Disposition' => 'attachment; filename="data-export-'.$export->user->username.'-'.$export->created_at->toIso8601String().'.zip"',
-                ]
-            );
+        if (! $export) {
+            throw (new ModelNotFoundException())->setModel(Export::class);
         }
 
-        throw new FileNotFoundException();
+        $export->downloaded_at = Carbon::now();
+        $export->downloaded_ip = $request->getAttribute('ipAddress');
+        $userAgent = $request->getHeaderLine('User-Agent');
+        $export->downloaded_user_agent = $userAgent !== '' ? mb_substr($userAgent, 0, 255) : null;
+        $export->save();
+
+        return new Response(
+            $this->storageManager->getStoredExport($export),
+            200,
+            [
+                'Content-Type' => 'application/zip',
+                'Content-Length' => (string) $this->storageManager->getStoredExportSize($export),
+                'Content-Disposition' => 'attachment; filename="data-export-'.$export->user->username.'-'.$export->created_at->toIso8601String().'.zip"',
+            ]
+        );
     }
 }

--- a/extensions/gdpr/src/Models/Export.php
+++ b/extensions/gdpr/src/Models/Export.php
@@ -15,13 +15,16 @@ use Flarum\User\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * @property int    $id
- * @property int    $user_id
- * @property int    $actor_id
- * @property string $file
- * @property Carbon $created_at
- * @property Carbon $destroys_at
- * @property User   $user
+ * @property int         $id
+ * @property int         $user_id
+ * @property int         $actor_id
+ * @property string|null $file
+ * @property Carbon      $created_at
+ * @property Carbon      $destroys_at
+ * @property Carbon|null $downloaded_at
+ * @property string|null $downloaded_ip
+ * @property string|null $downloaded_user_agent
+ * @property User        $user
  */
 class Export extends AbstractModel
 {
@@ -30,12 +33,20 @@ class Export extends AbstractModel
     protected $casts = [
         'created_at' => 'datetime',
         'destroys_at' => 'datetime',
+        'downloaded_at' => 'datetime',
     ];
 
-    public static function byFile(string $file): ?self
+    public static function byFile(?string $file): ?self
     {
+        if ($file === null || $file === '') {
+            return null;
+        }
+
         return self::query()
+            ->whereNotNull('file')
             ->where('file', $file)
+            ->where('destroys_at', '>', Carbon::now())
+            ->whereNull('downloaded_at')
             ->first();
     }
 
@@ -65,11 +76,19 @@ class Export extends AbstractModel
     }
 
     /**
+     * Exports whose stored ZIP should be cleaned up. Includes already-downloaded
+     * exports (artifact no longer needed) and those past their expiry window.
+     *
      * @return \Illuminate\Database\Eloquent\Builder<self>
      */
     public static function destroyable(): \Illuminate\Database\Eloquent\Builder
     {
         return self::query()
-            ->where('destroys_at', '<=', Carbon::now());
+            ->whereNotNull('file')
+            ->where(function ($query) {
+                $query
+                    ->where('destroys_at', '<=', Carbon::now())
+                    ->orWhereNotNull('downloaded_at');
+            });
     }
 }

--- a/extensions/gdpr/tests/integration/api/ExportTest.php
+++ b/extensions/gdpr/tests/integration/api/ExportTest.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Gdpr\tests\integration\api;
 
+use Carbon\Carbon;
 use Flarum\Database\Eloquent\Collection;
 use Flarum\Gdpr\Models\Export;
 use Flarum\Notification\Notification;
@@ -261,6 +262,134 @@ class ExportTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $data = $response->getBody()->getContents();
         $this->assertNotEmpty($data);
+    }
+
+    #[Test]
+    public function download_records_audit_metadata()
+    {
+        $response = $this->makeExportRequest(2);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $export = $this->getExportRecordFor(2);
+        $this->assertNull($export->downloaded_at);
+        $this->assertNull($export->downloaded_ip);
+        $this->assertNull($export->downloaded_user_agent);
+
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/'.$export->file,
+                ['authenticatedAs' => 2]
+            )->withHeader('User-Agent', 'TestAgent/1.0')->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $export->refresh();
+
+        $this->assertNotNull($export->downloaded_at);
+        $this->assertNotNull($export->downloaded_ip);
+        $this->assertEquals('TestAgent/1.0', $export->downloaded_user_agent);
+    }
+
+    #[Test]
+    public function download_is_single_use()
+    {
+        $response = $this->makeExportRequest(2);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $export = $this->getExportRecordFor(2);
+        $fileName = $export->file;
+
+        $first = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/'.$fileName,
+                ['authenticatedAs' => 2]
+            )->withAttribute('bypassCsrfToken', true)
+        );
+        $this->assertEquals(200, $first->getStatusCode());
+
+        // ZIP still in storage (cron has not run); the row's downloaded_at filter
+        // is what must reject the second request.
+        $this->assertTrue($this->getStorageFilesystem()->exists("export-{$export->id}.zip"));
+
+        $second = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/'.$fileName,
+                ['authenticatedAs' => 2]
+            )->withAttribute('bypassCsrfToken', true)
+        );
+        $this->assertEquals(404, $second->getStatusCode());
+    }
+
+    #[Test]
+    public function expired_export_cannot_be_downloaded_even_if_zip_still_exists()
+    {
+        $response = $this->makeExportRequest(2);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $export = $this->getExportRecordFor(2);
+
+        // Simulate cron not having run yet — ZIP is on disk but the logical
+        // expiry has passed.
+        $export->destroys_at = Carbon::now()->subMinute();
+        $export->save();
+        $this->assertTrue($this->getStorageFilesystem()->exists("export-{$export->id}.zip"));
+
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/'.$export->file,
+                ['authenticatedAs' => 2]
+            )->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function download_with_empty_file_token_is_rejected()
+    {
+        // Create a row whose file has been nulled by the cleanup job. A request
+        // with an empty/missing token must not match it.
+        $this->makeExportRequest(2);
+        $export = $this->getExportRecordFor(2);
+        $export->file = null;
+        $export->save();
+
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/',
+                ['authenticatedAs' => 2]
+            )->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertNotEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function long_user_agent_is_truncated_to_column_length()
+    {
+        $response = $this->makeExportRequest(2);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $export = $this->getExportRecordFor(2);
+
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/gdpr/export/'.$export->file,
+                ['authenticatedAs' => 2]
+            )->withHeader('User-Agent', str_repeat('A', 500))->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $export->refresh();
+        $this->assertEquals(255, mb_strlen($export->downloaded_user_agent));
     }
 
     #[Test]

--- a/extensions/gdpr/tests/integration/console/DestroyExportsTest.php
+++ b/extensions/gdpr/tests/integration/console/DestroyExportsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\tests\integration\console;
+
+use Carbon\Carbon;
+use Flarum\Gdpr\Models\Export;
+use Flarum\Notification\Notification;
+use Flarum\Testing\integration\ConsoleTestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
+
+class DestroyExportsTest extends ConsoleTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-gdpr');
+
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'normal', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'normal@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'gdpr_exports' => [
+                // Expired (past destroys_at), ZIP still on disk in test setup below.
+                ['id' => 1, 'user_id' => 2, 'actor_id' => 2, 'file' => 'data-export-normal-expired', 'created_at' => Carbon::now()->subDays(2), 'destroys_at' => Carbon::now()->subDay()],
+                // Already downloaded — artifact no longer needed even though
+                // not yet expired.
+                ['id' => 2, 'user_id' => 2, 'actor_id' => 2, 'file' => 'data-export-normal-downloaded', 'created_at' => Carbon::now()->subHour(), 'destroys_at' => Carbon::now()->addHours(23), 'downloaded_at' => Carbon::now()->subMinutes(5), 'downloaded_ip' => '1.2.3.4', 'downloaded_user_agent' => 'TestAgent/1.0'],
+                // Fresh, undownloaded — must be left alone.
+                ['id' => 3, 'user_id' => 2, 'actor_id' => 2, 'file' => 'data-export-normal-fresh', 'created_at' => Carbon::now(), 'destroys_at' => Carbon::now()->addDay()],
+                // Already cleaned up by a prior run — file is null. Ensures the
+                // cron is idempotent and doesn't re-process these.
+                ['id' => 4, 'user_id' => 2, 'actor_id' => 2, 'file' => null, 'created_at' => Carbon::now()->subWeek(), 'destroys_at' => Carbon::now()->subWeek(), 'downloaded_at' => Carbon::now()->subWeek()],
+            ],
+            'notifications' => [
+                ['id' => 1, 'user_id' => 2, 'from_user_id' => 2, 'type' => 'gdprExportAvailable', 'subject_id' => 1, 'created_at' => Carbon::now()->subDays(2)],
+                ['id' => 2, 'user_id' => 2, 'from_user_id' => 2, 'type' => 'gdprExportAvailable', 'subject_id' => 2, 'created_at' => Carbon::now()->subHour()],
+                ['id' => 3, 'user_id' => 2, 'from_user_id' => 2, 'type' => 'gdprExportAvailable', 'subject_id' => 3, 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        // Seed storage so the deletion has something to remove for ids 1, 2, 3.
+        $fs = $this->getStorageFilesystem();
+        foreach ([1, 2, 3] as $id) {
+            $fs->put("export-{$id}.zip", 'fake-zip-contents');
+        }
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $fs = $this->getStorageFilesystem();
+        $fs->delete($fs->allFiles());
+    }
+
+    protected function getStorageFilesystem(): Filesystem
+    {
+        return $this->app()->getContainer()->make(Factory::class)->disk('gdpr-export');
+    }
+
+    #[Test]
+    public function expired_export_has_zip_deleted_and_file_nulled_but_row_kept()
+    {
+        $this->runCommand(['command' => 'gdpr:destroy-exports']);
+
+        $export = Export::find(1);
+        $this->assertNotNull($export, 'Audit row should be kept for expired export.');
+        $this->assertNull($export->file);
+        $this->assertFalse($this->getStorageFilesystem()->exists('export-1.zip'));
+    }
+
+    #[Test]
+    public function downloaded_export_has_zip_deleted_even_before_expiry()
+    {
+        $this->runCommand(['command' => 'gdpr:destroy-exports']);
+
+        $export = Export::find(2);
+        $this->assertNotNull($export);
+        $this->assertNull($export->file);
+        $this->assertFalse($this->getStorageFilesystem()->exists('export-2.zip'));
+        // Audit metadata is preserved.
+        $this->assertNotNull($export->downloaded_at);
+        $this->assertEquals('1.2.3.4', $export->downloaded_ip);
+        $this->assertEquals('TestAgent/1.0', $export->downloaded_user_agent);
+    }
+
+    #[Test]
+    public function fresh_undownloaded_export_is_untouched()
+    {
+        $this->runCommand(['command' => 'gdpr:destroy-exports']);
+
+        $export = Export::find(3);
+        $this->assertNotNull($export);
+        $this->assertEquals('data-export-normal-fresh', $export->file);
+        $this->assertTrue($this->getStorageFilesystem()->exists('export-3.zip'));
+    }
+
+    #[Test]
+    public function already_cleaned_up_row_is_untouched()
+    {
+        $this->runCommand(['command' => 'gdpr:destroy-exports']);
+
+        $export = Export::find(4);
+        $this->assertNotNull($export);
+        $this->assertNull($export->file);
+    }
+
+    #[Test]
+    public function notification_for_cleaned_up_export_is_marked_deleted()
+    {
+        $this->runCommand(['command' => 'gdpr:destroy-exports']);
+
+        $expired = Notification::find(1);
+        $this->assertEquals(1, $expired->is_deleted);
+
+        $downloaded = Notification::find(2);
+        $this->assertEquals(1, $downloaded->is_deleted);
+
+        // Fresh export's notification is untouched.
+        $fresh = Notification::find(3);
+        $this->assertEquals(0, $fresh->is_deleted);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the GDPR data-export download flow in response to a security report flagging the `GET /gdpr/export/{file}` route as having no authorization (CWE-862) and no enforced session expiration (CWE-613).

The token-as-bearer model is preserved for now (the link still works without a session — that's a UX decision to revisit in a follow-up with a UI-driven download), but the practical exploit surface is closed:

- **Active expiry check** — `Export::byFile()` now requires `destroys_at > now()`. Previously, expiry depended entirely on the daily `gdpr:destroy-exports` cron sweep, so a logically-expired token kept working until that ran (or indefinitely on instances where the scheduler isn't wired up).
- **Single-use** — once an export is downloaded, the row is marked with `downloaded_at` and subsequent requests with the same token return 404.
- **Audit trail** — successful downloads record `downloaded_at`, `downloaded_ip`, and `downloaded_user_agent` (truncated to 255 chars).
- **Two-stage lifecycle** — the daily cleanup job now deletes the ZIP and nulls the `file` column rather than dropping the row outright. The audit row persists for usage analysis. The cron also picks up already-downloaded exports early, since their artifacts are no longer needed.
- **Better 404** — `FileNotFoundException` (which fell through to a 500) replaced with `ModelNotFoundException` so missing/expired/used tokens return a proper 404.
- **Defense in depth** — `byFile()` rejects null/empty tokens and requires `file IS NOT NULL`, so a request with an empty `?file=` cannot match a row whose token has been nulled by cleanup.

## Schema

New migration adds three nullable columns to `gdpr_exports`:
- `downloaded_at` (datetime)
- `downloaded_ip` (varchar 45, IPv6-safe)
- `downloaded_user_agent` (varchar 255)

## Behaviour change for operators

`Exporter::destroy()` is renamed to `Exporter::expire()` and no longer deletes the row — it deletes the ZIP, nulls `file`, and marks notifications deleted. Audit rows accumulate over time but are cheap (one row per export request) and can be useful for understanding feature usage.