### PR TITLE
fix(emoji): reserve square box for img.emoji to avoid CLS

### DIFF
--- a/extensions/emoji/less/forum.less
+++ b/extensions/emoji/less/forum.less
@@ -1,5 +1,6 @@
 img.emoji {
   height: 1.5em;
+  aspect-ratio: 1; // reserve a square box while the SVG loads to avoid layout shift (CLS)
   margin: 0 .1em;
   vertical-align: -0.3em;
 }


### PR DESCRIPTION
Fixes #4681

### Problem

`img.emoji` (the inline Twemoji `<img>` rendered by the formatter) is styled in `extensions/emoji/less/forum.less` with a height but no `width` and no `aspect-ratio`. The Twemoji SVGs are loaded from the jsDelivr CDN and the rendered `<img>` carries no intrinsic dimensions (the s9e formatter template emits `<img alt="…" class="emoji" draggable="false" src="…"/>` with no `width`/`height`).

With `height: 1.5em` but `width: auto`, the browser reserves zero width for each emoji until its SVG downloads, then reflows the surrounding text once each SVG arrives. On emoji-heavy posts this produces visible Cumulative Layout Shift (CLS), especially on first paint / cold CDN cache / throttled mobile connections.

### Fix

Every Twemoji glyph is square (1:1), so declaring `aspect-ratio: 1` lets the browser derive `width: 1.5em` immediately from the existing height and reserve the correct box before the SVG loads — eliminating the shift.

This lives in the extension's own stylesheet rather than the generated formatter bundle, so it survives bundle regeneration and is deployment-agnostic (correct for every install).

### Testing

1. Post a message containing several emoji (e.g. 😀🎹🔥👍🎉).
2. Load the discussion with the Twemoji SVGs uncached (hard refresh, cache disabled, or network throttling).
3. Before: text reflows horizontally as each SVG finishes loading. After: no layout shift.

Credit to @ekumanov for the report and the suggested fix.