### PR TITLE
[2.x] fix: TypeError in Revised event when post content is NULL

### DIFF
--- a/framework/core/src/Post/CommentPost.php
+++ b/framework/core/src/Post/CommentPost.php
@@ -41,7 +41,10 @@ class CommentPost extends Post implements Formattable
     public function revise(string $content, User $actor): static
     {
         if ($this->content !== $content) {
-            $oldContent = $this->content;
+            // Coalesce to '' so legacy/imported posts with NULL content can
+            // still be edited — the Revised event's $oldContent is typed
+            // string and null would TypeError. See #4606.
+            $oldContent = $this->content ?? '';
 
             $this->setContentAttribute($content, $actor);
 

--- a/framework/core/tests/integration/api/posts/UpdateTest.php
+++ b/framework/core/tests/integration/api/posts/UpdateTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\posts;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\CommentPost;
+use Flarum\Post\Event\Revised;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class UpdateTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Discussion with post', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => null],
+            ],
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function revising_a_post_with_null_content_does_not_throw(): void
+    {
+        // Regression test for #4606. Posts can have NULL content (legacy
+        // imports, extension-created posts that don't set content). When
+        // such a post is edited, CommentPost::revise() raises a Revised
+        // event with $oldContent = null, but Revised's constructor types
+        // $oldContent as non-nullable string — TypeError.
+        $this->app();
+
+        /** @var CommentPost $post */
+        $post = CommentPost::find(1);
+        $this->assertNull($post->content);
+
+        $actor = User::find(2);
+
+        $post->revise('<t><p>new content</p></t>', $actor);
+
+        $post->save();
+
+        $this->assertSame('<t><p>new content</p></t>', $post->refresh()->content);
+    }
+
+    #[Test]
+    public function revising_a_post_with_null_content_raises_revised_event(): void
+    {
+        // Listeners that subscribed before the fix should still receive a
+        // Revised event when the post's old content was null. The event is
+        // the only way to know an edit happened, so dropping it would
+        // silently break audit/log/index extensions.
+        $this->app();
+
+        $post = CommentPost::find(1);
+        $actor = User::find(2);
+        $post->revise('<t><p>new content</p></t>', $actor);
+
+        $events = $post->releaseEvents();
+        $revised = array_filter($events, fn ($e) => $e instanceof Revised);
+
+        $this->assertCount(1, $revised, 'Revised event was not raised.');
+        $this->assertSame('', array_values($revised)[0]->oldContent, 'oldContent should be coalesced to empty string when the original was null.');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4606. \`CommentPost::revise()\` raises a \`Flarum\Post\Event\Revised\` whose constructor types \`\$oldContent\` as non-nullable \`string\`. But the \`posts.content\` column is nullable — legacy/imported posts and extension-created posts can have \`NULL\` content. Editing such a post throws a \`TypeError\` on every save and pollutes the log.

## Root cause

\`\`\`php
// CommentPost::revise()
\$oldContent = \$this->content;  // ← can be null
\$this->raise(new Revised(\$this, \$actor, \$oldContent));
\`\`\`

\`\`\`php
// Revised::__construct
public string \$oldContent  // ← rejects null
\`\`\`

\`\`\`
TypeError: Flarum\Post\Event\Revised::__construct(): Argument #3 (\$oldContent) must be of type string, null given
\`\`\`

## Fix

Coalesce at the call site:

\`\`\`php
\$oldContent = \$this->content ?? '';
\`\`\`

Chosen over widening \`Revised::\$oldContent\` to \`?string\` because:

1. **RC-friendly** — no public-API change. Any extension that does \`strlen(\$event->oldContent)\` or similar without a null check keeps working.
2. **Semantic loss is negligible** — distinguishing "was empty string" from "was null" is meaningful in principle, but no listener in core or any bundled extension actually uses that distinction; \`grep oldContent framework/ extensions/\` finds zero consumers.
3. **Future-friendly** — if a real need emerges to widen the type later, that's an additive change. Going \`?string\` now would commit us to that signature.

## Tests

New \`framework/core/tests/integration/api/posts/UpdateTest.php\` (the file didn't exist — there was no integration test for post updates):

1. \`revising_a_post_with_null_content_does_not_throw\` — calls \`revise()\` on a post whose \`content\` is null and asserts no exception, content updated correctly.
2. \`revising_a_post_with_null_content_raises_revised_event\` — asserts the event is still raised and \`oldContent\` is \`''\` (not skipped).

Both tests fail against pre-fix code with the exact \`TypeError\` from the bug report; both pass after the fix.