### PR TITLE
Detect and surface database driver/server mismatch

### DIFF
--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -7,6 +7,7 @@ import AdminPage from './AdminPage';
 import type { Children } from 'mithril';
 import AlertWidget from './AlertWidget';
 import Link from '../../common/components/Link';
+import Icon from '../../common/components/Icon';
 
 export default class DashboardPage extends AdminPage {
   headerInfo() {
@@ -77,6 +78,33 @@ export default class DashboardPage extends AdminPage {
           })}
         </AlertWidget>,
         100
+      );
+    }
+
+    if (app.data.dbDriverMismatch) {
+      items.add(
+        'db-driver-mismatch-warning',
+        <AlertWidget
+          className="DbDriverMismatchWarningWidget"
+          alert={{
+            type: 'error',
+            dismissible: false,
+            title: app.translator.trans('core.admin.database-driver-mismatch-warning.label'),
+            icon: 'fas fa-database',
+          }}
+        >
+          {app.translator.trans('core.admin.database-driver-mismatch-warning.detail', {
+            configured: app.data.dbDriver as string,
+            actual: app.data.dbDriverMismatch as string,
+            link: ({ children }: { children: Children }) => (
+              <Link href="https://docs.flarum.org/install/#database" external={true} target="_blank">
+                <Icon name="fas fa-external-link-alt" />
+                {children}
+              </Link>
+            ),
+          })}
+        </AlertWidget>,
+        90
       );
     }
 

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -233,6 +233,14 @@ core:
       section_disabled_help: These extensions are installed but not currently enabled. Enable them from their settings page, or remove them if no longer needed.
       suggested_by: "Suggested by {extension}"
 
+    # These translations are used in the database driver mismatch warning widget.
+    database-driver-mismatch-warning:
+      detail: |
+        Your <code>config.php</code> is configured to use the <code>{configured}</code> database driver, but Flarum has detected that the database server is actually <code>{actual}</code>.
+
+        Using the wrong driver can cause subtle, hard-to-diagnose bugs. Set <code>'driver' => ''{actual}''</code> in the <code>database</code> section of your <code>config.php</code> file. See <link>Flarum docs</link> for more information.
+      label: Database driver mismatch
+
     # These translations are used in the debug warning widget.
     debug-warning:
       detail: |

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -77,6 +77,7 @@ class AdminPayload
         $document->payload['phpVersion'] = $this->appInfo->identifyPHPVersion();
         $document->payload['dbDriver'] = $this->appInfo->identifyDatabaseDriver();
         $document->payload['dbVersion'] = $this->appInfo->identifyDatabaseVersion();
+        $document->payload['dbDriverMismatch'] = $this->appInfo->identifyDatabaseDriverMismatch();
         $document->payload['dbOptions'] = $this->appInfo->identifyDatabaseOptions();
         $document->payload['debugEnabled'] = Arr::get($this->config, 'debug');
 

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -94,6 +94,38 @@ class ApplicationInfoProvider
         };
     }
 
+    /**
+     * Detect when the configured database driver does not match the server
+     * actually being used.
+     *
+     * The common case is configuring the 'mysql' driver while connecting to a
+     * MariaDB server (or vice versa). Because Illuminate uses a distinct
+     * connection class and query grammar per driver, this mismatch can cause
+     * subtle, hard-to-diagnose query bugs.
+     *
+     * Returns the driver that *should* be configured, or null when the
+     * configured driver matches the server (or detection does not apply, e.g.
+     * for pgsql/sqlite which cannot be confused for one another).
+     */
+    public function identifyDatabaseDriverMismatch(): ?string
+    {
+        $configured = $this->config['database.driver'];
+
+        // Only MySQL and MariaDB can be mistaken for one another.
+        if (! in_array($configured, ['mysql', 'mariadb'], true)) {
+            return null;
+        }
+
+        $isMariaDb = $this->cache->remember('flarum:db_is_mariadb', 86400, function () {
+            // MariaDB always reports "MariaDB" in its version string; MySQL never does.
+            return Str::contains($this->db->selectOne('select version() as version')->version, 'MariaDB');
+        });
+
+        $actual = $isMariaDb ? 'mariadb' : 'mysql';
+
+        return $actual === $configured ? null : $actual;
+    }
+
     public function identifyDatabaseOptions(): array
     {
         if ($this->config['database.driver'] === 'pgsql') {

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -66,7 +66,14 @@ class InfoCommand extends AbstractCommand
             $this->output->writeln("<info>PHP memory limit:</info> CLI: {$cliMemoryLimit}, Web: unable to detect");
         }
 
-        $this->output->writeln('<info>'.$this->appInfo->identifyDatabaseDriver().' version:</info> '.$this->appInfo->identifyDatabaseVersion());
+        $dbMismatch = $this->appInfo->identifyDatabaseDriverMismatch();
+        $dbLine = '<info>'.$this->appInfo->identifyDatabaseDriver().' version:</info> '.$this->appInfo->identifyDatabaseVersion();
+
+        if ($dbMismatch) {
+            $dbLine .= " <error>(driver mismatch — config.php is set to '{$this->config['database.driver']}', but the server is {$dbMismatch})</error>";
+        }
+
+        $this->output->writeln($dbLine);
 
         $phpExtensions = implode(', ', get_loaded_extensions());
         $this->output->writeln("<info>Loaded extensions:</info> $phpExtensions");
@@ -89,6 +96,14 @@ class InfoCommand extends AbstractCommand
             $this->output->writeln('');
             $this->error(
                 "Don't forget to turn off debug mode! It should never be turned on in a production system."
+            );
+        }
+
+        if ($dbMismatch) {
+            $this->output->writeln('');
+            $this->error(
+                "Your database driver is misconfigured! config.php is set to '{$this->config['database.driver']}', but the server is actually {$dbMismatch}. ".
+                "Set 'driver' => '{$dbMismatch}' in the 'database' section of config.php to avoid subtle query bugs."
             );
         }
 

--- a/framework/core/tests/unit/Foundation/ApplicationInfoProviderTest.php
+++ b/framework/core/tests/unit/Foundation/ApplicationInfoProviderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Foundation;
+
+use Flarum\Foundation\ApplicationInfoProvider;
+use Flarum\Foundation\Config;
+use Flarum\Locale\Translator;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\SessionManager;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Database\ConnectionInterface;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use SessionHandlerInterface;
+
+class ApplicationInfoProviderTest extends TestCase
+{
+    #[Test]
+    public function mysql_driver_against_a_mysql_server_reports_no_mismatch()
+    {
+        $provider = $this->provider('mysql', '8.0.32');
+
+        $this->assertNull($provider->identifyDatabaseDriverMismatch());
+    }
+
+    #[Test]
+    public function mysql_driver_against_a_mariadb_server_reports_a_mismatch()
+    {
+        $provider = $this->provider('mysql', '10.11.2-MariaDB-0+deb12u2');
+
+        $this->assertSame('mariadb', $provider->identifyDatabaseDriverMismatch());
+    }
+
+    #[Test]
+    public function mariadb_driver_against_a_mariadb_server_reports_no_mismatch()
+    {
+        $provider = $this->provider('mariadb', '10.11.2-MariaDB-0+deb12u2');
+
+        $this->assertNull($provider->identifyDatabaseDriverMismatch());
+    }
+
+    #[Test]
+    public function mariadb_driver_against_a_mysql_server_reports_a_mismatch()
+    {
+        $provider = $this->provider('mariadb', '8.0.32');
+
+        $this->assertSame('mysql', $provider->identifyDatabaseDriverMismatch());
+    }
+
+    #[Test]
+    public function pgsql_driver_is_never_flagged_and_does_not_query_the_server()
+    {
+        // No version is provided, so the connection mock asserts selectOne() is never called.
+        $provider = $this->provider('pgsql', null);
+
+        $this->assertNull($provider->identifyDatabaseDriverMismatch());
+    }
+
+    #[Test]
+    public function sqlite_driver_is_never_flagged_and_does_not_query_the_server()
+    {
+        $provider = $this->provider('sqlite', null);
+
+        $this->assertNull($provider->identifyDatabaseDriverMismatch());
+    }
+
+    /**
+     * Build a provider with a configured driver and the version string the
+     * server would report from `select version()`. Pass a null version for
+     * drivers that should never trigger a version query (pgsql/sqlite).
+     */
+    private function provider(string $configuredDriver, ?string $serverVersion): ApplicationInfoProvider
+    {
+        $cache = m::mock(CacheRepository::class);
+        // Execute the cached closure inline so the detection logic is exercised.
+        $cache->shouldReceive('remember')
+            ->andReturnUsing(fn ($key, $ttl, $callback) => $callback());
+
+        $db = m::mock(ConnectionInterface::class);
+
+        if ($serverVersion !== null) {
+            $db->shouldReceive('selectOne')
+                ->with('select version() as version')
+                ->andReturn((object) ['version' => $serverVersion]);
+        } else {
+            $db->shouldNotReceive('selectOne');
+        }
+
+        $config = new Config([
+            'url' => 'http://localhost',
+            'database' => ['driver' => $configuredDriver],
+        ]);
+
+        return new ApplicationInfoProvider(
+            $cache,
+            m::mock(Translator::class),
+            m::mock(Schedule::class),
+            $db,
+            $config,
+            m::mock(SessionManager::class),
+            m::mock(SessionHandlerInterface::class),
+            m::mock(Queue::class),
+        );
+    }
+}


### PR DESCRIPTION
## The problem

Since 2.x, Flarum treats **MariaDB as a database driver distinct from MySQL**. On Illuminate 13 each driver has its own connection class (`MySqlConnection` vs `MariaDbConnection`) and its own query grammar, so the two are **not** interchangeable.

In practice, a large number of "something isn't working" reports come down to a single misconfiguration: the user has `'driver' => 'mysql'` in `config.php` while actually connecting to a MariaDB server (or, less commonly, the reverse). This is extremely easy to do when upgrading from 1.x or following older guides, where `mysql` was the only relevant option. Because the connection still succeeds, the mismatch is invisible — it only shows up later as subtle, hard-to-diagnose query bugs that look unrelated to the database config.

Today nothing tells the admin that their configured driver doesn't match the server they're actually talking to.

## What this does

Detects the mismatch and makes it impossible to miss, in the two places admins already look:

- **Admin dashboard** — a non-dismissible **error** banner (modelled on the existing debug-mode warning) that names the configured driver, the detected server, and the exact `'driver' => '…'` value to set in `config.php`, with a link to the docs.
- **`php flarum info`** — the database line is flagged inline, plus a trailing error explaining how to fix it (alongside the existing debug-mode notice).

## How detection works

Only MySQL and MariaDB can be confused for one another, so detection is scoped to those two drivers. A new `ApplicationInfoProvider::identifyDatabaseDriverMismatch()` compares the configured driver against the server's reported `version()` string — the same `MariaDB` marker the installer already relies on in `ConnectToDatabase`. It returns the driver that *should* be configured, or `null` when everything matches. The lookup reuses the existing 24h cache layer, so there's no per-request query cost. `pgsql`/`sqlite` short-circuit and never hit the database.