### PR TITLE
[2.x] fix: allow boolean settings with truthy defaults to be disabled

### DIFF
--- a/framework/core/js/src/admin/components/AdminPage.tsx
+++ b/framework/core/js/src/admin/components/AdminPage.tsx
@@ -226,7 +226,7 @@ export default abstract class AdminPage<CustomAttrs extends IPageAttrs = IPageAt
    * with the setting key, which is used by `resetButton()` in the reset modal.
    */
   setting(key: string, fallback: string = '', label?: Mithril.Children): Stream<string> {
-    this.settings[key] = this.settings[key] || Stream<string>(app.data.settings[key] || fallback);
+    this.settings[key] = this.settings[key] || Stream<string>(app.data.settings[key] ?? fallback);
 
     if (label !== undefined) {
       this.settingLabels[key] = label;

--- a/framework/core/js/tests/integration/admin/components/AdminPageSetting.test.ts
+++ b/framework/core/js/tests/integration/admin/components/AdminPageSetting.test.ts
@@ -1,0 +1,67 @@
+import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
+import AdminPage from '../../../../src/admin/components/AdminPage';
+import { app } from '../../../../src/admin';
+
+beforeAll(() => bootstrapAdmin());
+
+/**
+ * `setting(key, fallback)` seeds a stream from the saved value, falling back to
+ * the given default when there is nothing saved.
+ *
+ * Settings are stored in a string column, so a saved `false` comes back as `''`
+ * and a saved `0` as `'0'` — both falsy in JavaScript. Choosing the fallback on
+ * falsiness therefore discarded values an administrator had deliberately saved,
+ * and a setting whose default is truthy could never be turned off: it reverted
+ * on every reload (flarum/framework#4781). Only the *absence* of a saved value
+ * should reach for the default.
+ */
+describe('AdminPage.setting()', () => {
+  class TestPage extends AdminPage {
+    content() {
+      return null;
+    }
+  }
+
+  /** The value `setting()` seeds its stream with, for a given saved value. */
+  const seeded = (saved: string | undefined, fallback: string): string => {
+    const key = 'test.setting';
+
+    if (saved === undefined) {
+      delete app.data.settings[key];
+    } else {
+      app.data.settings[key] = saved;
+    }
+
+    // A fresh page each time: `setting()` caches its streams per instance.
+    const page = new TestPage();
+    (page as any).settings = {};
+
+    return page.setting(key, fallback)();
+  };
+
+  test('a saved value is used', () => {
+    expect(seeded('1', '')).toBe('1');
+  });
+
+  test('the fallback is used when nothing is saved', () => {
+    expect(seeded(undefined, 'the-default')).toBe('the-default');
+  });
+
+  /**
+   * The reported case: a boolean setting defaulting to on, switched off. `false`
+   * is stored as an empty string, which must not be mistaken for "unset".
+   */
+  test('a saved empty string is kept rather than falling back', () => {
+    expect(seeded('', '1')).toBe('');
+  });
+
+  /**
+   * `'0'` was never affected — the string is truthy in JavaScript, unlike the
+   * number. Pinned so the distinction is not lost if this is ever revisited:
+   * the empty string is the only value a setting can hold that JavaScript reads
+   * as absent.
+   */
+  test('a saved "0" is kept', () => {
+    expect(seeded('0', '10')).toBe('0');
+  });
+});


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4781**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Resolves a bug in `AdminPage.tsx` where boolean settings (toggles) that have a truthy default value could not be turned off by the administrator.

By switching from the logical OR operator (`||`) to the nullish coalescing operator (`??`), the setting stream correctly recognizes `""` as a valid saved state. The fallback is now only applied when the setting is strictly `undefined` or `null` (e.g., during a fresh installation where the setting hasn't been saved to the database yet).

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

https://github.com/user-attachments/assets/45e50f09-02f5-4d9c-aebf-6ac307cab0a9

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
