### PR TITLE
[2.x] Continue lists when pressing Enter in the Markdown editor

### DIFF
--- a/extensions/markdown/js/src/common/index.tsx
+++ b/extensions/markdown/js/src/common/index.tsx
@@ -48,6 +48,34 @@ function makeShortcut(id: string, key: string, editorDriver: BasicEditorDriver) 
   };
 }
 
+const listItemRegex = /^(\s*)(?:(\d+)([.)])|([-*+]))(\s+)(.*)$/;
+
+function continueList(editorDriver: BasicEditorDriver) {
+  return function (e: KeyboardEvent) {
+    if (e.key !== 'Enter' || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey || e.isComposing) return;
+
+    const textarea = editorDriver.el;
+    if (textarea.selectionStart !== textarea.selectionEnd) return;
+
+    const cursor = textarea.selectionStart;
+    const lineStart = textarea.value.lastIndexOf('\n', cursor - 1) + 1;
+    const match = textarea.value.slice(lineStart, cursor).match(listItemRegex);
+    if (!match) return;
+
+    const [, indent, number, delimiter, bullet, spacing, content] = match;
+    e.preventDefault();
+
+    // Pressing Enter on an empty item ends the list.
+    if (content.trim() === '') {
+      editorDriver.insertBetween(lineStart, cursor, '');
+      return;
+    }
+
+    const marker = number !== undefined ? `${parseInt(number, 10) + 1}${delimiter}${spacing}` : `${bullet}${spacing}`;
+    editorDriver.insertAtCursor(`\n${indent}${marker}`);
+  };
+}
+
 let shortcutHandler: ((e: KeyboardEvent) => void) | undefined;
 
 function markdownToolbarItems(this: any, oldFunc: (() => ItemList<unknown>) | undefined) {
@@ -96,6 +124,7 @@ export function initialize() {
   (extend as any)(BasicEditorDriver.prototype, 'keyHandlers', function (this: BasicEditorDriver, items: ItemList<(e: KeyboardEvent) => void>) {
     items.add('bold', makeShortcut('bold', 'b', this));
     items.add('italic', makeShortcut('italic', 'i', this));
+    items.add('continueList', continueList(this));
   });
 
   override('flarum/common/components/TextEditor', 'markdownToolbarItems', markdownToolbarItems);


### PR DESCRIPTION
Fixes #4232

### Changes proposed in this pull request

The Markdown editor never continued lists when pressing <kbd>Enter</kbd> — it just inserted a plain newline. So the only way to add a numbered item was to re-click the toolbar button, which always emits `1. ` for the current line. The result was that you couldn't build a `1.`/`2.`/`3.` list by typing, which is what #4232 reports.

This adds list continuation to the editor's existing `keyHandlers` extender (the same place the bold/italic shortcuts live, so core stays generic). On a plain <kbd>Enter</kbd> inside a list item it now:

- continues **ordered** lists, incrementing the number — `1. a` → `2. ` → `3. ` (also handles the `1)` delimiter and 9 → 10);
- continues **unordered** lists, repeating the bullet (`-`, `*`, `+`);
- **ends the list** when <kbd>Enter</kbd> is pressed on an empty item;
- preserves leading indentation;
- ignores <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>/<kbd>Shift</kbd>/<kbd>Alt</kbd>+<kbd>Enter</kbd> (submit / soft newline) and IME composition, and only acts on a collapsed selection.

This mirrors the list-continuation behaviour people expect from GitHub's editor and most Markdown editors.

### Reviewers should focus on

- `extensions/markdown/js/src/common/index.tsx` — the `continueList` handler and its registration. The `dist` changes are the rebuilt bundle.
- Whether `keyHandlers` on `BasicEditorDriver` is the right home for this vs. core. I kept it in the markdown extension since list markers are Markdown syntax.

### Confirmed

- [x] Frontend changes: tested in the latest Firefox and Chrome.
- [x] Translations added for any user-facing text — N/A (no new strings).
- [x] Backend changes — N/A.

### Testing

Verified manually in a 2.0.0-rc.4 forum (with the rich-text editor disabled so the Markdown textarea editor is active): typing a numbered list and pressing Enter now produces `1.`, `2.`, `3.`; unordered lists repeat the bullet; and pressing Enter on an empty item ends the list.