### PR TITLE
[2.x] Implement content negotiation for forum error handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,13 +116,14 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "fortawesome/font-awesome": "^7.0",
+        "bitworking/mimeparse": "^2.3",
         "composer/composer": "^2.7",
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6.2",
         "dragonmantank/cron-expression": "^3.3",
         "fakerphp/faker": "^1.9.1",
         "flarum/json-api-server": "^0.1.0",
+        "fortawesome/font-awesome": "^7.0",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "*",
         "illuminate/bus": "^13.0",
@@ -156,6 +157,7 @@
         "nelexa/zip": "^4.0.2",
         "nesbot/carbon": "^3.0",
         "nikic/fast-route": "^1.3",
+        "plesk/ratchetphp": "v1.0.4",
         "psr/http-message": "^1.1",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
@@ -172,8 +174,7 @@
         "symfony/postmark-mailer": "^7.0",
         "symfony/translation": "^7.0",
         "symfony/yaml": "^7.0",
-        "wikimedia/less.php": "^5.3",
-        "plesk/ratchetphp": "v1.0.4"
+        "wikimedia/less.php": "^5.3"
     },
     "require-dev": {
         "flarum/testing-tests": "*@dev",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -37,11 +37,13 @@
     },
     "require": {
         "php": "^8.3",
-        "fortawesome/font-awesome": "^7.0",
+        "bitworking/mimeparse": "^2.3",
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6",
         "dragonmantank/cron-expression": "*",
         "fakerphp/faker": "^1.9.1",
+        "flarum/json-api-server": "^0.1.0",
+        "fortawesome/font-awesome": "^7.0",
         "franzl/whoops-middleware": "2.0",
         "guzzlehttp/guzzle": "^7.7",
         "illuminate/bus": "^13.0",
@@ -90,7 +92,6 @@
         "symfony/translation": "^7.0",
         "symfony/translation-contracts": "^2.5",
         "symfony/yaml": "^7.0",
-        "flarum/json-api-server": "^0.1.0",
         "wikimedia/less.php": "^5.3"
     },
     "require-dev": {

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -82,11 +82,13 @@ class ForumServiceProvider extends AbstractServiceProvider
         });
 
         $this->container->bind('flarum.forum.error_handler', function (Container $container) {
+            $inDebugMode = $container['flarum.config']->inDebugMode();
+
             return new HttpMiddleware\HandleErrors(
                 $container->make(Registry::class),
                 new ContentNegotiationFormatter(
-                    $container->make(JsonApiFormatter::class),
-                    $container['flarum.config']->inDebugMode() ? $container->make(WhoopsFormatter::class) : $container->make(ViewFormatter::class),
+                    new JsonApiFormatter($inDebugMode),
+                    $inDebugMode ? $container->make(WhoopsFormatter::class) : $container->make(ViewFormatter::class),
                 ),
                 $container->tagged(Reporter::class)
             );

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -13,6 +13,8 @@ use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\ErrorHandling\ContentNegotiationFormatter;
+use Flarum\Foundation\ErrorHandling\JsonApiFormatter;
 use Flarum\Foundation\ErrorHandling\Registry;
 use Flarum\Foundation\ErrorHandling\Reporter;
 use Flarum\Foundation\ErrorHandling\ViewFormatter;
@@ -82,7 +84,10 @@ class ForumServiceProvider extends AbstractServiceProvider
         $this->container->bind('flarum.forum.error_handler', function (Container $container) {
             return new HttpMiddleware\HandleErrors(
                 $container->make(Registry::class),
-                $container['flarum.config']->inDebugMode() ? $container->make(WhoopsFormatter::class) : $container->make(ViewFormatter::class),
+                new ContentNegotiationFormatter(
+                    $container->make(JsonApiFormatter::class),
+                    $container['flarum.config']->inDebugMode() ? $container->make(WhoopsFormatter::class) : $container->make(ViewFormatter::class),
+                ),
                 $container->tagged(Reporter::class)
             );
         });

--- a/framework/core/src/Foundation/ErrorHandling/ContentNegotiationFormatter.php
+++ b/framework/core/src/Foundation/ErrorHandling/ContentNegotiationFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Flarum\Foundation\ErrorHandling;
+
+use Flarum\Http\RequestUtil;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+readonly class ContentNegotiationFormatter implements HttpFormatter
+{
+    public function __construct(
+        private HttpFormatter $jsonFormatter,
+        private HttpFormatter $htmlFormatter,
+    ) {}
+
+    public function format(HandledError $error, Request $request): Response
+    {
+        /**
+         * If this request is an API request, and we got an error,
+         * return a JSON response instead of HTML.
+         */
+        if (RequestUtil::isApiRequest($request)) {
+            return $this->jsonFormatter->format($error, $request);
+        }
+
+        return $this->htmlFormatter->format($error, $request);
+    }
+}

--- a/framework/core/src/Foundation/ErrorHandling/ContentNegotiationFormatter.php
+++ b/framework/core/src/Foundation/ErrorHandling/ContentNegotiationFormatter.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Foundation\ErrorHandling;
 
 use Flarum\Http\RequestUtil;
@@ -11,7 +18,8 @@ readonly class ContentNegotiationFormatter implements HttpFormatter
     public function __construct(
         private HttpFormatter $jsonFormatter,
         private HttpFormatter $htmlFormatter,
-    ) {}
+    ) {
+    }
 
     public function format(HandledError $error, Request $request): Response
     {

--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -37,9 +37,11 @@ class RequestUtil
     }
 
     /**
+     * Determine the client's preferred content type out of the given list.
+     *
      * @param Request $request
      * @param array $types The content types to check against, in order of priority. The best match will be returned.
-     * @return string
+     * @return string The best matching type, or an empty string if none could be determined.
      */
     public static function getPreferredContentType(Request $request, array $types): string
     {
@@ -50,7 +52,17 @@ class RequestUtil
             $accept = '*/*';
         }
 
-        return Mimeparse::bestMatch($types, $accept);
+        // This is called from the error handler, so it must never throw or emit noise.
+        // `bestMatch()` returns null when nothing matches, and on a malformed Accept
+        // header (e.g. a media range without a subtype) it emits a warning and then
+        // throws. The `@` swallows that warning and the catch swallows the exception;
+        // in either case we fall back to an empty string, which callers treat as
+        // "no preference" (i.e. not an API request).
+        try {
+            return @Mimeparse::bestMatch($types, $accept) ?? '';
+        } catch (\UnexpectedValueException) {
+            return '';
+        }
     }
 
     public static function getActor(Request $request): User

--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Http;
 
+use Bitworking\Mimeparse;
 use Flarum\User\User;
 use Illuminate\Support\Str;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -16,12 +17,19 @@ use Tobyz\JsonApiServer\Exception\BadRequestException;
 
 class RequestUtil
 {
+    /**
+     * Determine if the request is an API request. We do not manually set the `Accepts` header
+     * for API requests, so we need to check the priority list to determine whether it is or not.
+     * Normal browsing requests will have `text/html` as their preferred content type, while API will have `* / *`.
+     */
     public static function isApiRequest(Request $request): bool
     {
-        return Str::contains(
-            $request->getHeaderLine('Accept'),
-            'application/vnd.api+json'
+        $preferred = self::getPreferredContentType(
+            $request,
+            ['application/vnd.api+json', 'application/json', 'text/html']
         );
+
+        return in_array($preferred, ['application/vnd.api+json', 'application/json'], true);
     }
 
     public static function isHtmlRequest(Request $request): bool
@@ -30,6 +38,13 @@ class RequestUtil
             $request->getHeaderLine('Accept'),
             'text/html'
         );
+    }
+
+    public static function getPreferredContentType(Request $request, array $types): string
+    {
+        $accept = $request->getHeaderLine('Accept');
+
+        return Mimeparse::bestMatch($types, $accept);
     }
 
     public static function getActor(Request $request): User

--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -34,15 +34,22 @@ class RequestUtil
 
     public static function isHtmlRequest(Request $request): bool
     {
-        return Str::contains(
-            $request->getHeaderLine('Accept'),
-            'text/html'
-        );
+        return ! self::isApiRequest($request);
     }
 
+    /**
+     * @param Request $request
+     * @param array $types The content types to check against, in order of priority. The best match will be returned.
+     * @return string
+     */
     public static function getPreferredContentType(Request $request, array $types): string
     {
         $accept = $request->getHeaderLine('Accept');
+
+        // We get some errors if $accept is empty, so we need to check for that and set it to */* if it is.
+        if (! filled($accept)) {
+            $accept = '*/*';
+        }
 
         return Mimeparse::bestMatch($types, $accept);
     }

--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -11,7 +11,6 @@ namespace Flarum\Http;
 
 use Bitworking\Mimeparse;
 use Flarum\User\User;
-use Illuminate\Support\Str;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Tobyz\JsonApiServer\Exception\BadRequestException;
 

--- a/framework/core/tests/integration/forum/ErrorNegotiationTest.php
+++ b/framework/core/tests/integration/forum/ErrorNegotiationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\forum;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ErrorNegotiationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Register a forum route that always errors, so we can assert how the
+        // forum error handler formats the response based on the Accept header
+        // (the regression from #3850, where forum errors were always HTML).
+        $this->extend(
+            (new Extend\Routes('forum'))
+                ->get('/test-error-negotiation', 'test.error-negotiation', ErrorThrowingRoute::class)
+        );
+    }
+
+    private function error(?string $accept): ResponseInterface
+    {
+        $request = $this->request('GET', '/test-error-negotiation');
+
+        if ($accept !== null) {
+            $request = $request->withHeader('Accept', $accept);
+        }
+
+        return $this->send($request);
+    }
+
+    #[Test]
+    public function forum_errors_are_returned_as_json_for_api_requests(): void
+    {
+        $response = $this->error('application/vnd.api+json');
+
+        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertStringContainsString('json', $response->getHeaderLine('Content-Type'));
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('errors', $body);
+    }
+
+    #[Test]
+    public function forum_errors_are_returned_as_json_for_xhr_requests_without_an_explicit_accept(): void
+    {
+        // Flarum's own XHR requests send `Accept: */*`. This is the regression from #3850:
+        // such requests previously received an HTML error page instead of JSON.
+        $response = $this->error('*/*');
+
+        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertStringContainsString('json', $response->getHeaderLine('Content-Type'));
+
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('errors', $body);
+    }
+
+    #[Test]
+    public function forum_errors_are_returned_as_html_for_browser_requests(): void
+    {
+        $response = $this->error('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8');
+
+        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertStringContainsString('html', $response->getHeaderLine('Content-Type'));
+        $this->assertNull(json_decode((string) $response->getBody(), true));
+    }
+}
+
+class ErrorThrowingRoute implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        throw (new ModelNotFoundException())->setModel('Test');
+    }
+}

--- a/framework/core/tests/unit/Foundation/ErrorHandling/ContentNegotiationFormatterTest.php
+++ b/framework/core/tests/unit/Foundation/ErrorHandling/ContentNegotiationFormatterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Foundation\ErrorHandling;
+
+use Exception;
+use Flarum\Foundation\ErrorHandling\ContentNegotiationFormatter;
+use Flarum\Foundation\ErrorHandling\HandledError;
+use Flarum\Foundation\ErrorHandling\HttpFormatter;
+use Flarum\Testing\unit\TestCase;
+use Laminas\Diactoros\ServerRequest;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ContentNegotiationFormatterTest extends TestCase
+{
+    private HandledError $error;
+    private ResponseInterface $jsonResponse;
+    private ResponseInterface $htmlResponse;
+    private HttpFormatter $json;
+    private HttpFormatter $html;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->error = new HandledError(new Exception(), 'unknown', 500);
+        $this->jsonResponse = m::mock(ResponseInterface::class);
+        $this->htmlResponse = m::mock(ResponseInterface::class);
+
+        $this->json = m::mock(HttpFormatter::class);
+        $this->html = m::mock(HttpFormatter::class);
+    }
+
+    private function formatter(): ContentNegotiationFormatter
+    {
+        return new ContentNegotiationFormatter($this->json, $this->html);
+    }
+
+    private function requestWithAccept(string $accept): ServerRequestInterface
+    {
+        return (new ServerRequest([], [], '/', 'GET'))->withHeader('Accept', $accept);
+    }
+
+    #[Test]
+    public function api_requests_are_formatted_as_json(): void
+    {
+        $request = $this->requestWithAccept('application/vnd.api+json');
+
+        $this->json->shouldReceive('format')->once()->with($this->error, $request)->andReturn($this->jsonResponse);
+        $this->html->shouldNotReceive('format');
+
+        $this->assertSame($this->jsonResponse, $this->formatter()->format($this->error, $request));
+    }
+
+    #[Test]
+    public function browser_requests_are_formatted_as_html(): void
+    {
+        $request = $this->requestWithAccept('text/html,application/xhtml+xml,*/*;q=0.8');
+
+        $this->html->shouldReceive('format')->once()->with($this->error, $request)->andReturn($this->htmlResponse);
+        $this->json->shouldNotReceive('format');
+
+        $this->assertSame($this->htmlResponse, $this->formatter()->format($this->error, $request));
+    }
+}

--- a/framework/core/tests/unit/Http/RequestUtilTest.php
+++ b/framework/core/tests/unit/Http/RequestUtilTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Http;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Testing\unit\TestCase;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+
+class RequestUtilTest extends TestCase
+{
+    private function requestWithAccept(?string $accept): ServerRequestInterface
+    {
+        $request = new ServerRequest([], [], '/', 'GET');
+
+        return $accept === null ? $request : $request->withHeader('Accept', $accept);
+    }
+
+    public static function apiAcceptHeaders(): array
+    {
+        return [
+            'JSON:API media type' => ['application/vnd.api+json'],
+            'plain JSON' => ['application/json'],
+            'wildcard (our XHR requests)' => ['*/*'],
+            'no Accept header at all' => [null],
+        ];
+    }
+
+    public static function htmlAcceptHeaders(): array
+    {
+        return [
+            'explicit text/html' => ['text/html'],
+            'typical browser header' => ['text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'],
+            // No offered type matches -> bestMatch() returns null -> treated as non-API.
+            'unrelated type' => ['application/xml'],
+            // Malformed media range -> bestMatch() throws -> must be swallowed and treated as non-API.
+            'malformed header' => ['this is not a valid accept header'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('apiAcceptHeaders')]
+    public function api_accept_headers_are_detected_as_api_requests(?string $accept): void
+    {
+        $request = $this->requestWithAccept($accept);
+
+        $this->assertTrue(RequestUtil::isApiRequest($request));
+        $this->assertFalse(RequestUtil::isHtmlRequest($request));
+    }
+
+    #[Test]
+    #[DataProvider('htmlAcceptHeaders')]
+    public function html_accept_headers_are_not_detected_as_api_requests(string $accept): void
+    {
+        $request = $this->requestWithAccept($accept);
+
+        $this->assertFalse(RequestUtil::isApiRequest($request));
+        $this->assertTrue(RequestUtil::isHtmlRequest($request));
+    }
+
+    #[Test]
+    public function get_preferred_content_type_returns_the_best_match(): void
+    {
+        $request = $this->requestWithAccept('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8');
+
+        $this->assertSame(
+            'text/html',
+            RequestUtil::getPreferredContentType($request, ['application/vnd.api+json', 'application/json', 'text/html'])
+        );
+    }
+
+    #[Test]
+    public function get_preferred_content_type_never_throws_on_a_malformed_header(): void
+    {
+        // The error handler relies on this never throwing.
+        $request = $this->requestWithAccept('garbage;;;');
+
+        $this->assertSame(
+            '',
+            RequestUtil::getPreferredContentType($request, ['application/vnd.api+json', 'text/html'])
+        );
+    }
+
+    #[Test]
+    public function get_preferred_content_type_returns_empty_string_when_nothing_matches(): void
+    {
+        $request = $this->requestWithAccept('application/xml');
+
+        $this->assertSame(
+            '',
+            RequestUtil::getPreferredContentType($request, ['application/vnd.api+json', 'text/html'])
+        );
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #3850**

**Changes proposed in this pull request:**
- Create a error handler for the forum that determines whether to forward to JSON or HTML view
  - Use JSON API Formatter for forum errors if the request did not explicitly state `text/html` in `Accepts` header
  - Fixes `/login` route not returning JSON from forum
  - Fixes `HighMaintenanceModeHandler` not returning JSON for requests initiated by forum (uses `isApiRequest`, and our requests do not set the header)

**Reviewers should focus on:**
I added the `bitworking/mimeparse` package (last updated end of 2025) to parse more complex `Accepts` headers (eg. with quality priority). It looks like browsers basically always (wasn't able to find concrete evidence of this) have `text/html` in their Accepts. While our XHR requests have `Accepts: */*`.

However, this did make `isHtmlRequest` a weaker check that could be true at the same time as `isApiRequest` (due to the quality priorities). I think properly parsing with this package makes sense, however, perhaps `isHtmlRequest` should just be the negation of the stronger `isApiRequest` check (**made this change**)? Additionally, `isHtmlRequest` is only used in `LogInController` for the maintenance login error validaiton.

I also thought that adding this check to the forum-wide error handler made more sense than just the login route alone.
Plus, I didn't think just slapping an `Accepts` header to our JS requests was the proper solution.

**Screenshot**
<img width="555" height="208" alt="image" src="https://github.com/user-attachments/assets/7116f4bb-79da-4a66-a39f-8a5bd177e96f" />
<img width="644" height="158" alt="image" src="https://github.com/user-attachments/assets/c69dd641-6f4c-4326-a8c6-7762882ef0a2" />


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
