### PR TITLE
[2.x] fix(flags): drop literal 'undefined' from Inappropriate reason and lazy-load FlagPostModal

### DIFF
--- a/extensions/flags/extend.php
+++ b/extensions/flags/extend.php
@@ -29,6 +29,7 @@ use Flarum\User\User;
 return [
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
+        ->jsDirectory(__DIR__.'/js/dist/forum')
         ->css(__DIR__.'/less/forum.less')
         ->route('/flags', 'flags', AssertRegistered::class),
 

--- a/extensions/flags/js/src/forum/addFlagControl.js
+++ b/extensions/flags/js/src/forum/addFlagControl.js
@@ -3,15 +3,13 @@ import app from 'flarum/forum/app';
 import PostControls from 'flarum/forum/utils/PostControls';
 import Button from 'flarum/common/components/Button';
 
-import FlagPostModal from './components/FlagPostModal';
-
 export default function () {
   extend(PostControls, 'userControls', function (items, post) {
     if (post.isHidden() || post.contentType() !== 'comment' || !post.canFlag()) return;
 
     items.add(
       'flag',
-      <Button icon="fas fa-flag" onclick={() => app.modal.show(FlagPostModal, { post })}>
+      <Button icon="fas fa-flag" onclick={() => app.modal.show(() => import('./components/FlagPostModal'), { post })}>
         {app.translator.trans('flarum-flags.forum.post_controls.flag_button')}
       </Button>
     );

--- a/extensions/flags/js/src/forum/components/FlagPostModal.js
+++ b/extensions/flags/js/src/forum/components/FlagPostModal.js
@@ -92,9 +92,11 @@ export default class FlagPostModal extends FormModal {
           onclick={withAttr('value', this.reason)}
         />
         <strong>{app.translator.trans('flarum-flags.forum.flag_post.reason_inappropriate_label')}</strong>
-        {app.translator.trans('flarum-flags.forum.flag_post.reason_inappropriate_text', {
-          a: guidelinesUrl ? <a href={guidelinesUrl} target="_blank" /> : undefined,
-        })}
+        {guidelinesUrl
+          ? app.translator.trans('flarum-flags.forum.flag_post.reason_inappropriate_text', {
+              a: <a href={guidelinesUrl} target="_blank" />,
+            })
+          : app.translator.trans('flarum-flags.forum.flag_post.reason_inappropriate_text_no_guidelines')}
         {this.reason() === 'inappropriate' && (
           <textarea
             className="FormControl"

--- a/extensions/flags/js/src/forum/forum.ts
+++ b/extensions/flags/js/src/forum/forum.ts
@@ -5,6 +5,5 @@ import './addFlagsDropdown';
 import './models/Flag';
 
 import './components/FlagList';
-import './components/FlagPostModal';
 import './components/FlagsPage';
 import './components/FlagsDropdown';

--- a/extensions/flags/locale/en.yml
+++ b/extensions/flags/locale/en.yml
@@ -28,6 +28,7 @@ flarum-flags:
       reason_details_placeholder: Additional details (optional)
       reason_inappropriate_label: Inappropriate
       reason_inappropriate_text: "This post is offensive, abusive, or violates our <a>community guidelines</a>."
+      reason_inappropriate_text_no_guidelines: This post is offensive or abusive.
       reason_missing_message: Please provide some details for our moderators.
       reason_off_topic_label: "Off-topic"
       reason_off_topic_text: This post is not relevant to the current discussion and should be moved elsewhere.


### PR DESCRIPTION
## Summary

Two related changes to the Flarum-Flags "Inappropriate" flag-post path:

1. **Fix `{undefined}` rendering when no Community Guidelines URL is set.** With no URL configured, the modal currently renders:

   > This post is offensive, abusive, or violates our **{undefined}**.

   The reason: `FlagPostModal` passes `undefined` as the `<a>` rich-placeholder value to the translator, which stringifies it (the translator wraps undefined args as `'{undefined}'` at [Translator.tsx:131](framework/core/js/src/common/Translator.tsx#L131), and `<a>` is not in the auto-provided element fallback list).

   Use a separate translation key (`reason_inappropriate_text_no_guidelines`) when the URL is unset, instead of trying to pass `undefined` as a placeholder. Matches the reporter's suggested wording ("This post is offensive or abusive.").

2. **Lazy-load `FlagPostModal`.** The modal was imported eagerly via a side-effect `import './components/FlagPostModal'` in `forum.ts` plus a static `import FlagPostModal from ...` in `addFlagControl.js`, so its ~4 KB was always shipped in the main forum bundle even for users who never click flag. Switch to the documented lazy-load pattern:

   ```js
   <Button onclick={() => app.modal.show(() => import('./components/FlagPostModal'), { post })}>
   ```

   `forum.js` drops from 12,454 → 11,509 bytes; `FlagPostModal.js` becomes a deferred ~4 KB chunk loaded on first click.

   Required follow-up: declare `->jsDirectory(__DIR__.'/js/dist/forum')` on the `Extend\Frontend('forum')` registration so Flarum's asset publisher copies the chunked sub-bundles into `assets/extensions/flarum-flags/forum/components/`. Without this, the chunk requests 404.

## Backwards compatibility (lazy-load)

`FlagPostModal` is no longer in the registry at boot time — it's only registered when the lazy chunk loads (first flag-button click). Third-party extensions using the **string-path** form of `extend()` (`extend('flarum/flags/components/FlagPostModal', 'view', fn)`) are unaffected: the registry's `onLoad` hook applies pending patches when the chunk lands ([common/extend.ts:36-43](framework/core/js/src/common/extend.ts#L36-L43)).

Extensions using the **direct-prototype** form (`import FlagPostModal from 'flarum/flags/...'; extend(FlagPostModal.prototype, ...)`) at initializer-time would break, because the import would resolve to `undefined` until the chunk loads. The string-path form is the documented recommended pattern for cross-extension extension specifically because of this; any extension targeting 2.x's registry-based module model should already be using it.

## Test plan

- [x] Unset Community Guidelines URL → flag modal Inappropriate option reads "This post is offensive or abusive." (no `{undefined}`).
- [x] Set Community Guidelines URL → reads "This post is offensive, abusive, or violates our [community guidelines]." with working link.
- [x] Initial page load: no `FlagPostModal*.js` request in Network tab.
- [x] First flag-button click: chunk requests successfully from `assets/extensions/flarum-flags/forum/components/FlagPostModal.js`; modal renders.
- [x] Second click: no additional chunk fetch (already loaded).
- [x] Submit flag → flow completes normally.

Closes #4574