### PR TITLE
[2.x] feat(approval): log discussion approval in the audit log

### DIFF
--- a/extensions/approval/extend.php
+++ b/extensions/approval/extend.php
@@ -72,8 +72,13 @@ return [
             (new \Flarum\Audit\Extend\Audit())
                 ->group('flarum-approval')
                 ->listen(PostWasApproved::class, 'post.approved', fn ($e) => [
-                    'discussion_id' => $e->post->discussion->id,
+                    'discussion_id' => $e->post->discussion_id,
                     'post_id' => $e->post->id,
-                ]),
+                ])
+                // Approving the first post approves its discussion (see
+                // UpdateDiscussionAfterPostApproval); record that as its own action.
+                ->listen(PostWasApproved::class, 'discussion.approved', fn ($e) => $e->post->number == 1 ? [
+                    'discussion_id' => $e->post->discussion_id,
+                ] : null),
         ]),
 ];

--- a/extensions/approval/locale/en.yml
+++ b/extensions/approval/locale/en.yml
@@ -42,5 +42,7 @@ flarum-approval:
 flarum-audit:
   lib:
     browser:
+      discussion:
+        approved: Approved {discussion}
       post:
         approved: Approved {postuser}'s {post} in {discussion}

--- a/extensions/approval/tests/integration/AuditTest.php
+++ b/extensions/approval/tests/integration/AuditTest.php
@@ -34,7 +34,8 @@ class AuditTest extends TestCase
             Discussion::class => [
                 // first_post_id must reference the seeded post (id 2); PostgreSQL enforces the
                 // discussions_first_post_id_foreign FK, unlike MySQL/SQLite in the test config.
-                ['id' => 1, 'title' => 'A', 'created_at' => $date, 'is_approved' => false, 'last_posted_at' => $date, 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1],
+                // Discussion 1 / post 2: unapproved first post (used for approval).
+                ['id' => 1, 'title' => 'A', 'created_at' => $date, 'is_approved' => false, 'last_posted_at' => $date, 'user_id' => 1, 'first_post_id' => 2, 'last_post_id' => 2, 'last_post_number' => 1, 'comment_count' => 1],
             ],
             Post::class => [
                 ['id' => 2, 'number' => 1, 'discussion_id' => 1, 'created_at' => $date, 'is_approved' => false, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>A</p></t>'],
@@ -58,6 +59,24 @@ class AuditTest extends TestCase
         $this->assertLogExists('post.approved', [
             'discussion_id' => 1,
             'post_id' => 2,
+        ]);
+    }
+
+    #[Test]
+    public function approving_the_first_post_logs_the_discussion_approval()
+    {
+        $this->sendSuccessfulRequest('PATCH', '/api/posts/2', [
+            'json' => [
+                'data' => [
+                    'attributes' => [
+                        'isApproved' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertLogExists('discussion.approved', [
+            'discussion_id' => 1,
         ]);
     }
 }

--- a/extensions/audit/tests/integration/RegisteredActionsTest.php
+++ b/extensions/audit/tests/integration/RegisteredActionsTest.php
@@ -26,8 +26,7 @@ class RegisteredActionsTest extends TestCase
     {
         parent::setUp();
 
-        // Enable first-party extensions so their conditional integrations register too.
-        $this->extension('flarum-audit', 'flarum-tags', 'flarum-flags', 'flarum-suspend', 'flarum-lock', 'flarum-sticky', 'flarum-nicknames', 'flarum-approval');
+        $this->extension('flarum-audit');
     }
 
     private function registeredActions(): array
@@ -63,12 +62,14 @@ class RegisteredActionsTest extends TestCase
     }
 
     #[Test]
-    public function core_and_first_party_actions_are_registered()
+    public function core_actions_are_registered()
     {
         $registered = $this->registeredActions();
 
+        // Actions owned by the audit extension itself (its own inline listeners). Actions
+        // contributed by other extensions are each extension's responsibility to register
+        // and to test — audit does not assert their presence here.
         $expected = [
-            // Core (audit itself / inline listeners)
             'audit_log_cleared',
             'cache_cleared',
             'setting_changed',
@@ -80,15 +81,6 @@ class RegisteredActionsTest extends TestCase
             'group.renamed',
             'group.deleted',
             'developer_token_created',
-            // First-party integrations (gated behind whenExtensionEnabled)
-            'post.approved',          // flarum-approval
-            'post.flagged',           // flarum-flags
-            'discussion.locked',      // flarum-lock
-            'discussion.stickied',    // flarum-sticky
-            'user.suspended',         // flarum-suspend
-            'user.nickname_changed',  // flarum-nicknames
-            'discussion.tagged',      // flarum-tags
-            'tag.created',            // flarum-tags admin
         ];
 
         foreach ($expected as $action) {
@@ -97,15 +89,11 @@ class RegisteredActionsTest extends TestCase
     }
 
     #[Test]
-    public function actions_are_grouped_by_extension()
+    public function actions_are_grouped_under_core()
     {
         $this->app();
 
-        // Core actions group under 'core'; first-party ones under their extension id.
         $this->assertArrayHasKey('core', AuditLogger::$registeredActions);
         $this->assertContains('user.password_change_requested', AuditLogger::$registeredActions['core']);
-
-        $this->assertArrayHasKey('flarum-flags', AuditLogger::$registeredActions);
-        $this->assertContains('post.flagged', AuditLogger::$registeredActions['flarum-flags']);
     }
 }


### PR DESCRIPTION
Records discussion approval in the audit log.

Approving the first post of a discussion approves the discussion itself (handled by `UpdateDiscussionAfterPostApproval`). That was not logged distinctly. When `flarum/audit` is enabled, this now logs a `discussion.approved` action alongside the existing `post.approved`, derived from the existing `PostWasApproved` event (gated on the first post). The label is shipped in the approval locale.

Also slims the audit `RegisteredActionsTest` to audit-owned actions only — each extension is responsible for registering and testing its own actions.

Note: an earlier version of this branch added an un-approval capability and `not_approved` actions. That was dropped — Flarum has no UI or API path that un-approves already-approved content (the frontend only ever sends `isApproved: true`, and there is no un-approve control), so those events had no trigger.

Docs: flarum/docs#538.