### PR TITLE
[2.x] perf(admin): lazy-load sortablejs to shrink admin bundles

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./framework/core/js/dist/*.js",
-            "maxSize": "160KB"
+            "maxSize": "150KB"
         },
         {
             "path": "./framework/core/js/dist/{admin,common,forum}/**/*.js",

--- a/extensions/tags/js/src/admin/components/TagsPage.js
+++ b/extensions/tags/js/src/admin/components/TagsPage.js
@@ -1,5 +1,3 @@
-import sortable from 'sortablejs';
-
 import app from 'flarum/admin/app';
 import ExtensionPage from 'flarum/admin/components/ExtensionPage';
 import Button from 'flarum/common/components/Button';
@@ -49,7 +47,12 @@ export default class TagsPage extends ExtensionPage {
 
     this.loading = true;
 
-    app.tagList.load(['parent']).then(() => {
+    // Lazy-load sortablejs (~120KB) so it only ships when this page is opened, but
+    // resolve it up front (alongside the tag load) so onListOnCreate can attach it
+    // synchronously once the list renders — keeping the original drag behaviour.
+    // We reuse core's loadSortable chunk rather than bundling our own copy.
+    Promise.all([app.tagList.load(['parent']), import('flarum/admin/utils/loadSortable')]).then(([, sortableModule]) => {
+      this.sortable = sortableModule.default;
       this.loading = false;
 
       m.redraw();
@@ -148,7 +151,7 @@ export default class TagsPage extends ExtensionPage {
     this.$('.TagList')
       .get()
       .map((e) => {
-        sortable.create(e, {
+        this.sortable.create(e, {
           group: 'tags',
           delay: 50,
           delayOnTouchOnly: true,

--- a/framework/core/js/dist-typings/admin/components/GroupBar.d.ts
+++ b/framework/core/js/dist-typings/admin/components/GroupBar.d.ts
@@ -21,9 +21,17 @@ export interface IGroupBarAttrs extends ComponentAttrs {
  */
 export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
     groups: Group[];
+    /** sortablejs, lazy-loaded; attached once available. */
+    sortable: typeof import('sortablejs') | null;
     oninit(vnode: Mithril.Vnode<CustomAttrs, this>): void;
     onupdate(vnode: Mithril.VnodeDOM<CustomAttrs, this>): void;
     view(): JSX.Element;
     onGroupBarCreate(vnode: Mithril.VnodeDOM): void;
+    /**
+     * Attach sortable once both the element exists and sortablejs has loaded. Called
+     * from both `oncreate` and the lazy import's resolution, so it runs whichever
+     * completes last.
+     */
+    makeSortable(): void;
     onSortUpdate(): void;
 }

--- a/framework/core/js/dist-typings/admin/utils/loadSortable.d.ts
+++ b/framework/core/js/dist-typings/admin/utils/loadSortable.d.ts
@@ -1,0 +1,11 @@
+import sortable from 'sortablejs';
+/**
+ * Re-exports sortablejs from a local module so it can be lazy-loaded via Flarum's
+ * chunk system. Dynamically importing a node_modules package directly does not get
+ * a correctly-namespaced chunk URL (the chunk-name loader only rewrites `src/`-relative
+ * and `flarum:`/`ext:` imports); importing this local wrapper does.
+ *
+ * Extensions can reuse this chunk by lazy-importing `flarum/admin/utils/loadSortable`
+ * rather than bundling their own copy of sortablejs.
+ */
+export default sortable;

--- a/framework/core/js/src/admin/components/GroupBar.tsx
+++ b/framework/core/js/src/admin/components/GroupBar.tsx
@@ -1,5 +1,3 @@
-import sortable from 'sortablejs';
-
 import app from '../../admin/app';
 import Component, { ComponentAttrs } from '../../common/Component';
 import GroupBadge from '../../common/components/GroupBadge';
@@ -32,10 +30,21 @@ export interface IGroupBarAttrs extends ComponentAttrs {
 export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttrs> extends Component<CustomAttrs> {
   groups: Group[] = [];
 
+  /** sortablejs, lazy-loaded; attached once available. */
+  sortable: typeof import('sortablejs') | null = null;
+
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
 
     this.groups = sortGroups(this.attrs.groups);
+
+    // Lazy-load sortablejs (~120KB) so it only ships when the permissions page,
+    // the one place GroupBar is used, is opened. Importing a local wrapper (rather
+    // than the package directly) gives the chunk a correctly-namespaced URL.
+    import('../utils/loadSortable').then(({ default: sortable }) => {
+      this.sortable = sortable;
+      this.makeSortable();
+    });
   }
 
   onupdate(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
@@ -61,7 +70,25 @@ export default class GroupBar<CustomAttrs extends IGroupBarAttrs = IGroupBarAttr
   }
 
   onGroupBarCreate(vnode: Mithril.VnodeDOM) {
-    sortable.create(vnode.dom as HTMLElement, {
+    this.element = vnode.dom;
+    this.makeSortable();
+  }
+
+  /**
+   * Attach sortable once both the element exists and sortablejs has loaded. Called
+   * from both `oncreate` and the lazy import's resolution, so it runs whichever
+   * completes last.
+   */
+  makeSortable() {
+    // `this.sortable` and `this.element` are populated by two independent triggers
+    // (the lazy import resolving and `oncreate`); bail until both are ready. We also
+    // require the element to still be in the document, since the import can resolve
+    // after the component is gone.
+    if (!this.sortable || !this.element?.isConnected) {
+      return;
+    }
+
+    this.sortable.create(this.element as HTMLElement, {
       group: 'groups',
       delay: 50,
       delayOnTouchOnly: true,

--- a/framework/core/js/src/admin/utils/loadSortable.ts
+++ b/framework/core/js/src/admin/utils/loadSortable.ts
@@ -1,0 +1,12 @@
+import sortable from 'sortablejs';
+
+/**
+ * Re-exports sortablejs from a local module so it can be lazy-loaded via Flarum's
+ * chunk system. Dynamically importing a node_modules package directly does not get
+ * a correctly-namespaced chunk URL (the chunk-name loader only rewrites `src/`-relative
+ * and `flarum:`/`ext:` imports); importing this local wrapper does.
+ *
+ * Extensions can reuse this chunk by lazy-importing `flarum/admin/utils/loadSortable`
+ * rather than bundling their own copy of sortablejs.
+ */
+export default sortable;


### PR DESCRIPTION
### Changes

`sortablejs` (~120KB raw / ~14KB gzip) was statically imported by core's `GroupBar` (permissions page) and the tags extension's `TagsPage`, so it shipped in **every** admin pageload — even though drag-to-reorder is only used on those two pages. This pushed `core` `admin.js` to the edge of the 150KB bundlewatch budget (it briefly required bumping the budget to 160KB as a stopgap during #4752).

This PR moves `sortablejs` behind a dynamic `import()` via a small local `loadSortable` wrapper module:

- Importing the package directly does **not** get a correctly-namespaced chunk URL — the chunk-name loader only rewrites `src/`-relative and `flarum:`/`ext:` imports, so a bare `import('sortablejs')` produces a chunk that 404s. The local wrapper is what gives the chunk a working namespaced URL (`core/admin/utils/loadSortable.js`).
- The **tags** extension reuses core's chunk by lazy-importing `flarum/admin/utils/loadSortable` rather than bundling (and duplicating) its own copy of `sortablejs`.
- `GroupBar` now attaches sortable from whichever of the lazy import and `oncreate` resolves last, guarding on `element.isConnected` so a late-resolving import cannot attach to a detached node.

### Results (gzip)

| bundle | before | after |
| --- | --- | --- |
| core `admin.js` | 153 KB | **135.6 KB** |
| tags `admin.js` | 19.7 KB | **7.4 KB** |

Restores the core bundlewatch budget to **150KB** (reverting the 160KB stopgap).

### Testing

- `yarn test` (core): 59 suites / 219 tests pass.
- `yarn check-typings` (core): clean.
- Manually verified in a running 2.x install: opening **Admin → Permissions** and **Admin → Tags** loads `core/admin/utils/loadSortable.js` once (HTTP 200, no 404), and drag-reorder works on both pages.