### PR TITLE
[2.x] fix: align mentions in post with the rest of the text

### DIFF
--- a/extensions/mentions/less/forum.less
+++ b/extensions/mentions/less/forum.less
@@ -14,7 +14,7 @@
 }
 .UserMention, .PostMention, .GroupMention, .TagMention {
   padding: 2px 5px;
-  vertical-align: middle;
+  vertical-align: baseline;
   border: 0 !important;
   white-space: nowrap;
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Switch vertical alignment from middle to baseline. Effectively the same as removing the line.
Not sure why this broke -- it has been `middle` since v1.8 with https://github.com/flarum/framework/pull/3769.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before:
<img width="1460" height="196" alt="image" src="https://github.com/user-attachments/assets/f5f78323-6745-4fa7-890b-7b82aa873060" />


After:
<img width="1460" height="192" alt="image" src="https://github.com/user-attachments/assets/665444d8-1ccb-434e-8c2a-450beb407cd2" />


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
- [x] Core developer confirmed locally this works as intended.
- ~~Tests have been added, or are not appropriate here.~~
