### PR TITLE
[2.x] fix(realtime): only relay client events to subscribed channels

### DIFF
--- a/extensions/realtime/src/Websocket/Channel/Channel.php
+++ b/extensions/realtime/src/Websocket/Channel/Channel.php
@@ -103,6 +103,10 @@ class Channel
             $signature .= ":{$payload->channel_data}";
         }
 
+        if (! isset($payload->auth) || ! is_string($payload->auth)) {
+            throw new InvalidSignature;
+        }
+
         $hash = hash_hmac('sha256', $signature, $this->settings->appSecret);
 
         if (! hash_equals(

--- a/extensions/realtime/src/Websocket/Message/Message.php
+++ b/extensions/realtime/src/Websocket/Message/Message.php
@@ -11,6 +11,7 @@ namespace Flarum\Realtime\Websocket\Message;
 
 use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use stdClass;
 
@@ -22,16 +23,55 @@ class Message
 
     public function respond(): void
     {
+        if (! $this->isAuthorizedClientEvent()) {
+            return;
+        }
+
         $channel = $this->manager->find($this->payload->channel);
 
-        optional($channel)
-            ->broadcastToEveryoneExcept(
-                $this->payload,
-                /** @phpstan-ignore-next-line */
-                $this->connection->socketId
-            );
+        $channel->broadcastToEveryoneExcept(
+            $this->payload,
+            /** @phpstan-ignore-next-line */
+            $this->connection->socketId
+        );
 
         $this->relayIndexTyping();
+    }
+
+    /**
+     * Client-originated events are only permitted under the same rules Pusher
+     * enforces, so a connection cannot forge events into channels it has no
+     * business broadcasting to:
+     *
+     *   - the event name must be prefixed `client-`;
+     *   - the target must be a private/presence channel (never a public one);
+     *   - the channel must already exist and the sending connection must be
+     *     subscribed to it.
+     *
+     * Without this, any connection holding the public app key could inject forged
+     * events (e.g. spoofed notifications) into another user's private channel
+     * without ever authorising a subscription.
+     */
+    protected function isAuthorizedClientEvent(): bool
+    {
+        $channelName = $this->payload->channel ?? null;
+        $event = $this->payload->event ?? null;
+
+        if (! is_string($channelName) || ! is_string($event)) {
+            return false;
+        }
+
+        if (! Str::startsWith($event, 'client-')) {
+            return false;
+        }
+
+        if (! Str::startsWith($channelName, ['private-', 'presence-'])) {
+            return false;
+        }
+
+        $channel = $this->manager->find($channelName);
+
+        return $channel !== null && $channel->hasConnection($this->connection);
     }
 
     /**

--- a/extensions/realtime/tests/unit/Websocket/ChannelSubscriptionAuthTest.php
+++ b/extensions/realtime/tests/unit/Websocket/ChannelSubscriptionAuthTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\unit\Websocket;
+
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\Channel\PresenceChannel;
+use Flarum\Realtime\Websocket\Channel\PrivateChannel;
+use Flarum\Realtime\Websocket\Exception\InvalidSignature;
+use Flarum\Realtime\Websocket\Settings;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * Locks in the authorization boundary that the realtime confidentiality model
+ * depends on: a connection may only subscribe to a private or presence channel
+ * if it presents a valid HMAC signature (issued server-side by the
+ * permission-checked /api/websocket/auth endpoint).
+ *
+ * This is the sibling of the client-event injection check (see MessageTest). If
+ * it ever regresses, an attacker holding only the public app key could subscribe
+ * to another user's private channel and *read* their realtime stream — a far
+ * more severe (confidentiality) break than the injection bug. These tests fail
+ * loudly if that gate is removed or weakened.
+ */
+class ChannelSubscriptionAuthTest extends TestCase
+{
+    private const SECRET = 'test-app-secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Channel resolves Manager and Settings from the container in its
+        // constructor; provide both. Settings is stubbed so reading `appSecret`
+        // returns a known value without going through the full validation path.
+        $container = new Container();
+
+        $settings = $this->createStub(Settings::class);
+        $settings->method('__get')->willReturnCallback(
+            fn (string $name) => $name === 'appSecret' ? self::SECRET : null
+        );
+
+        $container->instance(Settings::class, $settings);
+        $container->instance(Manager::class, $this->createStub(Manager::class));
+
+        Container::setInstance($container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        parent::tearDown();
+    }
+
+    private function connection(string $socketId): ConnectionInterface
+    {
+        $connection = new class implements ConnectionInterface {
+            public ?string $socketId = null;
+
+            public function send($data): void
+            {
+            }
+
+            public function close(): void
+            {
+            }
+        };
+
+        $connection->socketId = $socketId;
+
+        return $connection;
+    }
+
+    private function validAuth(string $socketId, string $channel, ?string $channelData = null): string
+    {
+        $signature = "$socketId:$channel";
+
+        if ($channelData !== null) {
+            $signature .= ":$channelData";
+        }
+
+        return 'test-app-key:'.hash_hmac('sha256', $signature, self::SECRET);
+    }
+
+    #[Test]
+    public function private_channel_rejects_subscription_without_a_signature(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PrivateChannel('private-user=1');
+
+        $this->expectException(InvalidSignature::class);
+
+        // No `auth` at all — the forged-subscribe attempt.
+        $channel->subscribe($connection, (object) ['channel' => 'private-user=1']);
+    }
+
+    #[Test]
+    public function private_channel_rejects_subscription_with_a_wrong_signature(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PrivateChannel('private-user=1');
+
+        $this->expectException(InvalidSignature::class);
+
+        $channel->subscribe($connection, (object) [
+            'channel' => 'private-user=1',
+            'auth' => 'test-app-key:'.str_repeat('0', 64),
+        ]);
+    }
+
+    #[Test]
+    public function private_channel_rejects_a_signature_minted_for_a_different_channel(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PrivateChannel('private-user=1');
+
+        $this->expectException(InvalidSignature::class);
+
+        // A valid signature, but for someone else's channel — must not transfer.
+        $channel->subscribe($connection, (object) [
+            'channel' => 'private-user=1',
+            'auth' => $this->validAuth('1.1', 'private-user=2'),
+        ]);
+    }
+
+    #[Test]
+    public function private_channel_accepts_a_correctly_signed_subscription(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PrivateChannel('private-user=1');
+
+        $result = $channel->subscribe($connection, (object) [
+            'channel' => 'private-user=1',
+            'auth' => $this->validAuth('1.1', 'private-user=1'),
+        ]);
+
+        $this->assertTrue($result);
+        $this->assertTrue($channel->hasConnection($connection));
+    }
+
+    #[Test]
+    public function presence_channel_rejects_subscription_without_a_signature(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PresenceChannel('presence-foo');
+
+        $this->expectException(InvalidSignature::class);
+
+        $channel->subscribe($connection, (object) [
+            'channel' => 'presence-foo',
+            'channel_data' => json_encode(['user_id' => 1]),
+        ]);
+    }
+
+    #[Test]
+    public function presence_channel_rejects_subscription_with_a_wrong_signature(): void
+    {
+        $connection = $this->connection('1.1');
+        $channel = new PresenceChannel('presence-foo');
+
+        $this->expectException(InvalidSignature::class);
+
+        $channel->subscribe($connection, (object) [
+            'channel' => 'presence-foo',
+            'channel_data' => json_encode(['user_id' => 1]),
+            'auth' => 'test-app-key:'.str_repeat('0', 64),
+        ]);
+    }
+}

--- a/extensions/realtime/tests/unit/Websocket/FactoryRoutingTest.php
+++ b/extensions/realtime/tests/unit/Websocket/FactoryRoutingTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\unit\Websocket;
+
+use Flarum\Realtime\Websocket\Channel\Channel;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\Message\Factory;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use Ratchet\RFC6455\Messaging\MessageInterface;
+
+/**
+ * Drives the real websocket entry point — Factory::forMessage(...)->respond() —
+ * with raw client payloads, reproducing the reported injection scenarios end to
+ * end (frame routing + authorization), not just the Message logic in isolation
+ * (see MessageTest). This guards against a regression that re-routes non-pusher:
+ * frames around the authorization gate.
+ */
+class FactoryRoutingTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container = new Container();
+        Container::setInstance($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        parent::tearDown();
+    }
+
+    private function connection(string $socketId): ConnectionInterface
+    {
+        $connection = new class implements ConnectionInterface {
+            public ?string $socketId = null;
+
+            public function send($data): void
+            {
+            }
+
+            public function close(): void
+            {
+            }
+        };
+
+        $connection->socketId = $socketId;
+
+        return $connection;
+    }
+
+    private function frame(array $payload): MessageInterface
+    {
+        $message = $this->createStub(MessageInterface::class);
+        $message->method('getPayload')->willReturn(json_encode($payload));
+
+        return $message;
+    }
+
+    /**
+     * @return array{0: Manager, 1: Channel}
+     */
+    private function managerWithChannel(string $name, bool $senderSubscribed, ConnectionInterface $sender): array
+    {
+        $channel = $this->getMockBuilder(Channel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasConnection', 'broadcastToEveryoneExcept'])
+            ->getMock();
+
+        $channel->method('hasConnection')
+            ->willReturnCallback(fn (ConnectionInterface $c) => $senderSubscribed && $c === $sender);
+
+        $manager = $this->createStub(Manager::class);
+        $manager->method('find')
+            ->willReturnCallback(fn (string $c) => $c === $name ? $channel : null);
+
+        return [$manager, $channel];
+    }
+
+    #[Test]
+    public function forged_notification_into_private_channel_is_dropped_via_the_entry_point(): void
+    {
+        // The exact attack from the report: an unsubscribed connection routes a
+        // non-pusher: `notification` frame at someone else's private channel.
+        $attacker = $this->connection('9.9');
+        [$manager, $channel] = $this->managerWithChannel('private-user=1', false, $attacker);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $frame = $this->frame([
+            'event' => 'notification',
+            'channel' => 'private-user=1',
+            'data' => json_encode(['data' => ['type' => 'notifications']]),
+        ]);
+
+        Factory::forMessage($frame, $attacker, $manager)->respond();
+    }
+
+    #[Test]
+    public function legitimate_client_event_routes_through_and_broadcasts(): void
+    {
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('private-user=1', true, $sender);
+
+        $channel->expects($this->once())->method('broadcastToEveryoneExcept');
+
+        $frame = $this->frame([
+            'event' => 'client-something',
+            'channel' => 'private-user=1',
+            'data' => [],
+        ]);
+
+        Factory::forMessage($frame, $sender, $manager)->respond();
+    }
+
+    #[Test]
+    public function forged_client_typing_does_not_reach_index_presence_via_the_entry_point(): void
+    {
+        $attacker = $this->connection('9.9');
+        [$manager, $channel] = $this->managerWithChannel('private-typing=42', false, $attacker);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $presence = $this->createMock(IndexTypingPresence::class);
+        $presence->expects($this->never())->method('touch');
+        $this->container->instance(IndexTypingPresence::class, $presence);
+
+        $frame = $this->frame([
+            'event' => 'client-typing',
+            'channel' => 'private-typing=42',
+            'data' => [],
+        ]);
+
+        Factory::forMessage($frame, $attacker, $manager)->respond();
+    }
+}

--- a/extensions/realtime/tests/unit/Websocket/MessageTest.php
+++ b/extensions/realtime/tests/unit/Websocket/MessageTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\unit\Websocket;
+
+use Flarum\Realtime\Websocket\Channel\Channel;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\Message\Message;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use stdClass;
+
+class MessageTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Message::relayIndexTyping() uses the resolve() helper, which reads from
+        // the global container. Give it a clean one per test.
+        $this->container = new Container();
+        Container::setInstance($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        parent::tearDown();
+    }
+
+    /**
+     * A connection keyed by socket id, matching how Channel stores connections.
+     * Uses a declared-property stub rather than a mock so $socketId is a real
+     * property (the websocket server stamps it dynamically in production).
+     */
+    private function connection(string $socketId): ConnectionInterface
+    {
+        $connection = new class implements ConnectionInterface {
+            public ?string $socketId = null;
+
+            public function send($data): void
+            {
+            }
+
+            public function close(): void
+            {
+            }
+        };
+
+        $connection->socketId = $socketId;
+
+        return $connection;
+    }
+
+    private function payload(string $event, mixed $channel, array $extra = []): stdClass
+    {
+        return (object) array_merge([
+            'event' => $event,
+            'channel' => $channel,
+            'data' => new stdClass(),
+        ], $extra);
+    }
+
+    /**
+     * A Manager whose find() returns a channel that reports whether the sender is
+     * subscribed, and records whether it was broadcast to.
+     *
+     * @return array{0: Manager, 1: Channel}
+     */
+    private function managerWithChannel(string $name, bool $senderSubscribed, ConnectionInterface $sender): array
+    {
+        // Channel's constructor resolves Manager/Settings from the container, which
+        // we don't want in a unit test — bypass it and stub only what we exercise.
+        $channel = $this->getMockBuilder(Channel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasConnection', 'broadcastToEveryoneExcept'])
+            ->getMock();
+
+        $channel->method('hasConnection')
+            ->willReturnCallback(fn (ConnectionInterface $c) => $senderSubscribed && $c === $sender);
+
+        $manager = $this->createStub(Manager::class);
+        $manager->method('find')
+            ->willReturnCallback(fn (string $c) => $c === $name ? $channel : null);
+
+        return [$manager, $channel];
+    }
+
+    #[Test]
+    public function rebroadcasts_client_event_when_sender_is_subscribed_to_private_channel(): void
+    {
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('private-user=1', true, $sender);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->anything(), '1.1');
+
+        $payload = $this->payload('client-something', 'private-user=1');
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function drops_event_when_sender_is_not_subscribed_to_the_channel(): void
+    {
+        // The core CVE: an attacker that never subscribed forges an event into a
+        // private channel an online victim is subscribed to.
+        $attacker = $this->connection('9.9');
+        [$manager, $channel] = $this->managerWithChannel('private-user=1', false, $attacker);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $payload = $this->payload('client-something', 'private-user=1');
+
+        (new Message($payload, $attacker, $manager))->respond();
+    }
+
+    #[Test]
+    public function drops_non_client_event_even_when_sender_is_subscribed(): void
+    {
+        // Pusher only permits `client-` prefixed events from clients. A forged
+        // `notification` must never be rebroadcast, even by a subscribed connection.
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('private-user=1', true, $sender);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $payload = $this->payload('notification', 'private-user=1');
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function drops_client_event_on_a_public_channel(): void
+    {
+        // Client events are forbidden on public channels.
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('public-foo', true, $sender);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $payload = $this->payload('client-something', 'public-foo');
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function rebroadcasts_client_event_on_a_presence_channel_when_subscribed(): void
+    {
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('presence-foo', true, $sender);
+
+        $channel->expects($this->once())->method('broadcastToEveryoneExcept');
+
+        $payload = $this->payload('client-something', 'presence-foo');
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function drops_event_with_non_string_channel_without_error(): void
+    {
+        $sender = $this->connection('1.1');
+        $manager = $this->createMock(Manager::class);
+        $manager->expects($this->never())->method('find');
+
+        $payload = $this->payload('client-something', null);
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function drops_event_when_channel_does_not_exist(): void
+    {
+        $sender = $this->connection('1.1');
+        $manager = $this->createStub(Manager::class);
+        $manager->method('find')->willReturn(null);
+
+        // Reaching find() with a well-formed client event on a private channel is
+        // fine; the guard is that a missing channel simply yields no broadcast.
+        $payload = $this->payload('client-something', 'private-user=1');
+
+        (new Message($payload, $sender, $manager))->respond();
+
+        $this->assertTrue(true); // no exception thrown
+    }
+
+    #[Test]
+    public function relays_client_typing_to_index_presence_when_authorized(): void
+    {
+        $sender = $this->connection('1.1');
+        [$manager, $channel] = $this->managerWithChannel('private-typing=42', true, $sender);
+
+        $channel->expects($this->once())->method('broadcastToEveryoneExcept');
+
+        $presence = $this->createMock(IndexTypingPresence::class);
+        $presence->expects($this->once())->method('touch')->with(42);
+        $this->container->instance(IndexTypingPresence::class, $presence);
+
+        $payload = $this->payload('client-typing', 'private-typing=42');
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function does_not_relay_index_typing_for_unauthorized_client_typing(): void
+    {
+        $attacker = $this->connection('9.9');
+        [$manager, $channel] = $this->managerWithChannel('private-typing=42', false, $attacker);
+
+        $channel->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $presence = $this->createMock(IndexTypingPresence::class);
+        $presence->expects($this->never())->method('touch');
+        $this->container->instance(IndexTypingPresence::class, $presence);
+
+        $payload = $this->payload('client-typing', 'private-typing=42');
+
+        (new Message($payload, $attacker, $manager))->respond();
+    }
+}


### PR DESCRIPTION
Client-originated websocket events were rebroadcast to the channel named in the payload regardless of the sending connection. This let a connection relay events to channels it had not subscribed to.

Changes:
- Relay client events only when the event is `client-` prefixed, the channel is private/presence, and the sender is subscribed to it.
- Reject channel subscriptions that omit the auth signature (previously raised a warning before failing).

Adds unit coverage for the message routing, the relay authorization, and channel subscription auth.