### PR TITLE
[2.x] fix: send erasure completion email in user's locale

### DIFF
--- a/extensions/gdpr/src/Jobs/ErasureJob.php
+++ b/extensions/gdpr/src/Jobs/ErasureJob.php
@@ -85,6 +85,11 @@ class ErasureJob extends GdprJob
             $this->erasureRequest
         ));
 
+        // Capture the user's locale on the shared translator before
+        // anonymization wipes their preferences. The completion email below
+        // re-uses the same translator instance, so this carries through.
+        $translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
+
         $this->{$mode}($user, $processor);
 
         $this->sendUserConfirmation($mode, $username, $email, $mailer, $translator);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
