### PR TITLE
[2.x] fix(api): guard EloquentBuffer against orphaned/mock models

### DIFF
--- a/framework/core/src/Api/Resource/EloquentBuffer.php
+++ b/framework/core/src/Api/Resource/EloquentBuffer.php
@@ -114,7 +114,18 @@ abstract class EloquentBuffer
             return $query;
         };
 
-        $collection = $model->newCollection($models);
+        // Filter out models that do not exist in the database (e.g. mock models
+        // created by the JSON:API BelongsTo linkage shortcut for orphaned foreign
+        // keys). Passing them to Laravel's load()/loadAggregate() would crash
+        // when mapping query results back to the collection.
+        $collection = $model->newCollection($models)
+            ->filter(fn (Model $m) => $m->exists && $m->getKey() !== null);
+
+        self::setBuffer($model, $relationName, $aggregate, []);
+
+        if ($collection->isEmpty()) {
+            return;
+        }
 
         if (! $aggregate && $relationship) {
             $collection->load([$relationName => $loader]);
@@ -140,7 +151,5 @@ abstract class EloquentBuffer
             $alias = Str::snake($aggregate['name']);
             $collection->loadAggregate(["$relationName as $alias" => $loader], $aggregate['column'], $aggregate['function']);
         }
-
-        self::setBuffer($model, $relationName, $aggregate, []);
     }
 }

--- a/framework/core/tests/integration/api/EloquentBufferTest.php
+++ b/framework/core/tests/integration/api/EloquentBufferTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api;
+
+use Flarum\Api\Context;
+use Flarum\Api\Resource\EloquentBuffer;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\Attributes\Test;
+use Tobyz\JsonApiServer\JsonApi;
+
+class EloquentBufferTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function aggregate_load_does_not_crash_for_models_that_do_not_exist_in_the_database()
+    {
+        $this->app();
+
+        // Simulate the JSON:API BelongsTo linkage shortcut for an orphaned FK:
+        // a model created via newInstance()->forceFill([key => $orphanId]) with
+        // exists=false. Without a guard, EloquentBuffer::load() would forward
+        // this to Laravel's Collection::loadAggregate(), which fatals when
+        // mapping results because the orphaned key has no matching DB row.
+        $orphan = (new User())->forceFill(['id' => 999999]);
+
+        $aggregate = [
+            'name' => 'postCount',
+            'relation' => 'posts',
+            'column' => '*',
+            'function' => 'count',
+            'constrain' => null,
+        ];
+
+        EloquentBuffer::add($orphan, 'posts', $aggregate);
+
+        EloquentBuffer::load(
+            $orphan,
+            'posts',
+            null,
+            new Context(new JsonApi(), new ServerRequest()),
+            $aggregate,
+        );
+
+        $this->assertFalse($orphan->exists);
+    }
+}


### PR DESCRIPTION
## Summary
- Filter models with `exists=false` (or a null key) out of the collection passed to `load()`/`loadAggregate()` in `EloquentBuffer::load()`, and always clear the buffer entry so stale mocks don't accumulate.

## Background
Closes #4667.

Laravel's `Illuminate\Database\Eloquent\Collection::loadAggregate()` (see `Collection.php:127`) reads attributes off the per-key result map without a null check:

```php
$extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
```

If a model in the source collection has a key that doesn't match any DB row, `$models->get(...)` is `null` and the request fatals with `Call to a member function getAttributes() on null`.

The JSON:API BelongsTo linkage shortcut in `EloquentResource::getRelationshipValue()` (`vendor/flarum/json-api-server`) and the mirror in our `AbstractDatabaseResource::getRelationshipValue()` create exactly this kind of mock model:

```php
return $related->newInstance()->forceFill([$related->getKeyName() => $key]);
```

When such a mock ends up in `EloquentBuffer` for a `relationAggregate` field (e.g. fof/upload's `countRelation('foffiles')` on `UserResource`), the flush at the end of the request crashes the whole response with a 500 — affecting any page that serializes that resource (including the forum index for guests).

## Fix
In `EloquentBuffer::load()`:

- Filter the buffered models down to those that actually exist and have a non-null key before constructing the collection that gets passed to `load()` / `loadAggregate()`.
- Clear the buffer entry unconditionally (moved above the early return) so the same stale mocks aren't re-walked on subsequent loads.

## Test plan
- [x] New regression test `EloquentBufferTest::aggregate_load_does_not_crash_for_models_that_do_not_exist_in_the_database` — fails on `2.x` with the exact stack from the issue, passes with this fix.
- [x] `tests/integration/extenders/ApiResourceTest.php` — 41/41 pass.
- [x] `tests/integration/api/discussions/` — 39/39 pass.
- [x] `tests/integration/api/users/` + `tests/integration/api/posts/` — 136/136 pass.