### PR TITLE
[2.x] fix: send user slug, not username, for profile author filter

### DIFF
--- a/framework/core/js/src/common/components/SearchModal.tsx
+++ b/framework/core/js/src/common/components/SearchModal.tsx
@@ -462,7 +462,7 @@ export default class SearchModal<CustomAttrs extends ISearchModalAttrs = ISearch
     }
 
     if (app.current.data.routeName && app.current.data.routeName.includes('user.posts') && app.current.data.user) {
-      filters.posts.author = app.current.data.user.username();
+      filters.posts.author = app.current.data.user.slug();
     }
 
     return filters;

--- a/framework/core/js/src/forum/components/DiscussionsUserPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionsUserPage.tsx
@@ -19,7 +19,7 @@ export default class DiscussionsUserPage extends UserPage<IUserPageAttrs, Discus
     super.show(user);
 
     this.state = new DiscussionListState({
-      filter: { author: user.username() },
+      filter: { author: user.slug() },
       sort: 'newest',
     });
 

--- a/framework/core/js/src/forum/components/PostsUserPage.tsx
+++ b/framework/core/js/src/forum/components/PostsUserPage.tsx
@@ -47,7 +47,7 @@ export default class PostsUserPage extends UserPage {
 
   params(user: User) {
     return {
-      filter: { author: user.username() },
+      filter: { author: user.slug() },
     };
   }
 }


### PR DESCRIPTION
## Summary

When a non-default user slug driver is active (e.g. `IdWithDisplayName`, `id`), the Discussions and Posts tabs on user profiles are empty, even though the count badges report the correct totals.

Root cause: `DiscussionsUserPage`, `PostsUserPage`, and `SearchModal` build `filter[author] = user.username()`. The server-side `AuthorFilter` resolves that value through the configured slug driver. Under `IdWithDisplayName`, a plain username does not parse as `<id>-<name>`, so the filter throws `ModelNotFoundException`, the slug is silently skipped, and the query becomes `whereIn(..., [])`.

The existing slug-driver test (`tests/integration/api/discussions/ListTest.php::author_filter_works_with_slug_driver`) already pins the API contract: `filter[author]` takes whatever slug the active driver produces. This change brings the three frontend call sites in line with that contract.

## Test plan

- [x] `IdWithDisplayName` driver: own profile and another user's profile both populate Discussions and Posts tabs.
- [x] `id` driver: same.
- [x] `username` driver (default): no regression on own or other profiles.
- [x] Search modal from `/u/<slug>/posts`: pre-fills the author filter correctly under each driver.
- [x] Browser console clean; `?filter[author]=…` query string matches the active driver's slug.

Closes #4603