### PR TITLE
[1.x] ci: allow `commit_all_dirty` in build

### DIFF
--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -33,6 +33,11 @@ on:
         type: string
         required: false
         default: test
+      commit_all_dirty:
+        description: "Set to `true` to commit all file changes, not just files in the dist JS directory."
+        type: boolean
+        required: false
+        default: false
 
       enable_bundlewatch:
         description: "Enable Bundlewatch?"
@@ -170,6 +175,7 @@ jobs:
           package_manager: ${{ inputs.js_package_manager }}
           js_path: ${{ inputs.frontend_directory }}
           do_not_commit: ${{ github.ref != format('refs/heads/{0}', inputs.main_git_branch) || github.event_name != 'push' }}
+          commit_all_dirty: ${{ inputs.commit_all_dirty }}
           git_actor_name: ${{ inputs.git_actor_name || '' }}
           git_actor_email: ${{ inputs.git_actor_email || '' }}
 


### PR DESCRIPTION
Added `commit_all_dirty`, so extensions with custom build (eg. copying assets) can use this without copying entire workflow just to add this param.