### PR TITLE
[2.x] perf(likes): don't default-include post likes on discussion index

### DIFF
--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -52,9 +52,17 @@ return [
         ),
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
+        // Only default-include post likes where the post is actually displayed
+        // (Show/Create render the post stream). The discussion list (Index) never
+        // renders firstPost/lastPost likes, and default-including them there forces
+        // a full serialization of two posts per discussion — content rendering,
+        // per-post permission attributes and the likers — for data the list UI
+        // does not read. The relationships remain includable (see
+        // eagerLoadWhenIncluded below) for clients that explicitly request them.
+        // See flarum/framework#4788.
         ->endpoint(
-            [Endpoint\Show::class, Endpoint\Index::class, Endpoint\Create::class],
-            function (Endpoint\Show|Endpoint\Index|Endpoint\Create $endpoint): Endpoint\Endpoint {
+            [Endpoint\Show::class, Endpoint\Create::class],
+            function (Endpoint\Show|Endpoint\Create $endpoint): Endpoint\Endpoint {
                 return $endpoint->addDefaultInclude(['firstPost.likes', 'lastPost.likes']);
             }
         )

--- a/extensions/likes/tests/integration/api/ListDiscussionsTest.php
+++ b/extensions/likes/tests/integration/api/ListDiscussionsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Likes\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class ListDiscussionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-likes');
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                [
+                    'id' => 100,
+                    'title' => __CLASS__,
+                    'created_at' => Carbon::now(),
+                    'last_posted_at' => Carbon::now(),
+                    'user_id' => 1,
+                    'first_post_id' => 101,
+                    'last_post_id' => 102,
+                    'comment_count' => 2,
+                ],
+            ],
+            Post::class => [
+                ['id' => 101, 'discussion_id' => 100, 'number' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>first</p></t>'],
+                ['id' => 102, 'discussion_id' => 100, 'number' => 2, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>last</p></t>'],
+            ],
+            User::class => [
+                $this->normalUser(),
+                ['id' => 102, 'username' => 'liker', 'email' => 'liker@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'post_likes' => [
+                ['user_id' => 102, 'post_id' => 101, 'created_at' => Carbon::now()],
+                ['user_id' => 102, 'post_id' => 102, 'created_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    private function listDiscussions(array $queryParams = [])
+    {
+        return $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 1])
+                ->withQueryParams($queryParams)
+        );
+    }
+
+    private function includedTypes(string $body): array
+    {
+        return array_column(json_decode($body, true)['included'] ?? [], 'type');
+    }
+
+    #[Test]
+    public function index_does_not_default_include_posts_or_their_likes()
+    {
+        // The discussion list UI never renders firstPost/lastPost likes, so the
+        // Index endpoint should not pay to serialize those posts (and their
+        // likers) by default. See flarum/framework#4788.
+        $response = $this->listDiscussions();
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertNotContains('posts', $this->includedTypes((string) $response->getBody()));
+    }
+
+    #[Test]
+    public function index_still_allows_explicitly_including_post_likes()
+    {
+        // Dropping the default include must not remove the ability to request it.
+        $response = $this->listDiscussions([
+            'include' => 'firstPost,firstPost.likes,lastPost,lastPost.likes',
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = (string) $response->getBody();
+        $decoded = json_decode($body, true);
+
+        $this->assertContains('posts', $this->includedTypes($body));
+
+        // The requested firstPost should carry its likes relationship.
+        $firstPost = collect($decoded['included'])->firstWhere(fn ($r) => $r['type'] === 'posts' && $r['id'] === '101');
+        $this->assertNotNull($firstPost);
+        $this->assertArrayHasKey('likes', $firstPost['relationships']);
+    }
+}


### PR DESCRIPTION
Fixes #4788

`flarum/likes` default-included `firstPost.likes` and `lastPost.likes` on the `DiscussionResource` **Index** endpoint. Because a nested include pulls in its parent, this forced a full serialization of **two posts per discussion** on the discussion list — `contentHtml` rendering, per-post permission attributes (`canEdit`, `canDelete`, `canHide`, `canFlag`, `canLike`, …) and the likers' user resources — none of which the list UI renders.

Core's own Index endpoint only default-includes `mostRelevantPost` (for search excerpts), not `firstPost`/`lastPost`, so this was extension-added serialization work with no consumer on the list. It also reintroduced the per-fresh-`User` permission N+1 (the #4666 pattern) via the gate calls on those extra posts.

## Fix
Drop `Endpoint\Index` from the default-include list (keep `Show`/`Create`, where the post stream actually displays likes). The relationships remain **includable**, and the existing `eagerLoadWhenIncluded` wiring on Index still handles the explicit opt-in efficiently.

## Testing
Added `tests/integration/api/ListDiscussionsTest.php`:
- the Index endpoint no longer default-includes posts/likes;
- explicitly requesting `include=firstPost.likes,lastPost.likes` still works.

Full likes integration suite passes (22 tests).

## Credit
Diagnosis and reproduction by @ekumanov in #4788.