### PR TITLE
[2.x] fix(testing): reorder boot sequence in `OverrideExtensionManagerForTests`

### DIFF
--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -34,11 +34,11 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
             $container->singleton(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
             $extensionManager = $container->make(ExtensionManager::class);
 
+            $extensionManager->booted = true;
+
             foreach ($this->extensions as $extension) {
                 $extensionManager->enable($extension);
             }
-
-            $extensionManager->booted = true;
 
             $extensionManager->extend($container);
         }

--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -35,8 +35,10 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
             /** @var ExtensionManagerIncludeCurrent $extensionManager */
             $extensionManager = $container->make(ExtensionManager::class);
 
+            $extensionManager->booted = true;
             $extensionManager->extend($container);
 
+            $extensionManager->booted = false;
             foreach ($this->extensions as $extension) {
                 $extensionManager->enable($extension);
             }

--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -35,13 +35,13 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
             /** @var ExtensionManagerIncludeCurrent $extensionManager */
             $extensionManager = $container->make(ExtensionManager::class);
 
-            $extensionManager->booted = true;
+            $extensionManager->extend($container);
 
             foreach ($this->extensions as $extension) {
                 $extensionManager->enable($extension);
             }
 
-            $extensionManager->extend($container);
+            $extensionManager->booted = true;
         }
     }
 }

--- a/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/php-packages/testing/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -32,6 +32,7 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
         $container->when(ExtensionManagerIncludeCurrent::class)->needs('$enabledIds')->give($this->extensions);
         if (count($this->extensions)) {
             $container->singleton(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
+            /** @var ExtensionManagerIncludeCurrent $extensionManager */
             $extensionManager = $container->make(ExtensionManager::class);
 
             $extensionManager->booted = true;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4600**
Reorder the boot sequence in `OverrideExtensionManagerForTest`s to fix locale translations never loading in integration tests as described in #4600. `LocaleManager` was being resolved during `onEnable()` before `extend()` had registered the locale `resolving()` callbacks. This fix runs `extend()` first (with `booted=true`), then the `enable()` loop (with `booted=false` so migrations still run).



**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
* Whether the booted toggle could cause side effects which the testing suite of the framework itself doesn't catch

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
