### PR TITLE
[2.x] ci(core): overhaul reusable backend workflow

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -4,68 +4,74 @@ on:
   workflow_call:
     inputs:
       enable_backend_testing:
-        description: "Enable Backend Testing?"
+        description: Enable backend integration tests
         type: boolean
         default: true
         required: false
 
       enable_phpstan:
-        description: "Enable PHPStan Static Analysis?"
+        description: Enable PHPStan static analysis
         type: boolean
         default: false
         required: false
 
       backend_directory:
-        description: The directory of the project where backend code is located. This should contain a `composer.json` file, and is generally the root directory of the repo.
+        description: Directory containing composer.json
         type: string
         required: false
-        default: '.'
+        default: "."
 
-      # Only relevant in mono-repos.
       monorepo_tests:
-        description: "The list of directories to test in a monorepo. This should be a space-separated list of directories relative to the backend directory."
+        description: Space-separated list of directories to test in a monorepo
         type: string
         required: false
+
+      runner_type:
+        description: GitHub Actions runner type
+        type: string
+        required: false
+        default: "ubuntu-latest"
 
       php_versions:
-        description: Versions of PHP to test with. Should be array of strings encoded as JSON array
+        description: PHP versions to test (JSON array of strings)
         type: string
         required: false
-        # Keep PHP versions synced with build-install-packages.yml
         default: '["8.3", "8.4", "8.5"]'
 
       php_extensions:
-        description: PHP extensions to install.
+        description: PHP extensions to install
         type: string
         required: false
-        default: 'curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip'
-
-      db_versions:
-        description: Versions of databases to test with. Should be array of strings encoded as JSON array
-        type: string
-        required: false
-        default: '["mysql:5.7", "mysql:8.0.30", "mariadb", "sqlite:3", "postgres:10"]'
+        default: "curl, dom, gd, json, mbstring, openssl, pdo_mysql, pdo_pgsql, tokenizer, zip"
 
       php_ini_values:
         description: PHP ini values
         type: string
         required: false
-        default: error_reporting=E_ALL
+        default: "error_reporting=E_ALL"
 
-      runner_type:
-        description: The type of runner to use for the jobs. This should be one of the types supported by the `runs-on` keyword.
+      db_versions:
+        description: DB images to test (JSON array of Docker image strings)
         type: string
         required: false
-        default: 'ubuntu-latest'
+        default: '["mysql:9.7", "mariadb:12.3", "postgres:18", "sqlite:3"]'
+
+      db_prefixes:
+        description: >-
+          Table prefixes to test. JSON array of strings.
+          Default tests both no-prefix and flarum_ prefix.
+          Pass '[""]' to run without a prefix only.
+        type: string
+        required: false
+        default: '["", "flarum_"]'
 
     secrets:
       composer_auth:
-        description: The Composer auth tokens to use for private packages.
+        description: Composer auth tokens for private packages
         required: false
 
 env:
   COMPOSER_ROOT_VERSION: dev-main
-  # `inputs.composer_directory` defaults to `inputs.backend_directory`
   FLARUM_TEST_TMP_DIR_LOCAL: tests/integration/tmp
   COMPOSER_AUTH: ${{ secrets.composer_auth }}
   DB_DATABASE: flarum_test
@@ -73,94 +79,23 @@ env:
   DB_PASSWORD: password
 
 jobs:
-  test:
+  phpunit:
+    name: "PHPUnit / PHP ${{ matrix.php }} / ${{ matrix.db }}${{ matrix.prefix != '' && ' (prefix)' || '' }}"
     runs-on: ${{ inputs.runner_type }}
+    if: >-
+      inputs.enable_backend_testing &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     strategy:
+      fail-fast: false
       matrix:
         php: ${{ fromJSON(inputs.php_versions) }}
-        service: ${{ fromJSON(inputs.db_versions) }}
-        prefix: ['']
-        php_ini_values: [inputs.php_ini_values]
-
-        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
-        include:
-          # Expands the matrix by naming DBs.
-          - service: 'mysql:5.7'
-            db: MySQL 5.7
-            driver: mysql
-          - service: 'mysql:8.0.30'
-            db: MySQL 8.0
-            driver: mysql
-          - service: mariadb
-            db: MariaDB
-            driver: mariadb
-          - service: 'sqlite:3'
-            db: SQLite
-            driver: sqlite
-          - service: 'postgres:10'
-            db: PostgreSQL 10
-            driver: pgsql
-
-          # Include Database prefix tests with only one PHP version (latest).
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
-            service: 'mysql:5.7'
-            db: MySQL 5.7
-            driver: mysql
-            prefix: flarum_
-            prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
-            service: mariadb
-            db: MariaDB
-            driver: mariadb
-            prefix: flarum_
-            prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
-            service: 'sqlite:3'
-            db: SQLite
-            driver: sqlite
-            prefix: flarum_
-            prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
-            service: 'postgres:10'
-            db: PostgreSQL 10
-            driver: pgsql
-            prefix: flarum_
-            prefixStr: (prefix)
-
-        # To reduce number of actions:
-        # - MySQL 8.0 runs on all PHP versions (primary DB for PHP version coverage)
-        # - All other DBs run on latest PHP only (DB-specific bugs don't depend on PHP version)
-        # - MySQL 5.7 also runs on latest PHP only (floor version coverage)
-        exclude:
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[0] }}
-            service: 'postgres:10'
-          - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'postgres:10'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: 'postgres:10'
+        db: ${{ fromJSON(inputs.db_versions) }}
+        prefix: ${{ fromJSON(inputs.db_prefixes) }}
 
     services:
       mysql:
-        image: ${{ matrix.driver == 'mysql' && matrix.service || '' }}
+        image: ${{ startsWith(matrix.db, 'mysql') && matrix.db || '' }}
         env:
           MYSQL_DATABASE: ${{ env.DB_DATABASE }}
           MYSQL_USER: ${{ env.DB_USERNAME }}
@@ -170,7 +105,7 @@ jobs:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
       mariadb:
-        image: ${{ matrix.driver == 'mariadb' && matrix.service || '' }}
+        image: ${{ startsWith(matrix.db, 'mariadb') && matrix.db || '' }}
         env:
           MARIADB_DATABASE: ${{ env.DB_DATABASE }}
           MARIADB_USER: ${{ env.DB_USERNAME }}
@@ -180,7 +115,7 @@ jobs:
           - 3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: ${{ matrix.driver == 'pgsql' && matrix.service || '' }}
+        image: ${{ startsWith(matrix.db, 'postgres') && matrix.db || '' }}
         env:
           POSTGRES_DB: ${{ env.DB_DATABASE }}
           POSTGRES_USER: ${{ env.DB_USERNAME }}
@@ -193,34 +128,23 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    name: 'PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}'
-
-    if: >-
-      inputs.enable_backend_testing &&
-      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: none
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:v2
-          ini-values: ${{ matrix.php_ini_values }}
+          tools: composer:v2
+          ini-values: ${{ inputs.php_ini_values }}
 
       - name: Install Composer dependencies
-        run: composer install
+        run: composer install --no-interaction --prefer-dist
         working-directory: ${{ inputs.backend_directory }}
 
-      # If we have a `inputs.monorepo_tests`, we will run tests for each item of the provided array in a ::group::item
-      # If we don't have a `inputs.monorepo_tests`, we will run tests for the current repository
-      # We also have to run the `composer test:setup` script first before running each test
       - name: Run tests
         run: |
           if [ -z "${{ inputs.monorepo_tests }}" ]; then
@@ -237,50 +161,59 @@ jobs:
         working-directory: ${{ inputs.backend_directory }}
         env:
           DB_HOST: 127.0.0.1
-          DB_PORT: ${{ (matrix.driver == 'mysql' && job.services.mysql.ports['3306']) || (matrix.driver == 'mariadb' && job.services.mariadb.ports['3306']) || (matrix.driver == 'pgsql' && job.services.postgres.ports['5432']) }}
+          DB_PORT: ${{ (startsWith(matrix.db, 'mysql') && job.services.mysql.ports['3306']) || (startsWith(matrix.db, 'mariadb') && job.services.mariadb.ports['3306']) || (startsWith(matrix.db, 'postgres') && job.services.postgres.ports['5432']) || '' }}
           DB_PREFIX: ${{ matrix.prefix }}
-          DB_DRIVER: ${{ matrix.driver }}
+          DB_DRIVER: ${{ startsWith(matrix.db, 'mariadb') && 'mariadb' || startsWith(matrix.db, 'mysql') && 'mysql' || startsWith(matrix.db, 'postgres') && 'pgsql' || 'sqlite' }}
           COMPOSER_PROCESS_TIMEOUT: 600
 
   phpstan:
+    name: "PHPStan / PHP ${{ matrix.php }}"
     runs-on: ${{ inputs.runner_type }}
-
-    strategy:
-      matrix:
-        php: ${{ fromJson(inputs.php_versions) }}
-
-    name: 'PHPStan PHP ${{ matrix.php }}'
-
     if: >-
       inputs.enable_phpstan &&
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJSON(inputs.php_versions) }}
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: ${{ env.DB_DATABASE }}
+          MYSQL_USER: ${{ env.DB_USERNAME }}
+          MYSQL_PASSWORD: ${{ env.DB_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: none
           extensions: ${{ inputs.php_extensions }}
-          tools: phpunit, composer:v2
-          ini-values: ${{ matrix.php_ini_values }}
+          tools: composer:v2
+          ini-values: ${{ inputs.php_ini_values }}
 
       - name: Install Composer dependencies
-        run: composer install
+        run: composer install --no-interaction --prefer-dist
         working-directory: ${{ inputs.backend_directory }}
-
-      - name: Create MySQL Database
-        run: |
-          sudo systemctl start mysql
-          mysql -uroot -proot -e 'CREATE DATABASE flarum_test;' --port 3306
 
       - name: Run PHPStan
         run: composer analyse:phpstan
+        working-directory: ${{ inputs.backend_directory }}
         env:
-          DB_USERNAME: root
-          DB_PORT: 3306
-          DB_PASSWORD: root
+          DB_HOST: 127.0.0.1
+          DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+          DB_USERNAME: ${{ env.DB_USERNAME }}
+          DB_PASSWORD: ${{ env.DB_PASSWORD }}
           COMPOSER_PROCESS_TIMEOUT: 600
           FLARUM_TEST_TMP_DIR_LOCAL: ./tmp

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -36,6 +36,7 @@ on:
         description: PHP versions to test (JSON array of strings)
         type: string
         required: false
+        # Keep PHP versions synced with build-install-packages.yml
         default: '["8.3", "8.4", "8.5"]'
 
       php_extensions:

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -181,7 +181,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.4
+        image: mysql:9.7
         env:
           MYSQL_DATABASE: ${{ env.DB_DATABASE }}
           MYSQL_USER: ${{ env.DB_USERNAME }}

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -66,6 +66,12 @@ on:
         required: false
         default: '["", "flarum_"]'
 
+      fail_fast:
+        description: Cancel remaining matrix jobs if any job fails
+        type: boolean
+        required: false
+        default: true
+
     secrets:
       composer_auth:
         description: Composer auth tokens for private packages
@@ -88,7 +94,7 @@ jobs:
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.fail_fast }}
       matrix:
         php: ${{ fromJSON(inputs.php_versions) }}
         db: ${{ fromJSON(inputs.db_versions) }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,4 +8,5 @@ jobs:
     with:
       enable_backend_testing: true
       backend_directory: .
+      db_versions: '["mysql:5.7", "mysql:9.7", "mariadb:10.11", "mariadb:12.3","postgres:10", "postgres:18", "sqlite:3"]'
       monorepo_tests: "framework/core extensions/akismet extensions/approval extensions/flags extensions/likes extensions/mentions extensions/nicknames extensions/statistics extensions/sticky extensions/subscriptions extensions/suspend extensions/tags extensions/messages extensions/gdpr extensions/realtime php-packages/testing/tests"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,4 +9,5 @@ jobs:
       enable_backend_testing: true
       backend_directory: .
       db_versions: '["mysql:5.7", "mysql:9.7", "mariadb:10.11", "mariadb:12.3","postgres:10", "postgres:18", "sqlite:3"]'
+      fail_fast: false
       monorepo_tests: "framework/core extensions/akismet extensions/approval extensions/flags extensions/likes extensions/mentions extensions/nicknames extensions/statistics extensions/sticky extensions/subscriptions extensions/suspend extensions/tags extensions/messages extensions/gdpr extensions/realtime php-packages/testing/tests"


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
* **Introduces a new `db_prefixes` input:**
  Allows consuming workflows to pass in custom table prefix names or disable prefix testing altogether by passing `'[""]'`
* **Makes permutations of job executions predictable by dropping the include and exclude section in the matrix strategy:**
   Calling workflows can now predictably customize which permutations across DB Versions, PHP Versions and now as well DB Prefixes are run. The previous implementation did intend to make it possible for DB versions and PHP Versions already, but it didn't actually work consistently and was hard to understand. E.g. Sqlite tests were still run even when overriding `db_versions` in a calling workflow. 
* **Updates the used database versions for MySQL, MariaDB and PostgreSQL to the latest LTS versions:**
  While right now probably just a tiny fraction of Flarum Communities are running on those DB versions, it future proofs the workflows and is a tradeoff between covering a wide blast radius whilst not exploding the amount of Jobs being run per push. I'm open though to add additional DB versions if requested 
* **Upgrades `actions/checkout `from `v4` to `v6`**
* **Pins actions (`actions/checkout` and `shivammathur/setup-php` to immutable commit hashes):** 
   This allows consumer extensions to keep targeting 2.x for the reusable backend workflow whilst increasing protection against upstream supply chain attacks. Dependabot creates PR's to bump actions. This is the same approach Laravel does, see https://github.com/laravel/framework/pull/60364 for an example.
* **Sets `fail-fast` to false to continue run other jobs when a single fails:**
  This allows to get a full picture of the backend flows in one go.
* **Renames the backend test job names to be consistent with the structure of PHPStan jobs**
* **Simplifies terminology and removes some comments**

**Reviewers should focus on:**
* The GitHub Diff is pretty messed up. I recommend to use the Split View to review the changes
* When this gets merged I intend to cleanup the frontend reusable workflow as well (mainly thinking of pinning external actions right now) and reviewing the other workflows as well

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
