### PR TITLE
[2.x] feat(gdpr): audit-log the erasure request lifecycle

### DIFF
--- a/extensions/gdpr/resources/locale/en.yml
+++ b/extensions/gdpr/resources/locale/en.yml
@@ -188,6 +188,9 @@ flarum-audit:
     lib:
         browser:
             user:
+                gdpr_erasure_requested: Requested erasure of {username}'s data
+                gdpr_erasure_confirmed: Confirmed the erasure request for {username}'s data
+                gdpr_erasure_cancelled: Cancelled the erasure request for {username}'s data
                 gdpr_anonymized: Anonymized {username}'s data
                 gdpr_deleted: Deleted {username}'s data
                 gdpr_exported: Exported {username}'s data

--- a/extensions/gdpr/src/Api/Resource/ErasureRequestResource.php
+++ b/extensions/gdpr/src/Api/Resource/ErasureRequestResource.php
@@ -15,6 +15,8 @@ use Flarum\Api\Endpoint;
 use Flarum\Api\Resource;
 use Flarum\Api\Schema;
 use Flarum\Foundation\ValidationException;
+use Flarum\Gdpr\Events\ErasureCancelled;
+use Flarum\Gdpr\Events\ErasureRequested;
 use Flarum\Gdpr\Jobs\ErasureJob;
 use Flarum\Gdpr\Jobs\GdprJob;
 use Flarum\Gdpr\Models\ErasureRequest;
@@ -22,6 +24,7 @@ use Flarum\Gdpr\Notifications\ConfirmErasureBlueprint;
 use Flarum\Gdpr\Notifications\ErasureRequestCancelledBlueprint;
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -38,6 +41,7 @@ class ErasureRequestResource extends Resource\AbstractDatabaseResource
         protected NotificationSyncer $notifications,
         protected SettingsRepositoryInterface $settings,
         protected Queue $queue,
+        protected Dispatcher $events,
     ) {
     }
 
@@ -112,6 +116,8 @@ class ErasureRequestResource extends Resource\AbstractDatabaseResource
                     $request->save();
 
                     $this->notifications->sync(new ErasureRequestCancelledBlueprint($request), [$request->user]);
+
+                    $this->events->dispatch(new ErasureCancelled($context->getActor(), $request));
                 })
                 ->response(fn () => new EmptyResponse(204)),
             Endpoint\Index::make()
@@ -174,6 +180,8 @@ class ErasureRequestResource extends Resource\AbstractDatabaseResource
     public function created(object $model, OriginalContext $context): ?object
     {
         $this->notifications->sync(new ConfirmErasureBlueprint($model), [$context->getActor()]);
+
+        $this->events->dispatch(new ErasureRequested($context->getActor(), $model));
 
         return $model;
     }

--- a/extensions/gdpr/src/AuditIntegration.php
+++ b/extensions/gdpr/src/AuditIntegration.php
@@ -11,6 +11,9 @@ namespace Flarum\Gdpr;
 
 use Flarum\Audit\AuditLogger;
 use Flarum\Gdpr\Events\Erased;
+use Flarum\Gdpr\Events\ErasureCancelled;
+use Flarum\Gdpr\Events\ErasureConfirmed;
+use Flarum\Gdpr\Events\ErasureRequested;
 use Flarum\Gdpr\Events\Exported;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\User\User;
@@ -37,6 +40,9 @@ class AuditIntegration
      * @var string[]
      */
     public static array $actions = [
+        'user.gdpr_erasure_requested',
+        'user.gdpr_erasure_confirmed',
+        'user.gdpr_erasure_cancelled',
         'user.gdpr_anonymized',
         'user.gdpr_deleted',
         'user.gdpr_exported',
@@ -46,8 +52,38 @@ class AuditIntegration
     {
         $events = $container->make(Dispatcher::class);
 
+        $events->listen(ErasureRequested::class, [$this, 'erasureRequested']);
+        $events->listen(ErasureConfirmed::class, [$this, 'erasureConfirmed']);
+        $events->listen(ErasureCancelled::class, [$this, 'erasureCancelled']);
         $events->listen(Erased::class, [$this, 'erased']);
         $events->listen(Exported::class, [$this, 'exported']);
+    }
+
+    public function erasureRequested(ErasureRequested $event): void
+    {
+        AuditLogger::$actor = $event->actor;
+
+        AuditLogger::log('user.gdpr_erasure_requested', [
+            'user_id' => $event->request->user_id,
+        ]);
+    }
+
+    public function erasureConfirmed(ErasureConfirmed $event): void
+    {
+        AuditLogger::$actor = $event->actor;
+
+        AuditLogger::log('user.gdpr_erasure_confirmed', [
+            'user_id' => $event->request->user_id,
+        ]);
+    }
+
+    public function erasureCancelled(ErasureCancelled $event): void
+    {
+        AuditLogger::$actor = $event->actor;
+
+        AuditLogger::log('user.gdpr_erasure_cancelled', [
+            'user_id' => $event->request->user_id,
+        ]);
     }
 
     public function erased(Erased $event): void

--- a/extensions/gdpr/src/Events/ErasureCancelled.php
+++ b/extensions/gdpr/src/Events/ErasureCancelled.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Events;
+
+use Flarum\Gdpr\Models\ErasureRequest;
+use Flarum\User\User;
+
+/**
+ * Dispatched when an erasure request is cancelled. The `actor` is whoever
+ * cancelled it (the requesting user, or an admin acting on their behalf).
+ */
+class ErasureCancelled
+{
+    public function __construct(
+        public User $actor,
+        public ErasureRequest $request
+    ) {
+    }
+}

--- a/extensions/gdpr/src/Events/ErasureConfirmed.php
+++ b/extensions/gdpr/src/Events/ErasureConfirmed.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Events;
+
+use Flarum\Gdpr\Models\ErasureRequest;
+use Flarum\User\User;
+
+/**
+ * Dispatched when a user confirms their pending erasure request (e.g. via the
+ * emailed confirmation link). The `actor` is the user who confirmed.
+ */
+class ErasureConfirmed
+{
+    public function __construct(
+        public User $actor,
+        public ErasureRequest $request
+    ) {
+    }
+}

--- a/extensions/gdpr/src/Events/ErasureRequested.php
+++ b/extensions/gdpr/src/Events/ErasureRequested.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Events;
+
+use Flarum\Gdpr\Models\ErasureRequest;
+use Flarum\User\User;
+
+/**
+ * Dispatched when a user requests erasure of their own data (before any
+ * confirmation or processing). The `actor` is the user who made the request.
+ */
+class ErasureRequested
+{
+    public function __construct(
+        public User $actor,
+        public ErasureRequest $request
+    ) {
+    }
+}

--- a/extensions/gdpr/src/Http/Controller/ConfirmErasureController.php
+++ b/extensions/gdpr/src/Http/Controller/ConfirmErasureController.php
@@ -11,10 +11,12 @@ namespace Flarum\Gdpr\Http\Controller;
 
 use Carbon\Carbon;
 use Flarum\Foundation\ValidationException;
+use Flarum\Gdpr\Events\ErasureConfirmed;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\Http\RequestUtil;
 use Flarum\Http\SessionAuthenticator;
 use Flarum\Http\UrlGenerator;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -23,7 +25,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class ConfirmErasureController implements RequestHandlerInterface
 {
-    public function __construct(protected UrlGenerator $url, protected SessionAuthenticator $authenticator)
+    public function __construct(protected UrlGenerator $url, protected SessionAuthenticator $authenticator, protected Dispatcher $events)
     {
     }
 
@@ -57,6 +59,10 @@ class ConfirmErasureController implements RequestHandlerInterface
         $erasureRequest->verification_token = null;
         $erasureRequest->confirmation_ip = $ip;
         $erasureRequest->save();
+
+        // Attribute to the request's owner: confirmation may arrive via the
+        // emailed token while logged out, so $actor can be a guest.
+        $this->events->dispatch(new ErasureConfirmed($erasureRequest->user, $erasureRequest));
 
         return new RedirectResponse($this->url->to('forum')->base().'?erasureRequestConfirmed=1');
     }

--- a/extensions/gdpr/tests/integration/AuditTest.php
+++ b/extensions/gdpr/tests/integration/AuditTest.php
@@ -146,6 +146,66 @@ class AuditTest extends TestCase
     }
 
     #[Test]
+    public function self_service_erasure_request_is_logged()
+    {
+        // User 2 requests erasure of their own data.
+        $response = $this->send(
+            $this->request('POST', '/api/user-erasure-requests', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => ['attributes' => ['reason' => 'I want to be forgotten']],
+                    'meta' => ['password' => 'too-obscure'],
+                ],
+            ])->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        // Logged at request time, attributed to the requesting user.
+        $this->assertLogExists('user.gdpr_erasure_requested', [
+            'user_id' => 2,
+        ], 2);
+    }
+
+    #[Test]
+    public function erasure_confirmation_is_logged()
+    {
+        // Put user 4's request (id 1) back into the awaiting-confirmation state.
+        $this->database()->table('gdpr_erasure')->where('id', 1)->update([
+            'status' => 'awaiting_user_confirmation',
+            'verification_token' => 'confirm-tok',
+            'user_confirmed_at' => null,
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/gdpr/erasure/confirm/confirm-tok', ['authenticatedAs' => 4])
+        );
+
+        $this->assertEquals(302, $response->getStatusCode());
+
+        $this->assertLogExists('user.gdpr_erasure_confirmed', [
+            'user_id' => 4,
+        ], 4);
+    }
+
+    #[Test]
+    public function erasure_cancellation_is_logged()
+    {
+        // Request 1 belongs to user 4; they cancel it.
+        $response = $this->send(
+            $this->request('POST', '/api/user-erasure-requests/1/cancel', [
+                'authenticatedAs' => 4,
+            ])->withAttribute('bypassCsrfToken', true)
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertLogExists('user.gdpr_erasure_cancelled', [
+            'user_id' => 4,
+        ], 4);
+    }
+
+    #[Test]
     public function export_is_logged_with_requesting_actor()
     {
         $response = $this->send(


### PR DESCRIPTION
## Problem

The audit log only recorded a GDPR erasure when it was **carried out** — the `Erased`/`Exported` events fired by the queued jobs. The **request**, **confirmation**, and **cancellation** steps emitted no event, so a user requesting erasure of their data left no audit trail until (and unless) the erasure was actually processed.

This is inconsistent with the email-change flow, which logs both `user.email_change_requested` and `user.email_changed`. Erasure only logged the equivalent of the latter.

## Changes

- Add three events — `ErasureRequested`, `ErasureConfirmed`, `ErasureCancelled` — carrying the acting user and the erasure request (same shape as the existing `Erased`).
- Dispatch them at the lifecycle points: when a user requests erasure (`ErasureRequestResource::created`), confirms it (`ConfirmErasureController`), and when a request is cancelled (the cancel endpoint).
- `AuditIntegration` listens for all three and logs `user.gdpr_erasure_requested` / `_confirmed` / `_cancelled`, attributed to the acting user, alongside the existing `gdpr_anonymized`/`gdpr_deleted`/`gdpr_exported` actions.
- Audit-log labels for the three new actions (shipped in this extension's locale, under the `flarum-audit` namespace, as the existing ones are).

Confirmation is attributed to the request's owner, since it may arrive via the emailed token while logged out.

## Tests

Adds three cases to `AuditTest`: requesting, confirming, and cancelling an erasure each produce the corresponding audit entry attributed to the acting user. The existing erased/anonymized/exported/system-processed tests remain green (93 integration tests pass).