### PR TITLE
[2.x] chore: Update package-manager split remote to flarum/extension-manager

### DIFF
--- a/flarum-monorepo.json
+++ b/flarum-monorepo.json
@@ -68,7 +68,7 @@
       },
       {
         "name": "package-manager",
-        "gitRemote": "git@github.com:flarum/package-manager.git",
+        "gitRemote": "git@github.com:flarum/extension-manager.git",
         "mainBranch": "2.x"
       },
       {


### PR DESCRIPTION
The `flarum/package-manager` repo was renamed to `flarum/extension-manager`. Update the split's `gitRemote` to match.

`name` stays `package-manager` as it maps to the `extensions/package-manager` subtree path, which has not been renamed.