### PR TITLE
Add role attribute to PostStream item for accessibility

### DIFF
--- a/framework/core/js/src/forum/components/PostStream.js
+++ b/framework/core/js/src/forum/components/PostStream.js
@@ -79,7 +79,7 @@ export default class PostStream extends Component {
       }
 
       const postStreamElement = (
-        <div className="PostStream-item" {...attrs}>
+        <div className="PostStream-item" role="article" {...attrs}>
           {content}
         </div>
       );


### PR DESCRIPTION
**Changes proposed in this pull request:**
The PostStream document structure of a discussion is currently failing the "Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children." accessibility test. The parent PostStream <div> container has the "feed" ARIA role which requires children to have the "article ARIA role.
This pull request adds role="article" attribute to the PostStream-item.

**Reviewers should focus on:**
A few lines further down in PostStream.js (around line 92) there is another reference to a container with classes "className="PostStream-item PostStream-afterFirstPost"" - I haven't figured out under which circumstances this container gets inserted, but it might also require the role=article. If anyone can shed some light on whether this is also a child within the PostStream feed parent container.

**Screenshot**
<img width="1494" height="678" alt="image" src="https://github.com/user-attachments/assets/675d1c93-97bb-49af-bf6f-65ed045a1e82" />

**Necessity**

- [X] Has the problem that is being solved here been clearly explained?
- [X] If applicable, have various options for solving this problem been considered? - article ARIA role is the only one allowed per documentation. Semantically more correct would be something like role="comment", but whom am I to judge.
- [X] For core PRs, does this need to be in core, or could it be in an extension?
- [X] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.