### PR TITLE
[2.x] fix(core): debounce the loading indicator to avoid flicker

### DIFF
--- a/framework/core/js/src/common/states/AlertManagerState.ts
+++ b/framework/core/js/src/common/states/AlertManagerState.ts
@@ -20,6 +20,24 @@ export default class AlertManagerState {
   protected alertId: AlertIdentifier = 0;
   protected loadingPool: number = 0;
 
+  /**
+   * How long (ms) a load must run before the loading indicator is shown. Loads
+   * that complete faster than this never show an indicator, avoiding a flicker
+   * for fast (e.g. cached) chunk loads.
+   */
+  protected static readonly LOADING_DELAY = 250;
+
+  /**
+   * Pending timer for the delayed display of the loading indicator, or null when
+   * no display is pending.
+   */
+  protected loadingTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Identifier of the currently-shown loading alert, or null when none is shown.
+   */
+  protected loadingAlertId: AlertIdentifier | null = null;
+
   getActiveAlerts() {
     return this.activeAlerts;
   }
@@ -75,28 +93,55 @@ export default class AlertManagerState {
   }
 
   /**
-   * Shows a loading alert.
+   * Register an outstanding load and, if this is the first one, schedule the
+   * loading indicator to appear after {@link AlertManagerState.LOADING_DELAY}.
+   *
+   * Concurrent loads share a single indicator (tracked via `loadingPool`), so the
+   * UI never shows more than one "loading" alert regardless of how many chunks or
+   * requests are in flight. Loads that finish before the delay never show one.
    */
-  showLoading(): AlertIdentifier | null {
+  showLoading(): void {
     this.loadingPool++;
 
-    if (this.loadingPool > 1) return null;
+    // Only the first concurrent load arms the timer; the rest just join the pool.
+    if (this.loadingPool > 1 || this.loadingTimeout !== null || this.loadingAlertId !== null) {
+      return;
+    }
 
-    return this.show(
-      {
-        type: 'warning',
-        dismissible: false,
-      },
-      app.translator.trans('core.lib.loading_indicator.accessible_label')
-    );
+    this.loadingTimeout = setTimeout(() => {
+      this.loadingTimeout = null;
+
+      this.loadingAlertId = this.show(
+        {
+          type: 'warning',
+          dismissible: false,
+        },
+        app.translator.trans('core.lib.loading_indicator.accessible_label')
+      );
+    }, AlertManagerState.LOADING_DELAY);
   }
 
   /**
-   * Hides a loading alert.
+   * Mark one outstanding load as finished. When the last one completes, cancel a
+   * still-pending indicator (so a fast load never flickers) and dismiss the
+   * indicator if it was already shown.
    */
   clearLoading(): void {
-    this.loadingPool--;
+    // Guard against an unbalanced clearLoading() driving the pool negative.
+    if (this.loadingPool > 0) {
+      this.loadingPool--;
+    }
 
-    if (this.loadingPool === 0) this.clear();
+    if (this.loadingPool > 0) return;
+
+    if (this.loadingTimeout !== null) {
+      clearTimeout(this.loadingTimeout);
+      this.loadingTimeout = null;
+    }
+
+    if (this.loadingAlertId !== null) {
+      this.dismiss(this.loadingAlertId);
+      this.loadingAlertId = null;
+    }
   }
 }

--- a/framework/core/js/tests/integration/common/AlertManager.test.ts
+++ b/framework/core/js/tests/integration/common/AlertManager.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 import { app } from '../../../src/forum';
 import mq from 'mithril-query';
@@ -41,5 +42,148 @@ describe('AlertManager', () => {
 
     expect(manager).not.toContainRaw('Hello, world!');
     expect(manager).not.toContainRaw('Goodbye, world!');
+  });
+});
+
+describe('AlertManager loading indicator', () => {
+  beforeAll(() => app.boot());
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    app.alerts.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    app.alerts.clear();
+  });
+
+  // The loading indicator renders the `core.ref.loading` translation. The test
+  // translator emits the raw key reference rather than the resolved "Loading..."
+  // string, so match against the key the indicator is built from.
+  const LOADING_TOKEN = 'core.ref.loading';
+
+  /** Number of loading indicators currently rendered. */
+  const loadingCount = (manager: ReturnType<typeof mq>): number => {
+    manager.redraw();
+    const text: string = (manager.rootEl as HTMLElement).textContent ?? '';
+    return (text.match(new RegExp(LOADING_TOKEN.replace(/\./g, '\\.'), 'g')) || []).length;
+  };
+
+  test('a fast load resolved before the delay never shows the indicator', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading();
+    jest.advanceTimersByTime(150); // resolves before the 250ms threshold
+    app.alerts.clearLoading();
+
+    jest.advanceTimersByTime(500); // ensure the (cancelled) window has fully passed
+
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('a slow load shows the indicator only after the 250ms delay', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading();
+
+    jest.advanceTimersByTime(249);
+    expect(loadingCount(manager)).toBe(0);
+
+    jest.advanceTimersByTime(1);
+    expect(loadingCount(manager)).toBe(1);
+
+    app.alerts.clearLoading();
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('multiple concurrent loads combine into a single indicator', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading();
+    app.alerts.showLoading();
+    app.alerts.showLoading();
+
+    jest.advanceTimersByTime(250);
+
+    expect(loadingCount(manager)).toBe(1);
+
+    // Indicator persists until every outstanding load completes.
+    app.alerts.clearLoading();
+    expect(loadingCount(manager)).toBe(1);
+    app.alerts.clearLoading();
+    expect(loadingCount(manager)).toBe(1);
+    app.alerts.clearLoading();
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('staggered loads keep exactly one indicator', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading(); // A
+    jest.advanceTimersByTime(250); // A shown
+    expect(loadingCount(manager)).toBe(1);
+
+    app.alerts.showLoading(); // B starts while A is showing
+    jest.advanceTimersByTime(250);
+    expect(loadingCount(manager)).toBe(1); // still a single combined indicator
+
+    app.alerts.clearLoading(); // A done, B still running
+    expect(loadingCount(manager)).toBe(1);
+
+    app.alerts.clearLoading(); // B done
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('a fast load amongst concurrent loads does not prematurely clear', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading(); // A
+    app.alerts.showLoading(); // B
+    app.alerts.clearLoading(); // A finishes before the threshold
+
+    jest.advanceTimersByTime(250);
+
+    expect(loadingCount(manager)).toBe(1); // B still loading -> indicator shows
+
+    app.alerts.clearLoading(); // B done
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('completing the load before the delay leaves no pending timer', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.showLoading();
+    app.alerts.clearLoading();
+
+    // A subsequent, unrelated slow load should still behave correctly.
+    app.alerts.showLoading();
+    jest.advanceTimersByTime(250);
+    expect(loadingCount(manager)).toBe(1);
+
+    app.alerts.clearLoading();
+    expect(loadingCount(manager)).toBe(0);
+  });
+
+  test('finishing a load does not clear unrelated alerts', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    const id = app.alerts.show({ type: 'success' }, 'Hello, world!');
+    app.alerts.showLoading();
+    jest.advanceTimersByTime(250);
+
+    manager.redraw();
+    expect(manager).toContainRaw('Hello, world!');
+    expect(loadingCount(manager)).toBe(1);
+
+    app.alerts.clearLoading();
+    manager.redraw();
+    expect(manager).toContainRaw('Hello, world!'); // unrelated alert survives
+    expect(loadingCount(manager)).toBe(0);
+
+    app.alerts.dismiss(id);
+    manager.redraw();
+    expect(manager).not.toContainRaw('Hello, world!');
   });
 });


### PR DESCRIPTION
Lazy chunk loads (and other callers of `app.alerts.showLoading()`) showed the loading alert synchronously and removed it on resolve. Fast loads — e.g. a cached chunk resolving in ~150ms — produced a brief flicker of the "Loading..." alert in the corner.

## Change

`AlertManagerState.showLoading()` now schedules the indicator behind a 250ms timer instead of showing it immediately. `clearLoading()` cancels a still-pending timer, so a load that finishes before 250ms never shows an indicator; if the indicator was already shown, it is dismissed as before.

- Concurrent loads still share a single indicator via the existing `loadingPool` — the UI never shows more than one "Loading" alert regardless of how many loads are in flight.
- `clearLoading()` now dismisses only the loading alert rather than calling `clear()`, so unrelated alerts shown during a load are no longer wiped.
- `showLoading()` no longer returns an identifier (it can't, now that display is deferred); the only caller, `ExportRegistry`, did not use the return value.

## Tests

Added coverage for: fast load (no indicator), slow load (shown after 250ms), multiple concurrent loads (single combined indicator), staggered loads, a fast load amongst concurrent loads (no premature clear), timer cleanup, and that finishing a load leaves unrelated alerts intact.