### PR TITLE
[2.x] fix(api): surface event posts in discussion PATCH responses and route title via rename()

### DIFF
--- a/extensions/lock/js/src/forum/addLockControl.js
+++ b/extensions/lock/js/src/forum/addLockControl.js
@@ -19,10 +19,13 @@ export default function addLockControl() {
   DiscussionControls.lockAction = function () {
     this.save({ isLocked: !this.isLocked() }).then(() => {
       if (app.current.matches(DiscussionPage)) {
-        app.current.get('stream').update();
+        app.current
+          .get('stream')
+          .update()
+          .then(() => m.redraw());
+      } else {
+        m.redraw();
       }
-
-      m.redraw();
     });
   };
 }

--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -12,6 +12,7 @@ use Flarum\Api\Resource;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
+use Flarum\Realtime\Extend\Realtime as RealtimeExtend;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Sticky\Api\DiscussionResourceFields;
 use Flarum\Sticky\Event\DiscussionWasStickied;
@@ -58,4 +59,15 @@ return [
     (new Extend\Settings())
         ->default('flarum-sticky.only_sticky_unread_discussions', true)
         ->serializeToForum('onlyStickyUnreadDiscussions', 'flarum-sticky.only_sticky_unread_discussions', 'boolval'),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-realtime', fn () => [
+            (new RealtimeExtend())
+                ->broadcastModelEvent(
+                    [DiscussionWasStickied::class, DiscussionWasUnstickied::class],
+                    fn ($event) => $event->discussion,
+                    fn ($event) => $event->user,
+                    'stickiedEvent'
+                ),
+        ]),
 ];

--- a/extensions/sticky/js/src/forum/addStickyControl.js
+++ b/extensions/sticky/js/src/forum/addStickyControl.js
@@ -19,10 +19,13 @@ export default function addStickyControl() {
   DiscussionControls.stickyAction = function () {
     this.save({ isSticky: !this.isSticky() }).then(() => {
       if (app.current.matches(DiscussionPage)) {
-        app.current.get('stream').update();
+        app.current
+          .get('stream')
+          .update()
+          .then(() => m.redraw());
+      } else {
+        m.redraw();
       }
-
-      m.redraw();
     });
   };
 }

--- a/extensions/sticky/js/src/forum/extendRealtime.ts
+++ b/extensions/sticky/js/src/forum/extendRealtime.ts
@@ -1,0 +1,6 @@
+import app from 'flarum/forum/app';
+import RealtimeExtend from 'ext:flarum/realtime/forum/extenders/Realtime';
+
+export default function extendRealtime() {
+  new RealtimeExtend().onDiscussionStreamEvent('stickiedEvent').extend(app, { name: 'flarum-sticky', exports: {} });
+}

--- a/extensions/sticky/js/src/forum/index.js
+++ b/extensions/sticky/js/src/forum/index.js
@@ -4,6 +4,7 @@ import addStickyBadge from './addStickyBadge';
 import addStickyControl from './addStickyControl';
 import addStickyExcerpt from './addStickyExcerpt';
 import addStickyClass from './addStickyClass';
+import extendRealtime from './extendRealtime';
 
 export { default as extend } from './extend';
 
@@ -12,4 +13,10 @@ app.initializers.add('flarum-sticky', () => {
   addStickyControl();
   addStickyExcerpt();
   addStickyClass();
+
+  // Register a discussion stream update event with flarum/realtime when enabled.
+  // Stickying or unstickying a discussion will trigger a DiscussionPage stream reload for other users.
+  if ('flarum-realtime' in flarum.extensions) {
+    extendRealtime();
+  }
 });

--- a/extensions/sticky/js/tsconfig.json
+++ b/extensions/sticky/js/tsconfig.json
@@ -4,12 +4,13 @@
   // This will match all .ts, .tsx, .d.ts, .js, .jsx files in your `src` folder
   // and also tells your Typescript server to read core's global typings for
   // access to `dayjs` and `$` in the global namespace.
-  "include": ["src/**/*", "../../../framework/core/js/dist-typings/@types/**/*", "@types/**/*"],
+  "include": ["src/**/*", "../../../framework/core/js/dist-typings/@types/**/*", "@types/**/*", "../../realtime/js/dist-typings/@types/**/*"],
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
     "paths": {
-      "flarum/*": ["../../../framework/core/js/dist-typings/*"]
+      "flarum/*": ["../../../framework/core/js/dist-typings/*"],
+      "ext:flarum/realtime/*": ["../../realtime/js/dist-typings/*"]
     }
   }
 }

--- a/extensions/sticky/tests/integration/api/StickyDiscussionsTest.php
+++ b/extensions/sticky/tests/integration/api/StickyDiscussionsTest.php
@@ -98,4 +98,54 @@ class StickyDiscussionsTest extends TestCase
             [3, false, false],
         ];
     }
+
+    #[Test]
+    public function sticky_response_exposes_new_event_post_in_linkage()
+    {
+        // Discussion 2 starts un-stickied with one comment post (id 2). Stickying
+        // creates a `discussionStickied` event post via mergePost(). The PATCH
+        // response must surface that new post in the discussion's `posts`
+        // relationship linkage so the client can refresh its post stream without
+        // a full reload. See flarum/framework#TBD.
+        $response = $this->send(
+            $this->request('PATCH', '/api/discussions/2', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isSticky' => true,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $json = json_decode($body, true);
+
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $linkage = $json['data']['relationships']['posts']['data'] ?? null;
+        $this->assertIsArray($linkage, 'PATCH response must include the discussion posts relationship linkage');
+
+        $linkageIds = array_map(fn (array $entry) => $entry['id'], $linkage);
+
+        // The original comment post is still there.
+        $this->assertContains('2', $linkageIds, 'Linkage should still contain the original comment post id');
+
+        // And the newly-created event post is too — its id is whatever the next
+        // available id is after the fixture posts (1–4). The discussion gained
+        // exactly one post; assert the linkage grew by one.
+        $this->assertCount(2, $linkageIds, 'Linkage should contain the comment post and the new event post');
+
+        // Identify the new post id (the one that isn't '2') and assert it
+        // corresponds to a `discussionStickied` post in the included array.
+        $newPostId = array_values(array_diff($linkageIds, ['2']))[0] ?? null;
+        $this->assertNotNull($newPostId);
+
+        $stickiedRow = Post::query()->find($newPostId);
+        $this->assertNotNull($stickiedRow, 'New post in linkage should exist');
+        $this->assertEquals('discussionStickied', $stickiedRow->type);
+        $this->assertEquals(2, $stickiedRow->discussion_id);
+    }
 }

--- a/extensions/tags/extend.php
+++ b/extensions/tags/extend.php
@@ -17,6 +17,7 @@ use Flarum\Extend;
 use Flarum\Flags\Api\Resource\FlagResource;
 use Flarum\Post\Filter\PostSearcher;
 use Flarum\Post\Post;
+use Flarum\Realtime\Extend\Realtime as RealtimeExtend;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Tags\Access;
 use Flarum\Tags\Api;
@@ -178,4 +179,15 @@ return [
             return $endpoint
                 ->addDefaultInclude(['eventPostMentionsTags']);
         }),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-realtime', fn () => [
+            (new RealtimeExtend())
+                ->broadcastModelEvent(
+                    [DiscussionWasTagged::class],
+                    fn ($event) => $event->discussion,
+                    fn ($event) => $event->actor,
+                    'taggedEvent'
+                ),
+        ]),
 ];

--- a/extensions/tags/js/src/forum/components/TagDiscussionModal.tsx
+++ b/extensions/tags/js/src/forum/components/TagDiscussionModal.tsx
@@ -49,10 +49,13 @@ export default class TagDiscussionModal extends TagSelectionModal<TagDiscussionM
       if (discussion) {
         discussion.save({ relationships: { tags } }).then(() => {
           if (app.current.matches(DiscussionPage)) {
-            app.current.get('stream').update();
+            app.current
+              .get('stream')
+              .update()
+              .then(() => m.redraw());
+          } else {
+            m.redraw();
           }
-
-          m.redraw();
         });
       }
 

--- a/extensions/tags/js/src/forum/extendRealtime.ts
+++ b/extensions/tags/js/src/forum/extendRealtime.ts
@@ -1,0 +1,6 @@
+import app from 'flarum/forum/app';
+import RealtimeExtend from 'ext:flarum/realtime/forum/extenders/Realtime';
+
+export default function extendRealtime() {
+  new RealtimeExtend().onDiscussionStreamEvent('taggedEvent').extend(app, { name: 'flarum-tags', exports: {} });
+}

--- a/extensions/tags/js/src/forum/index.ts
+++ b/extensions/tags/js/src/forum/index.ts
@@ -7,6 +7,7 @@ import addTagFilter from './addTagFilter';
 import addTagLabels from './addTagLabels';
 import addTagControl from './addTagControl';
 import addTagComposer from './addTagComposer';
+import extendRealtime from './extendRealtime';
 
 export { default as extend } from './extend';
 
@@ -18,6 +19,12 @@ app.initializers.add('flarum-tags', () => {
   addTagLabels();
   addTagControl();
   addTagComposer();
+
+  // Register a discussion stream update event with flarum/realtime when enabled.
+  // Tag changes will trigger a DiscussionPage stream reload for other users.
+  if ('flarum-realtime' in flarum.extensions) {
+    extendRealtime();
+  }
 });
 
 import './forum';

--- a/extensions/tags/js/tsconfig.json
+++ b/extensions/tags/js/tsconfig.json
@@ -4,12 +4,13 @@
   // This will match all .ts, .tsx, .d.ts, .js, .jsx files in your `src` folder
   // and also tells your Typescript server to read core's global typings for
   // access to `dayjs` and `$` in the global namespace.
-  "include": ["src/**/*", "../../../framework/core/js/dist-typings/@types/**/*", "@types/**/*"],
+  "include": ["src/**/*", "../../../framework/core/js/dist-typings/@types/**/*", "@types/**/*", "../../realtime/js/dist-typings/@types/**/*"],
   "compilerOptions": {
     // This will output typings to `dist-typings`
     "declarationDir": "./dist-typings",
     "paths": {
-      "flarum/*": ["../../../framework/core/js/dist-typings/*"]
+      "flarum/*": ["../../../framework/core/js/dist-typings/*"],
+      "ext:flarum/realtime/*": ["../../realtime/js/dist-typings/*"]
     }
   }
 }

--- a/framework/core/js/src/forum/components/RenameDiscussionModal.tsx
+++ b/framework/core/js/src/forum/components/RenameDiscussionModal.tsx
@@ -70,9 +70,13 @@ export default class RenameDiscussionModal<
         .save({ title })
         .then(() => {
           if (app.viewingDiscussion(this.discussion)) {
-            app.current.get('stream').update();
+            app.current
+              .get('stream')
+              .update()
+              .then(() => m.redraw());
+          } else {
+            m.redraw();
           }
-          m.redraw();
           this.hide();
         })
         .catch(() => {

--- a/framework/core/src/Api/Resource/DiscussionResource.php
+++ b/framework/core/src/Api/Resource/DiscussionResource.php
@@ -117,6 +117,17 @@ class DiscussionResource extends AbstractDatabaseResource
                     return $context->creating()
                         || $context->getActor()->can('rename', $discussion);
                 })
+                ->set(function (Discussion $discussion, string $value, Context $context) {
+                    // On update, route through `rename()` so that `Renamed`
+                    // fires — the listener creates the `discussionRenamed`
+                    // event post and dispatches notifications. The default
+                    // attribute setter would silently skip both.
+                    if ($context->updating()) {
+                        $discussion->rename($value);
+                    } else {
+                        $discussion->title = $value;
+                    }
+                })
                 ->minLength(3)
                 ->maxLength(80),
             Schema\Str::make('content')
@@ -207,6 +218,7 @@ class DiscussionResource extends AbstractDatabaseResource
                 ->withLinkage(function (Context $context) {
                     return $context->showing(self::class)
                         || $context->creating(self::class)
+                        || $context->updating(self::class)
                         || $context->creating(PostResource::class);
                 })
                 ->get(function (Discussion $discussion, Context $context) {

--- a/framework/core/tests/integration/api/discussions/UpdateTest.php
+++ b/framework/core/tests/integration/api/discussions/UpdateTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class UpdateTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Original title', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1, 'last_post_number' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>first post</p></t>', 'number' => 1],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function renaming_creates_discussion_renamed_event_post(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Renamed title',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        // Server-side: a `discussionRenamed` post row was inserted.
+        $renamedPost = Post::query()
+            ->where('discussion_id', 1)
+            ->where('type', 'discussionRenamed')
+            ->first();
+
+        $this->assertNotNull($renamedPost, 'A discussionRenamed event post should be created when the title changes');
+
+        // Client-visible: the PATCH response carries the refreshed `posts`
+        // linkage with the new event post's id. Without this, frontend
+        // `stream.update()` can't surface the renamed event post.
+        $json = json_decode($body, true);
+
+        $linkage = $json['data']['relationships']['posts']['data'] ?? null;
+        $this->assertIsArray($linkage, 'PATCH response must include the discussion posts relationship linkage');
+
+        $linkageIds = array_map(fn (array $entry) => $entry['id'], $linkage);
+
+        $this->assertContains('1', $linkageIds, 'Linkage should still contain the original comment post id');
+        $this->assertContains((string) $renamedPost->id, $linkageIds, 'Linkage should contain the new event post id');
+    }
+
+    #[Test]
+    public function setting_title_to_same_value_creates_no_event_post(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/discussions/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Original title',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertNull(
+            Post::query()->where('discussion_id', 1)->where('type', 'discussionRenamed')->first(),
+            'No discussionRenamed event post should be created when the title is unchanged'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two related 2.x regressions where discussion changes silently fail to surface in the UI:

1. **Event posts created by `mergePost()` (sticky, tags, lock) are absent from PATCH responses.** The 1.x `UpdateDiscussionController` refreshed `posts` linkage and inlined modified posts on every update; the 2.x `DiscussionResource` rewrite dropped that. Result: the action originator sees no event post in their stream until reload — even though the post exists in the DB.
2. **Renaming a discussion no longer raises `Renamed`.** The 2.x `DiscussionResource` defines a `title` field that delegates to the default attribute setter, bypassing `Discussion::rename()`. The `DiscussionRenamedLogger` listener never runs, so no `discussionRenamed` event post is created and no notification is sent to the discussion author.

Together these regressions break the "rename → event post appears → original author gets notified" flow that worked end-to-end in 1.x.

## Changes

### Core

- **`framework/core/src/Api/Resource/DiscussionResource.php`**
  - Expand the `posts` field's `withLinkage` predicate to also fire on update. PATCH responses now carry the refreshed `posts` linkage including any new event post id(s) added via `mergePost()`. Frontend `stream.update()` then sees `count()` grow and `loadRange()` fetches the new post(s) in a single batched GET.
  - Add a `->set()` callback on the `title` field so updates route through `Discussion::rename()`. This restores the `Renamed` domain event, which in turn triggers `DiscussionRenamedLogger` to create the `discussionRenamed` event post and dispatch `DiscussionRenamedBlueprint` notifications.

- **`framework/core/js/src/forum/components/RenameDiscussionModal.tsx`** — Chain `m.redraw()` onto the `stream.update()` promise rather than calling it synchronously. Without this, the redraw fires before `loadRange()` resolves and the new event post stays invisible until something else triggers a redraw. Same pattern as `flarum/realtime`'s existing `websocketEventStreamUpdate` handler.

### Sticky, Tags, Lock (client timing)

- **`addStickyControl.js`, `TagDiscussionModal.tsx`, `addLockControl.js`** — same `update().then(m.redraw)` chaining fix. Lock had server-side realtime wired correctly but its client-side redraw timing was still off; sticky and tags had neither.

### Sticky, Tags (realtime broadcast)

- **`extensions/sticky/extend.php`** — Register `DiscussionWasStickied` / `DiscussionWasUnstickied` via the Realtime extender's `broadcastModelEvent`, broadcasting as `'stickiedEvent'`. Other users viewing the discussion see the event post in real time.
- **`extensions/sticky/js/src/forum/extendRealtime.ts`** (new) — register `'stickiedEvent'` via the Realtime JS extender's `onDiscussionStreamEvent`, mirroring `flarum-lock`.
- **`extensions/tags/extend.php`** — Same wiring for `DiscussionWasTagged`, broadcasting as `'taggedEvent'`. Recipient permission is enforced per-user by the Realtime extension's existing `Generator` (it issues an internal API request as the recipient, so users without access to a discussion don't receive the broadcast).
- **`extensions/tags/js/src/forum/extendRealtime.ts`** (new) — register `'taggedEvent'`.

## Tests

- **`framework/core/tests/integration/api/discussions/UpdateTest.php`** (new) — asserts that PATCHing `title` creates a `discussionRenamed` post, that the PATCH response's `posts` linkage contains its id, and that a no-op title change creates no event post.
- **`extensions/sticky/tests/integration/api/StickyDiscussionsTest.php`** — new test asserting that PATCH `isSticky: true` returns a response whose `posts` linkage contains both the original comment post and the newly-created `discussionStickied` event post.

## Manual verification

On a Flarum 2.0.0-rc.1 stack with `flarum-realtime` enabled:

- [x] Same-user (no realtime needed): sticky / unsticky / tag-edit / lock / rename → event post appears within one network round-trip, no reload.
- [x] Cross-user (realtime needed): a second logged-in browser viewing the same discussion sees the event post appear automatically when the first browser performs any of the above actions. Previously worked for `lock` only; now works for all four.
- [x] Rename notification: when User B renames User A's discussion, User A receives the `discussionRenamed` notification (provided the preference is enabled).
- [x] Permission gating: users without access to a discussion (via tag visibility) do not receive realtime broadcasts about it — verified by inspecting the Realtime extension's `Generator`, which runs the payload-generation API request as the recipient.

Closes #4620