### PR TITLE
[1.x] chore: peg composer version to LTS

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -151,7 +151,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:2.8
+          tools: phpunit, composer:2.2
           ini-values: ${{ matrix.php_ini_values }}
 
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
@@ -206,7 +206,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:2.8
+          tools: phpunit, composer:2.2
           ini-values: ${{ matrix.php_ini_values }}
 
       - name: Install Composer dependencies

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           php-version: '8.3'
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
-          tools: composer:2.8
+          tools: composer:2.2
 
       # Needed since tsconfig draws typings from vendor folder.
       - name: Install Composer dependencies


### PR DESCRIPTION
Context:
* https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens
* https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/
* https://github.com/flarum/framework/pull/4294
* https://github.com/composer/composer/issues/12849
* https://github.com/composer/composer/pull/12853/changes