### PR TITLE
[2.x] Make the realtime typing indicator reusable and movable

### DIFF
--- a/extensions/realtime/js/src/@types/shims.d.ts
+++ b/extensions/realtime/js/src/@types/shims.d.ts
@@ -1,5 +1,7 @@
 import 'flarum/common/Application';
+import 'flarum/common/models/Discussion';
 import Pusher, { Channel } from 'pusher-js';
+import type TypingState from '../forum/states/TypingState';
 
 declare module 'flarum/common/Application' {
   export default interface Application {
@@ -10,5 +12,16 @@ declare module 'flarum/common/Application' {
       /** Presence channel for the currently open discussion (typing indicator). */
       discussion?: Channel;
     };
+  }
+}
+
+declare module 'flarum/common/models/Discussion' {
+  export default interface Discussion {
+    /**
+     * The typing-indicator state for this discussion, present while its PostStream
+     * is mounted. Read it to render <TypingIndicator state={...} /> anywhere in the
+     * discussion layout — e.g. `app.current.get('discussion')?.typingState`.
+     */
+    typingState?: TypingState;
   }
 }

--- a/extensions/realtime/js/src/forum/components/TypingIndicator.tsx
+++ b/extensions/realtime/js/src/forum/components/TypingIndicator.tsx
@@ -1,0 +1,55 @@
+import app from 'flarum/forum/app';
+import Component, { type ComponentAttrs } from 'flarum/common/Component';
+import type Mithril from 'mithril';
+import Icon from 'flarum/common/components/Icon';
+import classList from 'flarum/common/utils/classList';
+import type TypingState from '../states/TypingState';
+
+export interface TypingIndicatorAttrs extends ComponentAttrs {
+  state: TypingState;
+}
+
+/**
+ * Renders the "X, Y and Z are typing" indicator for a discussion.
+ *
+ * The component is purely presentational: it is given a {@link TypingState}
+ * (which owns the currently-typing users, fed from the realtime socket) and
+ * renders its active set. Because it holds no socket logic, it can be placed
+ * anywhere — added to the PostStream `endItems` list by default, but also
+ * importable and rendered standalone wherever a theme or extension keeps a
+ * TypingState.
+ */
+export default class TypingIndicator extends Component<TypingIndicatorAttrs> {
+  view(): Mithril.Children {
+    const typingUsers = Object.keys(this.attrs.state.active());
+    const count = typingUsers.length;
+    const max = 3;
+
+    const classes = classList(['TypingUsersContainer', count > 0 && 'TypingUsersContainer-active']);
+    const typingIcon = count > 0 ? 'fas fa-ellipsis-h fa-beat' : 'fas fa-pause';
+    const namedUsers = typingUsers.slice(0, max).join(', ');
+
+    let showUsers = true;
+
+    if (app.session?.user) {
+      showUsers = app.session.user.preferences()?.['flarum-realtime.typing-indicator-full'] ?? true;
+    }
+
+    return (
+      <div className={classes}>
+        <div className="TypingUsers">
+          <Icon name={typingIcon} />
+          {count > 0
+            ? showUsers
+              ? app.translator.trans('flarum-realtime.forum.typing-indicator.users-are-typing', {
+                  users: namedUsers,
+                  count,
+                  others: Math.max(count - max, 0),
+                })
+              : app.translator.trans('flarum-realtime.forum.typing-indicator.people-are-typing', { number: count })
+            : app.translator.trans('flarum-realtime.forum.typing-indicator.no-activity')}
+        </div>
+      </div>
+    );
+  }
+}

--- a/extensions/realtime/js/src/forum/extend/Discussion/TypingIndicator.tsx
+++ b/extensions/realtime/js/src/forum/extend/Discussion/TypingIndicator.tsx
@@ -3,100 +3,32 @@ import app from 'flarum/forum/app';
 import Stream from 'flarum/common/utils/Stream';
 // @ts-ignore — lodash-es does not ship its own declaration files
 import throttle from 'lodash-es/throttle';
-import Icon from 'flarum/common/components/Icon';
-import classList from 'flarum/common/utils/classList';
-
-interface TypingUserMap {
-  [displayName: string]: number;
-}
-
-interface TypingData {
-  displayName: string;
-  discloseOnline: boolean;
-  time: number;
-}
+import TypingIndicator from '../../components/TypingIndicator';
+import TypingState, { type TypingData } from '../../states/TypingState';
 
 export default function (): void {
   extend('flarum/forum/components/PostStream', 'endItems', function (this: any, items) {
-    if (this.discussion.attribute('canViewWhoTypes')) {
-      const typingUsers = Object.keys(this.getTypingUsers());
-      const count = typingUsers.length;
-      const max = 3;
-
-      const classes = classList(['TypingUsersContainer', count > 0 && 'TypingUsersContainer-active']);
-      const typingIcon = count > 0 ? 'fas fa-ellipsis-h fa-beat' : 'fas fa-pause';
-      const namedUsers = typingUsers.slice(0, max).join(', ');
-
-      let showUsers = true;
-
-      if (app.session?.user) {
-        showUsers = app.session.user.preferences()?.['flarum-realtime.typing-indicator-full'] ?? true;
-      }
-
-      items.add(
-        'usersTyping',
-        <div className={classes} key="typing">
-          <div className="TypingUsers">
-            <Icon name={typingIcon} />
-            {count > 0
-              ? showUsers
-                ? app.translator.trans('flarum-realtime.forum.typing-indicator.users-are-typing', {
-                    users: namedUsers,
-                    count,
-                    others: Math.max(count - max, 0),
-                  })
-                : app.translator.trans('flarum-realtime.forum.typing-indicator.people-are-typing', { number: count })
-              : app.translator.trans('flarum-realtime.forum.typing-indicator.no-activity')}
-          </div>
-        </div>,
-        70
-      );
+    if (this.discussion.attribute('canViewWhoTypes') && this.discussion.typingState) {
+      // Added as a named item so themes and extensions can grab it —
+      // `items.remove('typingIndicator')` — and render a fresh <TypingIndicator> wherever
+      // they like (reading the state from `discussion.typingState`), choosing their own
+      // keying for that context.
+      //
+      // In this default placement the item is spread into PostStream's keyed children
+      // (alongside the posts, load-more and reply placeholder), so it needs a key here too,
+      // otherwise Mithril throws on the mixed keyed/unkeyed fragment.
+      items.add('typingIndicator', <TypingIndicator key="typingIndicator" state={this.discussion.typingState} />, 70);
     }
   });
 
   extend('flarum/forum/components/PostStream', 'oninit', function (this: any) {
     this.previousContent = (Stream as any)('') as ReturnType<typeof Stream>;
-    this.usersTyping = (Stream as any)({} as TypingUserMap) as ReturnType<typeof Stream>;
-    this.typingTruncationListener = null as ReturnType<typeof setTimeout> | null;
     this.typingListener = null as ReturnType<typeof setInterval> | null;
 
-    this.getTypingUsers = (): TypingUserMap => {
-      const invalidateWhen = Date.now() - 6000;
-      const users: TypingUserMap = { ...this.usersTyping() };
-      let latestTime: number | null = null;
-
-      for (const displayName of Object.keys(users)) {
-        if (users[displayName] < invalidateWhen) {
-          delete users[displayName];
-        } else if (!latestTime || latestTime < users[displayName]) {
-          latestTime = users[displayName];
-        }
-      }
-
-      this.usersTyping(users);
-
-      if (latestTime && this.typingTruncationListener) {
-        clearTimeout(this.typingTruncationListener);
-      }
-
-      if (latestTime) {
-        this.typingTruncationListener = setTimeout(() => m.redraw(), latestTime - Date.now());
-      }
-
-      return users;
-    };
-
-    this.userTyping = (data: TypingData): void => {
-      const users: TypingUserMap = { ...this.usersTyping() };
-
-      if (!data.discloseOnline) {
-        data.displayName = String(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
-      }
-
-      users[data.displayName] = data.time;
-      this.usersTyping(users);
-      m.redraw();
-    };
+    // The state lives on the discussion model so it can be reached anywhere in the
+    // discussion layout (e.g. `app.current.get('discussion')?.typingState`) without a
+    // reference to this PostStream. PostStream owns its lifecycle — see onremove.
+    this.discussion.typingState = new TypingState();
 
     this.actorIsTyping = (): void => {
       const discloseOnline = app.session.user?.preferences()?.discloseOnline;
@@ -132,7 +64,7 @@ export default function (): void {
 
       if (this.discussion.attribute('canViewWhoTypes')) {
         app.websocket_channels.discussion.bind('client-typing', (data: TypingData) => {
-          this.userTyping(data);
+          this.discussion.typingState?.add(data);
         });
       }
     }
@@ -140,6 +72,9 @@ export default function (): void {
 
   extend('flarum/forum/components/PostStream', 'onremove', function (this: any) {
     if (this.typingListener) clearInterval(this.typingListener);
-    if (this.typingTruncationListener) clearTimeout(this.typingTruncationListener);
+
+    this.discussion.typingState?.dispose();
+    // Don't leave runtime state lingering on the cached discussion model.
+    delete this.discussion.typingState;
   });
 }

--- a/extensions/realtime/js/src/forum/states/TypingState.ts
+++ b/extensions/realtime/js/src/forum/states/TypingState.ts
@@ -1,0 +1,81 @@
+import app from 'flarum/forum/app';
+
+export interface TypingUserMap {
+  [displayName: string]: number;
+}
+
+export interface TypingData {
+  displayName: string;
+  discloseOnline: boolean;
+  time: number;
+}
+
+/**
+ * Entries older than this (ms) are considered no longer typing.
+ */
+const EXPIRY_MS = 6000;
+
+/**
+ * Holds the set of users currently typing in a discussion.
+ *
+ * The realtime socket feeds incoming `client-typing` events in via {@link add},
+ * and the TypingIndicator component reads the live, expiry-pruned set via
+ * {@link active}. Keeping this state separate from PostStream lets the indicator
+ * be rendered anywhere — a theme or extension can hold its own TypingState and
+ * pass it to <TypingIndicator state={...} /> without touching PostStream.
+ */
+export default class TypingState {
+  protected usersTyping: TypingUserMap = {};
+  protected truncationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Record an incoming typing event. When the sender has not disclosed their
+   * online status, their name is replaced with the anonymous placeholder.
+   */
+  add(data: TypingData): void {
+    if (!data.discloseOnline) {
+      data.displayName = String(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
+    }
+
+    this.usersTyping[data.displayName] = data.time;
+    m.redraw();
+  }
+
+  /**
+   * The users currently typing, with expired entries pruned. Schedules a redraw
+   * for when the most recent entry will expire, so the indicator clears itself.
+   */
+  active(): TypingUserMap {
+    const invalidateWhen = Date.now() - EXPIRY_MS;
+    let latestTime: number | null = null;
+
+    for (const displayName of Object.keys(this.usersTyping)) {
+      if (this.usersTyping[displayName] < invalidateWhen) {
+        delete this.usersTyping[displayName];
+      } else if (!latestTime || latestTime < this.usersTyping[displayName]) {
+        latestTime = this.usersTyping[displayName];
+      }
+    }
+
+    if (this.truncationTimer) {
+      clearTimeout(this.truncationTimer);
+      this.truncationTimer = null;
+    }
+
+    if (latestTime) {
+      this.truncationTimer = setTimeout(() => m.redraw(), latestTime - Date.now());
+    }
+
+    return this.usersTyping;
+  }
+
+  /**
+   * Clear any pending expiry timer. Call when the owner is torn down.
+   */
+  dispose(): void {
+    if (this.truncationTimer) {
+      clearTimeout(this.truncationTimer);
+      this.truncationTimer = null;
+    }
+  }
+}


### PR DESCRIPTION
Makes the realtime typing indicator reusable and movable by extensions.

The indicator was rendered inline as a keyed vnode in `PostStream.endItems`, so the only way to relocate it was to grab and re-insert that vnode, which triggered Mithril keyed/unkeyed fragment errors.

It is now:

- A standalone `TypingIndicator` component, backed by a `TypingState` stored on the discussion model as `discussion.typingState`.
- Added to `PostStream.endItems` under the item name `typingIndicator`.

Extensions can `items.remove('typingIndicator')` and render a fresh `<TypingIndicator state={discussion.typingState} />` anywhere, choosing their own keying for that context. The component reads only from the shared state, so it can be rendered in multiple places at once.

Fixes #4619.

Docs: flarum/docs#536
