### PR TITLE
Stub the full Queue Pause/Resume surface on QueueFactory

### DIFF
--- a/framework/core/src/Queue/QueueFactory.php
+++ b/framework/core/src/Queue/QueueFactory.php
@@ -44,33 +44,88 @@ class QueueFactory implements Factory
         return $this->queue;
     }
 
+    /*
+     * Flarum's simplified queue factory stands in for Illuminate's full
+     * QueueManager. The methods below are the manager-level surface of the
+     * Queue Pause/Resume feature, which the queue Worker and console commands
+     * may call. Flarum does not support queue pausing *yet* — it is planned for
+     * a future Flarum version — so for now they are no-ops. Stubbing the whole
+     * family also means a new Illuminate release wiring up another pause method
+     * can't crash the worker with a "Call to undefined method" (as happened
+     * with isPaused() and, later, getPausedQueues()). Signatures mirror
+     * Illuminate\Queue\QueueManager.
+     *
+     * TODO: implement real queue pausing in a future Flarum version.
+     */
+
     /**
      * Determine if a queue is paused.
-     *
-     * This is a no-op implementation since Flarum's simplified queue factory
-     * doesn't support queue pausing. Laravel 12's Worker expects this method
-     * to exist on the queue manager.
      *
      * @param string $connection
      * @param string $queue
      * @return bool
      */
-    public function isPaused($connection, $queue)
+    public function isPaused($connection, $queue): bool
     {
         return false;
     }
 
     /**
-     * Get the list of paused queues.
+     * Determine which of the given queues are currently paused.
      *
-     * This is a no-op implementation since Flarum's simplified queue factory
-     * does not support queue pausing. illuminate/queue v13.11+ expects this
-     * method to exist on the queue manager.
-     *
+     * @param string $connection
+     * @param array $queues
      * @return array
      */
-    public function getPausedQueues(): array
+    public function getPausedQueues($connection, $queues): array
     {
         return [];
+    }
+
+    /**
+     * Pause a queue by its connection and name.
+     *
+     * @param string $connection
+     * @param string $queue
+     * @return void
+     */
+    public function pause($connection, $queue): void
+    {
+        // No-op for now: queue pausing is planned for a future Flarum version.
+    }
+
+    /**
+     * Pause a queue by its connection and name for a given amount of time.
+     *
+     * @param string $connection
+     * @param string $queue
+     * @param \DateTimeInterface|\DateInterval|int $ttl
+     * @return void
+     */
+    public function pauseFor($connection, $queue, $ttl): void
+    {
+        // No-op for now: queue pausing is planned for a future Flarum version.
+    }
+
+    /**
+     * Resume a paused queue by its connection and name.
+     *
+     * @param string $connection
+     * @param string $queue
+     * @return void
+     */
+    public function resume($connection, $queue): void
+    {
+        // No-op for now: queue pausing is planned for a future Flarum version.
+    }
+
+    /**
+     * Indicate that queue workers should not poll for restart or pause signals.
+     *
+     * @return void
+     */
+    public function withoutInterruptionPolling(): void
+    {
+        // No-op for now: queue pausing is planned for a future Flarum version.
     }
 }

--- a/framework/core/tests/unit/Queue/QueueFactoryTest.php
+++ b/framework/core/tests/unit/Queue/QueueFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Queue;
+
+use Flarum\Queue\QueueFactory;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Queue\Queue;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+class QueueFactoryTest extends TestCase
+{
+    #[Test]
+    public function connection_resolves_and_caches_the_queue_from_the_factory_callback(): void
+    {
+        $queue = m::mock(Queue::class);
+
+        $calls = 0;
+        $factory = new QueueFactory(function () use ($queue, &$calls) {
+            $calls++;
+
+            return $queue;
+        });
+
+        $this->assertSame($queue, $factory->connection());
+        // Resolving again returns the cached instance without re-invoking the callback.
+        $this->assertSame($queue, $factory->connection());
+        $this->assertSame(1, $calls);
+    }
+
+    #[Test]
+    public function is_paused_always_reports_false(): void
+    {
+        $this->assertFalse($this->factory()->isPaused('flarum', 'default'));
+    }
+
+    #[Test]
+    public function get_paused_queues_is_always_empty(): void
+    {
+        $this->assertSame([], $this->factory()->getPausedQueues('flarum', ['default', 'high']));
+    }
+
+    /**
+     * The Queue Pause/Resume manager methods Flarum does not support must be
+     * callable no-ops, so a queue worker invoking them can never crash with a
+     * "Call to undefined method".
+     */
+    #[Test]
+    public function pause_family_methods_are_callable_no_ops(): void
+    {
+        $factory = $this->factory();
+
+        $this->assertNull($factory->pause('flarum', 'default'));
+        $this->assertNull($factory->pauseFor('flarum', 'default', 60));
+        $this->assertNull($factory->resume('flarum', 'default'));
+        $this->assertNull($factory->withoutInterruptionPolling());
+    }
+
+    private function factory(): QueueFactory
+    {
+        return new QueueFactory(fn () => m::mock(Queue::class));
+    }
+}


### PR DESCRIPTION
## The problem

Flarum's `QueueFactory` is bound as the `'queue'` / `Factory` service and handed to Illuminate's `Worker` in the role normally filled by the full `QueueManager`. But the `Factory` contract only guarantees `connection()` — every other method the worker or queue commands call on the manager is something `QueueFactory` has to provide itself.

Illuminate's **Queue Pause/Resume** feature keeps growing that manager-level surface, and `QueueFactory` has been catching up only *after* each one breaks production:

- `isPaused()` had to be added when the worker started calling it.
- `getPausedQueues()` had to be added in #4673 when `illuminate/queue` v13.11's worker began calling it, crashing the queue with «Call to undefined method» and silently breaking all queued notifications and mail.

Both methods live on `QueueManager`, not on the queue connection, so there's no general fallback protecting us — the next pause method wired into the worker will break things the same way.

## What this does

Stubs the **whole** Queue Pause/Resume family up front, so a future Illuminate release calling any of them can't crash the worker:

- Adds no-op `pause()`, `pauseFor()`, `resume()` and `withoutInterruptionPolling()`.
- Fixes `getPausedQueues()` to take `($connection, $queues)`, matching the `QueueManager` contract and the worker's actual call — it previously only worked because PHP silently drops extra positional arguments.
- Adds a `: bool` return type to the existing `isPaused()` for consistency.

Signatures mirror `Illuminate\Queue\QueueManager`. Queue **pausing itself remains unsupported for now** — these are deliberate no-ops — but it is planned for a future Flarum version, noted with a `TODO`.

## Notes

A generic `__call()` forwarding to the connection (like `QueueManager` has) was considered and rejected: it would not have prevented either past crash, because the pause methods don't exist on the queue connection either. Explicitly stubbing the bounded manager-level family is the targeted fix.