### PR TITLE
[2.x] Fix lopsided post divider on mobile

### DIFF
--- a/framework/core/less/forum/PostStream.less
+++ b/framework/core/less/forum/PostStream.less
@@ -15,6 +15,12 @@
     @media @phone {
       margin: 0 -15px;
       padding: 0 15px;
+
+      // .Post loses its right padding on phones, so the post content spans
+      // the full width -- the divider must too, or it ends up lopsided.
+      &::after {
+        width: 100%;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #4690

**Changes proposed in this pull request:**
The divider between posts (`.PostStream-item::after`) is `calc(100% - var(--post-padding))` wide and left-aligned, which matches `.Post`'s 20px right padding on desktop. On phones `.Post` drops its right padding, so the post content goes full width while the divider stays 20px short on the right - at 390px wide that's a 15px gap on the left vs 35px on the right.

This makes the divider full width inside the existing `@media @phone` block, so it lines up with the post content again. Desktop is untouched.

**Reviewers should focus on:**
Checked at 390px in Chrome device emulation against current 2.x-dev and the same rule in rc.1: gaps go from 15/35 to 15/15. Nothing else uses that `::after`.

**Screenshot**
Before/after measurements are in #4690, can add actual screenshots if wanted.
