### PR TITLE
[2.x] fix(core): reject oversized-dimension images before decoding

### DIFF
--- a/framework/core/src/Foundation/AbstractImageValidator.php
+++ b/framework/core/src/Foundation/AbstractImageValidator.php
@@ -42,8 +42,10 @@ abstract class AbstractImageValidator extends AbstractValidator
         $this->laravelValidator = $this->makeValidator($attributes);
 
         $this->assertFileRequired($attributes[$this->filename]);
-        $this->assertFileMimes($attributes[$this->filename]);
+        // Check the (compressed) byte size before decoding the image, so an
+        // oversized upload is rejected without ever being read into memory.
         $this->assertFileSize($attributes[$this->filename]);
+        $this->assertFileMimes($attributes[$this->filename]);
     }
 
     protected function assertFileRequired(UploadedFileInterface $file): void
@@ -81,6 +83,23 @@ abstract class AbstractImageValidator extends AbstractValidator
             $this->raise('mimes', [':values' => implode(', ', $allowedTypes)]);
         }
 
+        // Reject images whose pixel dimensions exceed the maximum resolution
+        // *before* decoding them. Image libraries (e.g. GD) allocate a buffer
+        // sized to width * height from the header, regardless of the compressed
+        // byte size, so a tiny "decompression bomb" declaring huge dimensions
+        // could otherwise exhaust the available memory during the decode below.
+        $dimensions = @getimagesizefromstring((string) $file->getStream());
+
+        if ($dimensions === false) {
+            $this->raise('image');
+
+            return;
+        }
+
+        if ($dimensions[0] * $dimensions[1] > $this->getMaxResolution()) {
+            $this->raise('dimensions');
+        }
+
         try {
             $this->imageManager->read($file->getStream()->getMetadata('uri'));
         } catch (DecoderException|GifDecoderException) {
@@ -91,8 +110,11 @@ abstract class AbstractImageValidator extends AbstractValidator
     protected function assertFileSize(UploadedFileInterface $file): void
     {
         $maxSize = $this->getMaxSize();
+        $size = $file->getSize();
 
-        if ($file->getSize() / 1024 > $maxSize) {
+        // A null size means the size could not be determined; reject it rather
+        // than letting it bypass the cap (null / 1024 > $maxSize is false).
+        if ($size === null || $size / 1024 > $maxSize) {
             $this->raise('max.file', [':max' => $maxSize], 'max');
         }
     }
@@ -116,6 +138,18 @@ abstract class AbstractImageValidator extends AbstractValidator
     public function getMaxSize(): int
     {
         return 2048;
+    }
+
+    /**
+     * The maximum number of pixels (width * height) allowed in an uploaded
+     * image. This bounds the memory a single decode can allocate, guarding
+     * against decompression-bomb uploads that declare huge dimensions in a
+     * tiny file. ~24 megapixels comfortably covers legitimate photos while
+     * rejecting pathological dimensions.
+     */
+    public function getMaxResolution(): int
+    {
+        return 24_000_000;
     }
 
     protected function getAllowedTypes(): array

--- a/framework/core/tests/integration/user/AvatarImageValidationTest.php
+++ b/framework/core/tests/integration/user/AvatarImageValidationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\user;
+
+use Flarum\Foundation\ValidationException;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\AvatarValidator;
+use Laminas\Diactoros\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+
+class AvatarImageValidationTest extends TestCase
+{
+    private function validator(): AvatarValidator
+    {
+        return $this->app()->getContainer()->make(AvatarValidator::class);
+    }
+
+    private function uploadedFile(string $path, string $mediaType, string $filename): UploadedFile
+    {
+        return new UploadedFile($path, filesize($path) ?: 0, UPLOAD_ERR_OK, $filename, $mediaType);
+    }
+
+    #[Test]
+    public function accepts_a_normal_image(): void
+    {
+        $file = $this->uploadedFile(__DIR__.'/../../fixtures/assets/avatar.png', 'image/png', 'avatar.png');
+
+        $this->validator()->assertImageValid('avatar', $file);
+
+        // No exception thrown means the image validated successfully.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * A tiny PNG that declares enormous dimensions in its header ("decompression
+     * bomb") must be rejected *before* it is decoded, so it can never force a
+     * huge memory allocation.
+     *
+     * @see https://cwe.mitre.org/data/definitions/409.html
+     */
+    #[Test]
+    public function rejects_a_decompression_bomb(): void
+    {
+        // 33-byte PNG declaring 30000x30000 (900 megapixels). getimagesize reads
+        // the dimensions from the IHDR header without allocating the pixel buffer.
+        $ihdr = 'IHDR'.pack('N', 30000).pack('N', 30000)."\x08\x02\x00\x00\x00";
+        $png = "\x89PNG\r\n\x1a\n".pack('N', 13).$ihdr.pack('N', crc32($ihdr));
+
+        $path = tempnam(sys_get_temp_dir(), 'bomb').'.png';
+        file_put_contents($path, $png);
+
+        try {
+            $file = $this->uploadedFile($path, 'image/png', 'bomb.png');
+
+            $this->expectException(ValidationException::class);
+
+            $this->validator()->assertImageValid('avatar', $file);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`AbstractImageValidator` decodes uploaded images (`imageManager->read()`) inside `assertFileMimes()` **before** the size check runs — and the size check only ever looked at *compressed* bytes. Image libraries (GD) allocate a buffer of `width × height × channels` from the image header regardless of how small the compressed file is, so a tiny "decompression bomb" that declares enormous dimensions forces a huge allocation.

A ~100-byte PNG declaring `30000×30000` (900 megapixels) triggers a multi-GB allocation and a fatal "Allowed memory size exhausted". The avatar upload endpoint (`POST /api/users/{id}/avatar`) is reachable by any authenticated user for their own avatar, so this is a low-effort memory-exhaustion / DoS vector. The same validator also backs logo and favicon uploads.

Two smaller issues in the same validator:
- `assertFileSize()` ran *after* the decode, so the byte cap never prevented the allocation.
- `getSize() === null` bypassed the size cap entirely (`null / 1024 > $maxSize` is `false`).

## Fix

In `AbstractImageValidator`:
- Read the declared dimensions cheaply from the header with `getimagesizefromstring()` (no pixel-buffer allocation) and reject anything over a max-resolution cap **before** decoding.
- Add an overridable `getMaxResolution()` (default 24 MP) so subclasses/extensions can tune it.
- Move the byte-size check ahead of the decode.
- Reject `null` file sizes instead of letting them through.

24 MP comfortably covers legitimate avatars/logos/photos while bounding the memory a single decode can allocate.

## Testing

Added `tests/integration/user/AvatarImageValidationTest.php`:
- a normal image still validates;
- a 33-byte PNG declaring `30000×30000` is now rejected, and the test run stays at ~16 MB (previously this would attempt a multi-GB allocation).

Existing avatar unit tests pass.