### PR TITLE
[2.x] fix(admin): keep extension danger badge visible on long names

### DIFF
--- a/framework/core/js/src/admin/components/AdminNav.js
+++ b/framework/core/js/src/admin/components/AdminNav.js
@@ -156,8 +156,6 @@ export default class AdminNav extends Component {
         const query = this.query().toUpperCase();
         const title = extension.extra['flarum-extension'].title || '';
         const description = extension.description || '';
-        const isAbandoned = extension.abandoned;
-        const hasReplacement = typeof isAbandoned === 'string';
 
         if (!query || title.toUpperCase().includes(query) || description.toUpperCase().includes(query)) {
           items.add(
@@ -169,7 +167,6 @@ export default class AdminNav extends Component {
               title={description}
             >
               {title}
-              {isAbandoned && <span className={`Badge Badge--${hasReplacement ? 'danger' : 'warning'}`}>!</span>}
             </ExtensionLinkButton>,
             categories[category]
           );

--- a/framework/core/js/src/admin/components/ExtensionLinkButton.js
+++ b/framework/core/js/src/admin/components/ExtensionLinkButton.js
@@ -23,6 +23,14 @@ export default class ExtensionLinkButton extends LinkButton {
   statusItems(name) {
     const items = new ItemList();
 
+    const extension = app.data.extensions[name];
+    const isAbandoned = extension?.abandoned;
+
+    if (isAbandoned) {
+      const hasReplacement = typeof isAbandoned === 'string';
+      items.add('abandoned', <span className={`Badge Badge--${hasReplacement ? 'danger' : 'warning'}`}>!</span>, 10);
+    }
+
     items.add('enabled', <span className={'ExtensionListItem-Dot ' + (isExtensionEnabled(name) ? 'enabled' : 'disabled')} />);
 
     return items;

--- a/framework/core/less/admin/AdminNav.less
+++ b/framework/core/less/admin/AdminNav.less
@@ -216,10 +216,12 @@
 
 .ExtensionNavButton {
   .Badge {
-    margin-left: 5px;
     .Badge--size(16px);
     font-size: 10px;
     font-weight: bold;
+    position: absolute;
+    right: 33px;
+    margin: 3px 0;
 
     &.Badge--danger {
       --badge-bg: @error-color;


### PR DESCRIPTION
## Summary

In the admin sidebar's extension list, abandoned extensions show a red `!` danger badge (or yellow warning badge for abandonment without a replacement). When the extension's display name is long enough to trigger the ellipsis-truncation on `.Button-labelText`, the badge — rendered as a sibling of the title text inside the truncated label — gets clipped by the `overflow: hidden` and disappears off the right edge.

Originally reported in #4592 against 1.x; the same code path exists on 2.x.

## Fix

Move the badge from inside the truncated button label into `ExtensionLinkButton::statusItems()`, alongside the enabled/disabled status dot. The status items render as siblings of `.Button-label` (not inside it), so they're not affected by the label's `overflow: hidden`.

Position the badge absolutely to the left of the existing status dot. Vertically align it by matching the dot's `margin`-based centering — the dot uses `margin: 6px 5px` to center its 10px height in the button content area; the 16px-tall badge uses `margin: 3px 0` to center identically.

## Files

- **`framework/core/js/src/admin/components/AdminNav.js`** — stop rendering the badge inside the `ExtensionLinkButton` children.
- **`framework/core/js/src/admin/components/ExtensionLinkButton.js`** — add the badge to the `statusItems` `ItemList` when `extension.abandoned` is truthy, with priority `10` so it renders before the status dot.
- **`framework/core/less/admin/AdminNav.less`** — position the badge absolutely, to the left of the status dot, vertically aligned to match.

## Test plan

- [x] Reproduced the original bug on dev: with a long-named extension marked abandoned (via `app.data.extensions[id].abandoned = '...'`), the danger badge is invisible / clipped off the right edge of the sidebar.
- [x] With the fix applied: the badge is visible adjacent to the status dot regardless of name length.
- [x] Non-abandoned extensions still render the status dot in the same position with no badge.
- [x] Label text still truncates with ellipsis on long names.
- [x] Visual alignment of badge and dot verified.

Closes #4592