### PR TITLE
[2.x] perf(core): eager load discussion state on the posts endpoint

### DIFF
--- a/framework/core/src/Api/Resource/PostResource.php
+++ b/framework/core/src/Api/Resource/PostResource.php
@@ -120,7 +120,7 @@ class PostResource extends AbstractDatabaseResource
                     'hiddenUser',
                     'discussion'
                 ])
-                ->eagerLoad(['user.groups']),
+                ->eagerLoad(['user.groups', 'discussion.state']),
             Endpoint\Index::make()
                 ->extractOffset(function (Context $context, array $defaultExtracts): int {
                     $queryParams = $context->request->getQueryParams();
@@ -151,7 +151,7 @@ class PostResource extends AbstractDatabaseResource
                     'hiddenUser',
                     'discussion'
                 ])
-                ->eagerLoad(['user.groups'])
+                ->eagerLoad(['user.groups', 'discussion.state'])
                 ->defaultSort('number')
                 ->paginate(static::$defaultLimit),
         ];

--- a/framework/core/tests/integration/api/posts/ListDiscussionStateQueryCountTest.php
+++ b/framework/core/tests/integration/api/posts/ListDiscussionStateQueryCountTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\posts;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression test for the N+1 `discussion_user` (UserState) queries described in
+ * https://github.com/flarum/framework/issues/4769.
+ *
+ * The posts index includes `discussion`, and DiscussionResource serializes the
+ * per-actor `state` (its `lastReadAt` / `lastReadPostNumber` attributes read
+ * `$discussion->state`). Before the fix that relation was lazy-loaded once per
+ * distinct discussion, so the query count grew linearly with the number of
+ * discussions in the payload. After the fix it is eager-loaded in a single
+ * batched query.
+ */
+class ListDiscussionStateQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * Number of distinct discussions represented in the posts payload.
+     * Deliberately large so an N+1 produces many more `discussion_user` queries
+     * than the single batched load.
+     */
+    private const DISCUSSION_COUNT = 8;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $discussions = [];
+        $posts = [];
+        $discussionUser = [];
+
+        for ($i = 0; $i < self::DISCUSSION_COUNT; $i++) {
+            $discussionId = $i + 1;
+            $postId = 100 + $i;
+
+            $discussions[] = [
+                'id' => $discussionId,
+                'title' => __CLASS__.' '.$discussionId,
+                'created_at' => Carbon::now(),
+                'last_posted_at' => Carbon::now(),
+                'user_id' => 2,
+                'first_post_id' => $postId,
+                'comment_count' => 1,
+            ];
+            $posts[] = [
+                'id' => $postId,
+                'number' => 1,
+                'discussion_id' => $discussionId,
+                'created_at' => Carbon::now(),
+                'user_id' => 2,
+                'type' => 'comment',
+                'content' => '<t><p>post in '.$discussionId.'</p></t>',
+            ];
+            // A UserState row per discussion for the actor, so `state` is
+            // non-null and its attributes are serialized.
+            $discussionUser[] = [
+                'user_id' => 2,
+                'discussion_id' => $discussionId,
+                'last_read_post_number' => 1,
+            ];
+        }
+
+        $this->prepareDatabase([
+            Discussion::class => $discussions,
+            Post::class => $posts,
+            User::class => [$this->normalUser()],
+            'discussion_user' => $discussionUser,
+        ]);
+    }
+
+    private function listPosts(): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    #[Test]
+    public function discussion_state_is_batch_loaded_without_an_n_plus_one()
+    {
+        // Boot the app and populate the database before we start counting.
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $this->listPosts();
+
+        // The included discussions' per-actor `state` must be loaded in a single
+        // batched `where discussion_id in (...)` query — never one query per
+        // discussion (which was the N+1).
+        $batchedLoads = 0;
+        $individualLoads = 0;
+
+        foreach ($db->getQueryLog() as $query) {
+            if (stripos($query['query'], 'discussion_user') === false) {
+                continue;
+            }
+
+            if (stripos($query['query'], ' in (') !== false) {
+                $batchedLoads++;
+            } else {
+                $individualLoads++;
+            }
+        }
+
+        $db->disableQueryLog();
+
+        $this->assertSame(
+            0,
+            $individualLoads,
+            "Discussion states were loaded individually ($individualLoads times) instead of in a single batched query — this is the N+1 from issue #4769."
+        );
+        $this->assertGreaterThanOrEqual(
+            1,
+            $batchedLoads,
+            'Expected the discussion states to be eager-loaded in a single batched query.'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #4769

`GET /api/posts` default-includes `discussion`, and `DiscussionResource` serializes the per-actor `state` — its `lastReadAt` / `lastReadPostNumber` attributes read `$discussion->state`. The posts endpoints only eager-loaded `user.groups`, so the `state` relation was **lazy-loaded once per distinct discussion**: an N+1 that grows with the number of discussions in the payload (up to ~20 `discussion_user` queries on a default page).

`DiscussionResource`'s own Index/Show endpoints already avoid this via `->eagerLoad(['state', …])`; the posts endpoints just weren't carrying that onto the included discussion.

## Fix
Add `discussion.state` to the `eagerLoad(...)` on PostResource's **Index** and **Show** endpoints. The `state` relation is actor-scoped via the request-global `Discussion::setStateUser()` (set in `PopulateWithActor` middleware), so the nested eager load resolves for the current user and collapses the N+1 into one batched `discussion_user WHERE discussion_id in (...)` query.

## Testing
Added `tests/integration/api/posts/ListDiscussionStateQueryCountTest.php` (modeled on the #4695 query-count regression test): lists `/api/posts` across 8 discussions and asserts `discussion_user` is loaded in a single batched query, never per-discussion.

Full posts (36) and discussions (40) integration suites pass.

## Credit
Diagnosis by @DavideIadeluca in #4769.