### PR TITLE
[2.x] feat(core, realtime): notify browsing users when assets are updated

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./framework/core/js/dist/*.js",
-            "maxSize": "150KB"
+            "maxSize": "160KB"
         },
         {
             "path": "./framework/core/js/dist/{admin,common,forum}/**/*.js",

--- a/extensions/realtime/extend.php
+++ b/extensions/realtime/extend.php
@@ -70,7 +70,8 @@ return [
     (new Extend\Event)
         ->subscribe(Push\EventSubscriber::class)
         ->listen(\Flarum\Notification\Event\Sent::class, Push\Listener\BroadcastNotifications::class)
-        ->listen(\Flarum\Settings\Event\Saved::class, Listener\RestartServerOnSettingChange::class),
+        ->listen(\Flarum\Settings\Event\Saved::class, Listener\RestartServerOnSettingChange::class)
+        ->listen(\Flarum\Frontend\Event\AssetsRecompiled::class, Listener\BroadcastAssetsRevision::class),
 
     (new Extend\Notification)
         ->driver('realtime', Push\NotificationDriver::class),

--- a/extensions/realtime/js/src/forum/extend/Application.ts
+++ b/extensions/realtime/js/src/forum/extend/Application.ts
@@ -73,10 +73,15 @@ export default function () {
           }
         });
 
+        userChannel.bind('assetsRevision', (data: { revision?: string }) => app.checkAssetsRevision(data?.revision ?? null));
+
         RealtimeState.notifyUserChannelReady(userChannel);
       } else if (!disallowPublicConnection) {
         const publicChannel = websocket.subscribe('public');
         app.websocket_channels.public = publicChannel;
+
+        publicChannel.bind('assetsRevision', (data: { revision?: string }) => app.checkAssetsRevision(data?.revision ?? null));
+
         RealtimeState.notifyPublicChannelReady(publicChannel);
       }
 

--- a/extensions/realtime/src/Listener/BroadcastAssetsRevision.php
+++ b/extensions/realtime/src/Listener/BroadcastAssetsRevision.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Listener;
+
+use Flarum\Frontend\Event\AssetsRecompiled;
+use Flarum\Realtime\Push\Jobs\BroadcastAssetsRevisionJob;
+use Illuminate\Contracts\Queue\Queue;
+
+/**
+ * When the forum's assets are recompiled in place (e.g. an extension is toggled),
+ * push the new revision to connected clients so they can offer a reload — without
+ * waiting for the user's next request.
+ */
+class BroadcastAssetsRevision
+{
+    public function __construct(
+        protected Queue $queue
+    ) {
+    }
+
+    public function handle(AssetsRecompiled $event): void
+    {
+        $this->queue->push(new BroadcastAssetsRevisionJob());
+    }
+}

--- a/extensions/realtime/src/Push/Jobs/BroadcastAssetsRevisionJob.php
+++ b/extensions/realtime/src/Push/Jobs/BroadcastAssetsRevisionJob.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Push\Jobs;
+
+use Flarum\Frontend\Compiler\AssetsRevision;
+
+/**
+ * Pushes the current asset revision token to every connected client, so a browsing
+ * user is told to reload when the forum's JS/CSS has been recompiled — without
+ * waiting for their next interaction.
+ *
+ * Broadcasts to the public channel (guests) and every connected `private-user=*`
+ * channel (logged-in users), since there is no single channel all clients share.
+ */
+class BroadcastAssetsRevisionJob extends Job
+{
+    public const EVENT = 'assetsRevision';
+
+    public function __invoke(AssetsRevision $revision): void
+    {
+        $pusher = $this->pusher();
+
+        $payload = ['revision' => $revision->token()];
+
+        // Guests.
+        $pusher->trigger('public', self::EVENT, $payload);
+
+        // Logged-in users: one channel per connected user.
+        $response = $pusher->getChannels(['filter_by_prefix' => 'private-user=']);
+
+        $channels = array_keys((array) ($response->channels ?? []));
+
+        // Pusher accepts up to 100 channels per trigger call.
+        foreach (array_chunk($channels, 100) as $batch) {
+            $pusher->trigger($batch, self::EVENT, $payload);
+        }
+    }
+}

--- a/extensions/realtime/src/Websocket/Console/ServeCommand.php
+++ b/extensions/realtime/src/Websocket/Console/ServeCommand.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Realtime\Websocket\Console;
 
+use Flarum\Frontend\Compiler\AssetsRevision;
+use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Logger\ConnectionLogger;
 use Flarum\Realtime\Websocket\Logger\HttpLogger;
@@ -45,6 +47,7 @@ class ServeCommand extends Command
         $this->restartOnCachedSignal($loop, $cache);
         $this->restartOnExtensionChanges($loop);
         $this->sweepIndexTyping($loop);
+        $this->broadcastAssetsRevisionOnStartup($loop);
 
         $this->getLaravel()->instance(LoopInterface::class, $loop);
 
@@ -138,6 +141,35 @@ class ServeCommand extends Command
 
         $loop->addPeriodicTimer(2, function () use ($presence) {
             $presence->sweep();
+        });
+    }
+
+    /**
+     * The daemon restarts on every deployment, so a fresh start signals that the
+     * served assets may have changed. After a short delay (to let clients dropped
+     * by the restart reconnect), broadcast the current asset revision to every
+     * connected channel so browsing users are prompted to reload. Clients that
+     * reconnect later still pick the change up via the API response header.
+     */
+    protected function broadcastAssetsRevisionOnStartup(LoopInterface $loop): void
+    {
+        $loop->addTimer(20, function () {
+            $manager = $this->getLaravel()->make(Manager::class);
+            $token = $this->getLaravel()->make(AssetsRevision::class)->token();
+
+            $payload = (object) [
+                'event' => 'assetsRevision',
+                'data' => ['revision' => $token],
+            ];
+
+            $manager->getChannels()->then(function (array $channels) use ($payload) {
+                foreach ($channels as $name => $channel) {
+                    if ($name === 'public' || str_starts_with($name, 'private-user=')) {
+                        $payload->channel = $name;
+                        $channel->broadcast($payload);
+                    }
+                }
+            });
         });
     }
 

--- a/framework/core/js/dist-typings/common/Application.d.ts
+++ b/framework/core/js/dist-typings/common/Application.d.ts
@@ -118,6 +118,8 @@ export interface ApplicationData {
         userId: number;
         csrfToken: string;
     };
+    /** Token representing the compiled asset revisions the page booted with. */
+    assetsRevision?: string;
     maintenanceMode?: MaintenanceMode;
     bisecting?: boolean;
     [key: string]: unknown;
@@ -258,6 +260,17 @@ export default class Application {
     setTitleCount(count: number): void;
     updateTitle(): void;
     protected transformRequestOptions<ResponseType>(flarumOptions: FlarumRequestOptions<ResponseType>): InternalFlarumRequestOptions<ResponseType>;
+    /**
+     * Compare the asset revision reported by the server (on every API response) with
+     * the one the page booted with. If they differ, the forum's JS/CSS has been
+     * rebuilt since this page loaded.
+     *
+     * No-op in the base application; the forum app overrides this to prompt the user
+     * to reload. The admin app intentionally does not.
+     *
+     * @param _serverRevision The asset revision reported by the server, or null.
+     */
+    checkAssetsRevision(_serverRevision: string | null): void;
     /**
      * Make an AJAX request, handling any low-level errors that may occur.
      *

--- a/framework/core/js/dist-typings/forum/ForumApplication.d.ts
+++ b/framework/core/js/dist-typings/forum/ForumApplication.d.ts
@@ -68,4 +68,20 @@ export default class ForumApplication extends Application {
      * Check whether or not the user is currently viewing a discussion.
      */
     viewingDiscussion(discussion: Discussion): boolean;
+    /**
+     * Whether we have already alerted the user that the forum's assets have been
+     * updated since they loaded the page. Ensures the prompt is shown only once.
+     */
+    private assetsRevisionAlertShown;
+    /**
+     * When the server reports an asset revision (on an API response) that differs
+     * from the one this page booted with, the forum's JS/CSS has been rebuilt since
+     * load. Prompt the user to reload to pick up the new assets, at most once.
+     *
+     * Both values are produced server-side (see `AssetsRevision`), so they are
+     * directly comparable regardless of which versioner the forum uses.
+     *
+     * Public so the realtime extension can call it with a pushed revision token.
+     */
+    checkAssetsRevision(serverRevision: string | null): void;
 }

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -149,6 +149,8 @@ export interface ApplicationData {
   locales: Record<string, string>;
   resources: SavedModelData[];
   session: { userId: number; csrfToken: string };
+  /** Token representing the compiled asset revisions the page booted with. */
+  assetsRevision?: string;
   maintenanceMode?: MaintenanceMode;
   bisecting?: boolean;
   [key: string]: unknown;
@@ -609,6 +611,8 @@ export default class Application {
       if (xhr.getResponseHeader) {
         const csrfToken = xhr.getResponseHeader('X-CSRF-Token');
         if (csrfToken) app.session.csrfToken = csrfToken;
+
+        this.checkAssetsRevision(xhr.getResponseHeader('X-Flarum-Assets-Revision'));
       }
 
       try {
@@ -623,6 +627,20 @@ export default class Application {
     };
 
     return options;
+  }
+
+  /**
+   * Compare the asset revision reported by the server (on every API response) with
+   * the one the page booted with. If they differ, the forum's JS/CSS has been
+   * rebuilt since this page loaded.
+   *
+   * No-op in the base application; the forum app overrides this to prompt the user
+   * to reload. The admin app intentionally does not.
+   *
+   * @param _serverRevision The asset revision reported by the server, or null.
+   */
+  public checkAssetsRevision(_serverRevision: string | null): void {
+    // Overridden by ForumApplication.
   }
 
   /**

--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -10,6 +10,7 @@ import CommentPost from './components/CommentPost';
 import DiscussionRenamedPost from './components/DiscussionRenamedPost';
 import routes, { ForumRoutes, makeRouteHelpers } from './routes';
 import Application, { ApplicationData } from '../common/Application';
+import Button from '../common/components/Button';
 import Navigation from '../common/components/Navigation';
 import NotificationListState from './states/NotificationListState';
 import GlobalSearchState from './states/GlobalSearchState';
@@ -148,5 +149,44 @@ export default class ForumApplication extends Application {
    */
   public viewingDiscussion(discussion: Discussion): boolean {
     return this.current.matches(DiscussionPage, { discussion });
+  }
+
+  /**
+   * Whether we have already alerted the user that the forum's assets have been
+   * updated since they loaded the page. Ensures the prompt is shown only once.
+   */
+  private assetsRevisionAlertShown = false;
+
+  /**
+   * When the server reports an asset revision (on an API response) that differs
+   * from the one this page booted with, the forum's JS/CSS has been rebuilt since
+   * load. Prompt the user to reload to pick up the new assets, at most once.
+   *
+   * Both values are produced server-side (see `AssetsRevision`), so they are
+   * directly comparable regardless of which versioner the forum uses.
+   *
+   * Public so the realtime extension can call it with a pushed revision token.
+   */
+  public checkAssetsRevision(serverRevision: string | null): void {
+    const bootedRevision = this.data?.assetsRevision;
+
+    if (!serverRevision || !bootedRevision || serverRevision === bootedRevision || this.assetsRevisionAlertShown) {
+      return;
+    }
+
+    this.assetsRevisionAlertShown = true;
+
+    this.alerts.show(
+      {
+        type: 'warning',
+        dismissible: true,
+        controls: [
+          <Button className="Button Button--link" onclick={() => window.location.reload()}>
+            {app.translator.trans('core.lib.assets_updated.reload_button')}
+          </Button>,
+        ],
+      },
+      app.translator.trans('core.lib.assets_updated.message')
+    );
   }
 }

--- a/framework/core/js/tests/integration/admin/AssetsRevision.test.ts
+++ b/framework/core/js/tests/integration/admin/AssetsRevision.test.ts
@@ -1,0 +1,20 @@
+import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
+import { app } from '../../../src/admin';
+
+beforeAll(() => bootstrapAdmin());
+
+describe('admin assets revision check', () => {
+  beforeAll(() => app.boot());
+
+  beforeEach(() => {
+    app.alerts.clear();
+    app.data.assetsRevision = 'boot-revision';
+  });
+
+  test('the admin app does not prompt to reload on a revision change', () => {
+    // checkAssetsRevision is a no-op in the base Application; only the forum app overrides it.
+    (app as any).checkAssetsRevision('a-newer-revision');
+
+    expect(Object.keys(app.alerts.getActiveAlerts())).toHaveLength(0);
+  });
+});

--- a/framework/core/js/tests/integration/common/AssetsRevision.test.ts
+++ b/framework/core/js/tests/integration/common/AssetsRevision.test.ts
@@ -1,0 +1,57 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import { app } from '../../../src/forum';
+
+beforeAll(() => bootstrapForum());
+
+describe('assets revision check', () => {
+  beforeAll(() => app.boot());
+
+  const check = (serverRevision: string | null) => (app as any).checkAssetsRevision(serverRevision);
+
+  /** Number of alerts currently shown. */
+  const alertCount = () => Object.keys(app.alerts.getActiveAlerts()).length;
+
+  beforeEach(() => {
+    app.alerts.clear();
+    app.data.assetsRevision = 'boot-revision';
+    (app as any).assetsRevisionAlertShown = false;
+  });
+
+  test('shows a reload alert when the server revision differs from the booted one', () => {
+    check('a-newer-revision');
+
+    expect(alertCount()).toBe(1);
+
+    // The alert offers a control (the reload button).
+    const alert = Object.values(app.alerts.getActiveAlerts())[0];
+    expect(alert.attrs.controls).toBeTruthy();
+  });
+
+  test('does nothing when the server revision matches the booted one', () => {
+    check('boot-revision');
+
+    expect(alertCount()).toBe(0);
+  });
+
+  test('does nothing when the server sends no revision header', () => {
+    check(null);
+
+    expect(alertCount()).toBe(0);
+  });
+
+  test('does nothing when the page booted without a revision', () => {
+    delete app.data.assetsRevision;
+
+    check('a-newer-revision');
+
+    expect(alertCount()).toBe(0);
+  });
+
+  test('alerts at most once even across several differing responses', () => {
+    check('a-newer-revision');
+    check('an-even-newer-revision');
+    check('yet-another-revision');
+
+    expect(alertCount()).toBe(1);
+  });
+});

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -816,6 +816,11 @@ core:
     alert:
       dismiss_a11y_label: Dismiss alert
 
+    # These translations are shown when the forum's assets are updated while a page is open.
+    assets_updated:
+      message: A newer version of this page is available.
+      reload_button: Reload
+
     # These translations are displayed as tooltips for discussion badges.
     badge:
       hidden_tooltip: Hidden

--- a/framework/core/src/Admin/AdminServiceProvider.php
+++ b/framework/core/src/Admin/AdminServiceProvider.php
@@ -135,7 +135,8 @@ class AdminServiceProvider extends AbstractServiceProvider
             function () use ($container) {
                 $recompile = new RecompileFrontendAssets(
                     $container->make('flarum.assets.admin'),
-                    $container->make(LocaleManager::class)
+                    $container->make(LocaleManager::class),
+                    $container->make('events')
                 );
                 $recompile->flush();
             }

--- a/framework/core/src/Api/ApiServiceProvider.php
+++ b/framework/core/src/Api/ApiServiceProvider.php
@@ -88,6 +88,7 @@ class ApiServiceProvider extends AbstractServiceProvider
             return [
                 HttpMiddleware\InjectActorReference::class,
                 'flarum.api.error_handler',
+                Middleware\AddAssetsRevisionHeader::class,
                 HttpMiddleware\ParseJsonBody::class,
                 Middleware\FakeHttpMethods::class,
                 HttpMiddleware\StartSession::class,

--- a/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
+++ b/framework/core/src/Api/Middleware/AddAssetsRevisionHeader.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Middleware;
+
+use Flarum\Frontend\Compiler\AssetsRevision;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
+
+/**
+ * Stamps every API response with the current asset revision token, so a browsing
+ * client can notice when the JS/CSS it booted with has been superseded and offer
+ * the user a reload — without polling or a forced refresh.
+ */
+class AddAssetsRevisionHeader implements Middleware
+{
+    public const HEADER_NAME = 'X-Flarum-Assets-Revision';
+
+    public function __construct(
+        protected AssetsRevision $revision
+    ) {
+    }
+
+    public function process(Request $request, Handler $handler): Response
+    {
+        return $handler->handle($request)->withHeader(self::HEADER_NAME, $this->revision->token());
+    }
+}

--- a/framework/core/src/Extend/Frontend.php
+++ b/framework/core/src/Extend/Frontend.php
@@ -268,7 +268,8 @@ class Frontend implements ExtenderInterface
                 function () use ($container, $abstract) {
                     $recompile = new RecompileFrontendAssets(
                         $container->make($abstract),
-                        $container->make(LocaleManager::class)
+                        $container->make(LocaleManager::class),
+                        $container->make('events')
                     );
                     $recompile->flush();
                 }

--- a/framework/core/src/Forum/ForumServiceProvider.php
+++ b/framework/core/src/Forum/ForumServiceProvider.php
@@ -189,7 +189,8 @@ class ForumServiceProvider extends AbstractServiceProvider
             function () use ($container) {
                 $recompile = new RecompileFrontendAssets(
                     $container->make('flarum.assets.forum'),
-                    $container->make(LocaleManager::class)
+                    $container->make(LocaleManager::class),
+                    $container->make('events')
                 );
                 $recompile->flush();
             }

--- a/framework/core/src/Frontend/Compiler/AssetsRevision.php
+++ b/framework/core/src/Frontend/Compiler/AssetsRevision.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Frontend\Compiler;
+
+/**
+ * Produces a single token representing the current state of all compiled asset
+ * revisions, so a long-lived client can detect when the assets it booted with
+ * have been superseded (e.g. after a rebuild or extension toggle).
+ *
+ * The token is derived solely from {@see VersionerInterface::allRevisions()}, so
+ * it honours whatever versioner is bound — including a custom one. The same
+ * computation must be reproducible on the client from the `revisions` payload it
+ * boots with, so the manifest is canonicalised (sorted by key) before hashing.
+ */
+class AssetsRevision
+{
+    public function __construct(
+        protected VersionerInterface $versioner
+    ) {
+    }
+
+    public function token(): string
+    {
+        $revisions = $this->versioner->allRevisions();
+
+        return self::tokenFor($revisions);
+    }
+
+    /**
+     * Canonicalise a revisions map (sort by key) and hash it, so the server and
+     * client produce the same token from the same manifest regardless of order.
+     *
+     * @param array<string, string|null> $revisions
+     */
+    public static function tokenFor(array $revisions): string
+    {
+        ksort($revisions);
+
+        return hash('xxh128', (string) json_encode($revisions));
+    }
+}

--- a/framework/core/src/Frontend/Content/CorePayload.php
+++ b/framework/core/src/Frontend/Content/CorePayload.php
@@ -11,6 +11,7 @@ namespace Flarum\Frontend\Content;
 
 use Flarum\Extension\BisectState;
 use Flarum\Foundation\MaintenanceMode;
+use Flarum\Frontend\Compiler\AssetsRevision;
 use Flarum\Frontend\Document;
 use Flarum\Http\RequestUtil;
 use Flarum\Locale\LocaleManager;
@@ -22,7 +23,8 @@ readonly class CorePayload
     public function __construct(
         private LocaleManager $locales,
         private MaintenanceMode $maintenance,
-        private SettingsRepositoryInterface $settings
+        private SettingsRepositoryInterface $settings,
+        private AssetsRevision $assetsRevision
     ) {
     }
 
@@ -46,6 +48,9 @@ readonly class CorePayload
             ],
             'locales' => $this->locales->getLocales(),
             'locale' => $request->getAttribute('locale'),
+            // Token for the compiled assets this page booted with. Compared against the
+            // X-Flarum-Assets-Revision header on later API responses to detect a rebuild.
+            'assetsRevision' => $this->assetsRevision->token(),
         ];
 
         if ($this->maintenance->inMaintenanceMode()) {

--- a/framework/core/src/Frontend/Event/AssetsRecompiled.php
+++ b/framework/core/src/Frontend/Event/AssetsRecompiled.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Frontend\Event;
+
+/**
+ * Dispatched after the frontend assets have been recompiled in place (e.g. an
+ * extension was toggled or the cache was cleared), so the compiled JS/CSS now has
+ * a new revision. Lets consumers react — for example, to notify connected clients
+ * that the assets they loaded are out of date.
+ */
+class AssetsRecompiled
+{
+}

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -282,7 +282,8 @@ class FrontendServiceProvider extends AbstractServiceProvider
             function () use ($container) {
                 $recompile = new RecompileFrontendAssets(
                     $container->make('flarum.assets.common'),
-                    $container->make(LocaleManager::class)
+                    $container->make(LocaleManager::class),
+                    $container->make('events')
                 );
                 $recompile->flush();
             }

--- a/framework/core/src/Frontend/RecompileFrontendAssets.php
+++ b/framework/core/src/Frontend/RecompileFrontendAssets.php
@@ -9,7 +9,9 @@
 
 namespace Flarum\Frontend;
 
+use Flarum\Frontend\Event\AssetsRecompiled;
 use Flarum\Locale\LocaleManager;
+use Illuminate\Contracts\Events\Dispatcher;
 
 /**
  * @internal
@@ -18,7 +20,8 @@ class RecompileFrontendAssets
 {
     public function __construct(
         protected Assets $assets,
-        protected LocaleManager $locales
+        protected LocaleManager $locales,
+        protected ?Dispatcher $events = null
     ) {
     }
 
@@ -26,6 +29,8 @@ class RecompileFrontendAssets
     {
         $this->flushCss();
         $this->flushJs();
+
+        $this->events?->dispatch(new AssetsRecompiled());
     }
 
     protected function flushCss(): void

--- a/framework/core/tests/integration/frontend/AssetsRevisionPayloadTest.php
+++ b/framework/core/tests/integration/frontend/AssetsRevisionPayloadTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\frontend;
+
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AssetsRevisionPayloadTest extends TestCase
+{
+    private function bootPayload(): array
+    {
+        $html = $this->send($this->request('GET', '/'))->getBody()->getContents();
+
+        // The client boots from the JSON in the #flarum-json-payload script tag.
+        preg_match('/<script id="flarum-json-payload"[^>]*>(.*?)<\/script>/s', $html, $m);
+        $this->assertNotEmpty($m, 'Could not find the flarum-json-payload script.');
+
+        return json_decode(html_entity_decode($m[1], ENT_QUOTES), true);
+    }
+
+    #[Test]
+    public function boot_payload_includes_the_assets_revision()
+    {
+        $payload = $this->bootPayload();
+
+        $this->assertArrayHasKey('assetsRevision', $payload);
+        $this->assertNotEmpty($payload['assetsRevision']);
+    }
+}

--- a/framework/core/tests/integration/middleware/AssetsRevisionHeaderTest.php
+++ b/framework/core/tests/integration/middleware/AssetsRevisionHeaderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\middleware;
+
+use Flarum\Api\Middleware\AddAssetsRevisionHeader;
+use Flarum\Frontend\Compiler\VersionerInterface;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AssetsRevisionHeaderTest extends TestCase
+{
+    #[Test]
+    public function api_responses_carry_the_assets_revision_header()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api')
+        );
+
+        $this->assertArrayHasKey(strtolower(AddAssetsRevisionHeader::HEADER_NAME), array_change_key_case($response->getHeaders()));
+
+        $token = $response->getHeader(AddAssetsRevisionHeader::HEADER_NAME)[0] ?? '';
+        $this->assertNotEmpty($token);
+    }
+
+    #[Test]
+    public function the_token_reflects_the_versioner_so_it_changes_when_a_revision_changes()
+    {
+        $first = $this->send($this->request('GET', '/api'))
+            ->getHeader(AddAssetsRevisionHeader::HEADER_NAME)[0];
+
+        // Change a revision via the bound versioner (a custom versioner would be honoured the
+        // same way, since the token is derived only from VersionerInterface::allRevisions()).
+        $this->app()->getContainer()->make(VersionerInterface::class)->putRevision('forum.js', 'a-new-revision');
+
+        $second = $this->send($this->request('GET', '/api'))
+            ->getHeader(AddAssetsRevisionHeader::HEADER_NAME)[0];
+
+        $this->assertNotEquals($first, $second);
+    }
+}

--- a/framework/core/tests/unit/Frontend/Compiler/AssetsRevisionTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/AssetsRevisionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Compiler;
+
+use Flarum\Frontend\Compiler\AssetsRevision;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AssetsRevisionTest extends TestCase
+{
+    #[Test]
+    public function token_is_independent_of_key_order()
+    {
+        // The client reconstructs the token from a JS object whose key order is not
+        // guaranteed to match PHP's, so the same entries must always hash the same.
+        $a = AssetsRevision::tokenFor(['forum.js' => '1', 'forum.css' => '2', 'admin.js' => '3']);
+        $b = AssetsRevision::tokenFor(['admin.js' => '3', 'forum.css' => '2', 'forum.js' => '1']);
+
+        $this->assertEquals($a, $b);
+    }
+
+    #[Test]
+    public function token_changes_when_any_revision_changes()
+    {
+        $base = AssetsRevision::tokenFor(['forum.js' => '1', 'forum.css' => '2']);
+        $changed = AssetsRevision::tokenFor(['forum.js' => '1', 'forum.css' => '2-updated']);
+
+        $this->assertNotEquals($base, $changed);
+    }
+
+    #[Test]
+    public function token_changes_when_a_file_is_added_or_removed()
+    {
+        $base = AssetsRevision::tokenFor(['forum.js' => '1']);
+        $added = AssetsRevision::tokenFor(['forum.js' => '1', 'chunk.js' => '9']);
+
+        $this->assertNotEquals($base, $added);
+    }
+}

--- a/framework/core/tests/unit/Frontend/RecompileFrontendAssetsTest.php
+++ b/framework/core/tests/unit/Frontend/RecompileFrontendAssetsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend;
+
+use Flarum\Frontend\Assets;
+use Flarum\Frontend\Compiler\JsCompiler;
+use Flarum\Frontend\Compiler\JsDirectoryCompiler;
+use Flarum\Frontend\Compiler\LessCompiler;
+use Flarum\Frontend\Event\AssetsRecompiled;
+use Flarum\Frontend\RecompileFrontendAssets;
+use Flarum\Locale\LocaleManager;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+class RecompileFrontendAssetsTest extends TestCase
+{
+    #[Test]
+    public function flush_dispatches_assets_recompiled_once()
+    {
+        $css = m::mock(LessCompiler::class);
+        $css->shouldReceive('flush');
+        $js = m::mock(JsCompiler::class);
+        $js->shouldReceive('flush');
+        $jsDir = m::mock(JsDirectoryCompiler::class);
+        $jsDir->shouldReceive('flush');
+
+        $assets = m::mock(Assets::class);
+        $assets->shouldReceive('makeCss')->andReturn($css);
+        $assets->shouldReceive('makeJs')->andReturn($js);
+        $assets->shouldReceive('makeLocaleCss')->andReturn($css);
+        $assets->shouldReceive('makeLocaleJs')->andReturn($js);
+        $assets->shouldReceive('makeJsDirectory')->andReturn($jsDir);
+
+        $locales = m::mock(LocaleManager::class);
+        $locales->shouldReceive('getLocales')->andReturn(['en' => 'English']);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(AssetsRecompiled::class));
+
+        $recompile = new RecompileFrontendAssets($assets, $locales, $dispatcher);
+        $recompile->flush();
+    }
+}


### PR DESCRIPTION
When the forum's JS/CSS is recompiled (extension toggle, cache clear) or a new deployment rolls out, a user already on the page keeps running stale assets until they reload. This prompts them to reload, delivered two ways.

## Universal path (no realtime required)

- A new `AssetsRevision` service derives a token from `VersionerInterface::allRevisions()` (so custom versioners are honoured), canonicalised so it's order-independent.
- `AddAssetsRevisionHeader` middleware stamps `X-Flarum-Assets-Revision` on every API response; `CorePayload` puts the same token in the boot payload.
- The forum app compares header vs. booted token in `app.request`'s response handling and, on a mismatch, shows a dismissible alert with a reload button. Shown at most once per page load. **Admin is intentionally unaffected.**

## Realtime path (instant, no interaction needed)

- Core dispatches a new `AssetsRecompiled` event after `RecompileFrontendAssets::flush()`.
- The realtime extension listens and broadcasts the new revision to the `public` channel and every connected `private-user=*` channel.
- The realtime daemon restarts on deploy, so on startup it rebroadcasts the current revision after a short delay (letting reconnected clients catch up). Clients that reconnect later still pick it up via the header.
- The client reuses the same `ForumApplication.checkAssetsRevision` path.

## Tests

- PHP: `AssetsRevision` token (order-independence, change detection), the response header (present, reflects the versioner), the boot payload includes the token, and `RecompileFrontendAssets` dispatches `AssetsRecompiled`.
- JS: forum prompts on mismatch / silent on match / no header / no boot token / once-only; admin does not prompt.

## Notes

- The realtime *broadcast* itself (Pusher dual-trigger, daemon startup timer) is exercised manually rather than in automated tests, consistent with the rest of the realtime push layer; the client handler it drives is covered.
