### PR TITLE
[2.x] fix(a11y): add accessible labels to composer control buttons

### DIFF
--- a/framework/core/js/src/forum/components/Composer.js
+++ b/framework/core/js/src/forum/components/Composer.js
@@ -348,6 +348,7 @@ export default class Composer extends Component {
         <ComposerButton
           icon="fas fa-compress"
           title={app.translator.trans('core.forum.composer.exit_full_screen_tooltip')}
+          aria-label={app.translator.trans('core.forum.composer.exit_full_screen_tooltip')}
           onclick={this.state.exitFullScreen.bind(this.state)}
         />
       );
@@ -361,6 +362,7 @@ export default class Composer extends Component {
               'fa-times': app.screen() === 'phone',
             })}
             title={app.translator.trans('core.forum.composer.minimize_tooltip')}
+            aria-label={app.translator.trans('core.forum.composer.minimize_tooltip')}
             onclick={this.state.minimize.bind(this.state)}
             itemClassName="App-backControl"
           />
@@ -371,6 +373,7 @@ export default class Composer extends Component {
           <ComposerButton
             icon="fas fa-expand"
             title={app.translator.trans('core.forum.composer.full_screen_tooltip')}
+            aria-label={app.translator.trans('core.forum.composer.full_screen_tooltip')}
             onclick={this.state.fullScreen.bind(this.state)}
           />
         );
@@ -381,6 +384,7 @@ export default class Composer extends Component {
         <ComposerButton
           icon="fas fa-times"
           title={app.translator.trans('core.forum.composer.close_tooltip')}
+          aria-label={app.translator.trans('core.forum.composer.close_tooltip')}
           onclick={this.state.close.bind(this.state)}
         />
       );


### PR DESCRIPTION
Adds `aria-label` to the composer's four icon-only control buttons — minimize, full screen, exit full screen, and close — reusing their existing `*_tooltip` translation strings.

These buttons set `title` but no `aria-label`. Since `Button` derives its accessible name only from `aria-label` or child text (not `title`), screen readers announced them as "Button" and Flarum's accessibility warning fired for each one when the composer was open.

Fixes #4716.
