### PR TITLE
[2.x] fix(audit): remove circular optional-dependencies on first-party extensions

### DIFF
--- a/extensions/audit/composer.json
+++ b/extensions/audit/composer.json
@@ -41,13 +41,6 @@
                 "color": "#fff"
             },
             "optional-dependencies": [
-                "flarum/approval",
-                "flarum/flags",
-                "flarum/lock",
-                "flarum/nicknames",
-                "flarum/sticky",
-                "flarum/suspend",
-                "flarum/tags",
                 "fof/geoip"
             ]
         },


### PR DESCRIPTION
Fixes a circular dependency that aborts the extension loader:

> Circular dependencies detected: Approval, Audit, Flags, FoF GeoIP, Lock, Nicknames, Realtime, Sticky, Suspend, Tags. Aborting.

When the first-party audit integrations moved into their respective extensions (#4711), those extensions began declaring `flarum/audit` as an `optional-dependency`. Audit still listed them in turn, so each `audit ↔ <extension>` pair formed a cycle.

Audit no longer references those extensions at boot — every integration now flows the other way (extension → audit). This removes the seven first-party entries from audit's `optional-dependencies`. `fof/geoip` stays: it's a one-way, render-time integration (it enhances core's IP address component) and does not depend back on audit, so it isn't part of a cycle.

Verified the resulting optional-dependency graph across the affected extensions is acyclic.
