### PR TITLE
[2.x] fix: TextEditor.onbuild race against async Mithril redraw

### DIFF
--- a/framework/core/js/src/common/components/TextEditor.js
+++ b/framework/core/js/src/common/components/TextEditor.js
@@ -72,9 +72,7 @@ export default class TextEditor extends Component {
   oncreate(vnode) {
     super.oncreate(vnode);
 
-    this._load().then(() => {
-      setTimeout(this.onbuild.bind(this), 50);
-    });
+    this._load().then(this.onbuild.bind(this));
   }
 
   onbuild() {
@@ -96,7 +94,12 @@ export default class TextEditor extends Component {
   _load() {
     return Promise.all(this._loaders.map((loader) => loader())).then(() => {
       this.loading = false;
-      m.redraw();
+      // Synchronous redraw so the editor container is in the DOM before
+      // `onbuild` runs. Mithril's regular `m.redraw()` queues for the next
+      // frame, which previously raced against a 50ms setTimeout and could
+      // leave `this.$('.TextEditor-editorContainer')[0]` undefined on slow
+      // first loads. See flarum/framework#4612.
+      m.redraw.sync();
     });
   }
 


### PR DESCRIPTION
## Summary

`TextEditor.oncreate` schedules `onbuild` via a hardcoded `setTimeout(..., 50)` after `_load()` resolves. `_load()` ends with `m.redraw()`, which is **async** (queued for the next frame). Under slow first-load conditions — cold CDN, heavy DOM, additional `_loaders` like the one the emoji extension registers — the redraw can land *after* the 50ms timer fires, leaving the conditional `<div class=\"TextEditor-editorContainer\">` out of the DOM when `onbuild` runs.

When that happens, `this.\$('.TextEditor-editorContainer')[0]` returns `undefined` and gets handed to whatever editor driver is being constructed:

```js
this.attrs.composer.editor = this.buildEditor(this.\$('.TextEditor-editorContainer')[0]);
```

For the stock `BasicEditorDriver`, this produces a broken textarea. For Tiptap-based drivers (e.g. fof/rich-text), Tiptap v3 only calls its internal `mount()` if `options.element` is truthy, so the view is permanently null and the composer renders a non-functional toolbar with no editor underneath. The bug is intermittent because it depends on whether the redraw beats the timer.

## Fix

Switch `_load`'s trailing `m.redraw()` to `m.redraw.sync()` and drop the 50ms timer in `oncreate`. After `m.redraw.sync()` returns, the DOM has been updated to reflect `loading = false`, so the container element is present when `onbuild` runs. The `.then` callback runs on a microtask outside any Mithril event handler, so calling `m.redraw.sync()` from there is safe.

```diff
   oncreate(vnode) {
     super.oncreate(vnode);

-    this._load().then(() => {
-      setTimeout(this.onbuild.bind(this), 50);
-    });
+    this._load().then(this.onbuild.bind(this));
   }

   _load() {
     return Promise.all(this._loaders.map((loader) => loader())).then(() => {
       this.loading = false;
-      m.redraw();
+      m.redraw.sync();
     });
   }
```

## Test plan

Repro using the script from the linked issue:

```js
const orig = m.redraw;
m.redraw = function() { setTimeout(() => orig(), 300); };
m.redraw.sync = orig.sync;
```

- [x] **Before fix**, with the slowdown applied: opening the composer produces a broken textarea (`this.\$('.TextEditor-editorContainer')[0]` is `undefined`).
- [x] **After fix**, with the slowdown applied: composer opens cleanly, editor mounts, typing works.
- [x] **After fix**, no slowdown: normal composer use is unchanged.

Closes #4612