### PR TITLE
[1.x] fix: mobile discussion total post count not updating on reply

### DIFF
--- a/framework/core/js/src/forum/components/PostStreamScrubber.js
+++ b/framework/core/js/src/forum/components/PostStreamScrubber.js
@@ -26,12 +26,16 @@ export default class PostStreamScrubber extends Component {
   view() {
     const count = this.stream.count();
 
-    // Index is left blank for performance reasons, it is filled in in updateScubberValues
-    const viewing = app.translator.trans('core.forum.post_scrubber.viewing_text', {
-      count,
-      index: <span className="Scrubber-index"></span>,
-      formattedCount: <span className="Scrubber-count">{formatNumber(count)}</span>,
-    });
+    // Index is left blank for performance reasons, it is filled in in updateScubberValues.
+    // Built as a function so each usage renders its own vnode tree — reusing a single vnode
+    // instance in two places breaks Mithril's diffing and leaves one copy stale (e.g. the
+    // total count in the mobile header not updating after posting a reply).
+    const viewing = () =>
+      app.translator.trans('core.forum.post_scrubber.viewing_text', {
+        count,
+        index: <span className="Scrubber-index"></span>,
+        formattedCount: <span className="Scrubber-count">{formatNumber(count)}</span>,
+      });
 
     const unreadCount = this.stream.discussion.unreadCount();
     const unreadPercent = count ? Math.min(count - this.stream.index, unreadCount) / count : 0;
@@ -58,7 +62,7 @@ export default class PostStreamScrubber extends Component {
     return (
       <div className={classNames.join(' ')}>
         <button className="Button Dropdown-toggle" data-toggle="dropdown">
-          {viewing} {icon('fas fa-sort')}
+          {viewing()} {icon('fas fa-sort')}
         </button>
 
         <div className="Dropdown-menu dropdown-menu">
@@ -72,7 +76,7 @@ export default class PostStreamScrubber extends Component {
               <div className="Scrubber-handle">
                 <div className="Scrubber-bar" />
                 <div className="Scrubber-info">
-                  <strong>{viewing}</strong>
+                  <strong>{viewing()}</strong>
                   <span className="Scrubber-description"></span>
                 </div>
               </div>


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4602**

Same issue exits in 1.x also
Backport fix https://github.com/flarum/framework/pull/4678 to 1.x

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

Same as 2.x

This PR fixes a UI regression in the `PostStreamScrubber` component where the total post count in the mobile discussion header fails to update when a user posts a reply. 

Previously, the `viewing` translation string was instantiated once as a static array of VNodes and injected into two distinct DOM locations (the dropdown header button and the scrubber handle). Because Mithril 2 does not support reusing VNode object references across multiple locations, the `vnode.dom` pointers for the header were silently overwritten by the scrubber handle. This caused subsequent `m.redraw()` cycles to update the total count and pluralization natively in the scrubber handle, but completely ignore the header button.

By wrapping the translation output in a `viewing()` closure function and calling `{viewing()}` in both JSX locations, we ensure fresh, independent VNodes are generated. This allows Mithril to accurately track and natively update both DOM elements during standard redraw cycles.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

Before:

https://github.com/user-attachments/assets/db0388d7-97a8-4867-a2f9-9a60a4372882

After:

https://github.com/user-attachments/assets/4517cece-618d-4335-bb78-fcf5c390dc8e

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
