### PR TITLE
[2.x] fix: notification + email duplicates from queue race in NotificationSyncer

### DIFF
--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -14,6 +14,8 @@ use Flarum\Notification\MailableInterface;
 use Flarum\Notification\NotificationMailer;
 use Flarum\Queue\AbstractJob;
 use Flarum\User\User;
+use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
 class SendEmailNotificationJob extends AbstractJob
 {
@@ -23,8 +25,40 @@ class SendEmailNotificationJob extends AbstractJob
     ) {
     }
 
-    public function handle(NotificationMailer $mailer): void
+    public function handle(NotificationMailer $mailer, CacheRepository $cache): void
     {
+        // Race guard for #4622: NotificationSyncer::sync() queues a
+        // SendEmailNotificationJob per recipient on every call. When sync()
+        // fires twice in quick succession (e.g. Posted then Revised), two
+        // identical jobs land in the queue for the same recipient, and
+        // without a guard each runs and sends an email. Take a short-lived
+        // atomic lock keyed by blueprint+recipient; the first job to claim
+        // it sends the email, the rest no-op. The lock TTL just needs to
+        // outlive normal mail-send latency — minutes is plenty.
+        $store = $cache->getStore();
+
+        if (! $store instanceof LockProvider) {
+            // Cache store doesn't support locks (custom driver). Fall back
+            // to non-atomic send — the worst case is a duplicate email,
+            // same as before this fix.
+            $mailer->send($this->blueprint, $this->recipient);
+            return;
+        }
+
+        $lockKey = sprintf(
+            'flarum.notification.email-sent:%s:%d',
+            $this->blueprint::getType(),
+            $this->recipient->id
+        );
+
+        $lock = $store->lock($lockKey, 600);
+
+        if (! $lock->get()) {
+            // Another worker has already claimed responsibility for this
+            // (blueprint, recipient) email. Drop silently.
+            return;
+        }
+
         $mailer->send($this->blueprint, $this->recipient);
     }
 }

--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -42,6 +42,7 @@ class SendEmailNotificationJob extends AbstractJob
             // to non-atomic send — the worst case is a duplicate email,
             // same as before this fix.
             $mailer->send($this->blueprint, $this->recipient);
+
             return;
         }
 

--- a/framework/core/src/Notification/Job/SendNotificationsJob.php
+++ b/framework/core/src/Notification/Job/SendNotificationsJob.php
@@ -26,6 +26,26 @@ class SendNotificationsJob extends AbstractJob
 
     public function handle(): void
     {
-        Notification::notify($this->recipients, $this->blueprint);
+        // Race guard for #4622: NotificationSyncer::sync() reads matchingBlueprint
+        // and decides who's a "new" recipient *before* the actual INSERT happens
+        // (here). If sync() is called twice in rapid succession (e.g. Posted
+        // followed quickly by Revised) before either job runs, both reads see no
+        // row and both jobs queue the same recipients. Re-run the dedup check at
+        // INSERT time so only the first job actually inserts; later jobs no-op.
+        $alreadyInserted = Notification::matchingBlueprint($this->blueprint)
+            ->whereIn('user_id', array_map(fn (User $user) => $user->id, $this->recipients))
+            ->pluck('user_id')
+            ->all();
+
+        $newRecipients = array_filter(
+            $this->recipients,
+            fn (User $user) => ! in_array($user->id, $alreadyInserted, true)
+        );
+
+        if (empty($newRecipients)) {
+            return;
+        }
+
+        Notification::notify($newRecipients, $this->blueprint);
     }
 }

--- a/framework/core/tests/integration/notification/SyncerRaceTest.php
+++ b/framework/core/tests/integration/notification/SyncerRaceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\notification;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Locale\TranslatorInterface;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Job\SendEmailNotificationJob;
+use Flarum\Notification\Job\SendNotificationsJob;
+use Flarum\Notification\MailableInterface;
+use Flarum\Notification\Notification;
+use Flarum\Notification\NotificationMailer;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class SyncerRaceTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'recipient', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'recipient@machine.local', 'is_email_confirmed' => 1],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function send_notifications_job_is_idempotent_for_repeated_runs(): void
+    {
+        // Race scenario from #4622: under a queued driver,
+        // NotificationSyncer::sync() queues a SendNotificationsJob, then
+        // BEFORE that job runs the syncer is called again (e.g. from a
+        // Revised event quickly following Posted). The second sync()
+        // reads the DB, sees no row yet, and queues a SECOND
+        // SendNotificationsJob with the same recipient. Without
+        // idempotence at insert-time, both jobs run and INSERT, producing
+        // duplicate rows.
+        $this->app();
+
+        $blueprint = new TestBlueprint();
+        $recipient = User::find(3);
+
+        (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+        (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+        (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+
+        $count = Notification::query()
+            ->where('type', $blueprint::getType())
+            ->where('user_id', $recipient->id)
+            ->count();
+
+        $this->assertEquals(1, $count, 'SendNotificationsJob is not idempotent — repeated runs created duplicate rows.');
+    }
+
+    #[Test]
+    public function send_notifications_job_still_inserts_new_recipients_alongside_existing(): void
+    {
+        // A SendNotificationsJob may carry a mix of recipients: some that
+        // already have a row (from an earlier job that ran) and some that
+        // don't. The idempotence check must skip only the former and insert
+        // the latter — not skip the entire batch.
+        $this->app();
+
+        $blueprint = new TestBlueprint();
+        $existing = User::find(3);
+        $newRecipient = User::find(2);
+
+        // Pre-populate a row for the existing recipient.
+        Notification::notify([$existing], $blueprint);
+
+        // Run a job with both — should not duplicate the existing one, but
+        // SHOULD insert a row for the new recipient.
+        (new SendNotificationsJob($blueprint, [$existing, $newRecipient]))->handle();
+
+        $existingCount = Notification::query()
+            ->where('type', $blueprint::getType())
+            ->where('user_id', $existing->id)
+            ->count();
+        $newCount = Notification::query()
+            ->where('type', $blueprint::getType())
+            ->where('user_id', $newRecipient->id)
+            ->count();
+
+        $this->assertEquals(1, $existingCount, 'Existing recipient was duplicated.');
+        $this->assertEquals(1, $newCount, 'New recipient was not inserted.');
+    }
+
+    #[Test]
+    public function send_email_notification_job_is_idempotent_for_repeated_runs(): void
+    {
+        // Same race, email half: the EmailNotificationDriver queues a
+        // SendEmailNotificationJob per-recipient per-call to sync(). When
+        // sync() is called twice before the first SendNotificationsJob has
+        // run, two SendEmailNotificationJobs land in the queue for the
+        // same recipient. Even after the first SendNotificationsJob
+        // INSERTs the row, the second SendEmailNotificationJob still runs
+        // and (without idempotence) sends a duplicate email.
+        $this->app();
+
+        $blueprint = new TestBlueprintMailable();
+        $recipient = User::find(3);
+
+        // Swap the mailer for a test double that counts send() calls.
+        $mailer = new CountingNotificationMailer();
+        $this->app()->getContainer()->instance(NotificationMailer::class, $mailer);
+
+        // Pre-insert the notification row to simulate "the first job ran."
+        Notification::notify([$recipient], $blueprint);
+
+        $cache = $this->app()->getContainer()->make(\Illuminate\Contracts\Cache\Repository::class);
+
+        (new SendEmailNotificationJob($blueprint, $recipient))->handle($mailer, $cache);
+        (new SendEmailNotificationJob($blueprint, $recipient))->handle($mailer, $cache);
+
+        $this->assertEquals(1, $mailer->sentCount, 'SendEmailNotificationJob is not idempotent — repeated runs sent duplicate emails.');
+    }
+}
+
+class TestBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): ?array
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'syncerRaceTest';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return 'syncerRaceTestSubjectModel';
+    }
+}
+
+class TestBlueprintMailable extends TestBlueprint implements MailableInterface
+{
+    public static function getType(): string
+    {
+        return 'syncerRaceTestMailable';
+    }
+
+    public function getEmailSubject(TranslatorInterface $translator): string
+    {
+        return 'Test';
+    }
+
+    public function getEmailViews(): array
+    {
+        return ['text' => 'unused', 'html' => 'unused'];
+    }
+}
+
+class CountingNotificationMailer extends NotificationMailer
+{
+    public int $sentCount = 0;
+
+    public function __construct()
+    {
+        // Intentionally skip parent constructor — we don't need its deps.
+    }
+
+    public function send(MailableInterface&BlueprintInterface $blueprint, User $user): void
+    {
+        $this->sentCount++;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4622. Under a queued driver, mentioned users (and other notification recipients) receive **multiple** notifications and **multiple** emails for the same logical event when \`Posted\` is followed quickly enough by \`Revised\` (or any back-to-back blueprint dispatch).

## Root cause

\`NotificationSyncer::sync()\` decides who's a "new recipient" *before* the actual INSERT happens — the INSERT lives in a queued \`SendNotificationsJob\`. With FIFO worker processing:

1. \`sync()\` #1 runs (from \`Posted\`) → reads \`matchingBlueprint\`, sees no row → queues \`SendNotificationsJob_A\` and \`SendEmailNotificationJob_A\`
2. \`sync()\` #2 runs (from \`Revised\`) **before A has dequeued** → reads, still sees no row → queues \`SendNotificationsJob_B\` and \`SendEmailNotificationJob_B\`
3. Worker runs A → INSERT row 1, email sent
4. Worker runs B → INSERT row 2 (duplicate), email sent (duplicate)

The race window is the entire interval between \`sync()\` and the queued \`SendNotificationsJob\` actually running — typically 30s–2min on a moderately loaded queue, well within normal user behaviour for an edit shortly after posting.

## Fix

Two-part guard at the job level:

**\`SendNotificationsJob::handle()\`** — re-runs \`matchingBlueprint\` filtered by recipient id at INSERT time. Only inserts recipients without an existing row. Idempotent regardless of how many sync() calls queued the same job.

**\`SendEmailNotificationJob::handle()\`** — takes a short-lived atomic cache lock keyed by \`(blueprint type, recipient id)\`. First job to claim the lock sends the email; later identical jobs no-op. 600s TTL outlives normal mail latency. Falls back to non-atomic send if the cache store doesn't implement \`LockProvider\` (custom drivers) — same behaviour as before.

The \`Notification\` row alone isn't a sufficient signal for the email-side dedup, because \`EmailJob_A\` runs *after* \`SendNotificationsJob_A\` has inserted the row, and we want \`EmailJob_A\` to send the email — only \`EmailJob_B\` should be suppressed. The atomic lock distinguishes "first email job for this (blueprint, user)" from "later one."

## Tests

Three integration tests in \`framework/core/tests/integration/notification/SyncerRaceTest.php\`:

1. \`SendNotificationsJob\` is idempotent across repeated runs (no duplicate rows)
2. \`SendNotificationsJob\` still inserts new recipients alongside existing in a mixed batch (the dedup doesn't skip the whole batch)
3. \`SendEmailNotificationJob\` is idempotent across repeated runs (no duplicate emails)

All three failed against the un-fixed code on sqlite (the race manifests at the application level, not the DB level — sqlite reproduces it just like MySQL).

## Why not a deeper architectural fix

Option 2 from the issue reporter — moving the INSERT itself into \`NotificationSyncer::sync()\` (synchronous) and keeping only email queued — would remove the bug class entirely. That's a better long-term shape but it's a bigger change with timing-semantics implications for any code observing the insert. Out of scope for an RC bug fix; worth revisiting post-2.0.

## Relationship to #4643

[#4643](https://github.com/flarum/framework/issues/4643) (merged in #4645) was a separate bug: the dedup *query* itself didn't work on MySQL for non-null-data blueprints. That fix made dedup work for \`postMentioned\`, \`newPost\`, etc.; this fix closes the residual race for null-data blueprints (\`userMentioned\`, \`postLiked\`) plus any non-null-data blueprint that races faster than the queue can drain.