### PR TITLE
[1.x] Add docs link to Audit extension

### DIFF
--- a/extensions/audit/composer.json
+++ b/extensions/audit/composer.json
@@ -9,7 +9,8 @@
     "support": {
         "issues": "https://github.com/flarum/framework/issues",
         "source": "https://github.com/flarum/audit",
-        "forum": "https://discuss.flarum.org"
+        "forum": "https://discuss.flarum.org",
+        "docs": "https://docs.flarum.org/extensions/audit"
     },
     "homepage": "https://flarum.org",
     "funding": [


### PR DESCRIPTION
Adds a `docs` support link to `flarum/audit`'s composer.json, pointing at the extension's documentation page (https://docs.flarum.org/extensions/audit, added in flarum/docs#535).