### PR TITLE
[2.x] dev: warn in debug mode when a main-bundle modal is shown eagerly

### DIFF
--- a/framework/core/js/src/common/ExportRegistry.ts
+++ b/framework/core/js/src/common/ExportRegistry.ts
@@ -140,6 +140,49 @@ export default class ExportRegistry implements IExportRegistry, IChunkRegistry {
     return exists ? this.get(namespace, id) : false;
   }
 
+  /**
+   * Reverse-lookup the registry key (`namespace:id`) for a registered export.
+   *
+   * The id is the build-time module path (e.g. `core:forum/components/FooModal`),
+   * which — unlike a class's `name` — is a literal string in the bundle and so
+   * survives production minification. Returns null if the object is not registered.
+   */
+  public keyFor(object: any): string | null {
+    for (const [namespace, modules] of this.moduleExports) {
+      for (const [id, registered] of modules) {
+        if (registered === object) {
+          return `${namespace}:${id}`;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Registry keys (`namespace:id`) emitted into an initial (main) bundle chunk at
+   * build time, populated by MarkMainBundleModulesPlugin. Used to tell a main-bundle
+   * module apart from one that lives only in an async/code-split chunk — a distinction
+   * the chunk-module map cannot make reliably.
+   */
+  mainBundleModules = new Set<string>();
+
+  /**
+   * Mark a module (by `namespace:id`) as shipping in the main bundle. Called from
+   * build-injected code on boot.
+   */
+  public markInMainBundle(key: string): void {
+    this.mainBundleModules.add(key);
+  }
+
+  /**
+   * Whether the given registry key ships in the main bundle (rather than only in a
+   * code-split chunk loaded on demand).
+   */
+  public isInMainBundle(key: string): boolean {
+    return this.mainBundleModules.has(key);
+  }
+
   addChunkModule(chunkId: number | string, moduleId: number | string, namespace: string, urlPath: string): void {
     if (!this.chunks.has(chunkId.toString())) {
       this.chunks.set(chunkId.toString(), {

--- a/framework/core/js/src/common/states/ModalManagerState.ts
+++ b/framework/core/js/src/common/states/ModalManagerState.ts
@@ -1,5 +1,6 @@
 import type Component from '../Component';
 import Modal, { IDismissibleOptions } from '../components/Modal';
+import fireDebugWarning from '../helpers/fireDebugWarning';
 
 /**
  * Ideally, `show` would take a higher-kinded generic, ala:
@@ -28,6 +29,13 @@ type ModalItem = {
  * Accessible on the `app` object via `app.modal` property.
  */
 export default class ModalManagerState {
+  /**
+   * Modal classes we've already warned about being shown eagerly, so the debug
+   * warning fires at most once per class rather than on every open. Keyed on the
+   * class itself (not its name, which minification mangles and can collide).
+   */
+  protected static eagerModalsWarnedAbout = new WeakSet<object>();
+
   /**
    * @internal
    */
@@ -88,6 +96,30 @@ export default class ModalManagerState {
       componentClass = (await componentClass()).default;
 
       this.loadingModal = false;
+    } else {
+      // The modal class was passed directly rather than as a lazy import. Nudge developers
+      // (in debug mode only) to lazy-load it — but only when it isn't already code-split.
+      const modalClass = componentClass as UnsafeModalClass;
+
+      // Identify the modal by its registry key (e.g. `core:forum/components/FooModal`): the
+      // build-time module path, a literal string that survives production minification.
+      const key = flarum.reg.keyFor(modalClass);
+
+      // Only warn about modals that ship in the main bundle — that's the case a developer can
+      // actually improve by lazy-loading. A modal whose code lives only in a code-split chunk
+      // is already lazy, even when shown here by a direct reference (e.g. a sub-modal opened
+      // from a modal in the same chunk). Unregistered modals are left alone too.
+      const inMainBundle = key !== null && flarum.reg.isInMainBundle(key);
+
+      if (inMainBundle && !ModalManagerState.eagerModalsWarnedAbout.has(modalClass)) {
+        ModalManagerState.eagerModalsWarnedAbout.add(modalClass);
+
+        const identifier = key ?? modalClass.name ?? '(unknown)';
+
+        fireDebugWarning(
+          `Modal "${identifier}" was shown eagerly via app.modal.show(), so its code is bundled in the main js, rather than split into a chunk loaded on demand. Consider passing a function that returns a dynamic import to app.modal.show() to lazy-load it instead.\n\nSee: https://docs.flarum.org/2.x/extend/code-splitting`
+        );
+      }
     }
 
     this.backdropShown = true;

--- a/framework/core/js/tests/integration/common/ModalManager.test.ts
+++ b/framework/core/js/tests/integration/common/ModalManager.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 import { app } from '../../../src/forum';
 import mq from 'mithril-query';
@@ -63,6 +64,190 @@ describe('ModalManager', () => {
     expect(manager).not.toContainRaw('Hello, world!');
   });
 });
+
+describe('ModalManager lazy-load warning', () => {
+  beforeAll(() => app.boot());
+
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+  let forumAttributes: Record<string, unknown>;
+
+  /** Whether any emitted warning mentions lazy loading. */
+  const warnedAboutLazyLoading = (): boolean =>
+    warnSpy.mock.calls.some((args) => args.some((a) => typeof a === 'string' && /lazy/i.test(a)));
+
+  /**
+   * Register a modal under a key and mark it as shipping in the main bundle, mimicking
+   * what the build does for an eagerly-bundled (non-code-split) modal.
+   */
+  const registerInMainBundle = (key: string, modalClass: typeof Modal): void => {
+    const [namespace, id] = key.split(/:(.+)/);
+    flarum.reg.add(namespace, id, modalClass);
+    flarum.reg.markInMainBundle(key);
+  };
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // fireDebugWarning only fires when the forum is in debug mode.
+    forumAttributes = (app.data.resources.find((r: any) => r.type === 'forums') as any).attributes;
+    forumAttributes.debug = true;
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete forumAttributes.debug;
+    app.modal.close();
+  });
+
+  test('warns when a main-bundle modal is shown eagerly', async () => {
+    registerInMainBundle('core:forum/components/EagerModalA', EagerModalA);
+
+    await app.modal.show(EagerModalA);
+
+    expect(warnedAboutLazyLoading()).toBe(true);
+  });
+
+  test('identifies the modal by its registry key (survives minification)', async () => {
+    registerInMainBundle('acme:forum/components/RegisteredModal', RegisteredModal);
+
+    await app.modal.show(RegisteredModal);
+
+    const namedByKey = warnSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('acme:forum/components/RegisteredModal'))
+    );
+
+    expect(namedByKey).toBe(true);
+  });
+
+  test('does not warn when a modal is shown via a lazy import', async () => {
+    await app.modal.show(() => Promise.resolve({ default: LazyModal }));
+
+    expect(warnedAboutLazyLoading()).toBe(false);
+  });
+
+  test('does not warn for a code-split modal shown by reference (e.g. a sub-modal of a lazy chunk)', async () => {
+    // The modal is registered but NOT marked as in the main bundle — its code lives only in a
+    // code-split chunk. Showing it by direct reference (as a sibling modal in the same chunk
+    // would) must not be flagged.
+    flarum.reg.add('core', 'forum/components/ChunkedModal', ChunkedModal);
+
+    await app.modal.show(ChunkedModal);
+
+    expect(warnedAboutLazyLoading()).toBe(false);
+  });
+
+  test('does not warn for an unregistered modal', async () => {
+    await app.modal.show(NamedModal);
+
+    expect(warnedAboutLazyLoading()).toBe(false);
+  });
+
+  test('warns only once per modal class, however many times it is shown', async () => {
+    registerInMainBundle('core:forum/components/EagerModalB', EagerModalB);
+
+    await app.modal.show(EagerModalB);
+    app.modal.close();
+    await app.modal.show(EagerModalB);
+    app.modal.close();
+    await app.modal.show(EagerModalB);
+
+    const lazyWarnings = warnSpy.mock.calls.filter((args) => args.some((a) => typeof a === 'string' && /lazy/i.test(a)));
+
+    expect(lazyWarnings).toHaveLength(1);
+  });
+
+  test('does not warn when the forum is not in debug mode', async () => {
+    delete forumAttributes.debug;
+    registerInMainBundle('core:forum/components/EagerModalC', EagerModalC);
+
+    await app.modal.show(EagerModalC);
+
+    expect(warnedAboutLazyLoading()).toBe(false);
+  });
+});
+
+class EagerModalA extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'A';
+  }
+  title() {
+    return 'A';
+  }
+}
+
+class EagerModalB extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'B';
+  }
+  title() {
+    return 'B';
+  }
+}
+
+class EagerModalC extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'C';
+  }
+  title() {
+    return 'C';
+  }
+}
+
+class LazyModal extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'Lazy';
+  }
+  title() {
+    return 'Lazy';
+  }
+}
+
+class NamedModal extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'Named';
+  }
+  title() {
+    return 'Named';
+  }
+}
+
+class RegisteredModal extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'Registered';
+  }
+  title() {
+    return 'Registered';
+  }
+}
+
+class ChunkedModal extends Modal {
+  className() {
+    return '';
+  }
+  content() {
+    return 'Chunked';
+  }
+  title() {
+    return 'Chunked';
+  }
+}
 
 class MyModal extends Modal {
   className(): string {

--- a/js-packages/webpack-config/src/MarkMainBundleModulesPlugin.cjs
+++ b/js-packages/webpack-config/src/MarkMainBundleModulesPlugin.cjs
@@ -1,0 +1,80 @@
+const path = require('path');
+const extensionId = require('./extensionId.cjs');
+const { Compilation } = require('webpack');
+const ConcatenatedModule = require('webpack/lib/optimize/ConcatenatedModule');
+
+/**
+ * Records which registered modules are emitted into an initial (main) bundle chunk,
+ * as opposed to living only in an async/code-split chunk.
+ *
+ * `flarum.reg`'s chunk-module map can't be used to tell these apart: a module may be
+ * registered there yet still be present in the main bundle. This plugin uses the
+ * authoritative build-time chunk graph instead, emitting
+ * `flarum.reg.markInMainBundle('namespace:id')` for each registered default export
+ * that webpack places in an initial chunk. Consumers (e.g. the dev-mode warning for
+ * eagerly-shown modals) can then reliably ask whether a module ships up front.
+ */
+class MarkMainBundleModulesPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('MarkMainBundleModulesPlugin', (compilation) => {
+      let done = false;
+
+      compilation.hooks.processAssets.tap(
+        {
+          name: 'MarkMainBundleModulesPlugin',
+          // Run after RegisterAsyncChunksPlugin (same stage) so our additions don't clash.
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        () => {
+          if (done) return;
+          done = true;
+
+          const thisComposerJson = require(path.resolve(process.cwd(), '../composer.json'));
+          const namespace = extensionId(thisComposerJson.name);
+
+          // The `src/`-relative path without extension — matches the id autoExportLoader
+          // registers a default export under (e.g. `forum/components/RenameDiscussionModal`).
+          const regPathSep = `\\${path.sep}`;
+          const idFor = (resource) =>
+            resource && resource.split(path.sep).includes('src')
+              ? resource.replace(new RegExp(`.*${regPathSep}src${regPathSep}([^.]+)\\..+`), '$1').replace(/\\/g, '/')
+              : null;
+
+          // A module that has a default export — autoExportLoader appends a `flarum.reg.add`
+          // for these, so they are the ones worth marking.
+          const hasDefaultExport = (m) => /flarum\.reg\.add\('[^']+', '[^']+',/.test(m?._source?._value ?? '');
+
+          const ids = new Set();
+
+          for (const chunk of compilation.chunks) {
+            if (!chunk.canBeInitial()) continue;
+
+            for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
+              const candidates = module instanceof ConcatenatedModule && module.modules ? module.modules : [module];
+
+              for (const m of candidates) {
+                if (!hasDefaultExport(m)) continue;
+
+                const id = idFor(m.resource);
+                if (id) ids.add(`${namespace}:${id}`);
+              }
+            }
+          }
+
+          if (ids.size === 0) return;
+
+          // Append the markers to an initial chunk's main asset so they run on boot.
+          const initialChunk = Array.from(compilation.chunks).find((c) => c.canBeInitial());
+          const file = initialChunk && Array.from(initialChunk.files)[0];
+          if (!file) return;
+
+          const marker = '\n' + Array.from(ids).map((key) => `flarum.reg.markInMainBundle(${JSON.stringify(key)});`).join('\n');
+
+          compilation.updateAsset(file, (old) => new compiler.webpack.sources.ConcatSource(old, marker));
+        }
+      );
+    });
+  }
+}
+
+module.exports = MarkMainBundleModulesPlugin;

--- a/js-packages/webpack-config/src/index.cjs
+++ b/js-packages/webpack-config/src/index.cjs
@@ -3,6 +3,7 @@ const path = require('path');
 const { NormalModuleReplacementPlugin } = require('webpack');
 const RegisterAsyncChunksPlugin = require('./RegisterAsyncChunksPlugin.cjs');
 const OverrideChunkLoaderFunction = require('./OverrideChunkLoaderFunction.cjs');
+const MarkMainBundleModulesPlugin = require('./MarkMainBundleModulesPlugin.cjs');
 
 const entryPointNames = ['forum', 'admin'];
 const entryPointExts = ['js', 'ts'];
@@ -64,6 +65,7 @@ if (useBundleAnalyzer) {
  */
 plugins.push(new RegisterAsyncChunksPlugin());
 plugins.push(new OverrideChunkLoaderFunction());
+plugins.push(new MarkMainBundleModulesPlugin());
 
 module.exports = function () {
   return {


### PR DESCRIPTION
Adds a debug-mode developer warning when a modal is shown via `app.modal.show(SomeModal)` (a direct class reference) and that modal's code ships in the main JS bundle rather than being code-split.

## Behaviour

- Fires only in debug mode (via `fireDebugWarning`), so production forums are unaffected.
- Warns once per modal class.
- Points to https://docs.flarum.org/2.x/extend/code-splitting.

It warns **only** for modals that actually live in the main bundle — the case a developer can improve. A modal whose code lives only in a code-split chunk is already lazy, even when shown by a direct reference (e.g. a sub-modal opened from a modal in the same chunk), and is not flagged.

## How main-bundle detection works

The registry's chunk-module map can't distinguish a main-bundle module from a chunk-resident one (a module can be registered there yet still be present in the main bundle). So a new build pass, `MarkMainBundleModulesPlugin`, walks the webpack chunk graph and emits `flarum.reg.markInMainBundle('namespace:id')` for each registered default export placed in an initial chunk. `ModalManagerState` then checks `flarum.reg.isInMainBundle(key)`.

The modal is identified by its registry key (the build-time module path), which survives production minification — unlike the class name.

## Changes

- `MarkMainBundleModulesPlugin` (new) + registration in webpack-config.
- `ExportRegistry`: `keyFor()`, `markInMainBundle()`, `isInMainBundle()`.
- `ModalManagerState.show()`: the warning.
- Tests covering: main-bundle modal warns, registry-key identity, lazy import not warned, code-split modal not warned, unregistered modal not warned, once-per-class, debug-gated.