### PR TITLE
fix: trailing-slash discussion URLs redirect to the homepage

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -378,6 +378,21 @@ export default class Application {
 
     this.drawer = new Drawer();
 
+    // Mithril matches routes on the exact pathname and does not tolerate a trailing
+    // slash (e.g. `/d/123-foo/`), so a shared or linked URL with one matches no route
+    // and falls through to the default route, landing the user on the homepage. Strip
+    // it before routing so the URL resolves the same as its slash-less form, mirroring
+    // the server-side strip in `ResolveRoute`. Only applies to path-routed apps (the
+    // forum); hash-routed apps (admin) keep their route in the fragment, so the
+    // pathname is irrelevant and the homepage (`basePath + '/'`) must be left alone.
+    if (m.route.prefix === '') {
+      const { pathname, search, hash } = window.location;
+
+      if (pathname !== basePath + '/' && pathname.length > 1 && pathname.endsWith('/')) {
+        window.history.replaceState(window.history.state, '', pathname.replace(/\/+$/, '') + search + hash);
+      }
+    }
+
     m.route(document.getElementById('content')!, basePath + '/', mapRoutes(this.routes, basePath));
 
     const appEl = document.getElementById('app')!;


### PR DESCRIPTION
Fixes #4504

### The problem

Opening a discussion URL with a trailing slash (e.g. `/d/123-foo/`) lands the user on the homepage instead of the discussion.

### Cause

This is the client-side half of #4504 that the server-side fix never covered. Mithril matches routes on the exact pathname and does **not** tolerate a trailing slash — its compiled templates are anchored regexes (`^/d/([^/]+)$`), and `parsePathname` only collapses repeated slashes, it doesn't strip a trailing one. So `/d/123-foo/` matches neither `/d/:id` nor `/d/:id/:near` and falls through to the default route → the homepage.

The server-side strip in `ResolveRoute` (#4511) already makes the **server** render the correct document, which is why a raw request returns the right content. But the browser URL still carries the slash when the SPA boots, so the **client** router never matches — and that's what the user actually sees.

### Fix

Strip a trailing slash from the path (via `history.replaceState`) before `m.route()` runs, mirroring the server-side behaviour. Scoped to path-routed apps (the forum) via the empty route prefix; hash-routed apps (admin) keep their route in the fragment and are untouched, and the homepage (`basePath + '/'`) is explicitly left alone. Query string and hash are preserved.