### PR TITLE
[2.x] fix(tags): update tag metadata when a pending discussion is approved

### DIFF
--- a/extensions/approval/composer.json
+++ b/extensions/approval/composer.json
@@ -91,6 +91,7 @@
     },
     "require-dev": {
         "flarum/audit": "*",
+        "flarum/tags": "*@dev",
         "flarum/testing": "^2.0"
     }
 }

--- a/extensions/approval/composer.json
+++ b/extensions/approval/composer.json
@@ -91,7 +91,7 @@
     },
     "require-dev": {
         "flarum/audit": "*",
-        "flarum/tags": "*@dev",
+        "flarum/tags": "*",
         "flarum/testing": "^2.0"
     }
 }

--- a/extensions/approval/extend.php
+++ b/extensions/approval/extend.php
@@ -67,6 +67,15 @@ return [
     (new Extend\ModelPrivate(CommentPost::class))
         ->checker(Listener\UnapproveNewContent::markUnapprovedContentAsPrivate(...)),
 
+    // Refresh tag metadata that flarum/tags skipped while the content was
+    // pending approval (and therefore private). Kept optional/conditional here
+    // so flarum/tags stays unaware of approval.
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-tags', fn () => [
+            (new Extend\Event())
+                ->listen(PostWasApproved::class, Listener\UpdateTagMetadataAfterApproval::class),
+        ]),
+
     (new Extend\Conditional())
         ->whenExtensionEnabled('flarum-audit', fn () => [
             (new \Flarum\Audit\Extend\Audit())

--- a/extensions/approval/src/Listener/UpdateTagMetadataAfterApproval.php
+++ b/extensions/approval/src/Listener/UpdateTagMetadataAfterApproval.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Approval\Listener;
+
+use Flarum\Approval\Event\PostWasApproved;
+use Flarum\Discussion\Discussion;
+
+class UpdateTagMetadataAfterApproval
+{
+    public function handle(PostWasApproved $event): void
+    {
+        $discussion = $event->post->discussion;
+
+        // flarum/tags counts a discussion only once its first post is approved;
+        // approving a later reply just needs the last-posted metadata refreshed.
+        $countable = $event->post->number === 1;
+
+        // flarum/tags skips private (pending-approval) content, so its counters
+        // are left stale after approval. The visibility change is applied
+        // separately by UpdateDiscussionAfterPostApproval and listener order is
+        // not guaranteed, so defer to the discussion's save while still private.
+        if ($discussion->is_private) {
+            $discussion->afterSave(fn (Discussion $discussion) => $this->refreshTags($discussion, $countable));
+        } else {
+            $this->refreshTags($discussion, $countable);
+        }
+    }
+
+    private function refreshTags(Discussion $discussion, bool $countable): void
+    {
+        if ($discussion->is_private || $discussion->hidden_at !== null) {
+            return;
+        }
+
+        foreach ($discussion->tags as $tag) {
+            if ($countable) {
+                $tag->discussion_count++;
+            }
+
+            $tag->refreshLastPostedDiscussion()->save();
+        }
+    }
+}

--- a/extensions/approval/tests/integration/TagMetadataTest.php
+++ b/extensions/approval/tests/integration/TagMetadataTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Approval\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class TagMetadataTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags', 'flarum-flags', 'flarum-approval');
+
+        $date = Carbon::parse('2021-01-01T12:00:00+00:00');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Pending', 'slug' => 'pending', 'discussion_count' => 0, 'last_posted_discussion_id' => null],
+            ],
+            Discussion::class => [
+                // A discussion that is still pending approval is private, so flarum/tags
+                // deliberately leaves it out of the tag's counters.
+                ['id' => 1, 'title' => 'A', 'created_at' => $date, 'last_posted_at' => $date, 'user_id' => 1, 'first_post_id' => 2, 'last_post_id' => 2, 'last_post_number' => 1, 'comment_count' => 1, 'is_approved' => false, 'is_private' => true],
+            ],
+            Post::class => [
+                ['id' => 2, 'number' => 1, 'discussion_id' => 1, 'created_at' => $date, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>A</p></t>', 'is_approved' => false, 'is_private' => true],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function approving_a_pending_discussion_refreshes_tag_metadata()
+    {
+        // While pending, the tag has not counted the discussion.
+        $tag = $this->database()->table('tags')->where('id', 1)->first();
+        $this->assertEquals(0, $tag->discussion_count);
+        $this->assertNull($tag->last_posted_discussion_id);
+
+        // Approving the first post (as the admin) makes the discussion visible.
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/2', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'isApproved' => true,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        // The tag now counts the newly visible discussion and points at it as the last posted.
+        $tag = $this->database()->table('tags')->where('id', 1)->first();
+        $this->assertEquals(1, $tag->discussion_count);
+        $this->assertEquals(1, $tag->last_posted_discussion_id);
+    }
+}


### PR DESCRIPTION
Fixes #4776

## Problem

With `flarum/approval` active, a discussion/post created pending approval is `is_private`, so `flarum/tags` correctly skips it while maintaining `discussion_count` / `last_posted_discussion_id`. But nothing refreshes those counters once the content is **approved**, so a tag is left with a permanently wrong count and stale last-posted discussion (e.g. the `/tags` tile shows the wrong number and no latest discussion).

## Fix

Reworked per review: this now lives entirely within `flarum/approval` as an optional, conditional integration with `flarum/tags`, mirroring how `flarum/mentions` refreshes its own metadata on approval.

- A new `Listener\UpdateTagMetadataAfterApproval` listens for the **typed** `PostWasApproved` event (no string-based listeners).
- It is registered only when tags is present, via `Extend\Conditional()->whenExtensionEnabled('flarum-tags', ...)`, so **`flarum/tags` is left completely untouched** and stays unaware of approval.
- On approval it refreshes the affected tags through their public model API: approving a first post makes the discussion countable (`+1`), an approved reply just refreshes the last-posted metadata. Since listener order relative to `UpdateDiscussionAfterPostApproval` (which flips `is_private`) is not guaranteed, it defers via `afterSave` while the discussion is still private.
- `flarum/approval` now dev-requires `flarum/tags` (as `flarum/mentions` does) for the integration test.

## Testing

- Added `TagMetadataTest` (integration): a pending discussion in a tag starts at `discussion_count = 0` with no last-posted; after its first post is approved the tag shows `discussion_count = 1` and points at the discussion. Passes locally.
- `composer analyse:phpstan` passes.
