### PR TITLE
[2.x] fix(core): Don't apply JSON:API query validation to internal API requests

### DIFF
--- a/framework/core/src/Api/Client.php
+++ b/framework/core/src/Api/Client.php
@@ -114,9 +114,11 @@ class Client
      */
     public function send(string $method, string $path): ResponseInterface
     {
-        $request = ServerRequestFactory::fromGlobals(null, $this->queryParams, $this->body)
-            ->withMethod($method)
-            ->withUri(new Uri($path));
+        $request = RequestUtil::withInternal(
+            ServerRequestFactory::fromGlobals(null, $this->queryParams, $this->body)
+                ->withMethod($method)
+                ->withUri(new Uri($path))
+        );
 
         if ($this->parent) {
             $request = $request

--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -37,6 +37,29 @@ class RequestUtil
     }
 
     /**
+     * Attribute key marking a request as an internal API call (dispatched via
+     * {@see \Flarum\Api\Client}, e.g. when a frontend page preloads its API
+     * document) rather than a request from an external client.
+     */
+    public const INTERNAL_ATTRIBUTE = 'flarum.api.internal';
+
+    public static function withInternal(Request $request): Request
+    {
+        return $request->withAttribute(self::INTERNAL_ATTRIBUTE, true);
+    }
+
+    /**
+     * Whether this request was dispatched internally. Internal requests are not
+     * held to the JSON:API spec's strict query-parameter validation: a frontend
+     * page forwards the browser's query string (which may carry tracking params
+     * like `fbclid`) into the API client, and those must not 400 the page.
+     */
+    public static function isInternal(Request $request): bool
+    {
+        return (bool) $request->getAttribute(self::INTERNAL_ATTRIBUTE, false);
+    }
+
+    /**
      * Determine the client's preferred content type out of the given list.
      *
      * @param Request $request

--- a/framework/core/src/Http/RouteHandlerFactory.php
+++ b/framework/core/src/Http/RouteHandlerFactory.php
@@ -47,7 +47,15 @@ class RouteHandlerFactory
             /** @var JsonApi $api */
             $api = $this->container->make(JsonApi::class);
 
-            $api->validateQueryParameters($request);
+            // Internal requests (e.g. a frontend page preloading its API
+            // document via Api\Client) forward the browser's query string,
+            // which may carry params like `fbclid` that the JSON:API spec
+            // requires us to reject on external requests. Skip that strict
+            // validation internally so such params don't 400 the page; the
+            // resource still only acts on the params it understands.
+            if (! RequestUtil::isInternal($request)) {
+                $api->validateQueryParameters($request);
+            }
 
             $request = $request->withQueryParams(array_merge($request->getQueryParams(), $routeParams));
 

--- a/framework/core/tests/integration/forum/IndexTest.php
+++ b/framework/core/tests/integration/forum/IndexTest.php
@@ -53,4 +53,31 @@ class IndexTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString('preferences', $response->getBody()->getContents());
     }
+
+    #[Test]
+    public function index_renders_with_unknown_query_parameters()
+    {
+        // Social/ad platforms append tracking params (fbclid, gclid, ...) to
+        // shared links. The frontend forwards the query string into the internal
+        // API document request; those params must not 400 the page even though
+        // the JSON:API spec requires rejecting them on external API requests.
+        $response = $this->send(
+            $this->request('GET', '/')->withQueryParams(['fbclid' => 'abc123', 'gclid' => 'xyz'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function external_api_still_rejects_unknown_query_parameters()
+    {
+        // The fix must not relax validation for real external API consumers,
+        // which the JSON:API spec requires to receive a 400 for an unknown
+        // (all-lowercase, non-reserved) query parameter.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')->withQueryParams(['fbclid' => 'abc123'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Fixes #4725.

## Problem

Sharing a forum URL with tracking parameters appended — e.g. `https://example.com/?fbclid=…` from Facebook, or `?gclid=…`, `?utm_*` etc. — returns a **400 Bad Request** for the whole page, breaking link previews and navigation from social media.

## Cause

The frontend page builders (`Forum\Content\Index`, `Posts`, and any extension that does the same) preload their API document by dispatching an internal request through `Api\Client`, forwarding the browser's query string. That internal request is routed through the same handler as external API requests, which runs `JsonApi::validateQueryParameters()`. Per the JSON:API spec, that validation **must** reject an unknown, all-lowercase query parameter (`fbclid`, `gclid`, …) with a 400 — so the forwarded tracking param fails the internal request and the page errors.

It reproduces on the forum index (`/?fbclid=…`) and the all-posts page (`/all?fbclid=…`); discussion/user routes pluck specific params and are unaffected. Not webserver-specific (reproduced against PHP directly).

## Fix

Mark requests dispatched through `Api\Client` as internal (`RequestUtil::withInternal()` / `isInternal()`), and skip `validateQueryParameters()` for internal requests in `RouteHandlerFactory::toApiResource`.

- **Universal**: fixes core `Index`/`Posts` and any third-party content builder that pipes through `Api\Client`, rather than patching each builder.
- **External API unchanged**: real `/api/` requests remain strict and spec-compliant (still 400 on unknown params).
- **Extensibility preserved**: all query parameters are still forwarded to the resource; nothing is stripped or whitelisted, so extensions reading their own params are unaffected.

## Tests

`tests/integration/forum/IndexTest`:
- the index renders 200 with unknown query params (`fbclid`/`gclid`) — fails without the fix;
- external `/api/discussions` still returns 400 for an unknown param — guards that the fix doesn't relax external validation.

Verified manually that `/?fbclid`, `/?gclid`, `/all?fbclid` return 200 while `/api/discussions?fbclid` still returns 400.