### PR TITLE
[2.x] fix(tags): restore subquery for permitted tag IDs (regression from #4502)

### DIFF
--- a/extensions/tags/src/Tag.php
+++ b/extensions/tags/src/Tag.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
  * @property int $id
@@ -212,98 +213,56 @@ class Tag extends AbstractModel
     }
 
     /**
-     * Per-request cache of resolved permitted tag IDs, keyed by User instance.
-     * Stored per user object so it is naturally scoped to the request lifecycle
-     * and does not persist across fresh User instances (e.g. in tests).
-     * Inner array is keyed by permission string; null value means all tags permitted (admin).
-     *
-     * @var \WeakMap<User, array<string, mixed>>|null
+     * Build a subquery that selects the IDs of tags the user has the given
+     * permission on. Used inline by scopeWhereHasPermission so the DB does
+     * the filtering — avoids fetching every tag into PHP per call.
      */
-    protected static ?\WeakMap $permittedTagIdCache = null;
-
-    /**
-     * Resolve the IDs of tags the user has the given permission on.
-     * Returns null if the user is an admin (all tags permitted).
-     * Results are cached on the User instance for the duration of the request.
-     *
-     * @return int[]|null
-     */
-    protected static function resolvePermittedTagIds(User $user, string $currPermission): ?array
+    protected static function buildPermissionSubquery(QueryBuilder $base, bool $isAdmin, bool $hasGlobalPermission, iterable $tagIdsWithPermission): void
     {
-        if (static::$permittedTagIdCache === null) {
-            /** @var \WeakMap<User, array<string, mixed>> $map */
-            $map = new \WeakMap();
-            static::$permittedTagIdCache = $map;
+        $base
+            ->from('tags as perm_tags')
+            ->select('perm_tags.id');
+
+        // Admins have all permissions in all tags by default; no need to
+        // narrow the subquery.
+        if ($isAdmin) {
+            return;
         }
 
-        $userCache = static::$permittedTagIdCache[$user] ?? [];
+        $base->where(function ($query) use ($tagIdsWithPermission) {
+            $query
+                ->where('perm_tags.is_restricted', true)
+                ->whereIn('perm_tags.id', $tagIdsWithPermission);
+        });
 
-        if (array_key_exists($currPermission, $userCache)) {
-            return $userCache[$currPermission];
+        if ($hasGlobalPermission) {
+            $base->orWhere('perm_tags.is_restricted', false);
         }
-
-        if ($user->isAdmin()) {
-            $userCache[$currPermission] = null;
-            static::$permittedTagIdCache[$user] = $userCache;
-
-            return null;
-        }
-
-        $hasGlobalPermission = $user->hasPermission($currPermission);
-
-        $tagIdsWithPermission = collect($user->getPermissions())
-            ->filter(fn ($p) => str_starts_with($p, 'tag') && str_contains($p, $currPermission))
-            ->map(fn ($p) => (int) substr(explode('.', $p, 2)[0], 3))
-            ->values()
-            ->all();
-
-        // Fetch tag id/is_restricted in one query and resolve permitted IDs in PHP.
-        $allTags = static::query()->select(['id', 'is_restricted'])->get();
-
-        $permitted = $allTags
-            ->filter(function (self $tag) use ($hasGlobalPermission, $tagIdsWithPermission) {
-                if (! $tag->is_restricted) {
-                    return $hasGlobalPermission;
-                }
-
-                return in_array($tag->id, $tagIdsWithPermission);
-            })
-            ->pluck('id')
-            ->all();
-
-        $userCache[$currPermission] = $permitted;
-        static::$permittedTagIdCache[$user] = $userCache;
-
-        return $permitted;
-    }
-
-    /**
-     * Flush the permitted tag ID cache.
-     * Only needed in long-running processes or tests that reuse User instances
-     * across logical requests. Normal PHP-FPM and test flows do not require this.
-     */
-    public static function flushPermittedTagCache(): void
-    {
-        static::$permittedTagIdCache = null;
     }
 
     public function scopeWhereHasPermission(Builder $query, User $user, string $currPermission): Builder
     {
-        $permittedIds = static::resolvePermittedTagIds($user, $currPermission);
+        $hasGlobalPermission = $user->hasPermission($currPermission);
+        $isAdmin = $user->isAdmin();
 
-        // Admin: no restriction needed.
-        if ($permittedIds === null) {
-            return $query;
-        }
+        $tagIdsWithPermission = collect($user->getPermissions())
+            ->filter(fn (string $p) => str_starts_with($p, 'tag') && str_contains($p, $currPermission))
+            ->map(fn (string $p) => (int) substr(explode('.', $p, 2)[0], 3))
+            ->values();
 
-        return $query->where(function ($query) use ($permittedIds) {
-            $query
-                ->whereIn('tags.id', $permittedIds)
-                ->where(
-                    fn ($query) => $query
-                    ->whereIn('tags.parent_id', $permittedIds)
-                    ->orWhereNull('tags.parent_id')
-                );
-        });
+        return $query
+            ->where(function ($query) use ($isAdmin, $hasGlobalPermission, $tagIdsWithPermission) {
+                $query
+                    ->whereIn('tags.id', function ($query) use ($isAdmin, $hasGlobalPermission, $tagIdsWithPermission) {
+                        static::buildPermissionSubquery($query, $isAdmin, $hasGlobalPermission, $tagIdsWithPermission);
+                    })
+                    ->where(
+                        fn ($query) => $query
+                            ->whereIn('tags.parent_id', function ($query) use ($isAdmin, $hasGlobalPermission, $tagIdsWithPermission) {
+                                static::buildPermissionSubquery($query, $isAdmin, $hasGlobalPermission, $tagIdsWithPermission);
+                            })
+                            ->orWhereNull('tags.parent_id')
+                    );
+            });
     }
 }

--- a/extensions/tags/tests/integration/api/discussions/PermissionScopeQueryCountTest.php
+++ b/extensions/tags/tests/integration/api/discussions/PermissionScopeQueryCountTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Tests\integration\api\discussions;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use Flarum\Tags\Tests\integration\RetrievesRepresentativeTags;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression test for #4605.
+ *
+ * Tag::scopeWhereHasPermission caches resolved permitted-tag IDs in a
+ * WeakMap keyed by User instance. Whenever the actor User instance is
+ * not the same PHP object across calls — and there are several places
+ * in the request flow that load the actor from the DB rather than
+ * reusing the existing instance — the cache misses, and each miss
+ * re-runs the full permission resolution, including a `SELECT id,
+ * is_restricted FROM tags` to enumerate every tag for the PHP-side
+ * filter.
+ *
+ * On a real forum the reporter measured ~30 of these duplicate
+ * permission lookups per /api/discussions request. This test
+ * reproduces the bug at smaller scale (multiple non-admin users with
+ * varied group sets, each authoring a discussion) and asserts the
+ * count of unconstrained `SELECT * FROM tags`-style queries stays
+ * bounded after the fix.
+ */
+class PermissionScopeQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use RetrievesRepresentativeTags;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $users = [$this->normalUser()];
+        $discussions = [];
+        $posts = [];
+        $groupUser = [['group_id' => 100, 'user_id' => 2]];
+        $groups = [
+            ['id' => 100, 'name_singular' => 'acme', 'name_plural' => 'acme'],
+            ['id' => 101, 'name_singular' => 'beta', 'name_plural' => 'beta'],
+            ['id' => 102, 'name_singular' => 'gamma', 'name_plural' => 'gamma'],
+            ['id' => 103, 'name_singular' => 'delta', 'name_plural' => 'delta'],
+        ];
+
+        // 10 distinct authors with varied group memberships, each
+        // authoring a discussion. The varied groups force distinct
+        // permission sets across authors, which is what the cache-miss
+        // path was supposed to share.
+        $groupAssignments = [
+            10 => [100],
+            11 => [101],
+            12 => [102],
+            13 => [103],
+            14 => [100, 101],
+            15 => [100, 102],
+            16 => [101, 103],
+            17 => [102, 103],
+            18 => [100, 103],
+            19 => [101, 102],
+        ];
+
+        foreach ($groupAssignments as $userId => $userGroups) {
+            $discussionId = 100 + ($userId - 10);
+            $users[] = [
+                'id' => $userId,
+                'username' => "author$userId",
+                'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                'email' => "author$userId@machine.local",
+                'is_email_confirmed' => 1,
+            ];
+            $discussions[] = [
+                'id' => $discussionId,
+                'title' => "Discussion by author$userId",
+                'user_id' => $userId,
+                'comment_count' => 1,
+            ];
+            $posts[] = [
+                'id' => $discussionId,
+                'discussion_id' => $discussionId,
+                'user_id' => $userId,
+                'type' => 'comment',
+                'content' => '<t><p></p></t>',
+            ];
+            foreach ($userGroups as $gid) {
+                $groupUser[] = ['group_id' => $gid, 'user_id' => $userId];
+            }
+        }
+
+        $this->prepareDatabase([
+            Tag::class => $this->tags(),
+            User::class => $users,
+            Group::class => $groups,
+            'group_user' => $groupUser,
+            'group_permission' => [
+                ['group_id' => 100, 'permission' => 'tag5.viewForum'],
+                ['group_id' => 101, 'permission' => 'tag8.viewForum'],
+                ['group_id' => 102, 'permission' => 'tag11.viewForum'],
+                ['group_id' => 103, 'permission' => 'tag5.viewForum'],
+            ],
+            Discussion::class => $discussions,
+            Post::class => $posts,
+        ]);
+    }
+
+    #[Test]
+    public function listing_discussions_does_not_re_enumerate_tags_per_permission_check(): void
+    {
+        $db = $this->database();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $log = $db->getQueryLog();
+        $db->flushQueryLog();
+
+        // The cache-miss path issues `select id, is_restricted from tags`
+        // (no WHERE) — this is the "enumerate every tag for the PHP-side
+        // filter" query. On the unfixed code this fires multiple times
+        // per request as the WeakMap-keyed cache misses on recreated
+        // actor instances. Match permissively: any select-from-tags
+        // without an `id`-restricting WHERE clause counts.
+        $tagEnumerations = array_filter(
+            $log,
+            function (array $q) {
+                if (! preg_match('/^select .* from [`"]tags[`"](?:\s|$)/i', $q['query'])) {
+                    return false;
+                }
+
+                // Exclude the visibility scope's own constraining queries.
+                return ! preg_match('/where\s+.*[`"]id[`"]\s*(=|in\b)/i', $q['query']);
+            }
+        );
+
+        // Filter to the specific signature of the regression: `select id,
+        // is_restricted from tags` (or `select * from tags`) with no
+        // narrowing WHERE. Other unconstrained tags queries — count(*)
+        // for GlobalPolicy's tag-quota check, etc. — are unrelated and
+        // bounded.
+        $regressionShapeQueries = array_filter(
+            $tagEnumerations,
+            fn (array $q) => preg_match('/^select\s+(?:[`"]id[`"]\s*,\s*[`"]is_restricted[`"]|\*)\s+from\s+[`"]tags[`"]\s*$/i', $q['query']) === 1
+        );
+
+        $this->assertLessThanOrEqual(
+            1,
+            count($regressionShapeQueries),
+            'Expected the discussion list to enumerate the tags table at most once, got '.count($regressionShapeQueries).' fetches of `select id, is_restricted from tags`. '.
+            'This is the signature of #4605 — the cache-miss path was running once per recreated actor User instance.'
+        );
+    }
+}

--- a/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
+++ b/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
@@ -33,8 +33,6 @@ class DiscussionVisibilityTest extends TestCase
     {
         parent::setUp();
 
-        Tag::flushPermittedTagCache();
-
         $this->extension('flarum-tags');
 
         $this->prepareDatabase([

--- a/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
+++ b/extensions/tags/tests/integration/visibility/DiscussionVisibilityTest.php
@@ -142,4 +142,77 @@ class DiscussionVisibilityTest extends TestCase
         $ids = Arr::pluck($discussions, 'id');
         $this->assertEqualsCanonicalizing([], $ids);
     }
+
+    #[Test]
+    public function permission_on_child_does_not_grant_visibility_when_parent_is_off_limits()
+    {
+        // The visibility scope's clause:
+        //   ->whereIn('tags.id', $permittedIds)
+        //   ->where(fn($q) => $q->whereIn('tags.parent_id', $permittedIds)
+        //                       ->orWhereNull('tags.parent_id'))
+        //
+        // means a tag is visible only if EITHER its parent is also in the
+        // permitted set OR the tag has no parent. This is a load-bearing
+        // protection: an admin who restricts a parent tag must not have
+        // their restriction silently undermined by a per-child permission
+        // grant on a descendant.
+        //
+        // Concretely in this fixture: tag 8 (Primary Restricted Child
+        // Restricted) has parent tag 6 (Primary Restricted). The user has
+        // tag8.arbitraryAbility but NOT tag6.arbitraryAbility — so any
+        // discussion tagged with tag 8 alone should NOT be visible.
+        $this->app();
+
+        $this->database()->table('discussion_tag')->insert([
+            ['discussion_id' => 1, 'tag_id' => 8],
+        ]);
+
+        $user = User::find(2);
+        $discussions = Discussion::whereVisibleTo($user, 'arbitraryAbility')->get();
+
+        $ids = Arr::pluck($discussions, 'id');
+        $this->assertNotContains(1, $ids, 'Permission on a restricted child tag must not bypass the parent-tag restriction.');
+    }
+
+    #[Test]
+    public function permission_on_child_grants_visibility_when_parent_is_unrestricted()
+    {
+        // Symmetric case: tag 5 (Primary 2 Child Restricted) has parent
+        // tag 2 (Primary 2, unrestricted). The user has tag5.arbitraryAbility
+        // and the global perm. A discussion tagged with tag 5 alone should
+        // be visible — the parent_id IS allowed (it's unrestricted, so any
+        // user with the global perm has access).
+        //
+        // Discussion 3 in the fixture has tags [2, 5] which already covers
+        // this; this test makes the property explicit with a single-tag
+        // case to isolate the parent_id clause.
+        $this->app();
+
+        $this->database()->table('discussion_tag')->insert([
+            ['discussion_id' => 1, 'tag_id' => 5],
+        ]);
+
+        $user = User::find(2);
+        $discussions = Discussion::whereVisibleTo($user, 'arbitraryAbility')->get();
+
+        $ids = Arr::pluck($discussions, 'id');
+        $this->assertContains(1, $ids, 'Permission on a restricted child tag whose parent is unrestricted should grant visibility.');
+    }
+
+    #[Test]
+    public function root_restricted_tag_with_explicit_permission_is_visible()
+    {
+        // Tag 14 (Primary Restricted 3) is restricted, has no parent, and
+        // the user has tag14.arbitraryAbility. The orWhereNull('tags.parent_id')
+        // branch of the visibility scope should let this through.
+        // Discussion 7 in the fixture covers this implicitly; this test
+        // pins the property explicitly.
+        $this->app();
+
+        $user = User::find(2);
+        $discussions = Discussion::whereVisibleTo($user, 'arbitraryAbility')->get();
+
+        $ids = Arr::pluck($discussions, 'id');
+        $this->assertContains(7, $ids, 'Permission on a restricted root tag (no parent) should grant visibility.');
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4605. \`Tag::scopeWhereHasPermission\` regressed in #4502 from a SQL subquery to a PHP-side filter cached in a \`WeakMap<User, …>\`. When the actor User instance is recreated mid-request (which happens in several places), the cache misses and re-runs:

\`\`\`sql
SELECT permission FROM group_permission WHERE group_id IN (?)
SELECT id, is_restricted FROM tags
\`\`\`

On a real forum (~20 discussions, multiple authors with varied groups) this produced ~30 redundant \`group_permission\` lookups and ~6 redundant tag enumerations per \`/api/discussions\` request, contributing measurably to page-render latency (1.27s on 2.0-rc.1 vs 0.38s on 1.8.16 on identical hardware).

## Diagnosis

The reporter (#4605) instrumented production traffic and identified two redundant query templates dominating the regression:

| Template | 2.0-rc.1 | 1.8.16 |
|---|---:|---:|
| \`SELECT permission FROM group_permission WHERE group_id IN (?)\` | 36 | 1 |
| \`SELECT id, is_restricted FROM tags\` | 6 | 0 |

Both come from the cache-miss path in \`resolvePermittedTagIds\`. The WeakMap is keyed by the actor User *object*, so any flow that re-loads the actor (or compares against a fresh instance) defeats the cache.

## Fix

Restore the SQL subquery approach that 1.x used:

\`\`\`php
// tags.id IN (SELECT id FROM tags AS perm_tags WHERE …)
\`\`\`

The DB does the filtering inline. No PHP-side cache, no enumeration of the entire tags table, no per-User-instance miss path. The subquery is cheap (a small filtered select on the tags table) and runs once per visibility-scope application — exactly what 1.x did.

\`flushPermittedTagCache()\` is dropped — it was scaffolding for the WeakMap (introduced in #4502) and the only caller was the test cleaning up after it.

## Tests

**Regression guard** — \`PermissionScopeQueryCountTest\` exercises the exact bug shape: 10 distinct non-admin authors with varied group memberships each authoring a discussion, then a non-admin actor lists the discussions. Asserts the unconstrained \`select id, is_restricted from tags\` query — the signature of #4605 — runs at most once per request.

- Pre-fix: 4 such enumerations on this fixture.
- Post-fix: 0.

**Visibility correctness** — Added 3 focused tests in \`DiscussionVisibilityTest\` to pin the parent/child clause property at single-tag granularity:

- \`permission_on_child_does_not_grant_visibility_when_parent_is_off_limits\` — restricted-child + restricted-parent + perm on child only → hidden
- \`permission_on_child_grants_visibility_when_parent_is_unrestricted\` — restricted-child + unrestricted-parent + perm on child → visible
- \`root_restricted_tag_with_explicit_permission_is_visible\` — restricted-root + perm → visible (the \`orWhereNull('parent_id')\` branch)

All three pass on **both** the un-fixed and fix branches, confirming they describe properties that hold under the existing implementation as well as the new one.

**Query-trace equivalence** — Captured the visibility SQL emitted by \`/api/discussions\` against an identical fixture on (a) the un-fixed code and (b) this fix. The outer parent/child predicate structure is byte-identical, and the permitted-set definitions (\`unrestricted ∪ explicit-perm restricted\` via PHP filter on un-fixed, vs \`is_restricted = false ∪ (is_restricted = true AND id IN explicit-perms)\` via SQL subquery on fixed) are mathematically equivalent. Full traces in [the analysis comment](https://github.com/flarum/framework/pull/4649#issuecomment-4412012639).

**Suite results** — 144/144 tags integration tests pass (1 pre-existing unrelated failure on \`ShowTest::can_show_tag_with_url_decoded_utf8_slug\` is present on \`2.x\` baseline). 673/673 core integration tests pass. PHPStan clean.

## Performance impact

The reporter's measurements suggest restoring 1.x's query count drops \`/forum/\` HTML render from 1.27s to ~0.85s on their forum (independent of an unrelated polls regression). The remaining headroom belongs to other work outside this PR.