### PR TITLE
[2.x] fix(core): harden avatar-from-URL fetch (streaming cap, resolution guard, link-local block)

### DIFF
--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -443,7 +443,7 @@ class UserResource extends AbstractDatabaseResource
 
         $urlContents = $this->retrieveAvatarFromUrl($url);
 
-        if ($urlContents === null) {
+        if ($urlContents === null || ! $this->withinMaxResolution($urlContents)) {
             return;
         }
 
@@ -489,17 +489,52 @@ class UserResource extends AbstractDatabaseResource
     {
         $contents = $this->retrieveAvatarFromUrl($url);
 
-        return $contents !== null ? $this->imageManager->read($contents) : null;
+        if ($contents === null || ! $this->withinMaxResolution($contents)) {
+            return null;
+        }
+
+        return $this->imageManager->read($contents);
     }
 
     private function retrieveAvatarFromUrl(string $url): ?string
     {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if (! is_string($host) || $host === '') {
+            return null;
+        }
+
+        // Resolve the host and reject it if it points at a link-local, loopback
+        // or otherwise reserved address (e.g. the cloud metadata endpoint
+        // 169.254.169.254). Private LAN ranges (RFC1918) are intentionally left
+        // reachable so Flarum keeps working behind Docker networks, reverse
+        // proxies and internal CDNs.
+        $ip = $this->resolveToAllowedIp($host);
+
+        if ($ip === null) {
+            return null;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        $port = parse_url($url, PHP_URL_PORT) ?: ($scheme === 'https' ? 443 : 80);
+
         $maxSizeBytes = $this->imageValidator->getMaxSize() * 1024;
 
-        $client = new Client([
+        $options = [
             'allow_redirects' => false,
             'timeout' => 5,
-        ]);
+            'stream' => true,
+        ];
+
+        // Pin the connection to the address we just validated, so a rebinding
+        // DNS record cannot swap in a blocked address between the check above
+        // and the actual connection. Requires the cURL handler; harmless if
+        // it is unavailable.
+        if (defined('CURLOPT_RESOLVE')) {
+            $options['curl'] = [CURLOPT_RESOLVE => ["$host:$port:$ip"]];
+        }
+
+        $client = new Client($options);
 
         try {
             $response = $client->get($url);
@@ -511,13 +546,72 @@ class UserResource extends AbstractDatabaseResource
             return null;
         }
 
-        $contentLength = $response->getHeaderLine('Content-Length');
+        // Read the body incrementally and abort once it exceeds the maximum
+        // size, rather than trusting the (optional, spoofable) Content-Length
+        // header after the entire response has already been buffered.
+        $body = $response->getBody();
+        $contents = '';
 
-        if ($contentLength !== '' && (int) $contentLength > $maxSizeBytes) {
-            return null;
+        while (! $body->eof()) {
+            $contents .= $body->read(8192);
+
+            if (strlen($contents) > $maxSizeBytes) {
+                return null;
+            }
         }
 
-        return $response->getBody()->getContents();
+        return $contents;
+    }
+
+    /**
+     * Resolve a hostname (or accept a literal IP) and return the first address
+     * that is safe to connect to, or null if the host is unresolvable or only
+     * resolves to blocked (link-local / loopback / reserved) addresses.
+     */
+    private function resolveToAllowedIp(string $host): ?string
+    {
+        $literal = trim($host, '[]');
+
+        if (filter_var($literal, FILTER_VALIDATE_IP)) {
+            return self::isAllowedIp($literal) ? $literal : null;
+        }
+
+        $ips = array_merge(
+            gethostbynamel($host) ?: [],
+            array_column(@dns_get_record($host, DNS_AAAA) ?: [], 'ipv6')
+        );
+
+        foreach ($ips as $ip) {
+            if (self::isAllowedIp($ip)) {
+                return $ip;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether an IP address is safe for Flarum to issue a server-side request
+     * to. Link-local, loopback and other reserved ranges are rejected; private
+     * LAN ranges (RFC1918) are intentionally allowed so internal and Docker
+     * hosts keep working.
+     */
+    private static function isAllowedIp(string $ip): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE) !== false;
+    }
+
+    /**
+     * Cheaply reject images whose declared dimensions exceed the maximum
+     * resolution before they are decoded, so a fetched "decompression bomb"
+     * cannot force a huge memory allocation.
+     */
+    private function withinMaxResolution(string $contents): bool
+    {
+        $dimensions = @getimagesizefromstring($contents);
+
+        return $dimensions !== false
+            && $dimensions[0] * $dimensions[1] <= $this->imageValidator->getMaxResolution();
     }
 
     private function fulfillToken(User $user, #[\SensitiveParameter] RegistrationToken $token): void

--- a/framework/core/tests/unit/Api/AvatarUrlIpFilterTest.php
+++ b/framework/core/tests/unit/Api/AvatarUrlIpFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Api;
+
+use Flarum\Api\Resource\UserResource;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+
+/**
+ * The avatar-from-URL fetch (used by OAuth registration) must not be usable to
+ * reach link-local / loopback / reserved addresses such as the cloud metadata
+ * endpoint (169.254.169.254). Private LAN ranges (RFC1918) MUST stay reachable,
+ * otherwise Flarum breaks behind Docker networks, reverse proxies and internal
+ * CDNs.
+ */
+class AvatarUrlIpFilterTest extends TestCase
+{
+    private function isAllowed(string $ip): bool
+    {
+        $method = new ReflectionMethod(UserResource::class, 'isAllowedIp');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $ip);
+    }
+
+    public static function ipProvider(): array
+    {
+        return [
+            // Blocked: link-local / cloud metadata / loopback / reserved.
+            'aws/gcp/azure metadata' => ['169.254.169.254', false],
+            'ipv4 loopback' => ['127.0.0.1', false],
+            'ipv6 loopback' => ['::1', false],
+            'ipv6 link-local' => ['fe80::1', false],
+            'unspecified' => ['0.0.0.0', false],
+
+            // Allowed: public + private LAN / Docker must keep working.
+            'public ipv4' => ['8.8.8.8', true],
+            'docker bridge' => ['172.17.0.2', true],
+            'rfc1918 10/8' => ['10.0.0.5', true],
+            'rfc1918 192.168/16' => ['192.168.1.10', true],
+            'public ipv6' => ['2606:4700:4700::1111', true],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('ipProvider')]
+    public function it_blocks_reserved_ranges_but_allows_private_and_public(string $ip, bool $allowed): void
+    {
+        $this->assertSame($allowed, $this->isAllowed($ip));
+    }
+}


### PR DESCRIPTION
Follows the partial hardening in #4548 and implements the agreed scope of #4549 for 2.x.

The avatar-from-URL fetch (OAuth registration path, `UserResource::retrieveAvatarFromUrl()`) had three residual weaknesses:

1. **Ineffective size limit** — the client buffered the entire response body, then checked `Content-Length` *after the fact*. A response without that header (e.g. chunked) had no size limit at all beyond the 5s timeout.
2. **Decompression bomb** — fetched content was passed straight to `imageManager->read()` with no dimension guard (the same class of issue as #4794, but on the URL path).
3. **No connection-level IP filtering** — a hostname resolving to an internal address could be fetched server-side.

## Changes
- Stream the download and abort once it exceeds the avatar size cap, instead of trusting `Content-Length`.
- Reject images whose declared dimensions exceed `getMaxResolution()` before decoding (applies to 1x/2x/3x).
- Resolve the host and block **link-local / loopback / reserved** ranges (`FILTER_FLAG_NO_RES_RANGE`) — e.g. the cloud-metadata endpoint `169.254.169.254`. **Private LAN / RFC1918 ranges are intentionally left reachable** so Flarum keeps working behind Docker networks, reverse proxies and internal CDNs. The connection is pinned to the validated IP (`CURLOPT_RESOLVE`) to defeat DNS rebinding.
- The 2x/3x companion URLs now go through the same checks (they previously bypassed validation entirely).

## Testing
Added `tests/unit/Api/AvatarUrlIpFilterTest.php` (metadata/loopback blocked; Docker/RFC1918/public allowed). Full unit suite passes.

Note: the existing avatar-URL integration tests in `CreateTest` hit the live network + DB and couldn't be run in my local env (pre-existing DB config failure on a clean tree).

Closes #4549