### PR TITLE
[2.x] fix(a11y): add accessible label to new discussion button

### DIFF
--- a/framework/core/js/src/forum/components/IndexSidebar.tsx
+++ b/framework/core/js/src/forum/components/IndexSidebar.tsx
@@ -35,6 +35,7 @@ export default class IndexSidebar<CustomAttrs extends IndexSidebarAttrs = IndexS
         icon="fas fa-edit"
         className="Button Button--primary IndexPage-newDiscussion"
         itemClassName="App-primaryControl"
+        aria-label="{app.translator.trans(`core.forum.index.${canStartDiscussion ? 'start_discussion_button' : 'cannot_start_discussion_button'}`)}"
         onclick={() => {
           // If the user is not logged in, the promise rejects, and a login modal shows up.
           // Since that's already handled, we dont need to show an error message in the console.


### PR DESCRIPTION
**Changes proposed in this pull request:**
The "New Discussion" button in the main forum sidebar has a visible button text on desktop. On mobile only the icon is shown without text so the mobile button is failing the "Buttons do not have an accessible name" accessibility test. This pull request thus adds the aria-label re-using the button text so the icon only mobile button variant can be read out e.g. by screen readers.

**Reviewers should focus on:**
Is it okay to re-use the button label or should a different text key be used for the accessible label

**Screenshot**
<img width="852" height="96" alt="image" src="https://github.com/user-attachments/assets/c87455b6-7e2d-4f70-b6f6-43a5b9b23cb1" />

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered?
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**
None
