### PR TITLE
[2.x] fix(messages): use correct route name in dialogs dropdown

### DIFF
--- a/extensions/messages/js/src/forum/components/DialogsDropdown.tsx
+++ b/extensions/messages/js/src/forum/components/DialogsDropdown.tsx
@@ -30,7 +30,7 @@ export default class DialogsDropdown<CustomAttrs extends IDialogsDropdownAttrs =
   }
 
   goToRoute() {
-    m.route.set(app.route('dialogs'));
+    m.route.set(app.route('messages'));
   }
 
   getUnreadCount() {


### PR DESCRIPTION
Fixes #4789

The dialogs dropdown's `goToRoute()` navigated to `app.route('dialogs')`, but no route with that name is registered — the extension registers `messages`, `dialog`, and `dialog.message`.

On desktop, clicking the messages header button opens the dropdown. On mobile the drawer is open, so `HeaderDropdown.onclick()` calls `goToRoute()` instead, which throws `Route 'dialogs' does not exist` and leaves the loader spinning.

This uses the registered `messages` route.

## Testing
1. Reduce the browser to mobile width (or use device tools)
2. Log in, open the burger drawer
3. Click Messages
4. Navigates to `/messages` instead of throwing