### PR TITLE
[2.x] fix: notification dedup query never matches non-null data on MySQL

### DIFF
--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -167,23 +167,27 @@ class Notification extends AbstractModel
             return $query->whereNull('data');
         }
 
-        // The `data` column is JSON. A plain string comparison only works on
-        // engines that store JSON as opaque text (SQLite). On engines that
-        // canonicalise it (MySQL stores `{"a": 1}` even when the input was
-        // `{"a":1}`), the column has to be cast or the parameter has to be
-        // wrapped in CAST(? AS JSON) for the comparison to round-trip. On
-        // PostgreSQL the column is true `json` and `=` on it is undefined,
-        // so we cast the column to text before comparing.
+        // The `data` column behaves differently per engine:
+        //
+        // - PostgreSQL stores it as native `json`, where `=` is undefined,
+        //   so we cast the column to text for the comparison.
+        // - MySQL stores it as native JSON and canonicalises the value,
+        //   turning `{"a":1}` into `{"a": 1}`. A plain string comparison
+        //   to the json_encode'd input never matches; CAST(? AS JSON) on
+        //   the parameter side makes the comparison round-trip through
+        //   MySQL's canonical form.
+        // - MariaDB and SQLite store JSON as opaque text (LONGTEXT and
+        //   plain TEXT respectively), so the bytes round-trip and a plain
+        //   string equality check works.
         return $query
             ->whenPgSql(function ($query) use ($data) {
                 return $query->whereRaw('data::text = ?', [$data]);
             }, function ($query) use ($data) {
-                return $query
-                    ->whenSqlite(function ($query) use ($data) {
-                        return $query->where('data', $data);
-                    }, function ($query) use ($data) {
-                        return $query->whereRaw('data = CAST(? AS JSON)', [$data]);
-                    });
+                return $query->whenMySql(function ($query) use ($data) {
+                    return $query->whereRaw('data = CAST(? AS JSON)', [$data]);
+                }, function ($query) use ($data) {
+                    return $query->where('data', $data);
+                });
             });
     }
 

--- a/framework/core/src/Notification/Notification.php
+++ b/framework/core/src/Notification/Notification.php
@@ -161,11 +161,29 @@ class Notification extends AbstractModel
         $data = $attributes['data'];
         unset($attributes['data']);
 
-        return $query->where($attributes)
+        $query->where($attributes);
+
+        if ($data === null) {
+            return $query->whereNull('data');
+        }
+
+        // The `data` column is JSON. A plain string comparison only works on
+        // engines that store JSON as opaque text (SQLite). On engines that
+        // canonicalise it (MySQL stores `{"a": 1}` even when the input was
+        // `{"a":1}`), the column has to be cast or the parameter has to be
+        // wrapped in CAST(? AS JSON) for the comparison to round-trip. On
+        // PostgreSQL the column is true `json` and `=` on it is undefined,
+        // so we cast the column to text before comparing.
+        return $query
             ->whenPgSql(function ($query) use ($data) {
                 return $query->whereRaw('data::text = ?', [$data]);
             }, function ($query) use ($data) {
-                return $query->where('data', $data);
+                return $query
+                    ->whenSqlite(function ($query) use ($data) {
+                        return $query->where('data', $data);
+                    }, function ($query) use ($data) {
+                        return $query->whereRaw('data = CAST(? AS JSON)', [$data]);
+                    });
             });
     }
 

--- a/framework/core/tests/integration/notification/MatchingBlueprintTest.php
+++ b/framework/core/tests/integration/notification/MatchingBlueprintTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\notification;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Notification;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class MatchingBlueprintTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'recipient', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'recipient@machine.local', 'is_email_confirmed' => 1],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function matching_blueprint_finds_existing_row_with_null_data(): void
+    {
+        $this->app();
+
+        $blueprint = new TestNotificationWithoutData();
+
+        Notification::notify([User::find(3)], $blueprint);
+
+        $found = Notification::matchingBlueprint($blueprint)->first();
+
+        $this->assertNotNull($found, 'matchingBlueprint() did not find the inserted row.');
+        $this->assertNull($found->data);
+    }
+
+    #[Test]
+    public function matching_blueprint_finds_existing_row_with_non_null_data(): void
+    {
+        // Regression test for #4643: on MySQL, the dedup query compared the
+        // JSON column directly to the json_encode'd string, but MySQL
+        // canonicalises stored JSON (`{"replyNumber": 58}`) and the encoded
+        // input is compact (`{"replyNumber":58}`) — string equality never
+        // matched, so every NotificationSyncer::sync() call on a blueprint
+        // with non-null data created a duplicate row.
+        $this->app();
+
+        $blueprint = new TestNotificationWithData();
+
+        Notification::notify([User::find(3)], $blueprint);
+
+        $found = Notification::matchingBlueprint($blueprint)->first();
+
+        $this->assertNotNull($found, 'matchingBlueprint() did not find the inserted row.');
+    }
+
+    #[Test]
+    public function syncer_does_not_create_duplicate_rows_on_repeated_sync_with_non_null_data(): void
+    {
+        // The user-visible symptom of #4643: editing a post that produced a
+        // notification (postMentioned, newPost, etc.) re-runs sync() with
+        // the same blueprint, and the broken matchingBlueprint() makes the
+        // syncer treat the recipient as new every time.
+        $syncer = $this->app()->getContainer()->make(NotificationSyncer::class);
+        $blueprint = new TestNotificationWithData();
+        $recipients = [User::find(3)];
+
+        $syncer->sync($blueprint, $recipients);
+        $syncer->sync($blueprint, $recipients);
+        $syncer->sync($blueprint, $recipients);
+
+        $count = Notification::query()
+            ->where('type', $blueprint::getType())
+            ->where('user_id', 3)
+            ->count();
+
+        $this->assertEquals(1, $count, 'Repeated sync() with the same blueprint produced duplicate rows.');
+    }
+}
+
+class TestNotificationWithData implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): array
+    {
+        return ['replyNumber' => 58];
+    }
+
+    public static function getType(): string
+    {
+        return 'testWithData';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return 'testWithDataSubjectModel';
+    }
+}
+
+class TestNotificationWithoutData implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): ?array
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'testWithoutData';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return 'testWithoutDataSubjectModel';
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4643. \`Notification::scopeMatchingBlueprint()\` on MySQL never matches existing rows when the blueprint's \`data\` is non-null, silently disabling dedup for every notification type whose blueprint returns non-null \`getData()\` — \`postMentioned\`, \`newPost\`, \`postMoved\`, plus extension types like \`byobuPrivateDiscussionReplied\`. Every edit of a post that triggered such a notification creates a new row and re-sends the email.

## Root cause

Before:

\`\`\`php
return $query->where($attributes)
    ->whenPgSql(function ($query) use ($data) {
        return $query->whereRaw('data::text = ?', [$data]);
    }, function ($query) use ($data) {
        return $query->where('data', $data);
    });
\`\`\`

The PostgreSQL branch correctly casts the column to text. The else branch (MySQL / MariaDB / SQLite) compares the JSON column directly to a string. \`getBlueprintAttributes()\` produces \`$data\` via \`json_encode($data)\` — compact form like \`{"replyNumber":58}\`. **MySQL** stores its JSON column canonicalised — with a space after the colon: \`{"replyNumber": 58}\`. Direct string comparison never matches.

## Fix

Branch by driver explicitly:

- **PostgreSQL** — cast column to text (\`data::text = ?\`). Unchanged.
- **MySQL** — cast parameter to JSON (\`data = CAST(? AS JSON)\`) so the comparison round-trips through MySQL's canonical form.
- **MariaDB** — its JSON type is just LONGTEXT and \`CAST(... AS JSON)\` isn't supported syntax. The bytes round-trip and plain string equality works.
- **SQLite** — JSON stored as plain TEXT, byte-for-byte round-trip, plain string equality works.

The null-data path is pulled out front since \`= NULL\` doesn't match anything on any engine.

## Tests

Three integration tests in \`framework/core/tests/integration/notification/MatchingBlueprintTest.php\`:

1. \`matchingBlueprint()\` finds existing rows when blueprint data is null (sanity check).
2. \`matchingBlueprint()\` finds existing rows when blueprint data is non-null (the regression).
3. \`NotificationSyncer::sync()\` called repeatedly with the same blueprint+recipient produces exactly one row, not duplicates (the user-visible symptom).

The first commit added these tests without the fix, so the CI matrix demonstrated which engines were affected (MySQL fail; PostgreSQL/MariaDB/SQLite pass — confirming the diagnosis). The second commit applied the fix; full matrix now green.

## Scale

From the issue reporter's production instance:

\`\`\`
type             dup_groups   total_dup_rows
postMentioned    665          1,477
newPost          2            4
\`\`\`

\`postMentioned\` is the dominant offender precisely because it has non-null data and the dedup query was broken for it.

## Relationship to #4622

#4622 describes a queue-timing race in \`NotificationSyncer::sync()\` for null-data blueprints (where the dedup query *does* work, so duplicates only arise from a narrow window). For non-null-data blueprints, this bug means duplicates were guaranteed on every edit regardless of timing — much higher impact, much simpler fix. Both are needed; this is the one users hit most often.