### PR TITLE
[2.x] feat(realtime): ambient typing dots on the index sidebar tag list

### DIFF
--- a/extensions/realtime/js/src/forum/RealtimeState.ts
+++ b/extensions/realtime/js/src/forum/RealtimeState.ts
@@ -1,5 +1,6 @@
 import type { Channel } from 'pusher-js';
 import IndexTypingState from './states/IndexTypingState';
+import IndexTagTypingState from './states/IndexTagTypingState';
 
 type ChannelReadyCallback = (channel: Channel) => void;
 type ReconnectCallback = () => void;
@@ -35,6 +36,13 @@ class RealtimeState {
    * every list item.
    */
   readonly indexTyping = new IndexTypingState();
+
+  /**
+   * Shared presence state for the index sidebar tag-list typing dots, fed by the
+   * same `index-typing` channels as {@link indexTyping} (which now also carry the
+   * tags a typing discussion belongs to) and read by the TagLinkButton extension.
+   */
+  readonly indexTagTyping = new IndexTagTypingState();
 
   // ---------------------------------------------------------------------------
   // Registration (called by extensions via the Realtime extender)

--- a/extensions/realtime/js/src/forum/extend/Application.ts
+++ b/extensions/realtime/js/src/forum/extend/Application.ts
@@ -86,8 +86,21 @@ export default function () {
       }
 
       const bindIndexTyping = (channel: ReturnType<Pusher['subscribe']>): void => {
-        channel.bind('index-typing', (data: { id: number; typing: boolean }) => {
-          RealtimeState.indexTyping.set(data.id, data.typing);
+        channel.bind('index-typing', (data: { id?: number; source?: string; typing: boolean; tags?: number[] }) => {
+          // Replies carry a discussion `id`; new-discussion compose typing has no id
+          // yet and carries only `tags` (+ a per-user `source` key). Only feed the
+          // discussion-list dot when there's an id.
+          if (data.id !== undefined) {
+            RealtimeState.indexTyping.set(data.id, data.typing);
+          }
+
+          // Light up the tag-list dots for the tags involved. The backend scopes
+          // `tags` per channel, so we only ever receive tag IDs the subscriber is
+          // allowed to see. `source` (discussion id or per-user key) lets concurrent
+          // typers in one tag coexist without clearing each other's dot.
+          if (data.tags?.length) {
+            RealtimeState.indexTagTyping.set(data.source ?? data.id ?? '', data.tags, data.typing);
+          }
         });
       };
 
@@ -102,22 +115,18 @@ export default function () {
       }
 
       // Restricted discussions can't go on the public channel without leaking, so
-      // they're routed per restricted tag. Subscribe to the channel of each
-      // restricted tag THIS user can see — channel auth (AuthController) enforces
-      // it server-side too. Bounded by visible-restricted-tag count, not user or
-      // discussion count, so it keeps the same scale guarantee. All feed the same
-      // IndexTypingState, so list rendering is unchanged.
-      if (indexTypingRestrictedEnabled && app.session.user) {
-        // Subscribe to the index-typing channel of every tag the user can see.
-        // We can't filter to restricted tags client-side: `isRestricted` is only
-        // serialized to admins, so a normal user can't tell which of their
-        // visible tags are restricted. We don't need to — the backend only ever
-        // broadcasts restricted discussions to these channels (public ones go to
-        // the public channel), and channel auth already gates each subscription
-        // to tags the actor can see (AuthController::indexTypingTag). Channels
-        // for non-restricted tags simply stay silent. Bounded by visible-tag count.
-        app.websocket_channels.indexTypingTags = app.store.all('tags').map((tag: any) => {
-          const channel = websocket.subscribe('private-index-typing-tag=' + tag.id());
+      // they're routed per restricted tag. Subscribe only to the channels of the
+      // restricted tags THIS user can see — the backend computes that list
+      // (`index-typing-tags`, gated on the setting + tag visibility) so we issue
+      // exactly one private-channel auth per restricted tag, rather than one per
+      // visible tag (most of which are unrestricted and never broadcast). Channel
+      // auth (AuthController::indexTypingTag) still enforces visibility server-side.
+      // All feed the same IndexTypingState, so list rendering is unchanged.
+      const indexTypingTagIds = this.forum.attribute<number[]>('flarum-realtime.index-typing-tags') ?? [];
+
+      if (indexTypingRestrictedEnabled && app.session.user && indexTypingTagIds.length) {
+        app.websocket_channels.indexTypingTags = indexTypingTagIds.map((tagId) => {
+          const channel = websocket.subscribe('private-index-typing-tag=' + tagId);
           bindIndexTyping(channel);
           return channel;
         });

--- a/extensions/realtime/js/src/forum/extend/Tags.ts
+++ b/extensions/realtime/js/src/forum/extend/Tags.ts
@@ -1,0 +1,13 @@
+import app from 'flarum/forum/app';
+import IndexTyping from './Tags/IndexTyping';
+
+/**
+ * Integrations with flarum-tags. Each extender targets a tags component via its
+ * registry path, so it lazily no-ops when flarum-tags isn't loaded (see core's
+ * `extend`, which defers string-target extension to `reg.onLoad`).
+ */
+export default function Tags() {
+  if (!!app.data['flarum-realtime.index-typing-indicator']) {
+    IndexTyping();
+  }
+}

--- a/extensions/realtime/js/src/forum/extend/Tags/IndexTyping.tsx
+++ b/extensions/realtime/js/src/forum/extend/Tags/IndexTyping.tsx
@@ -1,0 +1,89 @@
+import { extend } from 'flarum/common/extend';
+import app from 'flarum/forum/app';
+import Icon from 'flarum/common/components/Icon';
+import RealtimeState from '../../RealtimeState';
+
+/**
+ * Ambient "someone is typing here" dot on the index sidebar tag list.
+ *
+ * Presence comes from the same `index-typing` channels as the discussion-list
+ * dot (see Application), which now carry the tags a typing discussion belongs to.
+ * This extender only *reads* the shared IndexTagTypingState — there are no
+ * per-tag subscriptions beyond the ones realtime already makes, and the backend
+ * scopes the tag IDs per channel so a restricted tag is never surfaced to an
+ * audience that can't see it.
+ *
+ * The sidebar tag list is short and always on screen, so (unlike the
+ * discussion-list dot) it needs no IntersectionObserver or SubtreeRetainer:
+ * IndexTagTypingState.set()/isTyping() drive m.redraw() directly, including the
+ * self-clearing redraw when the dot should disappear.
+ *
+ * Only loaded when flarum-tags is active (see forum/index.ts).
+ */
+export default function (): void {
+  extend('ext:flarum/tags/forum/components/TagLinkButton', 'linkItems', function (this: any, items: any) {
+    const tag = this.attrs.model;
+
+    if (!tag || !RealtimeState.indexTagTyping.isTyping(tag.id())) {
+      return;
+    }
+
+    // Sit after the tag label (label is priority 90), trailing the link.
+    items.add(
+      'realtimeTyping',
+      <span className="TagLinkButton-typing" aria-label={app.translator.trans('flarum-realtime.forum.index-typing.someone-typing-tag')}>
+        <Icon name="fas fa-ellipsis-h fa-beat" className="TagLinkButton-typing-icon" />
+      </span>,
+      0
+    );
+  });
+
+  // Surface a dot on the relevant tags while someone is composing a NEW discussion
+  // in them — before the discussion (and its id) exists. The reply path can't cover
+  // this because it keys on a discussion id; here the client tells the server which
+  // tags it has selected (server-side re-authorised against the actor, so a restricted
+  // tag can't be spoofed). Fires on the user's own private channel.
+  extend('flarum/forum/components/DiscussionComposer', 'oninit', function (this: any) {
+    let previousContent: string | null = null;
+    let lastSentAt = 0;
+
+    // Send a ping whenever the content changes since the last poll, but never more
+    // than once per SEND_INTERVAL. Crucially we DON'T track lodash throttle edges
+    // here: the gate is "content changed AND it's been long enough", so a resume
+    // after a pause pings on the very next poll — the server's idle/active state and
+    // the dot's self-clearing TTL would otherwise drift apart and the dot wouldn't
+    // reliably come back. Re-pinging well within the 6s TTL keeps the dot alive.
+    const SEND_INTERVAL = 2000;
+
+    const checkTyping = (): void => {
+      const tags: any[] = this.composer?.fields?.tags || [];
+      const content: string = this.composer?.fields?.content?.() || '';
+
+      // Only signal once there's something being written and at least one tag chosen.
+      if (!content.length || !tags.length) {
+        previousContent = content;
+        return;
+      }
+
+      const changed = content !== previousContent;
+      previousContent = content;
+
+      const now = Date.now();
+      if (!changed || now - lastSentAt < SEND_INTERVAL) return;
+      lastSentAt = now;
+
+      app.websocket_channels?.user?.trigger('client-index-typing-tags', {
+        tags: tags.map((tag) => Number(tag.id())),
+      });
+    };
+
+    this._composeTypingListener = setInterval(checkTyping, 1000);
+  });
+
+  extend('flarum/forum/components/DiscussionComposer', 'onremove', function (this: any) {
+    if (this._composeTypingListener) {
+      clearInterval(this._composeTypingListener);
+      this._composeTypingListener = null;
+    }
+  });
+}

--- a/extensions/realtime/js/src/forum/index.ts
+++ b/extensions/realtime/js/src/forum/index.ts
@@ -2,6 +2,7 @@ import app from 'flarum/forum/app';
 import Application from './extend/Application';
 import Discussion from './extend/Discussion';
 import DiscussionList from './extend/DiscussionList';
+import Tags from './extend/Tags';
 import User from './extend/User';
 
 import RealtimeExtend from './extenders/Realtime';
@@ -18,5 +19,6 @@ app.initializers.add('flarum-realtime', () => {
   Application();
   Discussion();
   DiscussionList();
+  Tags();
   User();
 });

--- a/extensions/realtime/js/src/forum/states/IndexTagTypingState.ts
+++ b/extensions/realtime/js/src/forum/states/IndexTagTypingState.ts
@@ -1,0 +1,100 @@
+/**
+ * Entries older than this (ms) are considered no longer typing. Acts as a
+ * client-side backstop in case a falling-edge `index-typing` event is missed
+ * (e.g. dropped during a reconnect), so a dot self-clears within this window.
+ *
+ * Mirrors IndexTypingState's EXPIRY_MS so the tag-list dot and the
+ * discussion-list dot clear on the same cadence.
+ */
+const EXPIRY_MS = 6000;
+
+interface PresenceMap {
+  [tagId: string]: number;
+}
+
+/**
+ * Tracks which tags currently have someone typing in one of their discussions,
+ * for the ambient dot on the index sidebar tag list. Fed by the same
+ * `index-typing` channels as IndexTypingState (see Application), which now carry
+ * the tag IDs a typing discussion belongs to alongside its discussion id —
+ * scoped per channel so restricted tags are only ever surfaced to an audience
+ * that can see them.
+ *
+ * Several discussions can be typed in under one tag at once, so unlike the
+ * discussion-keyed state we count how many discussions are keeping each tag
+ * "warm": the dot clears only once the last of them falls idle.
+ */
+export default class IndexTagTypingState {
+  /** tagId => latest ping timestamp (ms), refreshed by any typing discussion under it. */
+  protected typing: PresenceMap = {};
+
+  /**
+   * tagId => set of discussion ids currently typing under it. A tag stays lit
+   * while any discussion is active, and only clears when the set empties.
+   */
+  protected discussions: { [tagId: string]: Set<string> } = {};
+
+  protected truncationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Record a coalesced presence signal for a discussion against the tags it
+   * belongs to. The same discussion's rising/falling edges add and remove it
+   * from each tag's active set.
+   */
+  set(source: number | string, tagIds: Array<number | string>, typing: boolean): void {
+    // `source` identifies who is typing under each tag: a discussion id for replies,
+    // or a per-user key (e.g. "u148") for someone composing a new discussion. A tag
+    // stays lit while ANY source is active, so concurrent typers don't clear each
+    // other's dot.
+    const sourceKey = String(source);
+
+    for (const rawTagId of tagIds) {
+      const tagId = String(rawTagId);
+      const set = (this.discussions[tagId] ??= new Set());
+
+      if (typing) {
+        set.add(sourceKey);
+        this.typing[tagId] = Date.now();
+      } else {
+        set.delete(sourceKey);
+        if (set.size === 0) {
+          delete this.discussions[tagId];
+          delete this.typing[tagId];
+        }
+      }
+    }
+
+    m.redraw();
+  }
+
+  /**
+   * Whether someone is currently typing in a discussion under the given tag.
+   * Prunes expired entries and schedules a redraw for when the most recent entry
+   * will expire, so a stale dot clears itself even if a falling-edge event never
+   * arrives.
+   */
+  isTyping(tagId: number | string): boolean {
+    const invalidateWhen = Date.now() - EXPIRY_MS;
+    let latestTime: number | null = null;
+
+    for (const id of Object.keys(this.typing)) {
+      if (this.typing[id] < invalidateWhen) {
+        delete this.typing[id];
+        delete this.discussions[id];
+      } else if (!latestTime || latestTime < this.typing[id]) {
+        latestTime = this.typing[id];
+      }
+    }
+
+    if (this.truncationTimer) {
+      clearTimeout(this.truncationTimer);
+      this.truncationTimer = null;
+    }
+
+    if (latestTime) {
+      this.truncationTimer = setTimeout(() => m.redraw(), latestTime - invalidateWhen);
+    }
+
+    return Object.prototype.hasOwnProperty.call(this.typing, String(tagId));
+  }
+}

--- a/extensions/realtime/resources/less/forum.less
+++ b/extensions/realtime/resources/less/forum.less
@@ -135,3 +135,16 @@
         --fa-beat-scale: 1.4;
     }
 }
+
+.TagLinkButton-typing {
+    color: var(--primary-color);
+    // Trail the tag name, pushed to the end of the sidebar row so the dot lines up
+    // down the list regardless of tag-name length.
+    margin-left: auto;
+    padding-left: 6px;
+
+    .TagLinkButton-typing-icon {
+        font-size: 0.85em;
+        --fa-beat-scale: 1.4;
+    }
+}

--- a/extensions/realtime/resources/locale/en.yml
+++ b/extensions/realtime/resources/locale/en.yml
@@ -10,6 +10,7 @@ flarum-realtime:
             no-activity: No one is typing
         index-typing:
             someone-typing: Someone is typing in this discussion
+            someone-typing-tag: Someone is typing in this tag
         user:
             settings:
                 heading: Realtime

--- a/extensions/realtime/src/Websocket/Api/ForumAttributes.php
+++ b/extensions/realtime/src/Websocket/Api/ForumAttributes.php
@@ -9,9 +9,12 @@
 
 namespace Flarum\Realtime\Websocket\Api;
 
+use Flarum\Api\Context;
+use Flarum\Api\Schema\Arr;
 use Flarum\Api\Schema\Boolean;
 use Flarum\Api\Schema\Str;
 use Flarum\Realtime\Websocket\Settings;
+use Flarum\Settings\SettingsRepositoryInterface;
 
 class ForumAttributes
 {
@@ -31,6 +34,38 @@ class ForumAttributes
                 ->get(fn () => $this->settings->jsClientPort),
             Boolean::make('websocket.secure')
                 ->get(fn () => $this->settings->jsClientSecure),
+
+            // The restricted tags the actor may see, so the client subscribes to
+            // exactly those per-tag index-typing channels instead of one channel
+            // (and one auth round-trip) per visible tag. Empty unless the
+            // restricted index-typing dots are enabled and Tags is active.
+            Arr::make('flarum-realtime.index-typing-tags')
+                ->get(fn ($model, Context $context) => $this->indexTypingTagIds($context)),
         ];
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function indexTypingTagIds(Context $context): array
+    {
+        $actor = $context->getActor();
+
+        if ($actor->isGuest() || ! class_exists(\Flarum\Tags\Tag::class)) {
+            return [];
+        }
+
+        $restrictedEnabled = (bool) resolve(SettingsRepositoryInterface::class)
+            ->get('flarum-realtime.index-typing-indicator-restricted');
+
+        if (! $restrictedEnabled) {
+            return [];
+        }
+
+        return \Flarum\Tags\Tag::whereVisibleTo($actor)
+            ->where('is_restricted', true)
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
     }
 }

--- a/extensions/realtime/src/Websocket/IndexTypingPresence.php
+++ b/extensions/realtime/src/Websocket/IndexTypingPresence.php
@@ -62,6 +62,15 @@ class IndexTypingPresence
     protected const EXPIRY_MS = 6000;
 
     /**
+     * While typing continues, re-broadcast the (still-true) rising edge at least this
+     * often. The frontend dot self-clears EXPIRY_MS after the last signal it received,
+     * but we coalesce a typing burst into a single rising edge — so without a periodic
+     * refresh the dot would vanish mid-typing once EXPIRY_MS elapsed. Re-announcing
+     * comfortably inside that window keeps the dot alive for as long as the typing does.
+     */
+    protected const REFRESH_MS = 3000;
+
+    /**
      * The set of channels a discussion's presence routes to is cached this many ms,
      * so a repeated typing burst on the same discussion doesn't re-query the database.
      */
@@ -73,12 +82,29 @@ class IndexTypingPresence
     protected array $lastSeen = [];
 
     /**
-     * discussionId => [string[] $channels, float $cachedAt]. The channels a
-     * discussion's typing presence is broadcast to — the public channel if it's
-     * guest-visible, otherwise its restricted-tag channels (when enabled), or an
-     * empty array if it can't be surfaced.
+     * Key => timestamp (ms) of the most recent rising-edge broadcast for that key
+     * (discussion id, or "{userId}:{tagId}" for compose typing). Used to re-announce
+     * a still-active typer before the frontend's dot TTL elapses. See REFRESH_MS.
+     */
+    protected array $lastBroadcast = [];
+
+    /**
+     * discussionId => [array<string, int[]> $channels, float $cachedAt]. Maps each
+     * channel a discussion's typing presence is broadcast to → the tag IDs that
+     * channel's audience may see lit up on the tag list. The public channel if it's
+     * guest-visible (carrying the discussion's guest-visible tags), otherwise its
+     * restricted-tag channels (when enabled, each carrying only its own tag), or an
+     * empty map if it can't be surfaced.
      */
     protected array $routing = [];
+
+    /**
+     * "{userId}:{tagId}" => timestamp (ms) of the most recent compose ping. Tracks
+     * users composing a *new* discussion in a tag — there's no discussion id yet, so
+     * the client tells us which tags it has selected and we key presence per
+     * (user, tag). Kept separate from {@link $lastSeen} (which is discussion-keyed).
+     */
+    protected array $tagLastSeen = [];
 
     protected ?bool $restrictedEnabled = null;
 
@@ -108,17 +134,128 @@ class IndexTypingPresence
 
         $this->lastSeen[$discussionId] = $now;
 
-        if (! $wasActive) {
+        // Rising edge when newly active, or a periodic refresh while typing continues
+        // (see REFRESH_MS) so the frontend dot doesn't self-clear mid-typing.
+        if (! $wasActive || $this->needsRefresh($discussionId, $now)) {
+            $this->lastBroadcast[$discussionId] = $now;
             $this->broadcast($discussionId, true);
         }
     }
 
     /**
-     * The channels a discussion's typing presence should be broadcast to. Cached
-     * briefly so a typing burst doesn't re-query. Mirrors the visibility scoping the
-     * rest of the realtime extension uses (see AuthController / Push\Jobs\Job).
+     * Whether a still-active typer's rising edge should be re-broadcast because the
+     * last one is old enough that the frontend dot is about to self-clear.
+     */
+    protected function needsRefresh(int|string $key, float $now): bool
+    {
+        return ! isset($this->lastBroadcast[$key])
+            || ($now - $this->lastBroadcast[$key]) >= self::REFRESH_MS;
+    }
+
+    /**
+     * Record that a user is composing a *new* discussion in the given tags. Unlike
+     * {@link touch}, there's no discussion yet, so the client tells us which tags it
+     * has selected and we re-authorise each against the actor before surfacing it —
+     * the IDs are client-supplied, so trusting them blindly would let a user light up
+     * (and thus disclose activity in) a restricted tag they can't see.
      *
-     * @return string[]
+     * Each (user, visible-tag) pair coalesces independently: a rising-edge signal is
+     * emitted only when that pair was idle, and the falling edge is emitted by
+     * {@link sweep} once the compose ping stops. Tags the actor can't see are dropped.
+     *
+     * @param int[] $claimedTagIds
+     */
+    public function touchTags(int $userId, array $claimedTagIds): void
+    {
+        if (! class_exists(\Flarum\Tags\Tag::class) || empty($claimedTagIds)) {
+            return;
+        }
+
+        $now = $this->now();
+
+        foreach ($this->visibleTags($userId, $claimedTagIds) as $tagId) {
+            $key = "$userId:$tagId";
+            $wasActive = $this->isTagActive($key, $now);
+
+            $this->tagLastSeen[$key] = $now;
+
+            // Rising edge, or a periodic refresh while compose typing continues, so
+            // the dot doesn't self-clear mid-typing (mirrors touch()).
+            if (! $wasActive || $this->needsRefresh($key, $now)) {
+                $this->lastBroadcast[$key] = $now;
+                $this->broadcastTagTyping($userId, $tagId, true);
+            }
+        }
+    }
+
+    /**
+     * Filter client-claimed tag IDs to those the actor may actually see, so a restricted
+     * tag is never surfaced to (or on behalf of) someone who can't see it.
+     *
+     * @param int[] $claimedTagIds
+     * @return int[]
+     */
+    protected function visibleTags(int $userId, array $claimedTagIds): array
+    {
+        $actor = \Flarum\User\User::query()->find($userId) ?? new Guest;
+
+        return \Flarum\Tags\Tag::whereVisibleTo($actor)
+            ->whereIn('id', array_map('intval', $claimedTagIds))
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+
+    protected function isTagActive(string $key, float $now): bool
+    {
+        return isset($this->tagLastSeen[$key])
+            && ($now - $this->tagLastSeen[$key]) < self::EXPIRY_MS;
+    }
+
+    /**
+     * Broadcast a compose-typing signal for a single (already-authorised) tag. Routes
+     * to the public channel if the tag is guest-visible, otherwise to its restricted
+     * channel — mirroring {@link resolveChannels}. Carries no discussion `id` (there
+     * isn't one yet); only the tag-list dot consumes this, keyed on `tags`.
+     */
+    protected function broadcastTagTyping(int $userId, int $tagId, bool $typing): void
+    {
+        $channelName = $this->tagIsGuestVisible($tagId)
+            ? self::PUBLIC_CHANNEL
+            : self::tagChannel($tagId);
+
+        $channel = $this->manager->find($channelName);
+
+        if (! $channel || ! $channel->hasConnections()) {
+            return;
+        }
+
+        $channel->broadcast((object) [
+            'event' => 'index-typing',
+            'channel' => $channelName,
+            'data' => [
+                // No discussion `id` yet — this is a new-discussion compose. `source`
+                // is a per-typer dedup key so concurrent composers in the same tag
+                // don't clear each other's dot (mirrors how `id` keys reply typing).
+                'source' => "u$userId",
+                'typing' => $typing,
+                'tags' => [$tagId],
+            ],
+        ]);
+    }
+
+    protected function tagIsGuestVisible(int $tagId): bool
+    {
+        return \Flarum\Tags\Tag::whereVisibleTo(new Guest)->where('id', $tagId)->exists();
+    }
+
+    /**
+     * The channels a discussion's typing presence should be broadcast to, each
+     * mapped to the tag IDs that channel's audience may see lit up on the tag list.
+     * Cached briefly so a typing burst doesn't re-query. Mirrors the visibility
+     * scoping the rest of the realtime extension uses (see AuthController / Push\Jobs\Job).
+     *
+     * @return array<string, int[]>
      */
     protected function channelsFor(int $discussionId): array
     {
@@ -136,12 +273,26 @@ class IndexTypingPresence
     }
 
     /**
-     * @return string[]
+     * Resolve the channel → visible-tag-IDs map for a discussion.
+     *
+     * The tag IDs are surfaced in the broadcast so the tag list can light up the
+     * tags a typing discussion belongs to. They're scoped per channel so a restricted
+     * tag is never disclosed to an audience that can't see it: the public channel
+     * carries the discussion's guest-visible tags, while each restricted-tag channel
+     * carries only its own tag (the one its subscribers are authorised for).
+     *
+     * @return array<string, int[]>
      */
     protected function resolveChannels(int $discussionId): array
     {
         if (Discussion::whereVisibleTo(new Guest)->where('id', $discussionId)->exists()) {
-            return [self::PUBLIC_CHANNEL];
+            // A guest-visible discussion's tags are themselves guest-visible, so it's
+            // safe to surface all of them on the public channel.
+            $tagIds = class_exists(\Flarum\Tags\Tag::class)
+                ? $this->tagIdsFor($discussionId, restrictedOnly: false)
+                : [];
+
+            return [self::PUBLIC_CHANNEL => $tagIds];
         }
 
         if (! $this->restrictedEnabled() || ! class_exists(\Flarum\Tags\Tag::class)) {
@@ -150,16 +301,36 @@ class IndexTypingPresence
 
         // The discussion's restricted tags. A user who can see ANY of them can see
         // the discussion (Flarum's OR semantics), so broadcasting to each restricted
-        // tag's channel reaches exactly the right audience. Queried via the pivot to
-        // avoid loading models in the hot path.
-        $tagIds = resolve(ConnectionInterface::class)
+        // tag's channel reaches exactly the right audience. Each channel carries only
+        // its own tag ID — a subscriber is authorised for that tag but not necessarily
+        // for the discussion's other (restricted) tags.
+        $channels = [];
+
+        foreach ($this->tagIdsFor($discussionId, restrictedOnly: true) as $tagId) {
+            $channels[self::tagChannel($tagId)] = [$tagId];
+        }
+
+        return $channels;
+    }
+
+    /**
+     * The IDs of a discussion's tags, optionally limited to restricted tags. Queried
+     * via the pivot to avoid loading models in the hot path.
+     *
+     * @return int[]
+     */
+    protected function tagIdsFor(int $discussionId, bool $restrictedOnly): array
+    {
+        $query = resolve(ConnectionInterface::class)
             ->table('discussion_tag')
             ->join('tags', 'tags.id', '=', 'discussion_tag.tag_id')
-            ->where('discussion_tag.discussion_id', $discussionId)
-            ->where('tags.is_restricted', true)
-            ->pluck('tags.id');
+            ->where('discussion_tag.discussion_id', $discussionId);
 
-        return $tagIds->map(fn ($id) => self::tagChannel((int) $id))->all();
+        if ($restrictedOnly) {
+            $query->where('tags.is_restricted', true);
+        }
+
+        return $query->pluck('tags.id')->map(fn ($id) => (int) $id)->all();
     }
 
     protected function restrictedEnabled(): bool
@@ -182,8 +353,17 @@ class IndexTypingPresence
 
         foreach ($this->lastSeen as $discussionId => $lastSeen) {
             if (! $this->isActive($discussionId, $now)) {
-                unset($this->lastSeen[$discussionId]);
+                unset($this->lastSeen[$discussionId], $this->lastBroadcast[$discussionId]);
                 $this->broadcast($discussionId, false);
+            }
+        }
+
+        // Falling edge for new-discussion compose typing, keyed per (user, tag).
+        foreach ($this->tagLastSeen as $key => $lastSeen) {
+            if (! $this->isTagActive($key, $now)) {
+                unset($this->tagLastSeen[$key], $this->lastBroadcast[$key]);
+                [$userId, $tagId] = array_map('intval', explode(':', $key));
+                $this->broadcastTagTyping($userId, $tagId, false);
             }
         }
 
@@ -204,7 +384,7 @@ class IndexTypingPresence
 
     protected function broadcast(int $discussionId, bool $typing): void
     {
-        foreach ($this->channelsFor($discussionId) as $channelName) {
+        foreach ($this->channelsFor($discussionId) as $channelName => $tagIds) {
             $channel = $this->manager->find($channelName);
 
             // Only allocate work if someone is actually listening on the list.
@@ -218,6 +398,8 @@ class IndexTypingPresence
                 'data' => [
                     'id' => $discussionId,
                     'typing' => $typing,
+                    // The tags this channel's audience may see lit up on the tag list.
+                    'tags' => $tagIds,
                 ],
             ]);
         }

--- a/extensions/realtime/src/Websocket/Message/Message.php
+++ b/extensions/realtime/src/Websocket/Message/Message.php
@@ -36,6 +36,7 @@ class Message
         );
 
         $this->relayIndexTyping();
+        $this->relayComposeTyping();
     }
 
     /**
@@ -87,5 +88,29 @@ class Message
         }
 
         resolve(IndexTypingPresence::class)->touch((int) $m[1]);
+    }
+
+    /**
+     * Feed compose-typing for a *new* discussion into the index-typing presence so
+     * the tag list lights up before the discussion exists. There's no discussion id
+     * yet, so the client sends the tag IDs it has selected, on its own
+     * `private-user={id}` channel — the user id comes from the (already authorised)
+     * channel name, never from the payload, and IndexTypingPresence re-authorises
+     * each claimed tag against that user before surfacing it.
+     */
+    protected function relayComposeTyping(): void
+    {
+        if ($this->payload->event !== 'client-index-typing-tags'
+            || ! preg_match('/^private-user=(\d+)$/', $this->payload->channel, $m)) {
+            return;
+        }
+
+        $tags = $this->payload->data->tags ?? null;
+
+        if (! is_array($tags)) {
+            return;
+        }
+
+        resolve(IndexTypingPresence::class)->touchTags((int) $m[1], $tags);
     }
 }

--- a/extensions/realtime/tests/integration/IndexTypingPresenceRoutingTest.php
+++ b/extensions/realtime/tests/integration/IndexTypingPresenceRoutingTest.php
@@ -121,11 +121,11 @@ class IndexTypingPresenceRoutingTest extends TestCase
     {
         [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
 
-        $clock = new class () {
+        $clock = new class() {
             public float $now = 1_000_000.0;
         };
 
-        $controllable = new class ($presence, $clock) extends IndexTypingPresence {
+        $controllable = new class($presence, $clock) extends IndexTypingPresence {
             public function __construct(private IndexTypingPresence $inner, private object $clock)
             {
                 // Reuse the already-built presence's Manager.

--- a/extensions/realtime/tests/integration/IndexTypingPresenceRoutingTest.php
+++ b/extensions/realtime/tests/integration/IndexTypingPresenceRoutingTest.php
@@ -1,0 +1,288 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Group\Group;
+use Flarum\Realtime\Websocket\Channel\Channel;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The index-typing presence tracker surfaces, in each broadcast, the tag IDs the
+ * receiving channel's audience may light up on the tag list. The IDs are scoped
+ * per channel so a restricted tag is never disclosed to an audience that can't
+ * see it: the public channel carries a guest-visible discussion's tags, while
+ * each restricted-tag channel carries only its own tag.
+ */
+class IndexTypingPresenceRoutingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'flarum-realtime');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'Member', 'name_plural' => 'Members'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 100],
+            ],
+            'group_permission' => [
+                // Group 100 (user 2) can view restricted tag 3, but NOT tag 4.
+                ['group_id' => 100, 'permission' => 'tag3.viewForum'],
+            ],
+            'tags' => [
+                ['id' => 1, 'name' => 'Open', 'slug' => 'open', 'is_restricted' => false],
+                ['id' => 2, 'name' => 'Secondary', 'slug' => 'secondary', 'is_restricted' => false],
+                ['id' => 3, 'name' => 'Members', 'slug' => 'members', 'is_restricted' => true],
+                ['id' => 4, 'name' => 'Staff', 'slug' => 'staff', 'is_restricted' => true],
+            ],
+            'discussions' => [
+                // Guest-visible: tagged with two unrestricted tags.
+                ['id' => 1, 'title' => 'Public', 'slug' => 'public', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
+                // Restricted: tagged with two restricted tags.
+                ['id' => 2, 'title' => 'Restricted', 'slug' => 'restricted', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 1, 'first_post_id' => 0, 'comment_count' => 1, 'is_private' => 0],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+                ['discussion_id' => 2, 'tag_id' => 3],
+                ['discussion_id' => 2, 'tag_id' => 4],
+            ],
+        ]);
+    }
+
+    /**
+     * Build a presence tracker whose Manager hands out a spy channel (always
+     * "has connections") for every channel name, recording each broadcast.
+     *
+     * The broadcasts are collected into a shared ArrayObject so the caller sees
+     * what the channel spies append (a plain array returned by value would be a
+     * snapshot taken before touch() runs).
+     *
+     * @return array{0: IndexTypingPresence, 1: \ArrayObject<int, object>}
+     */
+    private function presenceCapturingBroadcasts(): array
+    {
+        $broadcasts = new \ArrayObject();
+
+        $channelFor = function () use ($broadcasts): Channel {
+            // A stub (not a mock) — we only need it to record broadcasts, not to
+            // assert call expectations.
+            $channel = $this->createStub(Channel::class);
+
+            $channel->method('hasConnections')->willReturn(true);
+            $channel->method('broadcast')->willReturnCallback(function (object $payload) use ($broadcasts) {
+                $broadcasts->append($payload);
+
+                return true;
+            });
+
+            return $channel;
+        };
+
+        $manager = $this->createStub(Manager::class);
+        $manager->method('find')->willReturnCallback($channelFor);
+
+        // Boot the app so the global container (used by IndexTypingPresence's
+        // resolve() / Eloquent model connections) is bound to the test database.
+        $this->app();
+
+        return [new IndexTypingPresence($manager), $broadcasts];
+    }
+
+    /**
+     * Like {@link presenceCapturingBroadcasts} but the presence's clock is driven by
+     * a `&$clock` reference (ms), so tests can advance time deterministically to
+     * exercise the rising-edge refresh / falling-edge expiry without real sleeps.
+     *
+     * @return array{0: IndexTypingPresence, 1: \ArrayObject<int, object>, 2: object}
+     */
+    private function presenceWithControllableClock(): array
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        $clock = new class () {
+            public float $now = 1_000_000.0;
+        };
+
+        $controllable = new class ($presence, $clock) extends IndexTypingPresence {
+            public function __construct(private IndexTypingPresence $inner, private object $clock)
+            {
+                // Reuse the already-built presence's Manager.
+                $reflection = new \ReflectionProperty(IndexTypingPresence::class, 'manager');
+                parent::__construct($reflection->getValue($inner));
+            }
+
+            protected function now(): float
+            {
+                return $this->clock->now;
+            }
+        };
+
+        return [$controllable, $broadcasts, $clock];
+    }
+
+    #[Test]
+    public function continued_typing_re_broadcasts_the_rising_edge_to_refresh_the_dot(): void
+    {
+        [$presence, $broadcasts, $clock] = $this->presenceWithControllableClock();
+
+        $presence->touch(1);            // rising edge
+        $clock->now += 1000;            // 1s later — still within REFRESH window
+        $presence->touch(1);            // coalesced, no broadcast
+        $clock->now += 3500;            // now > REFRESH_MS since last broadcast
+        $presence->touch(1);            // refresh re-broadcast
+
+        // Two `typing:true` broadcasts: the initial rising edge and the refresh.
+        $this->assertCount(2, $broadcasts);
+        $this->assertTrue($broadcasts[0]->data['typing']);
+        $this->assertTrue($broadcasts[1]->data['typing']);
+    }
+
+    #[Test]
+    public function rapid_typing_within_the_refresh_window_stays_coalesced(): void
+    {
+        [$presence, $broadcasts, $clock] = $this->presenceWithControllableClock();
+
+        $presence->touch(1);
+        $clock->now += 500;
+        $presence->touch(1);
+        $clock->now += 500;
+        $presence->touch(1);
+
+        // All within REFRESH_MS of the first broadcast → a single rising edge.
+        $this->assertCount(1, $broadcasts);
+    }
+
+    #[Test]
+    public function public_discussion_routes_to_the_public_channel_with_all_its_tags(): void
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        $presence->touch(1);
+
+        $this->assertCount(1, $broadcasts);
+        $this->assertSame(IndexTypingPresence::PUBLIC_CHANNEL, $broadcasts[0]->channel);
+        $this->assertSame(1, $broadcasts[0]->data['id']);
+        $this->assertTrue($broadcasts[0]->data['typing']);
+        // Both of the public discussion's (guest-visible) tags are surfaced.
+        $this->assertEqualsCanonicalizing([1, 2], $broadcasts[0]->data['tags']);
+    }
+
+    #[Test]
+    public function restricted_discussion_routes_per_tag_with_only_that_tag_disclosed(): void
+    {
+        $this->setting('flarum-realtime.index-typing-indicator-restricted', '1');
+
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        $presence->touch(2);
+
+        // One broadcast per restricted tag channel.
+        $this->assertCount(2, $broadcasts);
+
+        $byChannel = [];
+        foreach ($broadcasts as $payload) {
+            $byChannel[$payload->channel] = $payload->data['tags'];
+        }
+
+        // Each restricted-tag channel carries ONLY its own tag — never the
+        // discussion's other restricted tag, which its audience may not see.
+        $this->assertSame([3], $byChannel[IndexTypingPresence::tagChannel(3)] ?? null);
+        $this->assertSame([4], $byChannel[IndexTypingPresence::tagChannel(4)] ?? null);
+    }
+
+    #[Test]
+    public function restricted_discussion_is_not_surfaced_when_the_setting_is_off(): void
+    {
+        // Setting defaults off; no restricted routing, so nothing is broadcast.
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        $presence->touch(2);
+
+        $this->assertCount(0, $broadcasts);
+    }
+
+    #[Test]
+    public function compose_typing_routes_public_tags_to_the_public_channel(): void
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        // User 2 composing a new discussion in the public tag 1.
+        $presence->touchTags(2, [1]);
+
+        $this->assertCount(1, $broadcasts);
+        $this->assertSame(IndexTypingPresence::PUBLIC_CHANNEL, $broadcasts[0]->channel);
+        $this->assertSame([1], $broadcasts[0]->data['tags']);
+        $this->assertTrue($broadcasts[0]->data['typing']);
+        // No discussion id yet, but a per-user source key for dedup.
+        $this->assertArrayNotHasKey('id', $broadcasts[0]->data);
+        $this->assertSame('u2', $broadcasts[0]->data['source']);
+    }
+
+    #[Test]
+    public function compose_typing_routes_a_visible_restricted_tag_to_its_channel(): void
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        // Tag 3 is restricted but user 2 can view it.
+        $presence->touchTags(2, [3]);
+
+        $this->assertCount(1, $broadcasts);
+        $this->assertSame(IndexTypingPresence::tagChannel(3), $broadcasts[0]->channel);
+        $this->assertSame([3], $broadcasts[0]->data['tags']);
+    }
+
+    #[Test]
+    public function compose_typing_drops_a_restricted_tag_the_actor_cannot_see(): void
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        // Tag 4 is restricted and user 2 CANNOT see it: claiming it must be ignored,
+        // never broadcast — otherwise a client could disclose activity in a tag it
+        // has no access to.
+        $presence->touchTags(2, [4]);
+
+        $this->assertCount(0, $broadcasts);
+    }
+
+    #[Test]
+    public function compose_typing_drops_hidden_tags_but_keeps_visible_ones(): void
+    {
+        [$presence, $broadcasts] = $this->presenceCapturingBroadcasts();
+
+        // Mixed claim: visible public 1, visible restricted 3, hidden restricted 4.
+        $presence->touchTags(2, [1, 3, 4]);
+
+        $channels = [];
+        foreach ($broadcasts as $payload) {
+            $channels[] = $payload->channel;
+        }
+
+        // Tag 4 is dropped; only the two the actor can see are surfaced.
+        $this->assertCount(2, $broadcasts);
+        $this->assertContains(IndexTypingPresence::PUBLIC_CHANNEL, $channels);
+        $this->assertContains(IndexTypingPresence::tagChannel(3), $channels);
+        $this->assertNotContains(IndexTypingPresence::tagChannel(4), $channels);
+    }
+}

--- a/extensions/realtime/tests/integration/api/IndexTypingTagsAttributeTest.php
+++ b/extensions/realtime/tests/integration/api/IndexTypingTagsAttributeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The forum carries `flarum-realtime.index-typing-tags`: the restricted tags the
+ * actor may see. The client subscribes to exactly those per-tag index-typing
+ * channels, so it issues one auth round-trip per restricted tag instead of one
+ * per visible tag. The attribute must follow tag visibility (never naming a
+ * restricted tag the actor can't see) and must be empty when the feature is off.
+ */
+class IndexTypingTagsAttributeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'flarum-realtime');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, in group 100
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'Member', 'name_plural' => 'Members'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 100],
+            ],
+            'tags' => [
+                ['id' => 1, 'name' => 'Open', 'slug' => 'open', 'is_restricted' => false],
+                ['id' => 2, 'name' => 'Members', 'slug' => 'members', 'is_restricted' => true],
+                ['id' => 3, 'name' => 'Admin only', 'slug' => 'admin-only', 'is_restricted' => true],
+            ],
+            'group_permission' => [
+                // Group 100 (user 2) can view restricted tag 2, but not tag 3.
+                ['group_id' => 100, 'permission' => 'tag2.viewForum'],
+            ],
+        ]);
+
+        $this->setting('flarum-realtime.index-typing-indicator-restricted', '1');
+    }
+
+    /**
+     * @return mixed the value of the forum attribute, or null if absent
+     */
+    private function indexTypingTags(?int $actorId)
+    {
+        $options = $actorId !== null ? ['authenticatedAs' => $actorId] : [];
+
+        $response = $this->send($this->request('GET', '/api', $options));
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['data']['attributes']['flarum-realtime.index-typing-tags'] ?? null;
+    }
+
+    #[Test]
+    public function admin_sees_all_restricted_tags(): void
+    {
+        $this->assertEqualsCanonicalizing([2, 3], $this->indexTypingTags(1));
+    }
+
+    #[Test]
+    public function member_sees_only_restricted_tags_they_can_view(): void
+    {
+        // Tag 2 only — never tag 3, which the member can't see. Tag 1 is excluded
+        // because it isn't restricted (it rides the public channel).
+        $this->assertEqualsCanonicalizing([2], $this->indexTypingTags(2));
+    }
+
+    #[Test]
+    public function guest_sees_no_restricted_tags(): void
+    {
+        $this->assertSame([], $this->indexTypingTags(null));
+    }
+
+    #[Test]
+    public function attribute_is_empty_when_the_restricted_setting_is_off(): void
+    {
+        $this->setting('flarum-realtime.index-typing-indicator-restricted', '0');
+
+        $this->assertSame([], $this->indexTypingTags(1));
+    }
+}


### PR DESCRIPTION
Extends the discussion-list ambient typing indicator (#4731) to the **index sidebar tag list**: a tag lights up with a presence-only dot while someone is typing in a discussion carrying it — including someone composing a *new* discussion in it.

Builds on #4755 (merged), which added the `linkItems` extension seam to `TagLinkButton`.

### Backend (`IndexTypingPresence`)

- The `index-typing` broadcast now carries the **tag IDs** a typing discussion belongs to, **scoped per channel** so a restricted tag is never disclosed to an audience that can't see it: the public channel carries a guest-visible discussion's tags; each restricted-tag channel carries only its own tag.
- **`touchTags()`** — new-discussion compose typing. There's no discussion id yet, so the client sends its selected tag IDs on its own `private-user={id}` channel. The user id is taken from the (already-authorised) channel name — never the payload — and **every claimed tag is re-authorised against that actor** before broadcasting, so a client can't light up (and thus disclose activity in) a restricted tag it can't see.
- While typing continues, the rising edge is **re-broadcast every `REFRESH_MS`** so the dot doesn't self-clear mid-typing (the frontend TTL would otherwise lapse between coalesced bursts). Falling edge on TTL expiry, as before.

### Frontend

- **`IndexTagTypingState`** — tag-keyed presence, keyed per *source* (discussion id, or a per-user compose key) so concurrent typers in one tag don't clear each other's dot.
- **`TagLinkButton`** renders the dot via its `linkItems` ItemList (the #4755 seam).
- The restricted-tag channel subscriptions now come from a server-computed forum attribute (`index-typing-tags`) listing the restricted tags the actor can see, **replacing the per-visible-tag subscribe loop** — this drops the websocket-auth requests on page load from one-per-tag to one-per-visible-restricted-tag.

Reuses the existing index-typing channels, subscriptions and dot styling. **No new admin settings** — the existing public / restricted index-typing toggles gate it.

### Testing

- `yarn check-typings`, `yarn build` (realtime): clean.
- PHP: unit 34, integration 34 — including new coverage for per-channel tag scoping, the compose-typing leak guard (a claimed-but-hidden restricted tag produces zero broadcasts), the `index-typing-tags` forum attribute per actor, and the rising-edge refresh/coalesce timing.
- Manually verified on a running 2.x install: dots appear/clear for replies and new-discussion composing, on both public and (visible) restricted tags, with no leak to users who can't see a tag.