### PR TITLE
[2.x] fix(tags): show friendly model name for tag slug driver setting

### DIFF
--- a/extensions/tags/js/src/admin/addTagSlugDriverLabels.ts
+++ b/extensions/tags/js/src/admin/addTagSlugDriverLabels.ts
@@ -1,13 +1,19 @@
 import app from 'flarum/admin/app';
 import { extend } from 'flarum/common/extend';
+import AdminPage from 'flarum/admin/components/AdminPage';
 import BasicsPage from 'flarum/admin/components/BasicsPage';
 import extractText from 'flarum/common/utils/extractText';
 
 /**
  * Provide translatable labels for the tag slug drivers shown on the admin
- * Basics page. Without this the dropdown renders the raw driver keys.
+ * Basics page. Without this the dropdown renders the raw driver keys, and the
+ * setting heading renders the raw model class name (e.g. "Flarum\Tags\Tag").
  */
 export default function () {
+  extend(AdminPage, 'modelLocale', function (locale: Record<string, string>) {
+    locale['Flarum\\Tags\\Tag'] = extractText(app.translator.trans('flarum-tags.admin.basics.tags_label'));
+  });
+
   extend(BasicsPage, 'driverLocale', function (locale: Record<string, any>) {
     locale.slug = locale.slug || {};
     locale.slug['Flarum\\Tags\\Tag'] = {


### PR DESCRIPTION
Fixes #4784

The Tag slug driver setting in Admin → Basics rendered its heading as the raw model class name — "Slug Driver: Flarum\Tags\Tag" — instead of "Slug Driver: Tags", inconsistent with the Discussions/Users slug driver settings.

## Cause
`BasicsPage` derives the model name in the heading from `AdminPage.modelLocale()`, falling back to the raw model key when there's no entry. Core's `modelLocale()` only maps `Discussion`/`User`/`Post`, and the tags extension only extended `driverLocale` (the dropdown *option* labels) — never the model label — so the tag model rendered as its raw class name.

## Fix
Extend `AdminPage.modelLocale` in the tags extension so `Flarum\Tags\Tag` resolves to "Tags" (via the existing `flarum-tags.admin.basics.tags_label` string). Because `modelLocale` is also used by the search-driver setting on AdvancedPage, this corrects that heading too.

## Testing
1. Enable Tags, go to Admin → Basics
2. The slug driver setting now reads "Slug Driver: Tags"