### PR TITLE
[1.x] Fix broken images and Tests badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-<a href="https://flarum.org/"><img src="https://flarum.org/images/flarum.svg"></a>
+<a href="https://flarum.org/"><img src="https://flarum.org/assets/img/flarum-banner.png" alt="Flarum"></a>
 </p>
 
 <p align="center">
-<a href="https://github.com/flarum/core/actions?query=workflow%3ATests"><img src="https://github.com/flarum/core/workflows/Tests/badge.svg" alt="PHP Tests"></a>
+<a href="https://github.com/flarum/framework/actions/workflows/backend.yml"><img src="https://github.com/flarum/framework/actions/workflows/backend.yml/badge.svg" alt="Backend Tests"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/dt/flarum/core" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/github/v/release/flarum/core?sort=semver" alt="Latest Version"></a>
 <a href="https://packagist.org/packages/flarum/core"><img src="https://img.shields.io/packagist/l/flarum/core" alt="License"></a>
@@ -20,7 +20,7 @@
 
 * **Powerful and extensible.** Customize, extend, and integrate Flarum to suit your community. Flarum’s architecture is amazingly flexible, with a powerful Extension API.
 
-![Screenshot of a Flarum instance, showing multiple discussions and tags.](https://flarum.org/assets/img/home-screenshot.png)
+![Screenshot of a Flarum instance, showing multiple discussions and tags.](https://flarum.org/assets/img/home-screenshot-new.png)
 
 ## Installation
 


### PR DESCRIPTION
The README logo and the backend tests badge both 404. This updates the logo and screenshot to their current `flarum.org` asset URLs and points the tests badge at the framework `backend.yml` workflow (matching 2.x).