### PR TITLE
[1.x] fix(tooltip): resolve native tooltip flash, async teardown leaks, and dynamic text

### DIFF
--- a/framework/core/js/src/admin/components/AnnouncementWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementWidget.tsx
@@ -84,7 +84,14 @@ export default class AnnouncementsWidget extends DashboardWidget {
               </Tooltip>
             )}
             <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
-              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
+              <Button
+                className="Button Button--icon"
+                icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'}
+                onclick={(e: any) => {
+                  this.toggleHidden();
+                  e.currentTarget.blur();
+                }}
+              />
             </Tooltip>
           </div>
         </div>

--- a/framework/core/js/src/admin/components/AnnouncementWidget.tsx
+++ b/framework/core/js/src/admin/components/AnnouncementWidget.tsx
@@ -84,14 +84,7 @@ export default class AnnouncementsWidget extends DashboardWidget {
               </Tooltip>
             )}
             <Tooltip text={app.translator.trans(this.hidden ? 'core.admin.announcements.show' : 'core.admin.announcements.hide')}>
-              <Button
-                className="Button Button--icon"
-                icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'}
-                onclick={(e: any) => {
-                  this.toggleHidden();
-                  e.currentTarget.blur();
-                }}
-              />
+              <Button className="Button Button--icon" icon={this.hidden ? 'fas fa-eye' : 'fas fa-eye-slash'} onclick={() => this.toggleHidden()} />
             </Tooltip>
           </div>
         </div>

--- a/framework/core/js/src/common/components/Tooltip.tsx
+++ b/framework/core/js/src/common/components/Tooltip.tsx
@@ -104,6 +104,7 @@ export default class Tooltip extends Component<TooltipAttrs> {
   private oldVisibility: boolean | undefined;
 
   private shouldRecreateTooltip: boolean = false;
+  private shouldUpdateText: boolean = false;
   private shouldChangeTooltipVisibility: boolean = false;
 
   view(vnode: Mithril.Vnode<TooltipAttrs, this>) {
@@ -124,10 +125,10 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
     const realText = this.getRealText();
 
-    // We need to recreate the tooltip if the text has changed
+    // We need to update the tooltip text if it has changed
     if (realText !== this.oldText) {
       this.oldText = realText;
-      this.shouldRecreateTooltip = true;
+      this.shouldUpdateText = true;
     }
 
     if (tooltipVisible !== this.oldVisibility) {
@@ -182,10 +183,20 @@ export default class Tooltip extends Component<TooltipAttrs> {
 
     this.checkDomNodeChanged();
     this.recreateTooltip();
+
+    if (this.shouldUpdateText) {
+      this.updateText();
+      this.shouldUpdateText = false;
+    }
   }
 
   private recreateTooltip() {
     if (this.shouldRecreateTooltip && this.childDomNode !== null) {
+      const tooltip = $(this.childDomNode).data('bs.tooltip');
+      if (tooltip && tooltip.$tip) {
+        tooltip.$tip.removeClass('fade');
+      }
+
       $(this.childDomNode).tooltip(
         'destroy',
         // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
@@ -198,6 +209,20 @@ export default class Tooltip extends Component<TooltipAttrs> {
     if (this.shouldChangeTooltipVisibility) {
       this.shouldChangeTooltipVisibility = false;
       this.updateVisibility();
+    }
+  }
+
+  private updateText() {
+    if (this.childDomNode === null) return;
+
+    const realText = this.getRealText();
+    this.childDomNode.setAttribute('data-original-title', realText);
+    this.childDomNode.setAttribute('aria-label', realText);
+
+    const tooltip = $(this.childDomNode).data('bs.tooltip');
+    if (tooltip && tooltip.$tip && tooltip.$tip.hasClass('in')) {
+      tooltip.$tip.find('.tooltip-inner')[this.attrs.html ? 'html' : 'text'](realText);
+      tooltip.show();
     }
   }
 
@@ -236,12 +261,13 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const trigger = typeof tooltipVisible === 'boolean' ? 'manual' : classList('hover', [showOnFocus && 'focus']);
 
     const realText = this.getRealText();
-    this.childDomNode.setAttribute('title', realText);
     this.childDomNode.setAttribute('aria-label', realText);
+    this.childDomNode.removeAttribute('title');
 
     // https://getbootstrap.com/docs/3.3/javascript/#tooltips-options
     $(this.childDomNode).tooltip(
       {
+        title: realText,
         html,
         delay,
         placement: position,
@@ -268,6 +294,17 @@ export default class Tooltip extends Component<TooltipAttrs> {
     const domNode = (this.firstChild as Mithril.VnodeDOM<any, any>).dom as HTMLElement;
 
     if (domNode && !domNode.isSameNode(this.childDomNode)) {
+      if (this.childDomNode) {
+        const tooltip = $(this.childDomNode).data('bs.tooltip');
+        if (tooltip && tooltip.$tip) {
+          tooltip.$tip.removeClass('fade');
+        }
+        $(this.childDomNode).tooltip(
+          'destroy',
+          // @ts-expect-error We don't want this arg to be part of the public API. It only exists to prevent deprecation warnings when using `$.tooltip` in this component.
+          'DANGEROUS_tooltip_jquery_fn_deprecation_exempt'
+        );
+      }
       this.childDomNode = domNode;
       this.shouldRecreateTooltip = true;
     }


### PR DESCRIPTION
**Fixes #4596**

Backport fix https://github.com/flarum/framework/pull/4674 to 1.x

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Almost same as 2.x

**`Tooltip` component (`common/components/Tooltip.tsx`):**
- Text-only changes now update the existing Bootstrap tooltip in-place (via `data-original-title` and `.tooltip-inner`) instead of destroying and recreating the entire instance, which caused an async race condition that left the element with no active tooltip.
- Tooltip is now initialized via the Bootstrap `title` config option with the DOM `title` attribute explicitly removed, preventing the
  browser's native tooltip from ever appearing as a fallback.
- After an in-place text update, `tooltip.show()` is called to force Bootstrap to recalculate positioning, preventing vertical
  misalignment when surrounding layout shifts (e.g. the announcement list expanding/collapsing).
- The `.fade` CSS class is stripped before every `destroy()` call to force synchronous cleanup, preventing stranded tooltip DOM nodes and race conditions during rapid updates.
- `checkDomNodeChanged()` now properly destroys the tooltip on the old DOM node before reassigning, fixing a pre-existing leak where swapped nodes left orphaned tooltip instances.


<del>**`AnnouncementWidget` (`admin/components/AnnouncementWidget.tsx`):**
Added `e.currentTarget.blur()` to the visibility toggle button's click handler so the tooltip dismisses on mouse-out after clicking. </del> Dropped as discussed in https://github.com/flarum/framework/pull/4674

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

<del>Same as 2.x, I am not sure if keeping the button focused after clicking it is a intended design or a bug. I will leave this to the team to decide. </del> Dropped as discussed in https://github.com/flarum/framework/pull/4674

But one discrepancy I realised is that the file name for AnnouncementWidget in 2.x is **AnnouncementsWidget (plural)** but in 1.x it is **AnnouncementWidget (singular)**. Also I am not sure which convention would the team like to follow.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Before applying `blur()`:

https://github.com/user-attachments/assets/d0003bb4-aa4c-46d7-b916-684e994a0541

After applying `blur()`:

https://github.com/user-attachments/assets/6b4982e5-284d-4e2a-8af6-68350b853d1f


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)