### PR TITLE
[2.x] Add getPausedQueues() to QueueFactory for illuminate/queue v13.11+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         "illuminate/filesystem": "^13.0",
         "illuminate/hashing": "^13.0",
         "illuminate/mail": "^13.0",
-        "illuminate/queue": "^13.0",
+        "illuminate/queue": "^13.11",
         "illuminate/session": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/validation": "^13.0",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -55,7 +55,7 @@
         "illuminate/filesystem": "^13.0",
         "illuminate/hashing": "^13.0",
         "illuminate/mail": "^13.0",
-        "illuminate/queue": "^13.0",
+        "illuminate/queue": "^13.11",
         "illuminate/session": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/validation": "^13.0",

--- a/framework/core/src/Queue/QueueFactory.php
+++ b/framework/core/src/Queue/QueueFactory.php
@@ -48,7 +48,7 @@ class QueueFactory implements Factory
      * Determine if a queue is paused.
      *
      * This is a no-op implementation since Flarum's simplified queue factory
-     * does not support queue pausing. Laravel 12's Worker expects this method
+     * doesn't support queue pausing. Laravel 12's Worker expects this method
      * to exist on the queue manager.
      *
      * @param string $connection

--- a/framework/core/src/Queue/QueueFactory.php
+++ b/framework/core/src/Queue/QueueFactory.php
@@ -48,7 +48,7 @@ class QueueFactory implements Factory
      * Determine if a queue is paused.
      *
      * This is a no-op implementation since Flarum's simplified queue factory
-     * doesn't support queue pausing. Laravel 12's Worker expects this method
+     * does not support queue pausing. Laravel 12's Worker expects this method
      * to exist on the queue manager.
      *
      * @param string $connection
@@ -58,5 +58,19 @@ class QueueFactory implements Factory
     public function isPaused($connection, $queue)
     {
         return false;
+    }
+
+    /**
+     * Get the list of paused queues.
+     *
+     * This is a no-op implementation since Flarum's simplified queue factory
+     * does not support queue pausing. illuminate/queue v13.11+ expects this
+     * method to exist on the queue manager.
+     *
+     * @return array
+     */
+    public function getPausedQueues(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
Fixes #4671
Replaces #4672, which was based on the wrong branch.

illuminate/queue added getPausedQueues() to queue drivers in November 2025 as part of the Queue Pause/Resume feature — laravel/framework#57800.

In v13.11, Worker.php began calling this method on all queue factories — including Flarum's custom QueueFactory, which doesn't implement it, causing the queue worker to crash with «Call to undefined method» and breaking all queued notifications and mail silently.

**Changes proposed in this pull request:**
- Added `getPausedQueues(): array` to `QueueFactory` with a no-op implementation, consistent with the existing `isPaused()` pattern.
- Updated `illuminate/queue` constraint to `^13.11` in `composer.json`.

**Reviewers should focus on:**
Whether returning an empty array is the correct behaviour, or if Flarum should implement actual queue pausing support in the future.