### PR TITLE
[2.x] Fix queue worker TypeError on null connection name (illuminate/queue 13.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - (core) stub the full Queue Pause/Resume surface on `QueueFactory` by @imorland [#4683]
 - (mentions) align mentions in post with the rest of the text by @dsevillamartin [#4692]
 - (emoji) reserve a square box for `img.emoji` to avoid layout shift (CLS) by @imorland [#4685]
+- (core) queue worker `TypeError` on a null connection name with `illuminate/queue` 13.15+ by @imorland [#4700]
 
 ### Performance
 

--- a/framework/core/src/Foundation/InstalledSite.php
+++ b/framework/core/src/Foundation/InstalledSite.php
@@ -159,7 +159,16 @@ class InstalledSite implements SiteInterface
                 'lifetime' => 120,
                 'files' => $this->paths->storage.'/sessions',
                 'cookie' => 'session'
-            ]
+            ],
+            // Flarum uses a single queue connection bound as 'flarum.queue.connection'
+            // rather than Laravel's named connections. The queue worker command falls
+            // back to config('queue.default') when no connection argument is given, so
+            // we provide a name here. Without it the name is null, which since
+            // illuminate/queue 13.15.0 throws a TypeError from WorkerIdle's typed
+            // string $connectionName in the worker loop.
+            'queue' => [
+                'default' => 'flarum',
+            ],
         ]);
     }
 

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -73,6 +73,12 @@ class QueueServiceProvider extends AbstractServiceProvider
 
             $queue->setContainer($container);
 
+            // Give the connection a name so events that carry it (e.g. WorkerIdle)
+            // receive a string rather than null. illuminate/queue 13.15.0 type-hinted
+            // WorkerIdle::$connectionName as `string`, so a null name now throws a
+            // TypeError in the worker loop.
+            $queue->setConnectionName('flarum');
+
             return $queue;
         });
 

--- a/framework/core/tests/integration/queue/QueueServiceProviderTest.php
+++ b/framework/core/tests/integration/queue/QueueServiceProviderTest.php
@@ -91,6 +91,39 @@ class QueueServiceProviderTest extends TestCase
         $this->assertContains(\Illuminate\Queue\Console\RetryCommand::class, $commandNames);
     }
 
+    /**
+     * Regression test: the queue connection must have a non-null string name.
+     *
+     * illuminate/queue 13.15.0 type-hinted WorkerIdle::$connectionName as
+     * `string`, so the worker loop throws a TypeError when the connection name
+     * is null. The name flows from the queue connection / config('queue.default').
+     */
+    #[Test]
+    public function queue_connection_has_a_non_null_string_name()
+    {
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->app();
+
+        $queue = $this->app()->getContainer()->make(Queue::class);
+
+        $this->assertIsString($queue->getConnectionName());
+        $this->assertNotEmpty($queue->getConnectionName());
+    }
+
+    #[Test]
+    public function default_queue_connection_name_is_configured()
+    {
+        $this->app();
+
+        $default = $this->app()->getContainer()->make('config')->get('queue.default');
+
+        // The worker command falls back to this when no connection argument is
+        // given; it must be a non-null string to satisfy WorkerIdle.
+        $this->assertIsString($default);
+        $this->assertNotEmpty($default);
+    }
+
     #[Test]
     public function it_uses_null_failed_job_provider_for_sync_queue()
     {


### PR DESCRIPTION
`illuminate/queue` **v13.15.0** (released 2026-06-08) type-hinted `WorkerIdle::$connectionName` as `string` (it was previously untyped and accepted `null`):

```php
// v13.15.0
public function __construct(
    public string $connectionName,
    public string $queue,
    public WorkerOptions $workerOptions,
) {}
```

Flarum's queue worker resolves its connection name from `config('queue.default')` — the fallback the `queue:work` command uses when no connection argument is passed (`$this->argument('connection') ?: $this->laravel['config']['queue.default']`). Flarum never set `queue.default`, so it resolved to `null`, the worker loop dispatched `new WorkerIdle(null, ...)`, and every idle tick now throws:

```
TypeError: Illuminate\Queue\Events\WorkerIdle::__construct():
Argument #1 ($connectionName) must be of type string, null given,
called in .../illuminate/queue/Worker.php on line 253
```

This surfaced in CI the moment a fresh `composer install` resolved 13.15.0; `2.x` was green earlier in the day on 13.14.0.

## Fix

- Set `config('queue.default')` to `'flarum'` in `InstalledSite::getIlluminateConfig()` so the worker command's fallback resolves to a string.
- Give the queue connection a name via `setConnectionName('flarum')` in `QueueServiceProvider`, so events that carry the connection name (`WorkerIdle`, `JobQueued`, …) receive a string.

This is a **code fix rather than a version constraint** — it works on `illuminate/queue` both before and after 13.15.0, so no minimum-version bump is needed (and `>=13.15` would be the wrong direction, since 13.15 is what introduced the stricter signature; the real fix is to stop passing `null`). It also follows the same defensive philosophy already documented on `QueueFactory` — a new Illuminate release shouldn't be able to crash the worker.

## Tests

Added two regression tests to `QueueServiceProviderTest` asserting the queue connection name and `config('queue.default')` are non-null strings. Verified red→green against `illuminate/queue` 13.15.0 locally: both fail without the fix (`null is of type string`), all pass with it.