### PR TITLE
[2.x] Fix 500 when page[limit]=0 is requested

### DIFF
--- a/framework/core/src/Http/RequestUtil.php
+++ b/framework/core/src/Http/RequestUtil.php
@@ -155,7 +155,11 @@ class RequestUtil
             $limit = $defaultLimit;
         }
 
-        if (! $limit) {
+        // Only short-circuit when there is genuinely no limit (no page[limit] and no
+        // default). A loose `! $limit` check here also caught the string "0", returning
+        // null which then broke OffsetPagination's non-nullable int $limit. An explicit
+        // page[limit]=0 must instead fall through to the `< 1` guard below and 400.
+        if ($limit === null) {
             return null;
         }
 

--- a/framework/core/tests/unit/Http/RequestUtilTest.php
+++ b/framework/core/tests/unit/Http/RequestUtilTest.php
@@ -15,6 +15,7 @@ use Laminas\Diactoros\ServerRequest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ServerRequestInterface;
+use Tobyz\JsonApiServer\Exception\BadRequestException;
 
 class RequestUtilTest extends TestCase
 {
@@ -23,6 +24,55 @@ class RequestUtilTest extends TestCase
         $request = new ServerRequest([], [], '/', 'GET');
 
         return $accept === null ? $request : $request->withHeader('Accept', $accept);
+    }
+
+    private function requestWithLimit(?string $limit): ServerRequestInterface
+    {
+        $request = new ServerRequest([], [], '/', 'GET');
+
+        return $request->withQueryParams($limit === null ? [] : ['page' => ['limit' => $limit]]);
+    }
+
+    #[Test]
+    public function extract_limit_uses_an_explicitly_requested_limit(): void
+    {
+        $this->assertSame(20, RequestUtil::extractLimit($this->requestWithLimit('20'), 50, 100));
+    }
+
+    #[Test]
+    public function extract_limit_caps_at_the_maximum(): void
+    {
+        $this->assertSame(50, RequestUtil::extractLimit($this->requestWithLimit('100'), 20, 50));
+    }
+
+    #[Test]
+    public function extract_limit_falls_back_to_the_default_when_absent(): void
+    {
+        $this->assertSame(20, RequestUtil::extractLimit($this->requestWithLimit(null), 20, 50));
+    }
+
+    #[Test]
+    public function extract_limit_returns_null_when_there_is_no_limit_and_no_default(): void
+    {
+        $this->assertNull(RequestUtil::extractLimit($this->requestWithLimit(null), null, 50));
+    }
+
+    #[Test]
+    public function extract_limit_rejects_an_explicit_zero(): void
+    {
+        // Regression test: page[limit]=0 used to return null and then break
+        // OffsetPagination's non-nullable int $limit with a 500. It must 400 instead.
+        $this->expectException(BadRequestException::class);
+
+        RequestUtil::extractLimit($this->requestWithLimit('0'), 20, 50);
+    }
+
+    #[Test]
+    public function extract_limit_rejects_a_negative_limit(): void
+    {
+        $this->expectException(BadRequestException::class);
+
+        RequestUtil::extractLimit($this->requestWithLimit('-5'), 20, 50);
     }
 
     public static function apiAcceptHeaders(): array


### PR DESCRIPTION
Fixes #4773.

### Problem

Any request to an offset-paginated endpoint with `page[limit]=0` returns a 500:

```
GET /api/discussions?page[limit]=0

TypeError: Cannot assign null to property
Tobyz\JsonApiServer\Pagination\OffsetPagination::$limit of type int
in core/src/Api/Endpoint/Index.php:133
```

This is what was recorded on discuss in #4773. It reproduces on a clean install with no extensions.

### Cause

`RequestUtil::extractLimit()` short-circuits with `null` on a falsy limit:

```php
if (! $limit) {
    return null;
}
```

The string `"0"` is falsy, so it returns `null` before reaching the `< 1` validation just below. That `null` is then assigned to `OffsetPagination::$limit`, which is a non-nullable `int`, so PHP throws.

The boundary confirms the mechanism — only the literal `0` hits this. `-5`, `00`, `0.0` are all rejected with a clean 400, because they are truthy strings that reach the `< 1` guard.

### Fix

Use a strict `=== null` check. A genuinely absent limit (no `page[limit]` and no default) still returns `null`, but an explicit `page[limit]=0` now falls through to the existing `< 1` guard and returns a 400, consistent with how negative limits are already handled.

Added unit tests in `RequestUtilTest` covering an explicit limit, capping at max, the default fallback, the no-limit `null` path, and rejection of `0` and negative values.