### PR TITLE
[2.x] fix(pusher) Boot crash and restore discussion-list updates

### DIFF
--- a/extensions/pusher/js/src/admin/extend.tsx
+++ b/extensions/pusher/js/src/admin/extend.tsx
@@ -7,6 +7,7 @@ export default [
       () => ({
         setting: 'flarum-pusher.app_id',
         label: app.translator.trans('flarum-pusher.admin.pusher_settings.app_id_label'),
+        help: app.translator.trans('flarum-pusher.admin.pusher_settings.app_id_help'),
         type: 'text',
       }),
       40
@@ -15,6 +16,7 @@ export default [
       () => ({
         setting: 'flarum-pusher.app_key',
         label: app.translator.trans('flarum-pusher.admin.pusher_settings.app_key_label'),
+        help: app.translator.trans('flarum-pusher.admin.pusher_settings.app_key_help'),
         type: 'text',
       }),
       30
@@ -23,6 +25,7 @@ export default [
       () => ({
         setting: 'flarum-pusher.app_secret',
         label: app.translator.trans('flarum-pusher.admin.pusher_settings.app_secret_label'),
+        help: app.translator.trans('flarum-pusher.admin.pusher_settings.app_secret_help'),
         type: 'text',
       }),
       20
@@ -31,6 +34,7 @@ export default [
       () => ({
         setting: 'flarum-pusher.app_cluster',
         label: app.translator.trans('flarum-pusher.admin.pusher_settings.app_cluster_label'),
+        help: app.translator.trans('flarum-pusher.admin.pusher_settings.app_cluster_help'),
         type: 'text',
       }),
       10
@@ -39,6 +43,7 @@ export default [
       () => ({
         setting: 'flarum-pusher.server_hostname',
         label: app.translator.trans('flarum-pusher.admin.pusher_settings.server_hostname_label'),
+        help: app.translator.trans('flarum-pusher.admin.pusher_settings.server_hostname_help'),
         type: 'text',
       }),
       0

--- a/extensions/pusher/js/src/forum/index.tsx
+++ b/extensions/pusher/js/src/forum/index.tsx
@@ -1,7 +1,7 @@
 import Pusher, { Channel } from 'pusher-js';
 import app from 'flarum/forum/app';
+import Application from 'flarum/common/Application';
 import { extend } from 'flarum/common/extend';
-import DiscussionList from 'flarum/forum/components/DiscussionList';
 import DiscussionPage from 'flarum/forum/components/DiscussionPage';
 import IndexPage from 'flarum/forum/components/IndexPage';
 import Button from 'flarum/common/components/Button';
@@ -18,91 +18,124 @@ export type PusherBinding = {
 };
 
 app.initializers.add('flarum-pusher', () => {
-  app.pusher = (async () => {
-    const socket: Pusher = new Pusher(app.forum.attribute('pusherKey'), {
-      authEndpoint: `${app.forum.attribute('apiUrl')}/pusher/auth`,
-      cluster: app.forum.attribute('pusherCluster'),
-      auth: {
-        headers: {
-          'X-CSRF-Token': app.session.csrfToken,
-        },
-      },
-      httpHost: app.forum.attribute('pusherHostname'),
-      wsHost: app.forum.attribute('pusherHostname'),
-    });
-
-    return {
-      channels: {
-        main: socket.subscribe('public'),
-        user: app.session.user ? socket.subscribe(`private-user${app.session.user.id()}`) : null,
-      },
-      pusher: socket,
-    };
-  })();
-
   app.pushedUpdates = [];
 
-  extend(DiscussionList.prototype, 'oncreate', function () {
-    app.pusher.then((binding: PusherBinding) => {
-      const pusher = binding.pusher;
-
-      pusher.bind('newPost', (data: { tagIds: string[]; discussionId: number }) => {
-        const params = app.discussions.getParams();
-
-        if (!params.q && !params.sort && !params.filter) {
-          if (params.tags) {
-            const tag = app.store.getBy<Tag>('tags', 'slug', params.tags);
-            const tagId = tag?.id();
-
-            if (!tagId || !data.tagIds.includes(tagId)) return;
-          }
-
-          const id = String(data.discussionId);
-
-          if ((!app.current.get('discussion') || id !== app.current.get('discussion').id()) && app.pushedUpdates.indexOf(id) === -1) {
-            app.pushedUpdates.push(id);
-
-            if (app.current.matches(IndexPage)) {
-              app.setTitleCount(app.pushedUpdates.length);
-            }
-
-            m.redraw();
-          }
-        }
+  // The socket is created in `mount`, not here. Initializers run before
+  // `app.forum` is populated (Application.boot sets `this.forum` after running
+  // initializers), so reading `app.forum.attribute(...)` at this point throws
+  // "Cannot read properties of undefined (reading 'attribute')" and aborts boot.
+  // The `extend`s below only touch `app.pusher` lazily inside lifecycle/`.then`
+  // callbacks that fire after boot, so they are safe to register here.
+  extend(Application.prototype, 'mount' as any, function () {
+    app.pusher = (async () => {
+      const socket: Pusher = new Pusher(app.forum.attribute('pusherKey'), {
+        authEndpoint: `${app.forum.attribute('apiUrl')}/pusher/auth`,
+        cluster: app.forum.attribute('pusherCluster'),
+        auth: {
+          headers: {
+            'X-CSRF-Token': app.session.csrfToken,
+          },
+        },
+        httpHost: app.forum.attribute('pusherHostname'),
+        wsHost: app.forum.attribute('pusherHostname'),
       });
-    });
-  });
 
-  extend(DiscussionList.prototype, 'onremove', function () {
+      return {
+        channels: {
+          main: socket.subscribe('public'),
+          user: app.session.user ? socket.subscribe(`private-user${app.session.user.id()}`) : null,
+        },
+        pusher: socket,
+      };
+    })();
+
     app.pusher.then((binding: PusherBinding) => {
-      binding.pusher.unbind('newPost');
+      const channels = binding.channels;
+
+      if (channels.user) {
+        channels.user.bind('notification', () => {
+          if (app.session.user) {
+            app.session.user.pushAttributes({
+              unreadNotificationCount: (app.session.user.unreadNotificationCount() ?? 0) + 1,
+              newNotificationCount: (app.session.user.newNotificationCount() ?? 0) + 1,
+            });
+          }
+          app.notifications.clear();
+          m.redraw();
+        });
+      }
     });
   });
 
-  extend(DiscussionList.prototype, 'view', function (this: DiscussionList, vdom: Children) {
-    if (app.pushedUpdates) {
-      const count = app.pushedUpdates.length;
+  // Discussion-list updates are wired on IndexPage (the stable page container)
+  // and rendered via its `contentItems` ItemList. On 2.x DiscussionList no
+  // longer exposes a vdom shape we can splice a banner into from `view`, and its
+  // lifecycle is less stable than the page's — so we mirror flarum/realtime's
+  // approach here rather than the 1.x DiscussionList vdom mutation.
+  const newPostListHandler = (data: { tagIds: string[]; discussionId: number }) => {
+    const params = app.discussions.getParams();
 
-      if (count && typeof vdom === 'object' && vdom && 'children' in vdom && vdom.children instanceof Array) {
-        vdom.children.unshift(
-          <Button
-            className="Button Button--block DiscussionList-update"
-            onclick={() => {
-              this.attrs.state.refresh().then(() => {
-                this.loadingUpdated = false;
-                app.pushedUpdates = [];
-                app.setTitleCount(0);
-                m.redraw();
-              });
-              this.loadingUpdated = true;
-            }}
-            loading={this.loadingUpdated}
-          >
-            {app.translator.trans('flarum-pusher.forum.discussion_list.show_updates_text', { count })}
-          </Button>
-        );
-      }
+    // `getParams()` always returns a `filter` object (empty on the default
+    // index), so test its contents — not truthiness — or we would bail on every
+    // event. Mirrors flarum/realtime's guard.
+    const hasFilters = Object.keys(params.filter ?? {}).length > 0;
+
+    if (params.q || params.sort || hasFilters) return;
+
+    if (params.tags) {
+      const tag = app.store.getBy<Tag>('tags', 'slug', params.tags);
+      const tagId = tag?.id();
+
+      if (!tagId || !data.tagIds.includes(tagId)) return;
     }
+
+    const id = String(data.discussionId);
+
+    if ((!app.current.get('discussion') || id !== app.current.get('discussion').id()) && app.pushedUpdates.indexOf(id) === -1) {
+      app.pushedUpdates.push(id);
+
+      if (app.current.matches(IndexPage)) {
+        app.setTitleCount(app.pushedUpdates.length);
+      }
+
+      m.redraw();
+    }
+  };
+
+  extend(IndexPage.prototype, 'oncreate', function () {
+    app.pusher.then((binding: PusherBinding) => {
+      binding.pusher.bind('newPost', newPostListHandler);
+    });
+  });
+
+  extend(IndexPage.prototype, 'onremove', function () {
+    app.pusher.then((binding: PusherBinding) => {
+      binding.pusher.unbind('newPost', newPostListHandler);
+    });
+  });
+
+  extend(IndexPage.prototype, 'contentItems', function (this: IndexPage, items: ItemList<Children>) {
+    const count = app.pushedUpdates?.length ?? 0;
+
+    if (!count) return;
+
+    items.add(
+      'pusherNewActivity',
+      <Button
+        className="Button DiscussionList-update"
+        aria-live="polite"
+        onclick={() => {
+          app.discussions.refresh().then(() => {
+            app.pushedUpdates = [];
+            app.setTitleCount(0);
+            m.redraw();
+          });
+        }}
+      >
+        {app.translator.trans('flarum-pusher.forum.discussion_list.show_updates_text', { count })}
+      </Button>,
+      95
+    );
   });
 
   extend(DiscussionPage.prototype, 'oncreate', function (this: DiscussionPage) {
@@ -138,22 +171,5 @@ app.initializers.add('flarum-pusher', () => {
 
   extend(IndexPage.prototype, 'actionItems', (items: ItemList<Children>) => {
     items.remove('refresh');
-  });
-
-  app.pusher.then((binding: PusherBinding) => {
-    const channels = binding.channels;
-
-    if (channels.user) {
-      channels.user.bind('notification', () => {
-        if (app.session.user) {
-          app.session.user.pushAttributes({
-            unreadNotificationCount: app.session.user.unreadNotificationCount() ?? 0 + 1,
-            newNotificationCount: app.session.user.newNotificationCount() ?? 0 + 1,
-          });
-        }
-        app.notifications.clear();
-        m.redraw();
-      });
-    }
   });
 });

--- a/extensions/pusher/less/forum.less
+++ b/extensions/pusher/less/forum.less
@@ -1,6 +1,13 @@
 .DiscussionList-update {
+  .Button--block();
   .Button--color(@alert-color, @alert-bg);
   margin-bottom: 5px;
+
+  @media @phone {
+    height: auto;
+    max-width: 100%;
+    white-space: pre-wrap;
+  }
 
   .DiscussionPage & {
     border-radius: 0;

--- a/extensions/pusher/locale/en.yml
+++ b/extensions/pusher/locale/en.yml
@@ -10,9 +10,15 @@ flarum-pusher:
     # These translations are used in the Pusher Settings modal dialog.
     pusher_settings:
       app_cluster_label: Cluster
+      app_cluster_help: The cluster your Pusher app is hosted in (for example <code>eu</code> or <code>us2</code>), shown on the app's "App Keys" page. Leave blank if you set a custom server hostname below.
       app_id_label: App ID
+      app_id_help: The numeric App ID from your Pusher app's "App Keys" page.
       app_key_label: App Key
+      app_key_help: The public key from your Pusher app's "App Keys" page. It is sent to browsers, so it is not secret.
       app_secret_label: App Secret
+      app_secret_help: The private secret from your Pusher app's "App Keys" page. Keep this confidential — it is only used server-side.
+      server_hostname_label: Server Hostname
+      server_hostname_help: Optional. Override the host the client connects to, for a self-hosted Pusher-compatible server (for example soketi). Leave blank to use Pusher's hosted service with the cluster above.
       title: Pusher Settings
 
   # Translations in this namespace are used by the admin interface.


### PR DESCRIPTION
Fixes #4727.

## Problem

With flarum/pusher enabled on 2.0, the forum fails to boot — the console shows `Uncaught TypeError: Cannot read properties of undefined (reading 'attribute')` and real-time features stop working.

The frontend initializer built the Pusher socket synchronously, reading `app.forum.attribute(...)`. Initializers run **before** `Application.boot` populates `app.forum`, so that read throws and aborts boot.

While fixing it, the discussion-list "show updates" banner was also found broken on 2.0: the old code bound on `DiscussionList` and spliced the banner into its `view` vdom — an approach that no longer matches the 2.x component output.

## Changes

- **Boot crash:** defer socket construction into an `Application` `mount` extend, which runs after `app.forum` is set (mirrors flarum/realtime).
- **Discussion-list updates:** bind `newPost` on `IndexPage` and render the banner via its `contentItems` ItemList instead of mutating `DiscussionList`'s vdom.
- **Notification badge:** `count() ?? 0 + 1` parsed as `count() ?? 1`, so the unread/new counts never incremented; corrected to `(count() ?? 0) + 1`.
- **Styling:** restore the full-width updates banner via the `Button--block` mixin (plus phone wrapping).

## Testing

Verified manually against a live Pusher instance (realtime disabled):
- forum boots with no console error;
- creating a discussion shows the full-width "show updates" banner on the index of another session, clearing on click;
- a reply live-updates an open discussion;
- a new notification increments the bell badge by exactly one and refreshes the list.