### PR TITLE
fix(realtime): show the correct notification toast, and stop dropping it

### DIFF
--- a/extensions/realtime/extend.php
+++ b/extensions/realtime/extend.php
@@ -68,7 +68,8 @@ return [
         ]),
 
     (new Extend\Event)
-        ->subscribe(Push\EventSubscriber::class),
+        ->subscribe(Push\EventSubscriber::class)
+        ->listen(\Flarum\Notification\Event\Sent::class, Push\Listener\BroadcastNotifications::class),
 
     (new Extend\Notification)
         ->driver('realtime', Push\NotificationDriver::class),

--- a/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
+++ b/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
@@ -11,6 +11,7 @@ namespace Flarum\Realtime\Push\Jobs;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Notification;
+use Flarum\User\User;
 use Illuminate\Contracts\Queue\Queue;
 
 class SendNotificationsJob extends Job
@@ -32,11 +33,7 @@ class SendNotificationsJob extends Job
                 continue;
             }
 
-            $notification = Notification::query()
-                ->where('user_id', $user->id)
-                ->where('type', $this->blueprint::getType())
-                ->latest()
-                ->first();
+            $notification = $this->notificationFor($user);
 
             if ($notification) {
                 $queue->push(
@@ -44,5 +41,20 @@ class SendNotificationsJob extends Job
                 );
             }
         }
+    }
+
+    /**
+     * Find the stored notification that the fired blueprint produced for this recipient.
+     *
+     * We match on the blueprint itself (type, subject, from-user and data) rather than just the
+     * type, so the broadcast carries the notification the event actually created — not whichever
+     * notification of the same type happens to be newest, which would surface a previous,
+     * unrelated notification (e.g. an older mention from a different user) in the toast.
+     */
+    public function notificationFor(User $user): ?Notification
+    {
+        return Notification::matchingBlueprint($this->blueprint)
+            ->where('user_id', $user->id)
+            ->first();
     }
 }

--- a/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
+++ b/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
@@ -25,36 +25,38 @@ class SendNotificationsJob extends Job
 
     public function handle(Queue $queue): void
     {
-        // Only dispatch notification jobs for users on the socket.
-        $intersect = $this->connectedUsers()->intersect($this->recipients);
+        $type = $this->blueprint::getType();
 
-        foreach ($intersect as $user) {
-            if (! $user->shouldAlert($this->blueprint::getType())) {
-                continue;
-            }
+        // Narrow to recipients who are on the socket and want an alert for this type. The
+        // shouldAlert() check reads the user's preferences (already loaded on the model), so
+        // this filtering costs no queries.
+        $recipients = $this->connectedUsers()
+            ->intersect($this->recipients)
+            ->filter(fn (User $user) => $user->shouldAlert($type));
 
-            $notification = $this->notificationFor($user);
+        if ($recipients->isEmpty()) {
+            return;
+        }
 
-            if ($notification) {
+        // One query for the whole set, rather than one per recipient. We match on the blueprint
+        // (type, subject, from-user and data) rather than just the type, so the broadcast carries
+        // the notification this event actually created — not whichever notification of the same
+        // type happens to be newest, which would surface a previous, unrelated notification (e.g.
+        // an older mention from a different user) in the toast.
+        //
+        // This job is dispatched from the Notification\Event\Sent listener, i.e. after the records
+        // have been inserted, so the matching rows are guaranteed to exist here.
+        $notifications = Notification::matchingBlueprint($this->blueprint)
+            ->whereIn('user_id', $recipients->map(fn (User $user) => $user->id)->all())
+            ->get()
+            ->keyBy('user_id');
+
+        foreach ($recipients as $user) {
+            if ($notification = $notifications->get($user->id)) {
                 $queue->push(
                     new SendGeneratedPayloadJob('notification', $notification, $user)
                 );
             }
         }
-    }
-
-    /**
-     * Find the stored notification that the fired blueprint produced for this recipient.
-     *
-     * We match on the blueprint itself (type, subject, from-user and data) rather than just the
-     * type, so the broadcast carries the notification the event actually created — not whichever
-     * notification of the same type happens to be newest, which would surface a previous,
-     * unrelated notification (e.g. an older mention from a different user) in the toast.
-     */
-    public function notificationFor(User $user): ?Notification
-    {
-        return Notification::matchingBlueprint($this->blueprint)
-            ->where('user_id', $user->id)
-            ->first();
     }
 }

--- a/extensions/realtime/src/Push/Listener/BroadcastNotifications.php
+++ b/extensions/realtime/src/Push/Listener/BroadcastNotifications.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Push\Listener;
+
+use Flarum\Notification\Event\Sent;
+use Flarum\Realtime\Push\Jobs\SendNotificationsJob;
+use Illuminate\Contracts\Queue\Queue;
+
+/**
+ * Queues the realtime broadcast for freshly-inserted notifications.
+ *
+ * Listening to {@see Sent} (dispatched after the records are inserted) rather than broadcasting
+ * from the notification driver — which runs in parallel with the insert — guarantees the rows
+ * exist by the time the broadcast job looks them up, so there is no race to drop or retry.
+ */
+class BroadcastNotifications
+{
+    public function __construct(
+        protected Queue $queue
+    ) {
+    }
+
+    public function handle(Sent $event): void
+    {
+        if (! count($event->recipients)) {
+            return;
+        }
+
+        $this->queue->push(
+            new SendNotificationsJob($event->blueprint, $event->recipients)
+        );
+    }
+}

--- a/extensions/realtime/src/Push/NotificationDriver.php
+++ b/extensions/realtime/src/Push/NotificationDriver.php
@@ -11,19 +11,21 @@ namespace Flarum\Realtime\Push;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Driver\NotificationDriverInterface;
-use Illuminate\Contracts\Queue\Queue;
 
 class NotificationDriver implements NotificationDriverInterface
 {
-    public function __construct(protected Queue $queue)
-    {
-    }
-
     public function send(BlueprintInterface $blueprint, array $users): void
     {
-        if (count($users)) {
-            $this->queue->push(new Jobs\SendNotificationsJob($blueprint, $users));
-        }
+        // The broadcast is intentionally NOT dispatched here. send() runs from
+        // NotificationSyncer::sync(), before the notification records are inserted (that happens
+        // in core's own queued Notification\Job\SendNotificationsJob). Dispatching the broadcast
+        // here races that insert and, on the async queue realtime requires, frequently looked the
+        // record up before it existed — dropping the toast.
+        //
+        // Instead we broadcast from the Notification\Event\Sent listener
+        // (Push\Listener\BroadcastNotifications), which fires *after* the records are inserted.
+        // The driver is still registered so 'realtime' is offered as a notification method and its
+        // per-type preference is created via registerType().
     }
 
     public function registerType(string $blueprintClass, array $driversEnabledByDefault): void

--- a/extensions/realtime/tests/integration/SendNotificationsJobTest.php
+++ b/extensions/realtime/tests/integration/SendNotificationsJobTest.php
@@ -81,5 +81,14 @@ class SendNotificationsJobTest extends TestCase
         $this->assertEquals(1, $selected->id, 'The broadcast must use the notification from the mention that fired (glowingblue), not the most recent unrelated one (wlork)');
         $this->assertEquals(4, $selected->from_user_id, 'from_user must be glowingblue (user 4)');
         $this->assertEquals(11, $selected->subject_id, 'subject must be the post that fired (11)');
+
+        // The blueprint + recipient must match exactly one notification. NotificationSyncer keeps
+        // a single record per user per blueprint, so the selection is unambiguous — `first()` has
+        // only one candidate and never depends on ordering.
+        $this->assertEquals(
+            1,
+            Notification::matchingBlueprint($blueprint)->where('user_id', $recipient->id)->count(),
+            'A blueprint should match exactly one notification per recipient'
+        );
     }
 }

--- a/extensions/realtime/tests/integration/SendNotificationsJobTest.php
+++ b/extensions/realtime/tests/integration/SendNotificationsJobTest.php
@@ -12,12 +12,18 @@ namespace Flarum\Realtime\Tests\integration;
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Mentions\Notification\UserMentionedBlueprint;
+use Flarum\Notification\Event\Sent;
 use Flarum\Notification\Notification;
 use Flarum\Post\Post;
+use Flarum\Realtime\Push\Jobs\SendGeneratedPayloadJob;
 use Flarum\Realtime\Push\Jobs\SendNotificationsJob;
+use Flarum\Realtime\Push\Listener\BroadcastNotifications;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\NullQueue;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
 
 class SendNotificationsJobTest extends TestCase
@@ -60,8 +66,56 @@ class SendNotificationsJobTest extends TestCase
         ]);
     }
 
+    /**
+     * A SendNotificationsJob whose connected-user set is supplied directly, so the test does not
+     * depend on a live Pusher `getChannels` call.
+     *
+     * @param User[] $recipients
+     * @param User[] $connected
+     */
+    private function jobWithConnected(UserMentionedBlueprint $blueprint, array $recipients, array $connected): SendNotificationsJob
+    {
+        return new class ($blueprint, $recipients, $connected) extends SendNotificationsJob {
+            /**
+             * @param User[] $recipients
+             * @param User[] $connected
+             */
+            public function __construct(UserMentionedBlueprint $blueprint, array $recipients, private array $connected)
+            {
+                parent::__construct($blueprint, $recipients);
+            }
+
+            protected function connectedUsers(?Discussion $visible = null): Collection
+            {
+                return Collection::make($this->connected);
+            }
+        };
+    }
+
+    /**
+     * A Queue stub that records every job pushed to it without running it.
+     *
+     * @param array<int, object> $pushed
+     */
+    private function recordingQueue(array &$pushed): Queue
+    {
+        return new class ($pushed) extends NullQueue {
+            /** @param array<int, object> $pushed */
+            public function __construct(private array &$pushed)
+            {
+            }
+
+            public function push($job, $data = '', $queue = null)
+            {
+                $this->pushed[] = $job;
+
+                return null;
+            }
+        };
+    }
+
     #[Test]
-    public function it_selects_the_notification_matching_the_fired_blueprint(): void
+    public function it_broadcasts_the_notification_matching_the_fired_blueprint(): void
     {
         $this->app();
 
@@ -73,22 +127,112 @@ class SendNotificationsJobTest extends TestCase
         // The blueprint that actually fired: glowingblue's mention on post 11.
         $blueprint = new UserMentionedBlueprint($firedPost);
 
-        $job = new SendNotificationsJob($blueprint, [$recipient]);
+        $pushed = [];
+        $job = $this->jobWithConnected($blueprint, [$recipient], [$recipient]);
 
-        $selected = $job->notificationFor($recipient);
+        $job->handle($this->recordingQueue($pushed));
 
-        $this->assertNotNull($selected, 'A notification should be selected for the recipient');
-        $this->assertEquals(1, $selected->id, 'The broadcast must use the notification from the mention that fired (glowingblue), not the most recent unrelated one (wlork)');
-        $this->assertEquals(4, $selected->from_user_id, 'from_user must be glowingblue (user 4)');
-        $this->assertEquals(11, $selected->subject_id, 'subject must be the post that fired (11)');
+        $this->assertCount(1, $pushed, 'Exactly one payload job should be pushed for the connected recipient');
 
-        // The blueprint + recipient must match exactly one notification. NotificationSyncer keeps
-        // a single record per user per blueprint, so the selection is unambiguous — `first()` has
-        // only one candidate and never depends on ordering.
-        $this->assertEquals(
-            1,
-            Notification::matchingBlueprint($blueprint)->where('user_id', $recipient->id)->count(),
-            'A blueprint should match exactly one notification per recipient'
-        );
+        /** @var SendGeneratedPayloadJob $payloadJob */
+        $payloadJob = $pushed[0];
+        $this->assertInstanceOf(SendGeneratedPayloadJob::class, $payloadJob);
+
+        $notification = $this->readPrivate($payloadJob, 'model');
+        $this->assertInstanceOf(Notification::class, $notification);
+        $this->assertEquals(1, $notification->id, 'The broadcast must use the notification from the mention that fired (glowingblue), not the most recent unrelated one (wlork)');
+        $this->assertEquals(4, $notification->from_user_id, 'from_user must be glowingblue (user 4)');
+        $this->assertEquals(11, $notification->subject_id, 'subject must be the post that fired (11)');
+    }
+
+    #[Test]
+    public function it_skips_recipients_who_do_not_want_an_alert(): void
+    {
+        $this->app();
+
+        /** @var Post $firedPost */
+        $firedPost = Post::query()->findOrFail(11);
+        /** @var User $recipient */
+        $recipient = User::query()->findOrFail(2);
+
+        // Opt the recipient out of the realtime alert for this type.
+        $recipient->setPreference('notify_userMentioned_alert', false);
+        $recipient->save();
+
+        $blueprint = new UserMentionedBlueprint($firedPost);
+
+        $pushed = [];
+        $job = $this->jobWithConnected($blueprint, [$recipient], [$recipient]);
+
+        $job->handle($this->recordingQueue($pushed));
+
+        $this->assertCount(0, $pushed, 'No payload job should be pushed for a recipient who opted out of the alert');
+    }
+
+    #[Test]
+    public function it_skips_recipients_who_are_not_connected(): void
+    {
+        $this->app();
+
+        /** @var Post $firedPost */
+        $firedPost = Post::query()->findOrFail(11);
+        /** @var User $recipient */
+        $recipient = User::query()->findOrFail(2);
+
+        $blueprint = new UserMentionedBlueprint($firedPost);
+
+        $pushed = [];
+        // Recipient is targeted but not on the socket — nothing to broadcast.
+        $job = $this->jobWithConnected($blueprint, [$recipient], []);
+
+        $job->handle($this->recordingQueue($pushed));
+
+        $this->assertCount(0, $pushed, 'No payload job should be pushed for a recipient who is not connected');
+    }
+
+    #[Test]
+    public function listener_queues_the_broadcast_job_for_a_sent_event(): void
+    {
+        $this->app();
+
+        /** @var Post $firedPost */
+        $firedPost = Post::query()->findOrFail(11);
+        /** @var User $recipient */
+        $recipient = User::query()->findOrFail(2);
+
+        $blueprint = new UserMentionedBlueprint($firedPost);
+
+        $pushed = [];
+        $listener = new BroadcastNotifications($this->recordingQueue($pushed));
+
+        $listener->handle(new Sent($blueprint, [$recipient]));
+
+        $this->assertCount(1, $pushed, 'The listener should queue exactly one broadcast job');
+        $this->assertInstanceOf(SendNotificationsJob::class, $pushed[0]);
+    }
+
+    #[Test]
+    public function listener_does_nothing_without_recipients(): void
+    {
+        $this->app();
+
+        /** @var Post $firedPost */
+        $firedPost = Post::query()->findOrFail(11);
+
+        $blueprint = new UserMentionedBlueprint($firedPost);
+
+        $pushed = [];
+        $listener = new BroadcastNotifications($this->recordingQueue($pushed));
+
+        $listener->handle(new Sent($blueprint, []));
+
+        $this->assertCount(0, $pushed, 'The listener should not queue a broadcast job when there are no recipients');
+    }
+
+    private function readPrivate(object $object, string $property): mixed
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+
+        return $reflection->getValue($object);
     }
 }

--- a/extensions/realtime/tests/integration/SendNotificationsJobTest.php
+++ b/extensions/realtime/tests/integration/SendNotificationsJobTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Mentions\Notification\UserMentionedBlueprint;
+use Flarum\Notification\Notification;
+use Flarum\Post\Post;
+use Flarum\Realtime\Push\Jobs\SendNotificationsJob;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class SendNotificationsJobTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-realtime', 'flarum-mentions');
+
+        // user 2 (recipient) has TWO `userMentioned` notifications from different mentions:
+        //   - one from `glowingblue` (user 4) on post 11 — this is the mention whose blueprint fires
+        //   - one from `wlork` (user 3) on post 10 — an unrelated mention that is NEWER in the table
+        //
+        // The bug: the broadcast job selected "this user's latest notification of this type"
+        // (`type` + `latest()`), which returns wlork's newer-but-unrelated notification instead of
+        // the one the firing blueprint actually produced. This reproduces the reported case where a
+        // mention from glowingblue surfaced a previous mention from wlork in the toast.
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'wlork', 'email' => 'wlork@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'glowingblue', 'email' => 'glowingblue@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Hello world', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 10, 'comment_count' => 3],
+            ],
+            Post::class => [
+                ['id' => 10, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>@you</p></t>'],
+                ['id' => 11, 'number' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now()->subMinute(), 'user_id' => 4, 'type' => 'comment', 'content' => '<t><p>@you</p></t>'],
+            ],
+            Notification::class => [
+                // glowingblue's mention (post 11) — the one whose blueprint fires below. Older row.
+                ['id' => 1, 'user_id' => 2, 'from_user_id' => 4, 'type' => 'userMentioned', 'subject_id' => 11, 'data' => null, 'created_at' => Carbon::now()->subMinute(), 'read_at' => null, 'is_deleted' => 0],
+                // wlork's mention (post 10) — unrelated, but the NEWEST userMentioned row for this user.
+                ['id' => 2, 'user_id' => 2, 'from_user_id' => 3, 'type' => 'userMentioned', 'subject_id' => 10, 'data' => null, 'created_at' => Carbon::now(), 'read_at' => null, 'is_deleted' => 0],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function it_selects_the_notification_matching_the_fired_blueprint(): void
+    {
+        $this->app();
+
+        /** @var Post $firedPost */
+        $firedPost = Post::query()->findOrFail(11);
+        /** @var User $recipient */
+        $recipient = User::query()->findOrFail(2);
+
+        // The blueprint that actually fired: glowingblue's mention on post 11.
+        $blueprint = new UserMentionedBlueprint($firedPost);
+
+        $job = new SendNotificationsJob($blueprint, [$recipient]);
+
+        $selected = $job->notificationFor($recipient);
+
+        $this->assertNotNull($selected, 'A notification should be selected for the recipient');
+        $this->assertEquals(1, $selected->id, 'The broadcast must use the notification from the mention that fired (glowingblue), not the most recent unrelated one (wlork)');
+        $this->assertEquals(4, $selected->from_user_id, 'from_user must be glowingblue (user 4)');
+        $this->assertEquals(11, $selected->subject_id, 'subject must be the post that fired (11)');
+    }
+}

--- a/extensions/realtime/tests/integration/SendNotificationsJobTest.php
+++ b/extensions/realtime/tests/integration/SendNotificationsJobTest.php
@@ -75,7 +75,7 @@ class SendNotificationsJobTest extends TestCase
      */
     private function jobWithConnected(UserMentionedBlueprint $blueprint, array $recipients, array $connected): SendNotificationsJob
     {
-        return new class ($blueprint, $recipients, $connected) extends SendNotificationsJob {
+        return new class($blueprint, $recipients, $connected) extends SendNotificationsJob {
             /**
              * @param User[] $recipients
              * @param User[] $connected
@@ -99,7 +99,7 @@ class SendNotificationsJobTest extends TestCase
      */
     private function recordingQueue(array &$pushed): Queue
     {
-        return new class ($pushed) extends NullQueue {
+        return new class($pushed) extends NullQueue {
             /** @param array<int, object> $pushed */
             public function __construct(private array &$pushed)
             {

--- a/framework/core/src/Notification/Event/Sent.php
+++ b/framework/core/src/Notification/Event/Sent.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Notification\Event;
+
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\User\User;
+
+/**
+ * Dispatched after notification records have been inserted for a blueprint.
+ *
+ * Unlike the moment a driver is asked to send (which happens before the rows exist), this fires
+ * once the rows are committed, so listeners can rely on the notifications being queryable — e.g.
+ * via {@see \Flarum\Notification\Notification::scopeMatchingBlueprint()}. Only carries the
+ * recipients for whom a row was actually inserted on this run (not those skipped as duplicates).
+ */
+class Sent
+{
+    /**
+     * @param User[] $recipients The users for whom a notification record was just inserted.
+     */
+    public function __construct(
+        public BlueprintInterface&AlertableInterface $blueprint,
+        public array $recipients
+    ) {
+    }
+}

--- a/framework/core/src/Notification/Job/SendNotificationsJob.php
+++ b/framework/core/src/Notification/Job/SendNotificationsJob.php
@@ -11,9 +11,11 @@ namespace Flarum\Notification\Job;
 
 use Flarum\Notification\AlertableInterface;
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Event\Sent;
 use Flarum\Notification\Notification;
 use Flarum\Queue\AbstractJob;
 use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class SendNotificationsJob extends AbstractJob
 {
@@ -48,5 +50,10 @@ class SendNotificationsJob extends AbstractJob
         }
 
         Notification::notify($newRecipients, $this->blueprint);
+
+        // Announce the insert so listeners can act on the now-existing records (e.g. realtime
+        // broadcasting). Resolved from the container rather than injected to keep handle()'s
+        // signature stable; mirrors the resolve() use in Notification::notify() itself.
+        resolve(Dispatcher::class)->dispatch(new Sent($this->blueprint, array_values($newRecipients)));
     }
 }

--- a/framework/core/tests/integration/notification/NotificationSentEventTest.php
+++ b/framework/core/tests/integration/notification/NotificationSentEventTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\notification;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Event\Sent;
+use Flarum\Notification\Job\SendNotificationsJob;
+use Flarum\Notification\Notification;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+class NotificationSentEventTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'recipient', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'recipient@machine.local', 'is_email_confirmed' => 1],
+            ],
+        ]);
+    }
+
+    /**
+     * Register a Sent listener that records each event plus whether its row was queryable
+     * at dispatch time, then run the given callback.
+     *
+     * @return array{0: Sent[], 1: bool[]} [captured events, row-existed-at-dispatch flags]
+     */
+    private function listenAndRun(callable $run): array
+    {
+        $captured = [];
+        $rowExisted = [];
+
+        $this->app()->getContainer()->make(Dispatcher::class)->listen(
+            Sent::class,
+            function (Sent $event) use (&$captured, &$rowExisted) {
+                $captured[] = $event;
+                // The whole point: the row must already exist when the event fires.
+                $rowExisted[] = Notification::matchingBlueprint($event->blueprint)->exists();
+            }
+        );
+
+        $run();
+
+        return [$captured, $rowExisted];
+    }
+
+    #[Test]
+    public function dispatches_sent_event_after_inserting_the_record(): void
+    {
+        $this->app();
+
+        $blueprint = new SentEventTestBlueprint();
+        $recipient = User::find(3);
+
+        [$captured, $rowExisted] = $this->listenAndRun(function () use ($blueprint, $recipient) {
+            (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+        });
+
+        $this->assertCount(1, $captured, 'Sent should be dispatched exactly once');
+        $this->assertSame($blueprint, $captured[0]->blueprint);
+        $this->assertEquals([3], array_map(fn (User $u) => $u->id, $captured[0]->recipients));
+        $this->assertSame([true], $rowExisted, 'The notification row must exist when Sent is dispatched');
+    }
+
+    #[Test]
+    public function does_not_dispatch_when_nothing_new_is_inserted(): void
+    {
+        $this->app();
+
+        $blueprint = new SentEventTestBlueprint();
+        $recipient = User::find(3);
+
+        // First run inserts the row.
+        (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+
+        // Second run is an idempotent no-op (the dedup skips the already-inserted recipient),
+        // so no Sent event should fire.
+        [$captured] = $this->listenAndRun(function () use ($blueprint, $recipient) {
+            (new SendNotificationsJob($blueprint, [$recipient]))->handle();
+        });
+
+        $this->assertCount(0, $captured, 'Sent must not fire when no new records are inserted');
+    }
+}
+
+class SentEventTestBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): ?array
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'sentEventTest';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return 'sentEventTestSubjectModel';
+    }
+}


### PR DESCRIPTION
Fixes two bugs with the realtime notification toast.

**Wrong toast** — the broadcast job selected the recipient's newest notification of the blueprint's *type* (`type` + `latest()`), so with more than one same-type notification it showed the wrong one (e.g. a new mention surfaced a previous mention from a different user). It now matches on the fired blueprint.

**Missing toast (race)** — the row is inserted by core's queued job while the broadcast was dispatched in parallel by the realtime driver. On the async queue realtime requires, the broadcast often ran before the row existed and dropped the toast. The broadcast now fires from a new `Notification\Event\Sent` event, after the rows are inserted, so the record is always present.

`Sent` is additive; the insert job's `handle()` signature is unchanged.
