### PR TITLE
[2.x] fix(avatar): ensure base image exists for small avatar uploads

### DIFF
--- a/framework/core/src/User/AvatarUploader.php
+++ b/framework/core/src/User/AvatarUploader.php
@@ -84,7 +84,8 @@ class AvatarUploader
 
         foreach (self::SIZES as $suffix => $size) {
             // Never upscale — skip this variant if the source is too small.
-            if ($sourceWidth < $size || $sourceHeight < $size) {
+            // HOWEVER: we need the base image to exist even if it's smaller than 100x100.
+            if ($suffix !== '' && ($sourceWidth < $size || $sourceHeight < $size)) {
                 continue;
             }
 

--- a/framework/core/tests/unit/User/AvatarUploaderTest.php
+++ b/framework/core/tests/unit/User/AvatarUploaderTest.php
@@ -196,6 +196,26 @@ class AvatarUploaderTest extends TestCase
     }
 
     #[Test]
+    public function test_upload_generates_base_variant_for_small_source()
+    {
+        $putPaths = [];
+        $this->filesystem->shouldReceive('put')->andReturnUsing(function (string $path) use (&$putPaths) {
+            $putPaths[] = $path;
+        });
+        $this->filesystem->shouldIgnoreMissing();
+
+        $user = new User();
+
+        // 50px source — should generate only the base variant, even though it would upscale, since we always want a 1x.
+        $this->uploader->upload($user, ImageManager::gd()->create(50, 50));
+
+        $this->assertCount(1, $putPaths);
+        $this->assertStringNotContainsString('@', $putPaths[0]);
+        $this->assertFalse($user->has_avatar_2x);
+        $this->assertFalse($user->has_avatar_3x);
+    }
+
+    #[Test]
     public function test_upload_presized_records_only_supplied_variants()
     {
         $this->filesystem->shouldReceive('put')->atLeast()->once();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4652**

**Changes proposed in this pull request:**
- Always resize base image to `100x100` even if it's smaller for the default size
  - Fixes smaller images not being uploaded at all due to all variants being skipped

**Reviewers should focus on:**
I thought about whether to resize to bigger 100x100 or not, and decided to because (1) it's a small dimension already, and (2) to stay constant with all base avatars with the same size and not overcomplicate the logic.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
