### PR TITLE
[2.x] feat(realtime): ambient typing indicators on the discussion list

### DIFF
--- a/extensions/realtime/.gitignore
+++ b/extensions/realtime/.gitignore
@@ -1,3 +1,4 @@
 js/node_modules
 vendor/
 composer.lock
+.phpunit.cache

--- a/extensions/realtime/composer.json
+++ b/extensions/realtime/composer.json
@@ -85,6 +85,7 @@
         "flarum/lock": "^2.0.0",
         "flarum/likes": "^2.0.0",
         "flarum/flags": "^2.0.0",
+        "flarum/tags": "^2.0.0",
         "fof/reactions": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0",

--- a/extensions/realtime/extend.php
+++ b/extensions/realtime/extend.php
@@ -69,7 +69,8 @@ return [
 
     (new Extend\Event)
         ->subscribe(Push\EventSubscriber::class)
-        ->listen(\Flarum\Notification\Event\Sent::class, Push\Listener\BroadcastNotifications::class),
+        ->listen(\Flarum\Notification\Event\Sent::class, Push\Listener\BroadcastNotifications::class)
+        ->listen(\Flarum\Settings\Event\Saved::class, Listener\RestartServerOnSettingChange::class),
 
     (new Extend\Notification)
         ->driver('realtime', Push\NotificationDriver::class),

--- a/extensions/realtime/extend.php
+++ b/extensions/realtime/extend.php
@@ -81,6 +81,8 @@ return [
         // In seconds. Defaults to 10 seconds.
         ->default('flarum-realtime.release-discussion-updates-interval', 10)
         ->default('flarum-realtime.typing-indicator', true)
+        ->default('flarum-realtime.index-typing-indicator', true)
+        ->default('flarum-realtime.index-typing-indicator-restricted', false)
         ->default('flarum-realtime.release-discussion-updates', true)
         ->default('flarum-realtime.notification-toast-dismiss-after', 10)
         ->serializeToForum('flarum-realtime.release-discussion-updates-interval', 'flarum-realtime.release-discussion-updates-interval', 'intval')

--- a/extensions/realtime/js/src/@types/shims.d.ts
+++ b/extensions/realtime/js/src/@types/shims.d.ts
@@ -11,6 +11,10 @@ declare module 'flarum/common/Application' {
       user: Channel | null;
       /** Presence channel for the currently open discussion (typing indicator). */
       discussion?: Channel;
+      /** Shared public channel feeding ambient typing dots on the discussion list. */
+      indexTyping?: Channel;
+      /** Per-restricted-tag channels feeding typing dots for restricted discussions. */
+      indexTypingTags?: Channel[];
     };
   }
 }

--- a/extensions/realtime/js/src/admin/extend.ts
+++ b/extensions/realtime/js/src/admin/extend.ts
@@ -19,6 +19,18 @@ export default [
       type: 'boolean',
     }))
     .setting(() => ({
+      setting: 'flarum-realtime.index-typing-indicator',
+      label: app.translator.trans('flarum-realtime.admin.settings.index-typing-indicator'),
+      help: app.translator.trans('flarum-realtime.admin.settings.index-typing-indicator-help'),
+      type: 'boolean',
+    }))
+    .setting(() => ({
+      setting: 'flarum-realtime.index-typing-indicator-restricted',
+      label: app.translator.trans('flarum-realtime.admin.settings.index-typing-indicator-restricted'),
+      help: app.translator.trans('flarum-realtime.admin.settings.index-typing-indicator-restricted-help'),
+      type: 'boolean',
+    }))
+    .setting(() => ({
       setting: 'flarum-realtime.release-discussion-updates',
       label: app.translator.trans('flarum-realtime.admin.settings.release-discussion-updates'),
       help: app.translator.trans('flarum-realtime.admin.settings.release-discussion-updates-help'),

--- a/extensions/realtime/js/src/forum/RealtimeState.ts
+++ b/extensions/realtime/js/src/forum/RealtimeState.ts
@@ -1,4 +1,5 @@
 import type { Channel } from 'pusher-js';
+import IndexTypingState from './states/IndexTypingState';
 
 type ChannelReadyCallback = (channel: Channel) => void;
 type ReconnectCallback = () => void;
@@ -27,6 +28,13 @@ class RealtimeState {
 
   private userChannel: Channel | null = null;
   private publicChannel: Channel | null = null;
+
+  /**
+   * Shared presence state for the discussion-list typing dots, fed by the
+   * `index-typing` channel and read by DiscussionListItem. One instance backs
+   * every list item.
+   */
+  readonly indexTyping = new IndexTypingState();
 
   // ---------------------------------------------------------------------------
   // Registration (called by extensions via the Realtime extender)

--- a/extensions/realtime/js/src/forum/extend/Application.ts
+++ b/extensions/realtime/js/src/forum/extend/Application.ts
@@ -34,6 +34,9 @@ export default function () {
       user: null,
     };
 
+    const indexTypingEnabled = !!app.data['flarum-realtime.index-typing-indicator'];
+    const indexTypingRestrictedEnabled = !!app.data['flarum-realtime.index-typing-indicator-restricted'];
+
     // Mount the notification toast container outside the main Mithril tree.
     // This persists across reconnect cycles — only the Pusher instance and
     // its channels are rebuilt.
@@ -48,6 +51,8 @@ export default function () {
     const setupChannels = (websocket: Pusher): void => {
       app.websocket_channels.public = null;
       app.websocket_channels.user = null;
+      app.websocket_channels.indexTyping = undefined;
+      app.websocket_channels.indexTypingTags = undefined;
 
       if (app.session.user) {
         const userChannel = websocket.subscribe('private-user=' + app.session.user.id());
@@ -73,6 +78,38 @@ export default function () {
         const publicChannel = websocket.subscribe('public');
         app.websocket_channels.public = publicChannel;
         RealtimeState.notifyPublicChannelReady(publicChannel);
+      }
+
+      const bindIndexTyping = (channel: ReturnType<Pusher['subscribe']>): void => {
+        channel.bind('index-typing', (data: { id: number; typing: boolean }) => {
+          RealtimeState.indexTyping.set(data.id, data.typing);
+        });
+      };
+
+      // Ambient typing dots on the discussion list. A single shared, public,
+      // presence-only channel — one subscription per viewer regardless of how
+      // many discussions are listed, so it stays cheap at any scale. Only
+      // guest-visible discussions are surfaced here (gated server-side).
+      if (indexTypingEnabled && (app.session.user || !disallowPublicConnection)) {
+        const indexTypingChannel = websocket.subscribe('public-index-typing');
+        app.websocket_channels.indexTyping = indexTypingChannel;
+        bindIndexTyping(indexTypingChannel);
+      }
+
+      // Restricted discussions can't go on the public channel without leaking, so
+      // they're routed per restricted tag. Subscribe to the channel of each
+      // restricted tag THIS user can see — channel auth (AuthController) enforces
+      // it server-side too. Bounded by visible-restricted-tag count, not user or
+      // discussion count, so it keeps the same scale guarantee. All feed the same
+      // IndexTypingState, so list rendering is unchanged.
+      if (indexTypingRestrictedEnabled && app.session.user) {
+        const restrictedTags = app.store.all('tags').filter((tag: any) => tag.isRestricted?.());
+
+        app.websocket_channels.indexTypingTags = restrictedTags.map((tag: any) => {
+          const channel = websocket.subscribe('private-index-typing-tag=' + tag.id());
+          bindIndexTyping(channel);
+          return channel;
+        });
       }
     };
 

--- a/extensions/realtime/js/src/forum/extend/Application.ts
+++ b/extensions/realtime/js/src/forum/extend/Application.ts
@@ -103,9 +103,15 @@ export default function () {
       // discussion count, so it keeps the same scale guarantee. All feed the same
       // IndexTypingState, so list rendering is unchanged.
       if (indexTypingRestrictedEnabled && app.session.user) {
-        const restrictedTags = app.store.all('tags').filter((tag: any) => tag.isRestricted?.());
-
-        app.websocket_channels.indexTypingTags = restrictedTags.map((tag: any) => {
+        // Subscribe to the index-typing channel of every tag the user can see.
+        // We can't filter to restricted tags client-side: `isRestricted` is only
+        // serialized to admins, so a normal user can't tell which of their
+        // visible tags are restricted. We don't need to — the backend only ever
+        // broadcasts restricted discussions to these channels (public ones go to
+        // the public channel), and channel auth already gates each subscription
+        // to tags the actor can see (AuthController::indexTypingTag). Channels
+        // for non-restricted tags simply stay silent. Bounded by visible-tag count.
+        app.websocket_channels.indexTypingTags = app.store.all('tags').map((tag: any) => {
           const channel = websocket.subscribe('private-index-typing-tag=' + tag.id());
           bindIndexTyping(channel);
           return channel;

--- a/extensions/realtime/js/src/forum/extend/DiscussionList.ts
+++ b/extensions/realtime/js/src/forum/extend/DiscussionList.ts
@@ -1,8 +1,13 @@
 import app from 'flarum/forum/app';
 import NewActivity from './DiscussionList/NewActivity';
+import IndexTyping from './DiscussionList/IndexTyping';
 
 export default function DiscussionList() {
   if (!!app.data['flarum-realtime.release-discussion-updates']) {
     NewActivity();
+  }
+
+  if (!!app.data['flarum-realtime.index-typing-indicator']) {
+    IndexTyping();
   }
 }

--- a/extensions/realtime/js/src/forum/extend/DiscussionList/IndexTyping.tsx
+++ b/extensions/realtime/js/src/forum/extend/DiscussionList/IndexTyping.tsx
@@ -1,0 +1,73 @@
+import { extend } from 'flarum/common/extend';
+import app from 'flarum/forum/app';
+import Icon from 'flarum/common/components/Icon';
+import RealtimeState from '../../RealtimeState';
+
+/**
+ * Ambient "someone is typing here" dot on discussion list rows.
+ *
+ * Presence comes from the single shared `index-typing` channel (see Application),
+ * so there are no per-discussion subscriptions — this extender only *reads* the
+ * shared IndexTypingState.
+ *
+ * DiscussionListItem retains its subtree (onbeforeupdate → SubtreeRetainer), so a
+ * bare m.redraw() does NOT re-run infoItems. We register a SubtreeRetainer check
+ * that tracks this discussion's typing flag (combined with the in-view flag) so
+ * the row re-renders precisely when its dot should appear or disappear.
+ *
+ * To keep redraw work bounded on long lists, a row only consults the typing state
+ * while it's actually in the viewport (tracked with an IntersectionObserver), so
+ * off-screen rows never schedule the self-clearing redraw timers isTyping() sets up.
+ */
+export default function (): void {
+  extend('flarum/forum/components/DiscussionListItem', 'oninit', function (this: any) {
+    // Default to in-view; the observer (set up in oncreate) corrects this once it
+    // reports. Avoids a row that's already on screen at load missing its first dot
+    // before the observer's initial async callback fires.
+    this._realtimeInView = true;
+
+    const isTyping = (): boolean => {
+      const discussion = this.attrs.discussion;
+      return !!discussion && this._realtimeInView && RealtimeState.indexTyping.isTyping(discussion.id());
+    };
+
+    // Re-render this row when its typing flag flips, despite subtree retention.
+    this.subtree.check(isTyping);
+  });
+
+  extend('flarum/forum/components/DiscussionListItem', 'oncreate', function (this: any, _val, vnode: any) {
+    const el = vnode.dom as HTMLElement;
+
+    this._realtimeObserver = new IntersectionObserver((entries) => {
+      const nowInView = entries[0]?.isIntersecting ?? false;
+      if (nowInView !== this._realtimeInView) {
+        this._realtimeInView = nowInView;
+        m.redraw();
+      }
+    });
+    this._realtimeObserver.observe(el);
+  });
+
+  extend('flarum/forum/components/DiscussionListItem', 'onremove', function (this: any) {
+    this._realtimeObserver?.disconnect();
+    this._realtimeObserver = null;
+  });
+
+  extend('flarum/forum/components/DiscussionListItem', 'infoItems', function (this: any, items) {
+    if (!this._realtimeInView) return;
+
+    const discussion = this.attrs.discussion;
+    if (!discussion || !RealtimeState.indexTyping.isTyping(discussion.id())) return;
+
+    items.add(
+      'realtimeTyping',
+      <span className="DiscussionListItem-typing" aria-label={app.translator.trans('flarum-realtime.forum.index-typing.someone-typing')}>
+        <Icon name="fas fa-ellipsis-h fa-beat" className="DiscussionListItem-typing-icon" />
+      </span>,
+      // Sit just after the tag label (flarum-tags adds 'tags' at priority 10) and
+      // before the "X replied/started" terminal post, so the tag stays the leading
+      // element of the info row — important on mobile where it's the first thing shown.
+      5
+    );
+  });
+}

--- a/extensions/realtime/js/src/forum/states/IndexTypingState.ts
+++ b/extensions/realtime/js/src/forum/states/IndexTypingState.ts
@@ -1,0 +1,68 @@
+/**
+ * Entries older than this (ms) are considered no longer typing. Acts as a
+ * client-side backstop in case a falling-edge `index-typing` event is missed
+ * (e.g. dropped during a reconnect), so a dot self-clears within this window.
+ *
+ * Mirrors TypingState's EXPIRY_MS so the list dot and the in-discussion
+ * indicator clear on the same cadence.
+ */
+const EXPIRY_MS = 6000;
+
+interface PresenceMap {
+  [discussionId: string]: number;
+}
+
+/**
+ * Tracks which discussions currently have someone typing, for the ambient dot on
+ * the discussion list. Fed by the single `index-typing` channel (see Application),
+ * which delivers coalesced, presence-only signals — no names, no per-discussion
+ * subscriptions. A single shared instance backs every DiscussionListItem.
+ */
+export default class IndexTypingState {
+  protected typing: PresenceMap = {};
+  protected truncationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Record a coalesced presence signal from the index channel.
+   */
+  set(discussionId: number | string, typing: boolean): void {
+    const id = String(discussionId);
+
+    if (typing) {
+      this.typing[id] = Date.now();
+    } else {
+      delete this.typing[id];
+    }
+
+    m.redraw();
+  }
+
+  /**
+   * Whether someone is currently typing in the given discussion. Prunes expired
+   * entries and schedules a redraw for when the most recent entry will expire, so
+   * a stale dot clears itself even if the falling-edge event never arrives.
+   */
+  isTyping(discussionId: number | string): boolean {
+    const invalidateWhen = Date.now() - EXPIRY_MS;
+    let latestTime: number | null = null;
+
+    for (const id of Object.keys(this.typing)) {
+      if (this.typing[id] < invalidateWhen) {
+        delete this.typing[id];
+      } else if (!latestTime || latestTime < this.typing[id]) {
+        latestTime = this.typing[id];
+      }
+    }
+
+    if (this.truncationTimer) {
+      clearTimeout(this.truncationTimer);
+      this.truncationTimer = null;
+    }
+
+    if (latestTime) {
+      this.truncationTimer = setTimeout(() => m.redraw(), latestTime - invalidateWhen);
+    }
+
+    return Object.prototype.hasOwnProperty.call(this.typing, String(discussionId));
+  }
+}

--- a/extensions/realtime/resources/less/forum.less
+++ b/extensions/realtime/resources/less/forum.less
@@ -122,3 +122,16 @@
         }
     }
 }
+
+.DiscussionListItem-typing {
+    color: var(--primary-color);
+    // Sits between the tag label and the "X replied" line — space it from both so
+    // it doesn't crowd the tag pill on its left or the reply icon on its right.
+    margin-left: 4px;
+    margin-right: 6px;
+
+    .DiscussionListItem-typing-icon {
+        font-size: 0.85em;
+        --fa-beat-scale: 1.4;
+    }
+}

--- a/extensions/realtime/resources/locale/en.yml
+++ b/extensions/realtime/resources/locale/en.yml
@@ -8,6 +8,8 @@ flarum-realtime:
             people-are-typing: "{number, plural, one {# person is typing} other {# people are typing}}"
             users-are-typing: "{count, plural, one {{users} is typing} other {{users}{others, plural, =1 { & # other} =0 {} other { & # others}} are typing}}"
             no-activity: No one is typing
+        index-typing:
+            someone-typing: Someone is typing in this discussion
         user:
             settings:
                 heading: Realtime
@@ -26,3 +28,7 @@ flarum-realtime:
             notification-toast-dismiss-after-help: How long (in seconds) a realtime notification toast stays on screen before being automatically dismissed. Set to 0 to disable toast notifications.
             typing-indicator: Typing indicator
             typing-indicator-help: When enabled, subject to permission, users can view the number of other users currently typing in a discussion. When disabled, typing activitiy is removed both from the UI and from the websocket payload.
+            index-typing-indicator: Discussion list typing dots
+            index-typing-indicator-help: When enabled, an ambient icon appears on the discussion list for any publicly-visible discussion that someone is currently typing in. No names are shown.
+            index-typing-indicator-restricted: Discussion list typing dots in restricted tags
+            index-typing-indicator-restricted-help: Also show typing dots for discussions in restricted tags, to users who can see those tags. Requires the Tags extension. Off by default.

--- a/extensions/realtime/src/Content/ForumContent.php
+++ b/extensions/realtime/src/Content/ForumContent.php
@@ -23,5 +23,7 @@ class ForumContent
     {
         $document->payload['flarum-realtime.typing-indicator'] = (bool) $this->settings->get('flarum-realtime.typing-indicator');
         $document->payload['flarum-realtime.release-discussion-updates'] = (bool) $this->settings->get('flarum-realtime.release-discussion-updates');
+        $document->payload['flarum-realtime.index-typing-indicator'] = (bool) $this->settings->get('flarum-realtime.index-typing-indicator');
+        $document->payload['flarum-realtime.index-typing-indicator-restricted'] = (bool) $this->settings->get('flarum-realtime.index-typing-indicator-restricted');
     }
 }

--- a/extensions/realtime/src/Listener/RestartServerOnSettingChange.php
+++ b/extensions/realtime/src/Listener/RestartServerOnSettingChange.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Listener;
+
+use Carbon\Carbon;
+use Flarum\Realtime\Websocket\Console\HaltCommand;
+use Flarum\Settings\Event\Saved;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Str;
+
+/**
+ * The websocket server is a long-running process that reads its settings once,
+ * so admin changes to realtime settings (e.g. enabling restricted-tag index
+ * typing) are not picked up until it restarts. When any `flarum-realtime.*`
+ * setting changes, signal the running daemon to halt — the same mechanism the
+ * `realtime:halt` command and extension-toggle watcher use — and the process
+ * supervisor brings it back up with the new settings.
+ */
+class RestartServerOnSettingChange
+{
+    public function __construct(
+        protected Repository $cache
+    ) {
+    }
+
+    public function handle(Saved $event): void
+    {
+        foreach (array_keys($event->settings) as $key) {
+            // Scope strictly to this extension's own settings so saves for
+            // other extensions / core never restart the websocket server.
+            if (Str::startsWith($key, 'flarum-realtime.')) {
+                $this->cache->put(HaltCommand::KEY, Carbon::now());
+
+                return;
+            }
+        }
+    }
+}

--- a/extensions/realtime/src/Websocket/Api/AuthController.php
+++ b/extensions/realtime/src/Websocket/Api/AuthController.php
@@ -39,6 +39,17 @@ class AuthController implements RequestHandlerInterface
         $this->actor = RequestUtil::getActor($request);
         $channel = Arr::get($attributes, 'channel_name');
 
+        if (preg_match('~^private-index-typing-tag=(?<id>[0-9]+)$~', $channel, $m)) {
+            if ($this->indexTypingTag((int) $m['id'])) {
+                $socketId = Arr::get($attributes, 'socket_id');
+                $body = $this->pusher->authorizeChannel($channel, $socketId);
+
+                return new JsonResponse(json_decode($body, true));
+            }
+
+            return new EmptyResponse(403);
+        }
+
         if (preg_match('~^private-(?<subject>[a-zA-Z]+)=(?<id>[0-9]+)$~', $channel, $m)) {
             if (method_exists($this, $m['subject']) && call_user_func([$this, $m['subject']], $m['id'])) {
                 $socketId = Arr::get($attributes, 'socket_id');
@@ -87,6 +98,19 @@ class AuthController implements RequestHandlerInterface
     protected function privateMessageTyping(int $id): bool
     {
         return \Flarum\Messages\Dialog::whereVisibleTo($this->actor)->where('id', $id)->exists();
+    }
+
+    /**
+     * Authorize a restricted-tag index-typing channel: the actor may listen iff
+     * they can see the tag. Reaching this without flarum-tags active is rejected.
+     */
+    protected function indexTypingTag(int $id): bool
+    {
+        if (! class_exists(\Flarum\Tags\Tag::class)) {
+            return false;
+        }
+
+        return \Flarum\Tags\Tag::whereVisibleTo($this->actor)->where('id', $id)->exists();
     }
 
     protected function online(User $actor): array

--- a/extensions/realtime/src/Websocket/Console/HaltCommand.php
+++ b/extensions/realtime/src/Websocket/Console/HaltCommand.php
@@ -18,7 +18,7 @@ class HaltCommand extends Command
     protected $signature = 'realtime:halt';
     protected $description = 'Forces the running daemon to stop.';
 
-    public const KEY = 'blomstra-realtime-require-halt';
+    public const KEY = 'flarum.realtime.require-halt';
 
     public function handle(Repository $cache): void
     {

--- a/extensions/realtime/src/Websocket/Console/ServeCommand.php
+++ b/extensions/realtime/src/Websocket/Console/ServeCommand.php
@@ -9,10 +9,10 @@
 
 namespace Flarum\Realtime\Websocket\Console;
 
+use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Logger\ConnectionLogger;
 use Flarum\Realtime\Websocket\Logger\HttpLogger;
 use Flarum\Realtime\Websocket\Logger\WebsocketLogger;
-use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Server\HttpServer;
 use Flarum\Realtime\Websocket\Settings;
 use Flarum\Settings\SettingsRepositoryInterface;

--- a/extensions/realtime/src/Websocket/Console/ServeCommand.php
+++ b/extensions/realtime/src/Websocket/Console/ServeCommand.php
@@ -12,6 +12,7 @@ namespace Flarum\Realtime\Websocket\Console;
 use Flarum\Realtime\Websocket\Logger\ConnectionLogger;
 use Flarum\Realtime\Websocket\Logger\HttpLogger;
 use Flarum\Realtime\Websocket\Logger\WebsocketLogger;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Server\HttpServer;
 use Flarum\Realtime\Websocket\Settings;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -43,6 +44,7 @@ class ServeCommand extends Command
 
         $this->restartOnCachedSignal($loop, $cache);
         $this->restartOnExtensionChanges($loop);
+        $this->sweepIndexTyping($loop);
 
         $this->getLaravel()->instance(LoopInterface::class, $loop);
 
@@ -123,6 +125,20 @@ class ServeCommand extends Command
 
         // Throw exceptions for actual errors
         throw new \Exception("$errno, $errstr, $errfile:$errline");
+    }
+
+    /**
+     * Expire stale index-typing presence and emit falling-edge "stopped typing"
+     * signals, so list dots clear without each client running its own per-discussion
+     * timer. Swept faster than the TTL (6s) to keep the clear-lag small.
+     */
+    protected function sweepIndexTyping(LoopInterface $loop): void
+    {
+        $presence = $this->getLaravel()->make(IndexTypingPresence::class);
+
+        $loop->addPeriodicTimer(2, function () use ($presence) {
+            $presence->sweep();
+        });
     }
 
     protected function restartOnCachedSignal(LoopInterface $loop, Repository $cache): void

--- a/extensions/realtime/src/Websocket/IndexTypingPresence.php
+++ b/extensions/realtime/src/Websocket/IndexTypingPresence.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Websocket;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Guest;
+use Illuminate\Database\ConnectionInterface;
+
+/**
+ * Tracks which discussions currently have someone typing, and broadcasts a
+ * coalesced, presence-only signal to the index channels so the discussion list
+ * can show an ambient "someone is typing here" dot.
+ *
+ * This runs in-process inside the long-lived websocket server (see ServeCommand),
+ * so state is a plain in-memory map — no Redis or DB needed. The raw `client-typing`
+ * firehose (one event every 2–3s per typer, carrying the typer's name) is never
+ * relayed to the list. Instead we emit at most one `index-typing` event per
+ * discussion per typing burst:
+ *
+ *   - rising edge  → { id, typing: true }  when a discussion goes from idle to typing
+ *   - falling edge → { id, typing: false } when TTL elapses with no further pings
+ *
+ * No display name or user id is ever included — the list only needs to know *that*
+ * someone is typing, not *who*. Opening the discussion reveals who, via the existing
+ * permission-checked TypingIndicator.
+ */
+class IndexTypingPresence
+{
+    /**
+     * The single public channel guest-visible discussions are surfaced on.
+     * Presence-only payload, so a public channel is safe.
+     */
+    public const PUBLIC_CHANNEL = 'public-index-typing';
+
+    /**
+     * Channel name for a restricted tag's typing presence. A discussion that isn't
+     * guest-visible is routed to the channels of its restricted tags; a user may
+     * only subscribe to one if they can see that tag (enforced in AuthController),
+     * so the audience matches Flarum's tag-scoped OR visibility semantics. Bounded
+     * by tag count, not user count — keeps the Phase 1 scale guarantee. Only used
+     * when the `index-typing-indicator-restricted` setting is on and tags is active.
+     */
+    public static function tagChannel(int $tagId): string
+    {
+        return "private-index-typing-tag=$tagId";
+    }
+
+    /**
+     * A discussion is considered "still being typed in" for this many ms after the
+     * last `client-typing` ping. Mirrors the frontend TypingState EXPIRY_MS so the
+     * dot and the in-discussion indicator clear on the same cadence.
+     */
+    protected const EXPIRY_MS = 6000;
+
+    /**
+     * The set of channels a discussion's presence routes to is cached this many ms,
+     * so a repeated typing burst on the same discussion doesn't re-query the database.
+     */
+    protected const ROUTING_TTL_MS = 30000;
+
+    /**
+     * discussionId => timestamp (ms) of the most recent typing ping.
+     */
+    protected array $lastSeen = [];
+
+    /**
+     * discussionId => [string[] $channels, float $cachedAt]. The channels a
+     * discussion's typing presence is broadcast to — the public channel if it's
+     * guest-visible, otherwise its restricted-tag channels (when enabled), or an
+     * empty array if it can't be surfaced.
+     */
+    protected array $routing = [];
+
+    protected ?bool $restrictedEnabled = null;
+
+    public function __construct(protected Manager $manager)
+    {
+    }
+
+    /**
+     * Record a typing ping for a discussion. Broadcasts a rising-edge signal only
+     * when the discussion was previously idle; repeat pings during an active burst
+     * are coalesced (no broadcast).
+     *
+     * The discussion is routed to the channels its audience can see: the public
+     * channel if guest-visible, otherwise its restricted-tag channels (when the
+     * restricted setting is on and tags is active). A discussion that can't be
+     * surfaced anywhere never emits a signal — surfacing a restricted discussion's
+     * ID/activity on a channel its audience can't see would leak it.
+     */
+    public function touch(int $discussionId): void
+    {
+        if (empty($this->channelsFor($discussionId))) {
+            return;
+        }
+
+        $now = $this->now();
+        $wasActive = $this->isActive($discussionId, $now);
+
+        $this->lastSeen[$discussionId] = $now;
+
+        if (! $wasActive) {
+            $this->broadcast($discussionId, true);
+        }
+    }
+
+    /**
+     * The channels a discussion's typing presence should be broadcast to. Cached
+     * briefly so a typing burst doesn't re-query. Mirrors the visibility scoping the
+     * rest of the realtime extension uses (see AuthController / Push\Jobs\Job).
+     *
+     * @return string[]
+     */
+    protected function channelsFor(int $discussionId): array
+    {
+        $now = $this->now();
+
+        if (isset($this->routing[$discussionId])
+            && ($now - $this->routing[$discussionId][1]) < self::ROUTING_TTL_MS) {
+            return $this->routing[$discussionId][0];
+        }
+
+        $channels = $this->resolveChannels($discussionId);
+        $this->routing[$discussionId] = [$channels, $now];
+
+        return $channels;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function resolveChannels(int $discussionId): array
+    {
+        if (Discussion::whereVisibleTo(new Guest)->where('id', $discussionId)->exists()) {
+            return [self::PUBLIC_CHANNEL];
+        }
+
+        if (! $this->restrictedEnabled() || ! class_exists(\Flarum\Tags\Tag::class)) {
+            return [];
+        }
+
+        // The discussion's restricted tags. A user who can see ANY of them can see
+        // the discussion (Flarum's OR semantics), so broadcasting to each restricted
+        // tag's channel reaches exactly the right audience. Queried via the pivot to
+        // avoid loading models in the hot path.
+        $tagIds = resolve(ConnectionInterface::class)
+            ->table('discussion_tag')
+            ->join('tags', 'tags.id', '=', 'discussion_tag.tag_id')
+            ->where('discussion_tag.discussion_id', $discussionId)
+            ->where('tags.is_restricted', true)
+            ->pluck('tags.id');
+
+        return $tagIds->map(fn ($id) => self::tagChannel((int) $id))->all();
+    }
+
+    protected function restrictedEnabled(): bool
+    {
+        if ($this->restrictedEnabled === null) {
+            $this->restrictedEnabled = (bool) resolve(SettingsRepositoryInterface::class)
+                ->get('flarum-realtime.index-typing-indicator-restricted');
+        }
+
+        return $this->restrictedEnabled;
+    }
+
+    /**
+     * Expire discussions whose last ping is older than the TTL, broadcasting a
+     * falling-edge signal for each. Call periodically from the server event loop.
+     */
+    public function sweep(): void
+    {
+        $now = $this->now();
+
+        foreach ($this->lastSeen as $discussionId => $lastSeen) {
+            if (! $this->isActive($discussionId, $now)) {
+                unset($this->lastSeen[$discussionId]);
+                $this->broadcast($discussionId, false);
+            }
+        }
+
+        // Evict expired routing entries so the cache doesn't grow unbounded over
+        // the lifetime of the long-running server process.
+        foreach ($this->routing as $discussionId => [$channels, $cachedAt]) {
+            if (($now - $cachedAt) >= self::ROUTING_TTL_MS) {
+                unset($this->routing[$discussionId]);
+            }
+        }
+    }
+
+    protected function isActive(int $discussionId, float $now): bool
+    {
+        return isset($this->lastSeen[$discussionId])
+            && ($now - $this->lastSeen[$discussionId]) < self::EXPIRY_MS;
+    }
+
+    protected function broadcast(int $discussionId, bool $typing): void
+    {
+        foreach ($this->channelsFor($discussionId) as $channelName) {
+            $channel = $this->manager->find($channelName);
+
+            // Only allocate work if someone is actually listening on the list.
+            if (! $channel || ! $channel->hasConnections()) {
+                continue;
+            }
+
+            $channel->broadcast((object) [
+                'event' => 'index-typing',
+                'channel' => $channelName,
+                'data' => [
+                    'id' => $discussionId,
+                    'typing' => $typing,
+                ],
+            ]);
+        }
+    }
+
+    protected function now(): float
+    {
+        return microtime(true) * 1000;
+    }
+}

--- a/extensions/realtime/src/Websocket/Message/Message.php
+++ b/extensions/realtime/src/Websocket/Message/Message.php
@@ -10,6 +10,7 @@
 namespace Flarum\Realtime\Websocket\Message;
 
 use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Ratchet\ConnectionInterface;
 use stdClass;
 
@@ -29,5 +30,22 @@ class Message
                 /** @phpstan-ignore-next-line */
                 $this->connection->socketId
             );
+
+        $this->relayIndexTyping();
+    }
+
+    /**
+     * In addition to relaying the raw typing event to the discussion's own channel,
+     * feed it into the coalesced index-typing presence so the discussion list can
+     * show an ambient dot. See {@link IndexTypingPresence}.
+     */
+    protected function relayIndexTyping(): void
+    {
+        if ($this->payload->event !== 'client-typing'
+            || ! preg_match('/^private-typing=(\d+)$/', $this->payload->channel, $m)) {
+            return;
+        }
+
+        resolve(IndexTypingPresence::class)->touch((int) $m[1]);
     }
 }

--- a/extensions/realtime/src/WebsocketProvider.php
+++ b/extensions/realtime/src/WebsocketProvider.php
@@ -14,6 +14,7 @@ use Flarum\Foundation\Config;
 use Flarum\Realtime\Push\RealtimeRegistry;
 use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
 use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Settings;
 use Illuminate\Contracts\Container\Container;
 use Psr\Log\LoggerInterface;
@@ -25,6 +26,7 @@ class WebsocketProvider extends AbstractServiceProvider
     {
         $this->container->singleton(RealtimeRegistry::class);
         $this->container->singleton(Manager::class);
+        $this->container->singleton(IndexTypingPresence::class);
         $this->container->singleton(PresenceChannelAuthorizer::class);
 
         $this->container->singleton(Pusher::class, function (Container $container) {

--- a/extensions/realtime/tests/integration/RestartOnSettingChangeTest.php
+++ b/extensions/realtime/tests/integration/RestartOnSettingChangeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration;
+
+use Flarum\Realtime\Websocket\Console\HaltCommand;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\Cache\Repository;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The websocket server reads its settings once, so changing a realtime setting
+ * must signal it to restart. The listener writes the halt key (the same one
+ * `realtime:halt` uses) when any `flarum-realtime.*` setting is saved — and only
+ * then, so saving unrelated settings does not needlessly drop live connections.
+ */
+class RestartOnSettingChangeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-realtime');
+    }
+
+    private function cache(): Repository
+    {
+        return $this->app()->getContainer()->make(Repository::class);
+    }
+
+    private function saveSetting(string $key, string $value): int
+    {
+        return $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => [$key => $value],
+            ])
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function saving_a_realtime_setting_signals_a_restart(): void
+    {
+        $this->cache()->forget(HaltCommand::KEY);
+
+        $status = $this->saveSetting('flarum-realtime.index-typing-indicator-restricted', '1');
+
+        $this->assertEquals(204, $status);
+        $this->assertTrue($this->cache()->has(HaltCommand::KEY), 'A realtime setting change should signal the websocket server to restart.');
+    }
+
+    #[Test]
+    public function saving_an_unrelated_setting_does_not_signal_a_restart(): void
+    {
+        $this->cache()->forget(HaltCommand::KEY);
+
+        $status = $this->saveSetting('some-other-extension.some_setting', 'value');
+
+        $this->assertEquals(204, $status);
+        $this->assertFalse($this->cache()->has(HaltCommand::KEY), 'A non-realtime setting change must not restart the websocket server.');
+    }
+}

--- a/extensions/realtime/tests/integration/api/IndexTypingTagAuthTest.php
+++ b/extensions/realtime/tests/integration/api/IndexTypingTagAuthTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The discussion-list typing dots route restricted discussions to per-tag
+ * channels (`private-index-typing-tag={id}`). Authorization for those channels
+ * must follow tag visibility: a user may only join the channel of a tag they
+ * can see. This guards against a user receiving typing activity (even just "a
+ * discussion here has activity") for a restricted tag they have no access to.
+ */
+class IndexTypingTagAuthTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'flarum-realtime');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, Members only
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'Member viewer', 'name_plural' => 'Member viewers'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 100],
+            ],
+            'tags' => [
+                ['id' => 1, 'name' => 'Open', 'slug' => 'open', 'is_restricted' => false],
+                ['id' => 2, 'name' => 'Members only', 'slug' => 'members-only', 'is_restricted' => true],
+                ['id' => 3, 'name' => 'Admin only', 'slug' => 'admin-only', 'is_restricted' => true],
+            ],
+            'group_permission' => [
+                // Group 100 (which user 2 is in) can view tag 2, but NOT tag 3.
+                ['group_id' => 100, 'permission' => 'tag2.viewForum'],
+            ],
+        ]);
+    }
+
+    private function authorize(int $tagId, ?int $actorId): int
+    {
+        $options = ['json' => ['channel_name' => "private-index-typing-tag=$tagId", 'socket_id' => '123.456']];
+
+        if ($actorId !== null) {
+            $options['authenticatedAs'] = $actorId;
+        }
+
+        return $this->send(
+            $this->request('POST', '/api/websocket/auth', $options)
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function user_can_authorize_a_visible_restricted_tag_channel(): void
+    {
+        // Tag 2 is restricted but user 2's group has viewForum on it.
+        $this->assertSame(200, $this->authorize(2, 2));
+    }
+
+    #[Test]
+    public function user_cannot_authorize_a_hidden_restricted_tag_channel(): void
+    {
+        // Tag 3 is restricted and user 2 has no permission to view it.
+        $this->assertSame(403, $this->authorize(3, 2));
+    }
+
+    #[Test]
+    public function guest_cannot_authorize_a_restricted_tag_channel(): void
+    {
+        $this->assertSame(403, $this->authorize(2, null));
+        $this->assertSame(403, $this->authorize(3, null));
+    }
+}


### PR DESCRIPTION
Show a small "someone is typing here" indicator on discussion-list rows, so activity is visible without opening a discussion — extending the existing in-discussion typing indicator to the index.

## How it works

Typing pings already flow over per-discussion channels (`private-typing={id}`). This adds a presence-only layer on top, coalesced server-side and broadcast to channels the discussion-list page subscribes to:

- **Public discussions** → a single shared `public-index-typing` channel.
- **Restricted (tag-gated) discussions** → per-tag `private-index-typing-tag={id}` channels, so the indicator only reaches users who can see the tag.

The payload is presence-only — `{ id, typing }` — never names or content. Who is typing is still revealed only inside the discussion, via the existing permission-checked indicator.

## Server side

- `IndexTypingPresence` (in the websocket server) coalesces raw `client-typing` pings into rising/falling-edge `index-typing` events, and routes each discussion to the correct channel(s) based on its visibility (guest-visible → public; otherwise its restricted tags). A periodic sweep emits the "stopped typing" edge.
- `AuthController` authorises `private-index-typing-tag={id}` only when the actor can see that tag (`Tag::whereVisibleTo`).
- The server reads some of these settings once, so a `Saved`-settings listener signals it to restart (via the existing halt mechanism) when any `flarum-realtime.*` setting changes.

## Client side

- A shared `IndexTypingState` (TTL-pruned, self-clearing) feeds a `DiscussionListItem` indicator, rendered only for rows in view.
- Subscribes to the public channel and to every visible tag's channel. (We can't filter to restricted tags client-side — `isRestricted` is only serialized to admins — but it isn't needed: the backend only broadcasts restricted discussions to those channels, and channel auth gates each subscription.)

## Settings

- `flarum-realtime.index-typing-indicator` (default **on**) — the public-discussion indicators.
- `flarum-realtime.index-typing-indicator-restricted` (default **off**) — extend to restricted/tag-gated discussions. Requires flarum/tags.

## Privacy

The boundary is enforced server-side: a user cannot subscribe to the typing channel of a tag they can't see (verified — a forbidden tag returns 403 from the auth endpoint, even if requested directly). Restricted discussions never broadcast on the public channel.

## Tests

- `IndexTypingTagAuthTest` — tag-channel auth boundary: visible-restricted → 200, hidden-restricted → 403, guest → 403.
- `RestartOnSettingChangeTest` — a realtime setting change signals a restart; an unrelated setting does not.

Also verified manually against a live setup (two browser sessions): dots appear/clear on the list as another user types, and a user permitted to see a restricted tag receives its dots while a non-permitted user does not.

## Housekeeping

- Renamed the leftover Blomstra-era halt cache key to `flarum.realtime.require-halt`.