### PR TITLE
[2.x] chore(core): add `MariaDB` to frontend `DatabaseDriver` enum

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -51,6 +51,7 @@ export interface Extension {
 
 export enum DatabaseDriver {
   MySQL = 'MySQL',
+  MariaDB = 'MariaDB',
   PostgreSQL = 'PostgreSQL',
   SQLite = 'SQLite',
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
With MariaDB and MySQL diverging more and more we've noticed and changed in the Framework that both databases need to be treaded separatly. Some more information on this can be viewed athttps://github.com/flarum/framework/pull/4682

**Changes proposed in this pull request:**
Add `MariaDB` to the `DatabaseDriver` enum

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
