### PR TITLE
[2.x] fix(tooltip): resolve native tooltip flash, async teardown leaks, and dynamic text

### DIFF
--- a/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
@@ -86,7 +86,7 @@ export default class AnnouncementsWidget extends DashboardWidget {
               </Tooltip>
             )}
             <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
-              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
+              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={(e: any) => { this.toggleHidden(); e.currentTarget.blur(); }} />
             </Tooltip>
           </div>
         </div>

--- a/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
@@ -86,7 +86,14 @@ export default class AnnouncementsWidget extends DashboardWidget {
               </Tooltip>
             )}
             <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
-              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={(e: any) => { this.toggleHidden(); e.currentTarget.blur(); }} />
+              <Button
+                className="Button Button--icon"
+                icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'}
+                onclick={(e: any) => {
+                  this.toggleHidden();
+                  e.currentTarget.blur();
+                }}
+              />
             </Tooltip>
           </div>
         </div>

--- a/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementsWidget.tsx
@@ -86,14 +86,7 @@ export default class AnnouncementsWidget extends DashboardWidget {
               </Tooltip>
             )}
             <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
-              <Button
-                className="Button Button--icon"
-                icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'}
-                onclick={(e: any) => {
-                  this.toggleHidden();
-                  e.currentTarget.blur();
-                }}
-              />
+              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
             </Tooltip>
           </div>
         </div>

--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -113,6 +113,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
   private oldVisibility: boolean | undefined;
 
   private shouldRecreateTooltip: boolean = false;
+  private shouldUpdateText: boolean = false;
   private shouldChangeTooltipVisibility: boolean = false;
 
   view(vnode: Mithril.Vnode<TooltipAttrs, this>) {
@@ -143,10 +144,10 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
     const realText = this.getRealText();
 
-    // We need to recreate the tooltip if the text has changed
+    // We need to update the tooltip text if it has changed
     if (realText !== this.oldText) {
       this.oldText = realText;
-      this.shouldRecreateTooltip = true;
+      this.shouldUpdateText = true;
     }
 
     if (tooltipVisible !== this.oldVisibility) {
@@ -201,6 +202,11 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
     this.checkDomNodeChanged();
     this.recreateTooltip();
+
+    if (this.shouldUpdateText) {
+      this.updateText();
+      this.shouldUpdateText = false;
+    }
   }
 
   onremove(vnode: Mithril.VnodeDOM<TooltipAttrs, this>) {
@@ -217,6 +223,11 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
   private recreateTooltip() {
     if (this.shouldRecreateTooltip && this.childDomNode !== null) {
+      const tooltip = $(this.childDomNode).data('bs.tooltip');
+      if (tooltip && tooltip.$tip) {
+        tooltip.$tip.removeClass('fade');
+      }
+
       $(this.childDomNode).tooltip(
         'destroy',
         // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
@@ -229,6 +240,20 @@ export default class Tooltip extends Component<TooltipAttrs> {
     if (this.shouldChangeTooltipVisibility) {
       this.shouldChangeTooltipVisibility = false;
       this.updateVisibility();
+    }
+  }
+
+  private updateText() {
+    if (this.childDomNode === null) return;
+
+    const realText = this.getRealText();
+    this.childDomNode.setAttribute('data-original-title', realText);
+    this.childDomNode.setAttribute('aria-label', realText);
+
+    const tooltip = $(this.childDomNode).data('bs.tooltip');
+    if (tooltip && tooltip.$tip && tooltip.$tip.hasClass('in')) {
+      tooltip.$tip.find('.tooltip-inner')[this.attrs.html ? 'html' : 'text'](realText);
+      tooltip.show();
     }
   }
 
@@ -268,12 +293,13 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const trigger = typeof tooltipVisible === 'boolean' ? 'manual' : classList('hover', [showOnFocus && 'focus']);
 
     const realText = this.getRealText();
-    this.childDomNode.setAttribute('title', realText);
     this.childDomNode.setAttribute('aria-label', realText);
+    this.childDomNode.removeAttribute('title');
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
     $(this.childDomNode).tooltip(
       {
+        title: realText,
         html,
         delay,
         placement: position,
@@ -301,6 +327,17 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
 
     if (domNode && !domNode.isSameNode(this.childDomNode)) {
+      if (this.childDomNode) {
+        const tooltip = $(this.childDomNode).data('bs.tooltip');
+        if (tooltip && tooltip.$tip) {
+          tooltip.$tip.removeClass('fade');
+        }
+        $(this.childDomNode).tooltip(
+          'destroy',
+          // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+          'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+        );
+      }
       this.childDomNode = domNode;
       this.shouldRecreateTooltip = true;
     }


### PR DESCRIPTION
**Fixes #4596**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**`Tooltip` component (`common/components/Tooltip.tsx`):**
- Text-only changes now update the existing Bootstrap tooltip in-place (via `data-original-title` and `.tooltip-inner`) instead of destroying and recreating the entire instance, which caused an async race condition that left the element with no active tooltip.
- Tooltip is now initialized via the Bootstrap `title` config option with the DOM `title` attribute explicitly removed, preventing the
  browser's native tooltip from ever appearing as a fallback.
- After an in-place text update, `tooltip.show()` is called to force Bootstrap to recalculate positioning, preventing vertical
  misalignment when surrounding layout shifts (e.g. the announcement list expanding/collapsing).
- The `.fade` CSS class is stripped before every `destroy()` call to force synchronous cleanup, preventing stranded tooltip DOM nodes and race conditions during rapid updates.
- `checkDomNodeChanged()` now properly destroys the tooltip on the old DOM node before reassigning, fixing a pre-existing leak where swapped nodes left orphaned tooltip instances.

**`AnnouncementsWidget` (`admin/components/AnnouncementsWidget.tsx`):**
- Added `e.currentTarget.blur()` to the visibility toggle button's click handler so the tooltip dismisses on mouse-out after clicking.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

For the `blur()` call in AnnouncementsWidget, I am not fully sure if this is the right approach. The issue is that after clicking the show/hide button, the browser keeps the button focused, which causes the tooltip to stay visible even after the cursor leaves (because tooltips trigger on both `hover` and `focus`). The `blur()` call fixes this, but other buttons in Flarum also has the same issue (e.g. the Tools button on top, shown in the video below).

So I am not sure if this is a intended design or this should be fix (if we are fixing that at a broader scope, then probably I should not include the fix for AnnouncementsWidget in this PR). I will leave this to the team to decide.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Before applying `blur()`:

https://github.com/user-attachments/assets/5a528a30-7f18-4710-ab7f-4af324e1c16e

After applying `blur()`:

https://github.com/user-attachments/assets/1d1454b7-5a58-43c1-9a7e-8e080da379b0

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
