### PR TITLE
[2.x] fix(core): refresh user count and list after user creation

### DIFF
--- a/framework/core/js/src/admin/components/CreateUserModal.tsx
+++ b/framework/core/js/src/admin/components/CreateUserModal.tsx
@@ -8,6 +8,7 @@ import type Mithril from 'mithril';
 import Switch from '../../common/components/Switch';
 import { generateRandomString } from '../../common/utils/string';
 import Form from '../../common/components/Form';
+import type User from '../../common/models/User';
 
 export interface ICreateUserModalAttrs extends IFormModalAttrs {
   username?: string;
@@ -15,6 +16,7 @@ export interface ICreateUserModalAttrs extends IFormModalAttrs {
   password?: string;
   token?: string;
   provided?: string[];
+  onCreated?: (user: User) => void;
 }
 
 export type SignupBody = {
@@ -212,13 +214,13 @@ export default class CreateUserModal<CustomAttrs extends ICreateUserModalAttrs =
       .save(this.submitData(), {
         errorHandler: this.onerror.bind(this),
       })
-      .then(() => {
+      .then((createdUser) => {
         if (this.bulkAdd()) {
           this.resetData();
         } else {
           this.hide();
         }
-
+        this.attrs.onCreated?.(createdUser);
         this.alertAttrs = null;
       })
       .finally(() => {

--- a/framework/core/js/src/admin/components/CreateUserModal.tsx
+++ b/framework/core/js/src/admin/components/CreateUserModal.tsx
@@ -210,7 +210,7 @@ export default class CreateUserModal<CustomAttrs extends ICreateUserModalAttrs =
     this.loading = true;
 
     app.store
-      .createRecord('users', {})
+      .createRecord<User>('users', {})
       .save(this.submitData(), {
         errorHandler: this.onerror.bind(this),
       })

--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -43,7 +43,7 @@ export default class UserListPage extends AdminPage {
   /**
    * Number of users to load per page.
    */
-  private numPerPage: number = 3;
+  private numPerPage: number = 50;
 
   /**
    * Current page number. Zero-indexed.

--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -43,7 +43,7 @@ export default class UserListPage extends AdminPage {
   /**
    * Number of users to load per page.
    */
-  private numPerPage: number = 50;
+  private numPerPage: number = 3;
 
   /**
    * Current page number. Zero-indexed.
@@ -62,15 +62,13 @@ export default class UserListPage extends AdminPage {
    * data provided by `AdminPayload.php`, or `flarum/statistics`
    * if installed.
    */
-  readonly userCount: number = app.data.modelStatistics.users.total;
+  private userCount: number = app.data.modelStatistics.users.total;
 
   /**
    * Get total number of user pages.
    */
   private getTotalPageCount(): number {
-    if (this.userCount === -1) return 0;
-
-    return Math.ceil(this.userCount / this.numPerPage);
+    return Math.max(1, Math.ceil(Math.max(0, this.userCount) / this.numPerPage));
   }
 
   /**
@@ -207,7 +205,22 @@ export default class UserListPage extends AdminPage {
 
     items.add(
       'createUser',
-      <Button className="Button UserListPage-createUserBtn" icon="fas fa-user-plus" onclick={() => app.modal.show(CreateUserModal)}>
+      <Button
+        className="Button UserListPage-createUserBtn"
+        icon="fas fa-user-plus"
+        onclick={() =>
+          app.modal.show(CreateUserModal, {
+            onCreated: (user: User) => {
+              this.userCount++;
+              if (app.data?.modelStatistics?.users) {
+                app.data.modelStatistics.users.total = this.userCount;
+              }
+              this.isLoadingPage = true;
+              this.loadPage(this.pageNumber);
+            },
+          })
+        }
+      >
         {app.translator.trans('core.admin.users.create_user_button')}
       </Button>,
       100


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
After creating a new user in the admin users list, the count and list would be stale and required a hard refresh to update the UI

**Changes proposed in this pull request:**
Refresh user count and user list after a new user is created

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
