### PR TITLE
[2.x] fix(realtime): push the notification record matching the blueprint, not the latest of its type

### DIFF
--- a/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
+++ b/extensions/realtime/src/Push/Jobs/SendNotificationsJob.php
@@ -17,8 +17,21 @@ class SendNotificationsJob extends Job
 {
     public static ?string $onQueue = null;
 
-    public function __construct(private BlueprintInterface $blueprint, private array $recipients)
-    {
+    /**
+     * The notification record is inserted by the alert driver's own queued job
+     * (Flarum\Notification\Job\SendNotificationsJob), which this job has no
+     * ordering guarantee with on concurrent queue workers. When the record
+     * isn't visible yet, re-check a bounded number of times instead of
+     * dropping the push.
+     */
+    protected const MAX_ATTEMPTS = 3;
+    protected const RETRY_DELAY_SECONDS = 2;
+
+    public function __construct(
+        private BlueprintInterface $blueprint,
+        private array $recipients,
+        private int $attempt = 1
+    ) {
         parent::__construct();
     }
 
@@ -27,22 +40,38 @@ class SendNotificationsJob extends Job
         // Only dispatch notification jobs for users on the socket.
         $intersect = $this->connectedUsers()->intersect($this->recipients);
 
+        $missing = [];
+
         foreach ($intersect as $user) {
             if (! $user->shouldAlert($this->blueprint::getType())) {
                 continue;
             }
 
-            $notification = Notification::query()
+            // Resolve the exact record this blueprint produced for the user.
+            // A latest()-of-type lookup is not equivalent: `created_at` has
+            // second granularity and restored records keep their original
+            // timestamp, so with several notifications of the same type it
+            // can resolve to a different, older record — pushing a stale
+            // notification to the client.
+            $notification = Notification::matchingBlueprint($this->blueprint)
                 ->where('user_id', $user->id)
-                ->where('type', $this->blueprint::getType())
-                ->latest()
+                ->latest('id')
                 ->first();
 
             if ($notification) {
                 $queue->push(
                     new SendGeneratedPayloadJob('notification', $notification, $user)
                 );
+            } elseif ($this->attempt < self::MAX_ATTEMPTS) {
+                $missing[] = $user;
             }
+        }
+
+        if (count($missing)) {
+            $queue->later(
+                self::RETRY_DELAY_SECONDS,
+                new self($this->blueprint, $missing, $this->attempt + 1)
+            );
         }
     }
 }

--- a/extensions/realtime/tests/integration/push/SendNotificationsJobTest.php
+++ b/extensions/realtime/tests/integration/push/SendNotificationsJobTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration\push;
+
+use Carbon\Carbon;
+use Flarum\Database\AbstractModel;
+use Flarum\Discussion\Discussion;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\Notification;
+use Flarum\Realtime\Push\Jobs\SendGeneratedPayloadJob;
+use Flarum\Realtime\Push\Jobs\SendNotificationsJob;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Queue\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Pusher\Pusher;
+use ReflectionProperty;
+
+class SendNotificationsJobTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-realtime');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'other', 'email' => 'other@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'First discussion', 'created_at' => Carbon::parse('2026-06-01 10:00:00'), 'last_posted_at' => Carbon::parse('2026-06-01 10:00:00'), 'user_id' => 3, 'comment_count' => 1],
+                ['id' => 2, 'title' => 'Second discussion', 'created_at' => Carbon::parse('2026-06-01 10:00:00'), 'last_posted_at' => Carbon::parse('2026-06-01 10:00:00'), 'user_id' => 3, 'comment_count' => 1],
+            ],
+            Notification::class => [
+                // The record for this test's blueprint (subject: discussion 1).
+                // Its created_at is OLDER — as happens when the syncer restores
+                // an existing record, which keeps the original timestamp.
+                ['id' => 1, 'user_id' => 2, 'from_user_id' => 3, 'type' => 'discussionRenamed', 'subject_id' => 1, 'data' => null, 'created_at' => Carbon::parse('2026-06-01 10:00:00'), 'read_at' => null, 'is_deleted' => 0],
+                // An unrelated notification of the SAME type with a newer timestamp.
+                ['id' => 2, 'user_id' => 2, 'from_user_id' => 3, 'type' => 'discussionRenamed', 'subject_id' => 2, 'data' => null, 'created_at' => Carbon::parse('2026-06-01 12:00:00'), 'read_at' => null, 'is_deleted' => 0],
+            ],
+        ]);
+    }
+
+    /**
+     * Runs the job with user 2 reported as connected, capturing every job
+     * pushed or scheduled on the queue.
+     *
+     * @return array{0: array, 1: array} [pushed jobs, delayed jobs]
+     */
+    private function runJob(SendNotificationsJob $job): array
+    {
+        $container = $this->app()->getContainer();
+
+        $pusher = $this->createStub(Pusher::class);
+        $pusher->method('getChannels')->willReturn((object) ['channels' => ['private-user=2' => (object) []]]);
+        $container->instance(Pusher::class, $pusher);
+
+        $pushed = [];
+        $delayed = [];
+
+        $queue = $this->createStub(Queue::class);
+        $queue->method('push')->willReturnCallback(function ($job) use (&$pushed) {
+            $pushed[] = $job;
+
+            return null;
+        });
+        $queue->method('later')->willReturnCallback(function ($delay, $job) use (&$delayed) {
+            $delayed[] = $job;
+
+            return null;
+        });
+
+        $job->handle($queue);
+
+        return [$pushed, $delayed];
+    }
+
+    #[Test]
+    public function pushes_the_record_matching_the_blueprint_not_the_latest_of_its_type(): void
+    {
+        // Boots the container and sets up the DB connection on models.
+        $this->app();
+
+        $blueprint = new RenamedStubBlueprint(Discussion::find(1), User::find(3));
+
+        [$pushed, $delayed] = $this->runJob(new SendNotificationsJob($blueprint, [User::find(2)]));
+
+        $this->assertCount(1, $pushed);
+        $this->assertInstanceOf(SendGeneratedPayloadJob::class, $pushed[0]);
+
+        $model = (new ReflectionProperty(SendGeneratedPayloadJob::class, 'model'))->getValue($pushed[0]);
+
+        $this->assertInstanceOf(Notification::class, $model);
+        // The blueprint concerns discussion 1, whose record is id 1 — NOT the
+        // same-type record with the newer created_at (id 2).
+        $this->assertSame(1, $model->id);
+
+        $this->assertCount(0, $delayed);
+    }
+
+    #[Test]
+    public function retries_when_the_record_is_not_yet_visible(): void
+    {
+        $this->app();
+
+        // No record matches this blueprint (no rename of discussion 2 by user 2)
+        // — as happens when the alert driver's insert job hasn't run yet.
+        $blueprint = new RenamedStubBlueprint(Discussion::find(2), User::find(2));
+
+        [$pushed, $delayed] = $this->runJob(new SendNotificationsJob($blueprint, [User::find(2)]));
+
+        $this->assertCount(0, $pushed);
+        $this->assertCount(1, $delayed);
+        $this->assertInstanceOf(SendNotificationsJob::class, $delayed[0]);
+
+        $attempt = (new ReflectionProperty(SendNotificationsJob::class, 'attempt'))->getValue($delayed[0]);
+
+        $this->assertSame(2, $attempt);
+    }
+
+    #[Test]
+    public function gives_up_after_max_attempts(): void
+    {
+        $this->app();
+
+        $blueprint = new RenamedStubBlueprint(Discussion::find(2), User::find(2));
+
+        [$pushed, $delayed] = $this->runJob(new SendNotificationsJob($blueprint, [User::find(2)], 3));
+
+        $this->assertCount(0, $pushed);
+        $this->assertCount(0, $delayed);
+    }
+}
+
+class RenamedStubBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function __construct(
+        private Discussion $discussion,
+        private ?User $fromUser = null
+    ) {
+    }
+
+    public function getFromUser(): ?User
+    {
+        return $this->fromUser;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return $this->discussion;
+    }
+
+    public function getData(): mixed
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'discussionRenamed';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return Discussion::class;
+    }
+}


### PR DESCRIPTION
## Background

Closes #4714.

Users on 2.0 rc report the realtime notification banner "showing old notifications", sometimes suspected to be connected to device backgrounding. The actual mechanism is server-side and has been present since the toast feature landed for rc.1 (#4473): the push job resolves the record to broadcast with a *latest-of-this-type-for-this-user* lookup that is not tied to the event being handled.

## Root cause

`SendNotificationsJob` receives the blueprint and recipients, but re-derives the record with:

```php
$notification = Notification::query()
    ->where('user_id', $user->id)
    ->where('type', $this->blueprint::getType())
    ->latest()
    ->first();
```

No subject constraint, no id tiebreak, ordering only on `created_at` — which is second-granularity, not covered by an index (so equal timestamps sort arbitrarily; observed on MySQL 8.0 returning the *older* id), and not updated when `NotificationSyncer` restores a record. On top of that, the record is inserted by the alert driver's own queued job (`Flarum\Notification\Job\SendNotificationsJob`), with no ordering guarantee once multiple queue workers run: the realtime job can read before the insert commits and resolve the user's *previous* notification of that type — possibly hours old. Full analysis with a SQL demonstration in #4714.

Either way the client toasts whatever record was picked (and increments the badge), while the actual new notification is never pushed.

## Fix

Resolve the record from the blueprint, which pins type + subject + sender + data — `Notification::matchingBlueprint()` is exactly the resolver core's `NotificationSyncer` uses to identify a blueprint's records — with `latest('id')` as a deterministic tiebreak:

```php
$notification = Notification::matchingBlueprint($this->blueprint)
    ->where('user_id', $user->id)
    ->latest('id')
    ->first();
```

When no record is visible yet (the insert job hasn't committed — the concurrent-worker case), the job now re-dispatches itself for the affected recipients only, with a short delay and a bounded number of attempts (3 total), instead of pushing a wrong record or dropping the event:

- Recipients whose record *was* found are pushed immediately and are not part of the retry, so a retry can never double-push them.
- On the sync queue driver `later()` executes immediately; the attempt bound keeps that finite (and on sync the insert always precedes this job anyway, so the retry path is effectively never taken there).
- After the final attempt the job gives up silently — same outcome as the pre-existing `if ($notification)` guard when nothing matched.

## Not addressed here (pre-existing, separate concern)

When core syncs the same blueprint twice in rapid succession (the #4622 scenario), core dedups the *insert* at queue time, but two realtime jobs are still queued and will now both resolve the same (correct) record and push it twice. That duplicate-push of an identical record is a distinct, rarer issue and is unchanged by this PR — flagging it for completeness.

## Verification

- New integration tests in `extensions/realtime/tests/integration/push/SendNotificationsJobTest.php`:
  - `pushes_the_record_matching_the_blueprint_not_the_latest_of_its_type` — fixtures contain the blueprint's record with an *older* `created_at` plus an unrelated same-type record with a newer one; asserts the pushed `SendGeneratedPayloadJob` carries the blueprint's record.
  - `retries_when_the_record_is_not_yet_visible` — no matching record: asserts nothing is pushed and a re-dispatch with an incremented attempt is scheduled.
  - `gives_up_after_max_attempts` — at the attempt cap: asserts no push and no further re-dispatch.
- All three tests **fail on current `2.x` HEAD** without the src change (the first resolves the wrong record; the other two observe a push for an event whose own record doesn't even exist — the bug in miniature) and pass with it.
- Full realtime suite green: 14 tests, 33 assertions (1 pre-existing skip; remaining deprecation notices come from `middlewares/utils` under PHP 8.4, unrelated).
- `phpstan analyse extensions/realtime/src` (level 6): no errors.
- PHP-only change — no JS source or `dist` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
