### PR TITLE
[2.x] fix(core): return HTTP 503 when upgrade page is shown

### DIFF
--- a/framework/core/src/Update/Controller/IndexController.php
+++ b/framework/core/src/Update/Controller/IndexController.php
@@ -13,6 +13,8 @@ use Flarum\Foundation\Config;
 use Flarum\Http\Controller\AbstractHtmlController;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Factory;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 class IndexController extends AbstractHtmlController
@@ -21,6 +23,17 @@ class IndexController extends AbstractHtmlController
         protected Factory $view,
         protected Config $config
     ) {
+    }
+
+    public function handle(Request $request): ResponseInterface
+    {
+        $view = $this->render($request);
+
+        if ($view instanceof Renderable) {
+            $view = $view->render();
+        }
+
+        return new HtmlResponse($view, 503);
     }
 
     public function render(Request $request): Renderable|string

--- a/framework/core/tests/integration/forum/UpgradePageTest.php
+++ b/framework/core/tests/integration/forum/UpgradePageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\forum;
+
+use Flarum\Foundation\Application;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class UpgradePageTest extends TestCase
+{
+    #[Test]
+    public function upgrade_page_returns_503_when_version_is_outdated(): void
+    {
+        $this->setting('version', '9999999.9999999.9999999');
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+
+        $this->assertEquals(503, $response->getStatusCode());
+        $this->assertStringContainsString('Update Flarum', (string) $response->getBody());
+    }
+
+    #[Test]
+    public function upgrade_page_is_not_shown_when_version_matches(): void
+    {
+        $this->setting('version', Application::VERSION);
+
+        $response = $this->send(
+            $this->request('GET', '/')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('Update Flarum', (string) $response->getBody());
+    }
+}

--- a/framework/core/tests/integration/forum/UpgradePageTest.php
+++ b/framework/core/tests/integration/forum/UpgradePageTest.php
@@ -18,7 +18,7 @@ class UpgradePageTest extends TestCase
     #[Test]
     public function upgrade_page_returns_503_when_version_is_outdated(): void
     {
-        $this->setting('version', '9999999.9999999.9999999');
+        $this->setting('version', '0.1.0');
 
         $response = $this->send(
             $this->request('GET', '/')


### PR DESCRIPTION


<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Previously a HTTP 200 response was returned for the upgrade page, which is semantically incorrect and might lead to false negatives in monitoring systems or in testing contexts. See:

<img width="1512" height="831" alt="Screenshot 2026-06-12 at 22 21 35" src="https://github.com/user-attachments/assets/50e23d93-b841-4bc5-82f5-35a8bf637ba4" />


**Changes proposed in this pull request:**
Return 503 which is **less** semantically incorrect than 200. not perfect but better

**Reviewers should focus on:**
Looking at the history it appears like it was actually a 503  10 years ago (see https://github.com/flarum/framework/commit/23eb4c805b8c49ea9a0df3724369356b38867ac9) but at one point was acidentally removed whilst refactoring, falling back to the default 200 response

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
