### PR TITLE
[2.x] fix: mobile discussion header total post count not updating on reply

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -28,11 +28,12 @@ export default class PostStreamScrubber extends Component {
     const count = this.stream.count();
 
     // Index is left blank for performance reasons, it is filled in in updateScubberValues
-    const getViewing = () => app.translator.trans('core.forum.post_scrubber.viewing_text', {
-      count,
-      index: <span className="Scrubber-index"></span>,
-      formattedCount: <span className="Scrubber-count">{formatNumber(count)}</span>,
-    });
+    const getViewing = () =>
+      app.translator.trans('core.forum.post_scrubber.viewing_text', {
+        count,
+        index: <span className="Scrubber-index"></span>,
+        formattedCount: <span className="Scrubber-count">{formatNumber(count)}</span>,
+      });
 
     const unreadCount = this.stream.discussion.unreadCount();
     const unreadPercent = count ? Math.min(count - this.stream.index, unreadCount) / count : 0;

--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -28,7 +28,7 @@ export default class PostStreamScrubber extends Component {
     const count = this.stream.count();
 
     // Index is left blank for performance reasons, it is filled in in updateScubberValues
-    const viewing = app.translator.trans('core.forum.post_scrubber.viewing_text', {
+    const getViewing = () => app.translator.trans('core.forum.post_scrubber.viewing_text', {
       count,
       index: <span className="Scrubber-index"></span>,
       formattedCount: <span className="Scrubber-count">{formatNumber(count)}</span>,
@@ -59,7 +59,7 @@ export default class PostStreamScrubber extends Component {
     return (
       <div className={classNames.join(' ')}>
         <button type="button" className="Button Dropdown-toggle" data-toggle="dropdown">
-          {viewing} <Icon name={'fas fa-sort'} />
+          {getViewing()} <Icon name={'fas fa-sort'} />
         </button>
 
         <div className="Dropdown-menu dropdown-menu">
@@ -73,7 +73,7 @@ export default class PostStreamScrubber extends Component {
               <div className="Scrubber-handle">
                 <div className="Scrubber-bar" />
                 <div className="Scrubber-info">
-                  <strong>{viewing}</strong>
+                  <strong>{getViewing()}</strong>
                   <span className="Scrubber-description"></span>
                 </div>
               </div>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4602**

**Changes proposed in this pull request:**

This PR fixes a UI regression in the `PostStreamScrubber` component where the total post count in the mobile discussion header fails to update when a user posts a reply. 

Previously, the `viewing` translation string was instantiated once as a static array of VNodes and injected into two distinct DOM locations (the dropdown header button and the scrubber handle). Because Mithril 2 does not support reusing VNode object references across multiple locations, the `vnode.dom` pointers for the header were silently overwritten by the scrubber handle. This caused subsequent `m.redraw()` cycles to update the total count and pluralization natively in the scrubber handle, but completely ignore the header button.

By wrapping the translation output in a `getViewing()` closure function and calling `{getViewing()}` in both JSX locations, we ensure fresh, independent VNodes are generated. This allows Mithril to accurately track and natively update both DOM elements during standard redraw cycles.

An alternative approach considered was: manually updating `.Scrubber-count` via jQuery inside `updateScrubberValues()` (similar to how the current scroll `index` is handled).
```
$scrubber.find('.Scrubber-count').text(formatNumber(count));
```
While this successfully forced the number to update in both locations, it was ultimately rejected because it bypassed Mithril's native rendering cycle. Bypassing Mithril for the total count is an anti-pattern and breaks the encapsulation of the UI component.

**Reviewers should focus on:**

- `framework/core/js/src/forum/components/PostStreamScrubber.js`
- Confirming that the transition from a static variable to a closure function (`getViewing()`) resolves the stale DOM issue without introducing unnecessary overhead during scroll events (since the index is still updated via jQuery).

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

https://github.com/user-attachments/assets/cda3fc10-b437-4200-ba7e-210d21293ec9

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
