### PR TITLE
[2.x] fix: Avoid loading target user's groups in editCredentials check

### DIFF
--- a/extensions/likes/tests/integration/api/ListPostsTest.php
+++ b/extensions/likes/tests/integration/api/ListPostsTest.php
@@ -75,6 +75,57 @@ class ListPostsTest extends TestCase
     }
 
     #[Test]
+    public function likers_groups_are_not_loaded_individually()
+    {
+        // Regression test for flarum/framework#4724. Each post serializes its
+        // `likes` (the likers, who are User resources). UserResource's email
+        // field runs `editCredentials` → `User::isAdmin()` → `$user->groups`
+        // per serialized liker. Before the fix that lazy-loaded a liker's groups
+        // one query at a time; with many likers it is an N+1.
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 2])
+                ->withQueryParams([
+                    'filter' => ['discussion' => 100],
+                    'include' => 'likes',
+                ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Count single-row `group_user where user_id = ?` loads targeting the
+        // likers (ids >= 102). They must be batch-loaded, never one per liker.
+        $individualLikerLoads = 0;
+
+        foreach ($db->getQueryLog() as $query) {
+            if (stripos($query['query'], 'group_user') === false) {
+                continue;
+            }
+            if (stripos($query['query'], ' in (') !== false) {
+                continue;
+            }
+            foreach ($query['bindings'] as $binding) {
+                if ((int) $binding >= 102) {
+                    $individualLikerLoads++;
+                }
+            }
+        }
+
+        $db->disableQueryLog();
+
+        $this->assertSame(
+            0,
+            $individualLikerLoads,
+            "Likers' groups were loaded individually ($individualLikerLoads times) instead of being batch-loaded — the N+1 from issue #4724."
+        );
+    }
+
+    #[Test]
     public function liked_filter_works()
     {
         $response = $this->send(

--- a/framework/core/src/User/Access/UserPolicy.php
+++ b/framework/core/src/User/Access/UserPolicy.php
@@ -24,14 +24,22 @@ class UserPolicy extends AbstractPolicy
 
     public function editCredentials(User $actor, User $user): ?string
     {
+        // Check the actor's permission first. When they cannot edit credentials
+        // at all (guests and normal users — the vast majority of serialized
+        // actors), we return no opinion without touching $user->isAdmin(), which
+        // would otherwise lazy-load $user->groups once per serialized user and
+        // cause an N+1 on render paths that serialize many users (e.g. post
+        // authors, likers). See flarum/framework#4724.
+        if (! $actor->hasPermission('user.editCredentials')) {
+            return null;
+        }
+
+        // The actor may edit credentials, but must not edit an admin's unless
+        // they are an admin themselves.
         if ($user->isAdmin() && ! $actor->isAdmin()) {
             return $this->deny();
         }
 
-        if ($actor->hasPermission('user.editCredentials')) {
-            return $this->allow();
-        }
-
-        return null;
+        return $this->allow();
     }
 }


### PR DESCRIPTION
Fixes #4724.

## Problem

`UserPolicy::editCredentials()` evaluated `$user->isAdmin()` — which reads `$user->groups` — **before** checking whether the actor can edit credentials at all:

```php
if ($user->isAdmin() && ! $actor->isAdmin()) {
    return $this->deny();
}
if ($actor->hasPermission('user.editCredentials')) {
    return $this->allow();
}
return null;
```

`UserResource`'s email-field visibility calls `editCredentials` for every serialized user. On render paths that serialize many users, `$user->isAdmin()` lazy-loads each one's `groups` — one `group_user` query per user. #4696 fixed this for post authors on the JSON:API posts endpoint by eager-loading `user.groups`, but it does not cover other serialized users — notably the **likers** included by default via flarum-likes' `likes` relationship, whose groups are not eager-loaded for post-stream posts.

## Fix

Check the actor's `user.editCredentials` permission first and return no opinion when they lack it. Guests and normal users — the vast majority of serialized actors — never reach `$user->isAdmin()`, so the target user's `groups` are never loaded. `$user->isAdmin()` is only consulted when the actor can actually edit credentials, where it is needed to stop a non-admin from editing an admin's credentials.

This eliminates the work for the common case rather than batching it, and the visibility outcome is unchanged in every case:

| actor has `editCredentials` | target is admin | actor is admin | before | after |
|---|---|---|---|---|
| no | – | – | deny/null → not allowed | null → not allowed |
| yes | no | – | allow | allow |
| yes | yes | no | deny | deny |
| yes | yes | yes | allow | allow |

## Tests

- New regression test in flarum-likes (`ListPostsTest::likers_groups_are_not_loaded_individually`): asserts likers' groups are batch-loaded, not one query per liker. Fails without this change (loads them individually), passes with it.
- The existing user API + policy suite (114 tests) remains green, covering the credential-protection behaviour the table above preserves.