### PR TITLE
[2.x] fix(realtime): only force-reconnect on iOS visibilitychange

### DIFF
--- a/extensions/realtime/js/src/forum/extend/Application.ts
+++ b/extensions/realtime/js/src/forum/extend/Application.ts
@@ -5,6 +5,7 @@ import Application from 'flarum/common/Application';
 import RealtimeState from '../RealtimeState';
 import NotificationToast from '../components/NotificationToast';
 import NotificationToastState from '../states/NotificationToastState';
+import isIOS from '../utils/isIOS';
 
 export default function () {
   extend(Application.prototype, 'mount' as any, function () {
@@ -78,12 +79,17 @@ export default function () {
     app.websocket = new Pusher(wsKey, pusherOptions);
     setupChannels(app.websocket);
 
-    // iOS Safari silently drops WebSocket connections when the tab is
-    // backgrounded or the device sleeps, without firing `close` — pusher-js's
-    // built-in recovery never triggers, so realtime updates go missing until
-    // the page is reloaded. iOS also bfcaches pages on app-switch, which
-    // restores via `pageshow` (persisted=true) and does NOT fire
-    // `visibilitychange` on return. We therefore hook both events.
+    // iOS browsers (all WebKit) silently drop WebSocket connections when
+    // the tab is backgrounded or the device sleeps, without firing `close`
+    // — pusher-js's built-in recovery never triggers, so realtime updates
+    // go missing until the page is reloaded. iOS also bfcaches pages on
+    // app-switch, which restores via `pageshow` (persisted=true) and does
+    // NOT fire `visibilitychange` on return. We therefore hook both events.
+    //
+    // The visibilitychange path is gated on `isIOS()`: desktop browsers
+    // (and Android) maintain the WebSocket fine across tab backgrounding
+    // and don't need a forced reconnect, which would otherwise cause an
+    // unnecessary discussion-list refetch on every tab-switch return.
     //
     // `forceReconnect` constructs a fresh Pusher instance rather than
     // calling `connect()` on the existing one. pusher-js 7.6's default
@@ -134,7 +140,7 @@ export default function () {
       if (hiddenSince === null) return;
       const wasHiddenFor = Date.now() - hiddenSince;
       hiddenSince = null;
-      if (wasHiddenFor > RECONNECT_HIDDEN_THRESHOLD_MS) {
+      if (wasHiddenFor > RECONNECT_HIDDEN_THRESHOLD_MS && isIOS()) {
         forceReconnect();
       }
     });

--- a/extensions/realtime/js/src/forum/utils/isIOS.ts
+++ b/extensions/realtime/js/src/forum/utils/isIOS.ts
@@ -1,0 +1,22 @@
+/**
+ * Detect whether the current browser is running on iOS / iPadOS.
+ *
+ * All iOS browsers (Safari, Chrome, Firefox, etc.) use WebKit under the hood
+ * and inherit Safari's WebSocket-backgrounding pathology — so this needs to
+ * be broader than `isSafariMobile()` (which excludes Chrome/Firefox on iOS).
+ *
+ * Detects iPadOS 13+ via the MacIntel + maxTouchPoints quirk: iPadOS 13+
+ * reports `navigator.platform === 'MacIntel'` but `maxTouchPoints > 1`,
+ * which desktop macOS never does.
+ */
+export default function isIOS(): boolean {
+  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+    return true;
+  }
+
+  if (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

#4654 added a `visibilitychange` listener that constructs a fresh Pusher instance and refreshes the visible discussion list whenever the tab has been hidden for more than 5 seconds. That workaround was needed on iOS Safari, where backgrounding silently drops the WebSocket without firing `close`. On every other platform the WebSocket survives tab backgrounding fine — but the listener still fired unconditionally, so on desktop Firefox/Chrome (and Android) every "switch to another tab, come back" cycle triggered an unnecessary `GET /api/discussions` request and a full IndexPage refresh.

## Fix

Gate the `visibilitychange`-triggered `forceReconnect()` on `isIOS()`. The `pageshow(persisted=true)` path stays unconditional — bfcache restore only happens on browsers that bfcached the page, and at that point the WebSocket was definitely torn down regardless of platform.

A new `isIOS()` utility is added rather than reusing the existing `isSafariMobile()` core helper, because `isSafariMobile()` excludes iOS Chrome (`CriOS`) and iOS Firefox (`FxiOS`) — both of which use WebKit on iOS and share the same backgrounding pathology this workaround was written for. `isIOS()` also detects iPadOS 13+ via the `MacIntel` + `maxTouchPoints > 1` quirk (iPadOS reports `navigator.platform === 'MacIntel'` but desktop Macs have `maxTouchPoints === 0`).

## Test plan

- [x] **Mac Firefox**: switch tabs for ≥10s, come back. No `GET /api/discussions` request fires. Discussion list does not visibly refresh. (Was happening before this fix.)
- [x] **iOS**: behavior unchanged — backgrounding for ≥10s and foregrounding still triggers the reconnect + discussion list refresh, as required by #4597.
- [x] **bfcache** (browsers that use it): unaffected — the `pageshow(persisted=true)` path is unchanged.

Regression from #4654.