### PR TITLE
[2.x] fix(nicknames): TypeError when creating a user with a nickname

### DIFF
--- a/extensions/nicknames/src/AuditIntegration.php
+++ b/extensions/nicknames/src/AuditIntegration.php
@@ -31,7 +31,14 @@ class AuditIntegration
      */
     public static array $actions = ['user.nickname_changed'];
 
-    protected string|false $originalNickname = false;
+    /**
+     * The nickname's value before a change, captured during the user `saving`
+     * event. `false` is the sentinel for "no nickname change this lifecycle"
+     * (so nothing is logged); a string or `null` is an actual prior value —
+     * `null` when the nickname is being set for the first time, e.g. on
+     * registration, where the user has no original nickname.
+     */
+    protected string|false|null $originalNickname = false;
 
     public function __invoke(Container $container): void
     {

--- a/extensions/nicknames/tests/integration/AuditTest.php
+++ b/extensions/nicknames/tests/integration/AuditTest.php
@@ -59,4 +59,35 @@ class AuditTest extends TestCase
             'new_nickname' => 'User 33',
         ]);
     }
+
+    #[Test]
+    public function registering_with_a_nickname_does_not_error_and_is_logged()
+    {
+        $this->setting('flarum-nicknames.set_on_registration', true);
+
+        // Registration creates a user with a nickname; there is no original
+        // value, so the saving listener must handle a null original (regression
+        // for the TypeError in flarum/framework#4733).
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'nickname' => 'New Nick',
+                    'username' => 'newuser',
+                    'password' => 'too-obscure',
+                    'email' => 'newuser@machine.local',
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $user = User::where('username', 'newuser')->firstOrFail();
+
+        // Registration is performed by a guest, so the audit entry has no actor.
+        $this->assertLogExists('user.nickname_changed', [
+            'user_id' => $user->id,
+            'old_nickname' => null,
+            'new_nickname' => 'New Nick',
+        ], null);
+    }
 }


### PR DESCRIPTION
Fixes #4733.

## Problem

When `flarum-audit` and `flarum-nicknames` are both enabled, creating a user that carries a nickname throws:

```
TypeError: Cannot assign null to property Flarum\Nicknames\AuditIntegration::$originalNickname of type string|false
  at nicknames/src/AuditIntegration.php:68
```

The request 500s. This affects any user-create that includes a nickname — most visibly **registration** when `set_on_registration` is on (the reporter hit it on discuss.flarum.org, and the stack trace bottoms out in `RegisterController`), and also an admin creating a user. It is not the audit-log viewer itself: the error was generated by a failed registration and merely noticed while browsing the logs.

## Cause

`AuditIntegration::saving()` captures the previous nickname so a change can be logged afterwards. On a brand-new user there is no previous value, so `$event->user->getOriginal('nickname')` returns `null` — which the `string|false` property type rejects, throwing before the user is even persisted.

## Fix

Widen the property to `string|false|null`:

- `false` remains the sentinel for \"no nickname change in this lifecycle\" (nothing is logged).
- `null` is a genuine prior value — the user had no nickname yet.

Setting a nickname on creation is therefore logged as `user.nickname_changed` with `old_nickname: null`, instead of crashing. The existing `userSaved` logic already renders `null`/empty as `null`, so no other change is needed.

## Note on existing data

No cleanup is required: the `TypeError` was thrown in the `saving` hook **before** the user (or any audit row) was persisted, so no malformed audit entries were written — the affected operations simply failed. The fix is forward-only.

## Tests

Adds a regression test: registering with a nickname returns 201 and logs `user.nickname_changed` (`old_nickname: null`, no actor, as registration is performed by a guest). It fails (500) without the fix. The existing nickname-change test and full suite (23 tests) remain green.