### PR TITLE
[2.x] Fix abandoned-extensions sync never being scheduled

### DIFF
--- a/framework/core/src/Extension/ExtensionServiceProvider.php
+++ b/framework/core/src/Extension/ExtensionServiceProvider.php
@@ -47,17 +47,12 @@ class ExtensionServiceProvider extends AbstractServiceProvider
 
             $manager->extend($container);
         });
-    }
 
-    public function boot(Dispatcher $events, SettingsRepositoryInterface $settings): void
-    {
-        BisectState::setSettings($settings);
-
-        $events->listen(
-            Disabling::class,
-            DefaultLanguagePackGuard::class
-        );
-
+        // Register the abandoned-extensions sync command and its weekly schedule here in
+        // register() rather than boot(). The ConsoleServiceProvider consumes the
+        // `flarum.console.scheduled` array in its own boot() method, and it is registered
+        // before this provider, so appending in boot() would happen too late and the task
+        // would never be scheduled.
         $this->container->extend('flarum.console.commands', function (array $commands) {
             $commands[] = SyncAbandonedExtensionsCommand::class;
 
@@ -73,5 +68,15 @@ class ExtensionServiceProvider extends AbstractServiceProvider
 
             return $scheduled;
         });
+    }
+
+    public function boot(Dispatcher $events, SettingsRepositoryInterface $settings): void
+    {
+        BisectState::setSettings($settings);
+
+        $events->listen(
+            Disabling::class,
+            DefaultLanguagePackGuard::class
+        );
     }
 }

--- a/framework/core/tests/integration/extension/ScheduledAbandonedSyncTest.php
+++ b/framework/core/tests/integration/extension/ScheduledAbandonedSyncTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\extension;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+
+class ScheduledAbandonedSyncTest extends ConsoleTestCase
+{
+    /**
+     * The abandoned-extensions sync command is registered by core's ExtensionServiceProvider.
+     * It must end up in the scheduler so the abandoned list is refreshed automatically.
+     *
+     * This is a regression test: the registration was previously done in the provider's boot()
+     * method, which ran after ConsoleServiceProvider::boot() had already consumed the
+     * `flarum.console.scheduled` array, so the task was silently dropped and never scheduled.
+     *
+     * @test
+     */
+    public function abandoned_sync_command_is_scheduled()
+    {
+        $output = $this->runCommand([
+            'command' => 'schedule:list',
+        ]);
+
+        $this->assertStringContainsString('extensions:sync-abandoned', $output);
+    }
+}

--- a/framework/core/tests/integration/extension/ScheduledAbandonedSyncTest.php
+++ b/framework/core/tests/integration/extension/ScheduledAbandonedSyncTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tests\integration\extension;
 
 use Flarum\Testing\integration\ConsoleTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ScheduledAbandonedSyncTest extends ConsoleTestCase
 {
@@ -20,9 +21,8 @@ class ScheduledAbandonedSyncTest extends ConsoleTestCase
      * This is a regression test: the registration was previously done in the provider's boot()
      * method, which ran after ConsoleServiceProvider::boot() had already consumed the
      * `flarum.console.scheduled` array, so the task was silently dropped and never scheduled.
-     *
-     * @test
      */
+    #[Test]
     public function abandoned_sync_command_is_scheduled()
     {
         $output = $this->runCommand([


### PR DESCRIPTION
Fixes #4705.

`ExtensionServiceProvider` registered the `extensions:sync-abandoned` command and its weekly schedule onto `flarum.console.scheduled` inside `boot()`. `ConsoleServiceProvider::boot()` is what consumes that array to build the Laravel schedule, and it is registered before `ExtensionServiceProvider`, so the entry was appended too late and the task was never scheduled. The weekly sync therefore never ran and the abandoned-extensions list was never refreshed.

This moves the `flarum.console.commands` and `flarum.console.scheduled` registrations into `register()`, which completes for all providers before any `boot()`, so the entry is present when the schedule is built. The `BisectState` setup and `Disabling` listener stay in `boot()` as they depend on the boot-injected services.

Adds an integration test asserting `extensions:sync-abandoned` appears in `schedule:list`.

This is the 2.x port of #4706.