### PR TITLE
[2.x] feat(queue): restore per-class queue routing on AbstractJob

### DIFF
--- a/extensions/gdpr/src/Jobs/ErasureJob.php
+++ b/extensions/gdpr/src/Jobs/ErasureJob.php
@@ -37,6 +37,7 @@ class ErasureJob extends GdprJob
 
     public function __construct(private ErasureRequest $erasureRequest)
     {
+        parent::__construct();
     }
 
     public function handle(

--- a/extensions/gdpr/src/Jobs/ExportJob.php
+++ b/extensions/gdpr/src/Jobs/ExportJob.php
@@ -22,6 +22,7 @@ class ExportJob extends GdprJob
 {
     public function __construct(private User $user, private User $actor)
     {
+        parent::__construct();
     }
 
     public function handle(Exporter $exporter, NotificationSyncer $notifications, Dispatcher $events): void

--- a/extensions/gdpr/src/Jobs/GdprJob.php
+++ b/extensions/gdpr/src/Jobs/GdprJob.php
@@ -13,5 +13,4 @@ use Flarum\Queue\AbstractJob;
 
 abstract class GdprJob extends AbstractJob
 {
-    public static ?string $onQueue = null;
 }

--- a/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
+++ b/extensions/mentions/src/Job/SendMentionsNotificationsJob.php
@@ -28,6 +28,7 @@ class SendMentionsNotificationsJob extends AbstractJob
         protected array $postMentions,
         protected array $groupMentions
     ) {
+        parent::__construct();
     }
 
     public function handle(NotificationSyncer $notifications): void

--- a/extensions/messages/src/Job/SendMessageNotificationsJob.php
+++ b/extensions/messages/src/Job/SendMessageNotificationsJob.php
@@ -21,6 +21,7 @@ class SendMessageNotificationsJob extends AbstractJob
     public function __construct(
         protected DialogMessage $message
     ) {
+        parent::__construct();
     }
 
     public function handle(NotificationSyncer $notifications): void

--- a/extensions/package-manager/src/Job/ComposerCommandJob.php
+++ b/extensions/package-manager/src/Job/ComposerCommandJob.php
@@ -29,6 +29,7 @@ class ComposerCommandJob extends AbstractJob implements ShouldBeUnique
         protected AbstractActionCommand $command,
         protected string $phpVersion
     ) {
+        parent::__construct();
     }
 
     public function handle(Dispatcher $bus): void

--- a/extensions/pusher/src/SendPusherNotificationsJob.php
+++ b/extensions/pusher/src/SendPusherNotificationsJob.php
@@ -21,6 +21,7 @@ class SendPusherNotificationsJob extends AbstractJob
         /** @var User[] */
         private readonly array $recipients
     ) {
+        parent::__construct();
     }
 
     public function handle(Pusher $pusher): void

--- a/extensions/realtime/src/Push/Jobs/Job.php
+++ b/extensions/realtime/src/Push/Jobs/Job.php
@@ -19,15 +19,6 @@ use Pusher\Pusher;
 
 abstract class Job extends AbstractJob
 {
-    public static ?string $onQueue = null;
-
-    public function __construct()
-    {
-        if (static::$onQueue) {
-            $this->onQueue(static::$onQueue);
-        }
-    }
-
     protected function pusher(): Pusher
     {
         return resolve(Pusher::class);

--- a/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
+++ b/framework/core/src/Mail/Job/SendAbandonedExtensionsEmailJob.php
@@ -25,6 +25,7 @@ class SendAbandonedExtensionsEmailJob extends AbstractJob
         private readonly string $forumTitle,
         private readonly ?string $locale = null,
     ) {
+        parent::__construct();
     }
 
     public function handle(Mailer $mailer, Factory $view, TranslatorInterface $translator): void

--- a/framework/core/src/Mail/Job/SendInformationalEmailJob.php
+++ b/framework/core/src/Mail/Job/SendInformationalEmailJob.php
@@ -30,6 +30,7 @@ class SendInformationalEmailJob extends AbstractJob
         ],
         private readonly ?string $locale = null,
     ) {
+        parent::__construct();
     }
 
     public function handle(Mailer $mailer, Factory $view, TranslatorInterface $translator): void

--- a/framework/core/src/Notification/Job/SendEmailNotificationJob.php
+++ b/framework/core/src/Notification/Job/SendEmailNotificationJob.php
@@ -23,6 +23,7 @@ class SendEmailNotificationJob extends AbstractJob
         private readonly MailableInterface&BlueprintInterface $blueprint,
         private readonly User $recipient
     ) {
+        parent::__construct();
     }
 
     public function handle(NotificationMailer $mailer, CacheRepository $cache): void

--- a/framework/core/src/Notification/Job/SendNotificationsJob.php
+++ b/framework/core/src/Notification/Job/SendNotificationsJob.php
@@ -22,6 +22,7 @@ class SendNotificationsJob extends AbstractJob
         /** @var User[] */
         private readonly array $recipients = []
     ) {
+        parent::__construct();
     }
 
     public function handle(): void

--- a/framework/core/src/Queue/AbstractJob.php
+++ b/framework/core/src/Queue/AbstractJob.php
@@ -31,4 +31,21 @@ class AbstractJob implements ShouldQueue
      * override with `public bool $deleteWhenMissingModels = false;`.
      */
     public bool $deleteWhenMissingModels = true;
+
+    /**
+     * Optional queue name onto which jobs of this class should be routed.
+     *
+     * Operators (or extensions) may set this on a subclass to dispatch all of
+     * its instances onto a dedicated queue without modifying the dispatch
+     * sites. Subclasses overriding `__construct` must call `parent::__construct()`
+     * to opt in.
+     */
+    public static ?string $onQueue = null;
+
+    public function __construct()
+    {
+        if (static::$onQueue !== null) {
+            $this->onQueue(static::$onQueue);
+        }
+    }
 }

--- a/framework/core/src/Search/Job/IndexJob.php
+++ b/framework/core/src/Search/Job/IndexJob.php
@@ -29,6 +29,7 @@ class IndexJob extends AbstractJob
          */
         protected string $operation,
     ) {
+        parent::__construct();
     }
 
     public function handle(Container $container): void

--- a/framework/core/src/User/Job/RequestPasswordResetJob.php
+++ b/framework/core/src/User/Job/RequestPasswordResetJob.php
@@ -24,6 +24,7 @@ class RequestPasswordResetJob extends AbstractJob
     public function __construct(
         protected string $email
     ) {
+        parent::__construct();
     }
 
     public function handle(

--- a/framework/core/tests/unit/Queue/AbstractJobTest.php
+++ b/framework/core/tests/unit/Queue/AbstractJobTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Queue;
+
+use Flarum\Queue\AbstractJob;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AbstractJobTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        AbstractJobTestStub::$onQueue = null;
+        AbstractJobTestSubclassStub::$onQueue = null;
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function defaults_to_no_queue_routing(): void
+    {
+        $job = new AbstractJobTestStub();
+
+        $this->assertNull($job->queue);
+    }
+
+    #[Test]
+    public function routes_onto_queue_named_by_static_property(): void
+    {
+        AbstractJobTestStub::$onQueue = 'priority';
+
+        $job = new AbstractJobTestStub();
+
+        $this->assertSame('priority', $job->queue);
+    }
+
+    #[Test]
+    public function static_property_is_resolved_via_late_static_binding(): void
+    {
+        AbstractJobTestStub::$onQueue = 'parent-queue';
+        AbstractJobTestSubclassStub::$onQueue = 'child-queue';
+
+        $this->assertSame('parent-queue', (new AbstractJobTestStub())->queue);
+        $this->assertSame('child-queue', (new AbstractJobTestSubclassStub())->queue);
+    }
+}
+
+class AbstractJobTestStub extends AbstractJob
+{
+    public static ?string $onQueue = null;
+}
+
+class AbstractJobTestSubclassStub extends AbstractJobTestStub
+{
+    public static ?string $onQueue = null;
+}


### PR DESCRIPTION
## Summary

Restores the `$onQueue` static property + constructor that 1.x's `AbstractJob` exposed, and **wires every in-tree job through it** so operators can route any shipped job onto a dedicated queue without subclassing.

Without this, there's no built-in way for an operator (or an extension) to dispatch all instances of a given job class onto a dedicated queue without patching every dispatch site. Multiple 2.x-compatible extensions have already re-implemented this hook themselves — see issue #4653 for examples from `FoF\GeoIP\Jobs\RetrieveIP` and `Flarum\Gdpr\Jobs\GdprJob`. Both have settled on the name `$onQueue` (rather than 1.x's `$sendOnQueue`), so this PR adopts the same name.

## Changes

**`Flarum\Queue\AbstractJob`** (commit 1):
- New `public static ?string $onQueue = null;` property.
- New `__construct()` that calls `$this->onQueue(static::$onQueue)` when the static property is set on the concrete subclass (late-static-bound, so each subclass gets its own routing knob).

**Every in-tree job that has its own constructor** (commit 2) now calls `parent::__construct()` so it inherits the routing behavior:
- `Flarum\Notification\Job\SendEmailNotificationJob`
- `Flarum\Notification\Job\SendNotificationsJob`
- `Flarum\Mail\Job\SendAbandonedExtensionsEmailJob`
- `Flarum\Mail\Job\SendInformationalEmailJob`
- `Flarum\User\Job\RequestPasswordResetJob`
- `Flarum\Search\Job\IndexJob`
- `Flarum\Messages\Job\SendMessageNotificationsJob`
- `Flarum\Pusher\SendPusherNotificationsJob`
- `Flarum\ExtensionManager\Job\ComposerCommandJob`
- `Flarum\Mentions\Job\SendMentionsNotificationsJob`
- `Flarum\Gdpr\Jobs\ExportJob`, `ErasureJob`

**Cleanups** for jobs that previously implemented the hook themselves:
- `Flarum\Gdpr\Jobs\GdprJob`: drop the local `$onQueue` shadow (inherited now).
- `Flarum\Realtime\Push\Jobs\Job`: drop the local `$onQueue` shadow and the workaround `__construct()` (inherited now). All concrete `Send*Job` subclasses in the same directory already call `parent::__construct()`, so routing flows through unchanged.

## Behavior

- `AbstractJob::$onQueue` defaults to `null`, so default behavior is unchanged.
- Operators (or extensions) set `SomeJob::$onQueue = 'queue-name'` once at boot to route all instances of that job class onto a specific queue.
- Late-static-binding means a `Child extends Parent` subclass's own `$onQueue` value wins over the parent's, as expected.

## Test plan

- [x] New unit test `tests/unit/Queue/AbstractJobTest.php` covers: default behavior (no routing), routing via the static property, and late-static-binding under inheritance.
- [x] Existing queue unit + integration tests pass unchanged (`tests/unit/Queue`, `tests/integration/queue`).
- [x] PHPStan clean on every changed file.

Closes #4653