### PR TITLE
[2.x] Fix realtime extender load order for tags & sticky (TypeError: not a constructor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - (mentions) align mentions in post with the rest of the text by @dsevillamartin [#4692]
 - (emoji) reserve a square box for `img.emoji` to avoid layout shift (CLS) by @imorland [#4685]
 - (core) queue worker `TypeError` on a null connection name with `illuminate/queue` 13.15+ by @imorland [#4700]
+- (tags, sticky) declare `flarum/realtime` as an optional dependency so the realtime extender loads before its consumers, fixing `TypeError: mt(...) is not a constructor` by @imorland [#4699]
 
 ### Performance
 

--- a/extensions/sticky/composer.json
+++ b/extensions/sticky/composer.json
@@ -34,7 +34,8 @@
             "title": "Sticky",
             "category": "feature",
             "optional-dependencies": [
-                "flarum-tags"
+                "flarum/realtime",
+                "flarum/tags"
             ],
             "icon": {
                 "name": "fas fa-thumbtack",

--- a/extensions/tags/composer.json
+++ b/extensions/tags/composer.json
@@ -38,6 +38,9 @@
         "flarum-extension": {
             "title": "Tags",
             "category": "feature",
+            "optional-dependencies": [
+                "flarum/realtime"
+            ],
             "icon": {
                 "name": "fas fa-tags",
                 "backgroundColor": "#F28326",

--- a/framework/core/tests/unit/Foundation/ExtensionDependencyResolutionTest.php
+++ b/framework/core/tests/unit/Foundation/ExtensionDependencyResolutionTest.php
@@ -121,6 +121,59 @@ class ExtensionDependencyResolutionTest extends TestCase
 
         $this->assertEquals($expected, ExtensionManager::resolveExtensionOrder($exts));
     }
+
+    /**
+     * Regression test for https://discuss.flarum.org/d/39359.
+     *
+     * flarum/realtime registers its `Realtime` JS extender on the export
+     * registry at module-evaluation time, and consumer extensions read it
+     * back via `flarum.reg.get(...)`. The combined forum.js concatenates
+     * extensions in resolved order, so realtime MUST be ordered before any
+     * consumer — otherwise the consumer's `reg.get` runs before realtime's
+     * `reg.add` and instantiates `undefined` ("mt(...) is not a constructor").
+     *
+     * With no dependency edge, resolveExtensionOrder falls back to
+     * REVERSE-alphabetical by id (Kahn's algorithm output is reversed at the
+     * end). So a consumer whose id sorts AFTER "flarum-realtime" — e.g.
+     * "flarum-tags" or "flarum-sticky" — is emitted BEFORE realtime: the
+     * broken order. (Consumers with ids before "flarum-realtime", like
+     * flags/likes/lock/messages, happen to come out after realtime and work by
+     * luck.) Declaring flarum/realtime as an optional dependency forces
+     * realtime ahead of the consumer regardless of id.
+     */
+    #[Test]
+    public function tags_without_realtime_dependency_falls_back_to_broken_order()
+    {
+        $realtime = new FakeExtension('flarum-realtime', []);
+        $tags = new FakeExtension('flarum-tags', []); // no optional dep — the bug
+
+        $resolved = ExtensionManager::resolveExtensionOrder([$tags, $realtime]);
+        $order = array_map(fn ($e) => $e->getId(), $resolved['valid']);
+
+        // Broken: "flarum-tags" sorts after "flarum-realtime", and reverse
+        // ordering therefore emits tags BEFORE realtime.
+        $this->assertSame(['flarum-tags', 'flarum-realtime'], $order);
+    }
+
+    #[Test]
+    public function tags_with_realtime_optional_dependency_is_ordered_after_realtime()
+    {
+        $realtime = new FakeExtension('flarum-realtime', []);
+        // The fix: declare flarum/realtime as an optional dependency.
+        $tags = new FakeExtension('flarum-tags', [], ['flarum-realtime']);
+
+        $resolved = ExtensionManager::resolveExtensionOrder([$tags, $realtime]);
+        $order = array_map(fn ($e) => $e->getId(), $resolved['valid']);
+
+        $this->assertEmpty($resolved['missingDependencies']);
+        $this->assertEmpty($resolved['circularDependencies']);
+        $this->assertSame(['flarum-realtime', 'flarum-tags'], $order);
+        $this->assertLessThan(
+            array_search('flarum-tags', $order),
+            array_search('flarum-realtime', $order),
+            'flarum-realtime must be ordered before a consumer that optionally depends on it'
+        );
+    }
 }
 
 class FakeExtension


### PR DESCRIPTION
Fixes the `flarum-tags failed to initialize / TypeError: mt(...) is not a constructor` error reported in https://discuss.flarum.org/d/39359 when `flarum/tags` and `flarum/realtime` are enabled together.

## Root cause

`flarum/realtime` registers its `Realtime` JS extender on the export registry at module-evaluation time (`flarum.reg.add('flarum-realtime', 'forum/extenders/Realtime', ...)`), and consumer extensions read it back via `flarum.reg.get(...)`. The combined `forum.js` concatenates extensions in the order returned by `ExtensionManager::resolveExtensionOrder()`, so realtime must be ordered **before** any consumer — otherwise the consumer's `reg.get` runs before realtime's `reg.add` and instantiates `undefined`.

With no dependency edge, that order falls back to reverse-alphabetical by id (Kahn's output is reversed). Extensions whose id sorts *after* `flarum-realtime` are therefore emitted *before* it — the broken order. That's `flarum-tags` and `flarum-sticky`. The other realtime consumers (`flags`, `likes`, `lock`, `messages`) already declare `flarum/realtime` as an optional dependency, which is why they were unaffected.

## Fix

Declare `flarum/realtime` as an optional dependency on the two consumers that were missing it, so realtime is always ordered ahead of them:

- `tags` — added `optional-dependencies: ["flarum/realtime"]` (had none)
- `sticky` — added `flarum/realtime` to its existing list (also normalised `flarum-tags` → `flarum/tags`)

## Tests

Added a regression test to `ExtensionDependencyResolutionTest` proving the ordering: without the edge, `[tags, realtime]` resolves to the broken order; with it, realtime is placed first.