### PR TITLE
[2.x] fix(search): harden pgsql search configuration handling

### DIFF
--- a/framework/core/src/Discussion/Search/FulltextFilter.php
+++ b/framework/core/src/Discussion/Search/FulltextFilter.php
@@ -121,16 +121,18 @@ class FulltextFilter extends AbstractFulltextFilter
 
         $grammar = $query->getGrammar();
 
-        $matchCondition = "to_tsvector('$searchConfig', ".$grammar->wrap('posts.content').") @@ plainto_tsquery('$searchConfig', ?)";
-        $matchScore = "ts_rank(to_tsvector('$searchConfig', ".$grammar->wrap('posts.content')."), plainto_tsquery('$searchConfig', ?))";
-        $matchTitleCondition = "to_tsvector('$searchConfig', ".$grammar->wrap('discussions.title').") @@ plainto_tsquery('$searchConfig', ?)";
-        $matchTitleScore = "ts_rank(to_tsvector('$searchConfig', ".$grammar->wrap('discussions.title')."), plainto_tsquery('$searchConfig', ?))";
+        $matchCondition = 'to_tsvector(?::regconfig, '.$grammar->wrap('posts.content').') @@ plainto_tsquery(?::regconfig, ?)';
+        $matchScore = 'ts_rank(to_tsvector(?::regconfig, '.$grammar->wrap('posts.content').'), plainto_tsquery(?::regconfig, ?))';
+        $matchTitleCondition = 'to_tsvector(?::regconfig, '.$grammar->wrap('discussions.title').') @@ plainto_tsquery(?::regconfig, ?)';
+        $matchTitleScore = 'ts_rank(to_tsvector(?::regconfig, '.$grammar->wrap('discussions.title').'), plainto_tsquery(?::regconfig, ?))';
         $mostRelevantPostId = 'CAST(SPLIT_PART(STRING_AGG(CAST('.$grammar->wrap('posts.id')." AS VARCHAR), ',' ORDER BY ".$matchScore.' DESC, '.$grammar->wrap('posts.number')."), ',', 1) AS INTEGER) as most_relevant_post_id";
+
+        $matchBindings = [$searchConfig, $searchConfig, $value];
 
         $discussionSubquery = Discussion::select('id')
             ->selectRaw('NULL as score')
             ->selectRaw('first_post_id as most_relevant_post_id')
-            ->whereRaw($matchTitleCondition, [$value]);
+            ->whereRaw($matchTitleCondition, $matchBindings);
 
         // Construct a subquery to fetch discussions which contain relevant
         // posts. Retrieve the collective relevance of each discussion's posts,
@@ -138,10 +140,10 @@ class FulltextFilter extends AbstractFulltextFilter
         // the ID of the most relevant post.
         $subquery = Post::whereVisibleTo($state->getActor())
             ->select('posts.discussion_id')
-            ->selectRaw("SUM($matchScore) as score", [$value])
-            ->selectRaw($mostRelevantPostId, [$value])
+            ->selectRaw("SUM($matchScore) as score", $matchBindings)
+            ->selectRaw($mostRelevantPostId, $matchBindings)
             ->where('posts.type', 'comment')
-            ->whereRaw($matchCondition, [$value])
+            ->whereRaw($matchCondition, $matchBindings)
             ->groupBy('posts.discussion_id')
             ->union($discussionSubquery);
 
@@ -168,8 +170,8 @@ class FulltextFilter extends AbstractFulltextFilter
                 ->fromSub($query, 'discussions')
         );
 
-        $state->setDefaultSort(function (Builder $query) use ($value, $matchTitleScore) {
-            $query->orderByRaw("$matchTitleScore desc", [$value]);
+        $state->setDefaultSort(function (Builder $query) use ($matchBindings, $matchTitleScore) {
+            $query->orderByRaw("$matchTitleScore desc", $matchBindings);
             $query->orderBy('discussions.score', 'desc');
         });
     }

--- a/framework/core/src/Post/Filter/FulltextFilter.php
+++ b/framework/core/src/Post/Filter/FulltextFilter.php
@@ -70,13 +70,15 @@ class FulltextFilter extends AbstractFulltextFilter
 
         $grammar = $query->getGrammar();
 
-        $matchCondition = "to_tsvector('$searchConfig', ".$grammar->wrap('posts.content').") @@ plainto_tsquery('$searchConfig', ?)";
-        $matchScore = "ts_rank(to_tsvector('$searchConfig', ".$grammar->wrap('posts.content')."), plainto_tsquery('$searchConfig', ?))";
+        $matchCondition = 'to_tsvector(?::regconfig, '.$grammar->wrap('posts.content').') @@ plainto_tsquery(?::regconfig, ?)';
+        $matchScore = 'ts_rank(to_tsvector(?::regconfig, '.$grammar->wrap('posts.content').'), plainto_tsquery(?::regconfig, ?))';
 
-        $query->whereRaw($matchCondition, [$value]);
+        $matchBindings = [$searchConfig, $searchConfig, $value];
 
-        $state->setDefaultSort(function (Builder $query) use ($value, $matchScore) {
-            $query->orderByRaw($matchScore.' desc', [$value]);
+        $query->whereRaw($matchCondition, $matchBindings);
+
+        $state->setDefaultSort(function (Builder $query) use ($matchBindings, $matchScore) {
+            $query->orderByRaw($matchScore.' desc', $matchBindings);
         });
     }
 }

--- a/framework/core/tests/integration/api/discussions/PgsqlSearchConfigurationInjectionTest.php
+++ b/framework/core/tests/integration/api/discussions/PgsqlSearchConfigurationInjectionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class PgsqlSearchConfigurationInjectionTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->database()->getDriverName() !== 'pgsql') {
+            $this->markTestSkipped('Postgres-specific filter path.');
+        }
+
+        $this->database()->rollBack();
+
+        $this->database()->table('discussions')->insert($this->rowsThroughFactory(Discussion::class, [
+            ['id' => 1, 'title' => 'hello world', 'user_id' => 1],
+        ]));
+        $this->database()->table('posts')->insert($this->rowsThroughFactory(Post::class, [
+            ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'content' => '<t><p>hello world body</p></t>'],
+        ]));
+
+        $this->database()->beginTransaction();
+
+        $this->populateDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->database()->table('discussions')->delete();
+        $this->database()->table('posts')->delete();
+
+        // Reset the setting in case the post-condition assertion was hit before reset.
+        $this->database()->table('settings')->where('key', 'pgsql_search_configuration')->update(['value' => 'english']);
+    }
+
+    #[Test]
+    public function baseline_default_search_config_returns_200(): void
+    {
+        // Sanity check: with the default config, a search succeeds.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['q' => 'hello']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function malicious_search_config_is_not_interpolated_into_sql(): void
+    {
+        // Admin (or anyone who can write to the settings table) attempts to inject
+        // SQL via the pgsql_search_configuration setting.
+        $payload = "english') || pg_sleep(0) || ('";
+
+        /** @var \Flarum\Settings\SettingsRepositoryInterface $settings */
+        $settings = $this->app()->getContainer()->make(\Flarum\Settings\SettingsRepositoryInterface::class);
+        $settings->set('pgsql_search_configuration', $payload);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['q' => 'hello']])
+        );
+
+        $body = (string) $response->getBody();
+
+        // Under the original vulnerability, the payload was concatenated into
+        // SQL as code: Postgres parsed `tsvector || pg_sleep(...)` and raised
+        // SQLSTATE 42883 "operator does not exist: tsvector || void".
+        //
+        // Under the fix, the payload is bound as a parameter and cast to
+        // `regconfig`. Postgres rejects it with SQLSTATE 42602 "invalid name
+        // syntax" — the value reached the DB as data, not code.
+        //
+        // We assert on the SQLSTATE, which is unambiguous: 42883 ↔ injection
+        // open, 42602 ↔ injection closed.
+        $this->assertStringNotContainsString(
+            '42883',
+            $body,
+            "Postgres tried to evaluate the payload as SQL (operator-does-not-exist error). Injection still possible.\nResponse body: $body"
+        );
+        $this->assertStringContainsString(
+            '42602',
+            $body,
+            "Expected Postgres to reject the payload at the regconfig cast (SQLSTATE 42602).\nResponse body: $body"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The `pgsql_search_configuration` setting was interpolated directly into the SQL strings built by `Discussion\Search\FulltextFilter::pgsql()` and `Post\Filter\FulltextFilter::pgsql()`, allowing a second-order SQL injection: an admin could write a payload to the setting and any subsequent search would execute it.
- Switched to `?::regconfig` parameter binding for the search configuration. The value is now treated as data, and Postgres rejects unknown configuration names at the cast — defence in depth for free.
- Added a Postgres-only integration test that exercises the reported attack chain end-to-end. It uses the `SQLSTATE` returned by Postgres as an unambiguous signal: `42883` (operator-does-not-exist on `tsvector || pg_sleep`) means the payload was treated as code; `42602` (`invalid name syntax` from the `regconfig` cast) means it was treated as data. Verified to fail against the un-patched code and pass against the patched code.

## Scope

- Admin-only (the setting is writable only with admin privileges).
- Postgres-only — MySQL/MariaDB and SQLite use different fulltext paths that already parameterise correctly.
- Flarum 1.x has no Postgres support and is unaffected.
- Non-breaking: SQL semantics are preserved; no public API changes.

## Test plan

- [x] `composer test:integration` against Postgres 16 with the new test passes.
- [x] Existing fulltext tests (`FulltextSearch|FulltextFilter|ListWithFulltext`) pass against Postgres with the fix.
- [x] Full `tests/integration/api/discussions` suite (39 tests) passes against Postgres.
- [x] New test confirmed to fail against the un-patched code (detecting `SQLSTATE 42883`) — i.e. the test would have caught the regression.

## Credit

Reported via the Flarum.org foundation contact form by **userb1ank**.