### PR TITLE
[2.x] fix(tags): serialize unslugged tag slug to API

### DIFF
--- a/extensions/tags/js/src/admin/components/EditTagModal.tsx
+++ b/extensions/tags/js/src/admin/components/EditTagModal.tsx
@@ -38,7 +38,7 @@ export default class EditTagModal extends FormModal<EditTagModalAttrs> {
     this.tag = this.attrs.model || app.store.createRecord('tags');
 
     this.name = Stream(this.tag.name() || '');
-    this.slug = Stream(this.tag.slug() || '');
+    this.slug = Stream(this.tag.storedSlug() || '');
     this.description = Stream(this.tag.description() || '');
     this.color = Stream(this.tag.color() || '');
     this.icon = Stream(this.tag.icon() || '');

--- a/extensions/tags/js/src/common/models/Tag.ts
+++ b/extensions/tags/js/src/common/models/Tag.ts
@@ -9,6 +9,9 @@ export default class Tag extends Model {
   slug() {
     return Model.attribute<string>('slug').call(this);
   }
+  storedSlug() {
+    return Model.attribute<string>('storedSlug').call(this);
+  }
   description() {
     return Model.attribute<string | null>('description').call(this);
   }

--- a/extensions/tags/src/Api/Resource/TagResource.php
+++ b/extensions/tags/src/Api/Resource/TagResource.php
@@ -98,6 +98,9 @@ class TagResource extends AbstractDatabaseResource
                 ->get(function (Tag $tag) {
                     return $this->slugManager->forResource($tag::class)->toSlug($tag);
                 }),
+            Schema\Str::make('storedSlug')
+                ->get(fn (Tag $tag) => $tag->slug)
+                ->visible(fn (Tag $tag, FlarumContext $context) => $context->getActor()->can('edit', $tag)),
             Schema\Str::make('color')
                 ->writable()
                 ->nullable()

--- a/extensions/tags/tests/integration/api/tags/ShowTest.php
+++ b/extensions/tags/tests/integration/api/tags/ShowTest.php
@@ -138,6 +138,52 @@ class ShowTest extends TestCase
     }
 
     #[Test]
+    public function admin_sees_stored_slug_attribute(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/tags/primary-1', ['authenticatedAs' => 1])
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+
+        $this->assertSame('primary-1', $attributes['storedSlug']);
+        $this->assertSame($attributes['slug'], $attributes['storedSlug']);
+    }
+
+    #[Test]
+    public function stored_slug_always_reflects_raw_column_regardless_of_active_driver(): void
+    {
+        $this->setting('slug_driver_'.Tag::class, 'id_with_slug');
+
+        $response = $this->send(
+            $this->request('GET', '/api/tags/1', ['authenticatedAs' => 1])
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+
+        $this->assertSame('1-primary-1', $attributes['slug']);
+
+        $this->assertSame('primary-1', $attributes['storedSlug']);
+    }
+
+    #[Test]
+    public function stored_slug_is_not_exposed_to_users_without_edit_permission(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/tags/primary-1', ['authenticatedAs' => 2])
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+        $this->assertArrayNotHasKey('storedSlug', $attributes);
+    }
+
+    #[Test]
     #[DataProvider('showTagIncludes')]
     public function user_sees_tag_relations_where_allowed(string $include, array $expectedIncludes)
     {


### PR DESCRIPTION
Follow up of https://github.com/flarum/framework/pull/4739

**Fixes #0000**
When using the `IdWithSlugDriver` and editing a Tag, the `slug` field whould show the already slugged `slug`. The implications of this is that the slug in the `EditTagModal` displays `1-general`. When users hit save the slug is stored as `1-general` in the database, which in turn would get slugged to `1-1-general`.

**Changes proposed in this pull request:**
Serialize unslugged slug to API for users with edit permissions.

**Reviewers should focus on:**
This PR was created more with the intention of making the issue easy to understand.  If backwards compatibiliy was no concern I would have opted to serialize the unslugged slug on the `slug` attribute and instead serialize the slugged slug on a new field called like `urlSlug` or similiar. With 2.0 stable so close we can't do that change.

One alternative I considered is detecting the current used Tag Slug Driver when editing a tag and if applicable strip away the id prefix, but that would go against pretty much the idea of any slug driver being plug and play. Open for ideas here

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
