### PR TITLE
[2.x] fix(flags): type Flag::$reason and $reason_detail as nullable

### DIFF
--- a/extensions/flags/src/Flag.php
+++ b/extensions/flags/src/Flag.php
@@ -21,8 +21,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $post_id
  * @property int $user_id
  * @property string $type
- * @property string $reason
- * @property string $reason_detail
+ * @property string|null $reason
+ * @property string|null $reason_detail
  * @property Carbon $created_at
  *
  * @property-read Post $post


### PR DESCRIPTION
Fixes #4759.

The `Flag` model docblock typed `$reason` and `$reason_detail` as plain `string`, but both are nullable everywhere else:

- **Migration:** `$table->string('reason')->nullable();` / `$table->string('reason_detail')->nullable();`
- **API:** `FlagResource` marks each as `requiredOnCreateWithout` the other — a flag is valid with only `reasonDetail` set (and `reason` null), or vice versa.

So the docblock was the only place claiming non-null, which made PHPStan level 6+ raise a false `assign.propertyType` error on legitimate runtime-valid code (e.g. extensions that store their message in `reason_detail` and leave `reason` null, currently forced to work around it with `setAttribute`/`@phpstan-ignore`/casts).

```diff
- * @property string $reason
- * @property string $reason_detail
+ * @property string|null $reason
+ * @property string|null $reason_detail
```

Docblock-only change — no runtime behaviour change.