### PR TITLE
[2.x] fix(core): add missing database display name on `ExtensionPage`

### DIFF
--- a/framework/core/js/src/admin/components/ExtensionPage.tsx
+++ b/framework/core/js/src/admin/components/ExtensionPage.tsx
@@ -271,6 +271,7 @@ export default class ExtensionPage<Attrs extends ExtensionPageAttrs = ExtensionP
         return (
           {
             mysql: 'MySQL',
+            mariadb: 'MariaDB',
             sqlite: 'SQLite',
             pgsql: 'PostgreSQL',
           }[database] || database


### PR DESCRIPTION
Follow up of https://github.com/flarum/framework/pull/4701

**Fixes #0000**
Incomplete addition of MariadB to the frontend logic of handling supported databases

**Changes proposed in this pull request:**
Add proper `MariaDB` display name which is shown on the ExtensionPage.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**

Before:
<img width="285" height="48" alt="Screenshot 2026-06-16 at 13 00 12" src="https://github.com/user-attachments/assets/2e4537df-894a-4ca6-afd3-7b36abeed661" />

After:
<img width="276" height="47" alt="Screenshot 2026-06-16 at 12 59 58" src="https://github.com/user-attachments/assets/c54b73ef-45c6-4688-b14b-5978279fe8c0" />


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
