### PR TITLE
[2.x] fix: prevent UserSecurityPage crash when user loads asynchronously

### DIFF
--- a/framework/core/js/src/forum/components/UserPage.tsx
+++ b/framework/core/js/src/forum/components/UserPage.tsx
@@ -90,17 +90,29 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
   /**
    * Given a username, load the user's profile from the store, or make a request
    * if we don't have it yet. Then initialize the profile page with that user.
+   *
+   * Resolves once `this.user` is set so that subclasses can safely chain
+   * dependent work (e.g. fetching related resources keyed off the user id).
    */
-  loadUser(username: string) {
+  loadUser(username: string): Promise<void> {
     const lowercaseUsername = username.toLowerCase();
 
-    // Load the preloaded user object, if any, into the global app store
-    // We don't use the output of the method because it returns raw JSON
-    // instead of the parsed models
-    app.preloadedApiDocument();
+    // On initial render the server preloads the target user as the primary
+    // resource of the API document, so prefer that — it stays correct under
+    // any slug driver (including IdWithDisplayName, where the route slug
+    // does not equal the username).
+    const preloaded = app.preloadedApiDocument<User>();
+
+    if (preloaded && !Array.isArray(preloaded) && preloaded.joinTime()) {
+      this.show(preloaded);
+      return Promise.resolve();
+    }
 
     app.store.all<User>('users').some((user) => {
-      if ((user.username().toLowerCase() === lowercaseUsername || user.id() === username) && user.joinTime()) {
+      if (
+        (user.username().toLowerCase() === lowercaseUsername || user.id() === username || user.slug() === username) &&
+        user.joinTime()
+      ) {
         this.show(user);
         return true;
       }
@@ -108,9 +120,11 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
       return false;
     });
 
-    if (!this.user) {
-      app.store.find<User>('users', username, { bySlug: true }).then(this.show.bind(this));
+    if (this.user) {
+      return Promise.resolve();
     }
+
+    return app.store.find<User>('users', username, { bySlug: true }).then(this.show.bind(this));
   }
 
   /**

--- a/framework/core/js/src/forum/components/UserPage.tsx
+++ b/framework/core/js/src/forum/components/UserPage.tsx
@@ -98,7 +98,7 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
     const lowercaseUsername = username.toLowerCase();
 
     // On initial render the server preloads the target user as the primary
-    // resource of the API document, so prefer that — it stays correct under
+    // resource of the API document, so prefer that. It stays correct under
     // any slug driver (including IdWithDisplayName, where the route slug
     // does not equal the username).
     const preloaded = app.preloadedApiDocument<User>();
@@ -109,10 +109,7 @@ export default class UserPage<CustomAttrs extends IUserPageAttrs = IUserPageAttr
     }
 
     app.store.all<User>('users').some((user) => {
-      if (
-        (user.username().toLowerCase() === lowercaseUsername || user.id() === username || user.slug() === username) &&
-        user.joinTime()
-      ) {
+      if ((user.username().toLowerCase() === lowercaseUsername || user.id() === username || user.slug() === username) && user.joinTime()) {
         this.show(user);
         return true;
       }

--- a/framework/core/js/src/forum/components/UserSecurityPage.tsx
+++ b/framework/core/js/src/forum/components/UserSecurityPage.tsx
@@ -29,11 +29,9 @@ export default class UserSecurityPage<CustomAttrs extends IUserPageAttrs = IUser
       m.route.set('/');
     }
 
-    this.loadUser(routeUsername);
-
     app.setTitle(extractText(app.translator.trans('core.forum.security.title')));
 
-    this.loadTokens();
+    this.loadUser(routeUsername).then(() => this.loadTokens());
   }
 
   content() {


### PR DESCRIPTION
`UserSecurityPage.oninit` calls `loadTokens()` immediately after `loadUser()`, assuming `this.user` is set synchronously. That assumption only holds when the route slug equals the user's username, so any non-default slug driver (built-in `IdWithDisplayName` included) crashes with:

```
TypeError: Cannot read properties of null (reading 'id') at UserSecurityPage.loadTokens (UserSecurityPage.tsx:201)
```

To reproduce: set the user slug driver to `IdWithDisplayName` in admin, then visit `/u/<id>-<name>/security`.

The fix has two parts:

1. `UserPage.loadUser` returns `Promise<void>` so subclasses can chain dependent work after the user resolves. `UserSecurityPage` chains `loadTokens()` onto it.
2. The in-store sync match in `loadUser` also compares `user.slug()`, and the preloaded API document's primary resource is used directly when present. This eliminates the loading flicker that otherwise appears on every initial render under non-default slug drivers (the page used to render `loading=true` while the async user fetch ran).

## Test plan

- [x] `yarn build` in `framework/core/js` passes.
- [x] `IdWithDisplayName` slug driver: `/u/<id>-<name>/security` loads without crash.