### PR TITLE
[2.x] fix(core): register default for show_language_selector setting

### DIFF
--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -27,6 +27,7 @@ class SettingsServiceProvider extends AbstractServiceProvider
                 'mail_format' => 'multipart',
                 'fontawesome_source' => 'local',
                 'maintenance_mode' => 'none',
+                'show_language_selector' => true,
                 'slug_driver_Flarum\Discussion\Discussion' => 'default',
                 'slug_driver_Flarum\User\User' => 'default',
                 'search_driver_Flarum\User\User' => 'default',


### PR DESCRIPTION
Fixes #4785

The "Show language selector" admin switch always initialised to *off* on a fresh install, even when the language selector was showing on the frontend.

## Cause
`show_language_selector` was missing from the `flarum.settings.default` collection. The admin frontend is hydrated from `settings->all()`, which merges stored values with that defaults collection — so on a fresh install the key read as `undefined` and the switch rendered off. Meanwhile the frontend defaults the selector to visible (`ForumResource` reads it with a `true` fallback), producing the mismatch.

This is the same class of bug as #4491.

## Fix
Add `'show_language_selector' => true` to the defaults collection so `all()` includes it and the admin switch reflects the real state. Save/toggle behaviour is unaffected — stored `'0'`/`'1'` still override the default.

## Testing
1. Fresh install, enable a second language pack
2. Admin → Basics: the "Show language selector" switch now shows *on*, matching the selector's presence on the frontend