### PR TITLE
[2.x] chore: update changelog for current 2.0.0-rc.4 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- (flags) type `Flag::$reason` and `$reason_detail` as nullable by @imorland [#4760]
+- (a11y) fix the aria-label text key for the new discussion button by @claudiushenrichs [#4758]
 - (core) debounce the loading indicator to avoid flicker by @imorland [#4750]
 - (avatar) ensure the base image exists for small avatar uploads by @dsevillamartin [#4740]
 - (tags) delegate tag slug resolution to the active slug driver by @imorland [#4739]


### PR DESCRIPTION
Updates the `v2.0.0-rc.4` changelog for the two PRs merged since the last changelog pass (#4757).

### Fixed
- (flags) type `Flag::$reason` and `$reason_detail` as nullable [#4760]
- (a11y) fix the aria-label text key for the new discussion button [#4758]