### PR TITLE
[2.x] fix(gdpr): share view data for the erasure completion email

### DIFF
--- a/extensions/gdpr/src/Jobs/ErasureJob.php
+++ b/extensions/gdpr/src/Jobs/ErasureJob.php
@@ -22,6 +22,7 @@ use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Mail\Message;
@@ -49,6 +50,7 @@ class ErasureJob extends GdprJob
         Factory $filesystemFactory,
         SettingsRepositoryInterface $settings,
         UrlGenerator $url,
+        ViewFactory $view,
     ): void {
         $this->translator = $translator;
         $this->filesystemFactory = $filesystemFactory;
@@ -92,7 +94,7 @@ class ErasureJob extends GdprJob
 
         $this->{$mode}($user, $processor);
 
-        $this->sendUserConfirmation($mode, $username, $email, $mailer, $translator);
+        $this->sendUserConfirmation($mode, $username, $email, $mailer, $translator, $view);
 
         $events->dispatch(new Erased(
             $username,
@@ -117,9 +119,24 @@ class ErasureJob extends GdprJob
         }
     }
 
-    private function sendUserConfirmation(string $mode, string $username, string $email, Mailer $mailer, TranslatorInterface $translator): void
+    private function sendUserConfirmation(string $mode, string $username, string $email, Mailer $mailer, TranslatorInterface $translator, ViewFactory $view): void
     {
         $blueprint = new ErasureCompletedBlueprint($this->erasureRequest, $username, $mode);
+
+        // The completion email is rendered through the shared email layout and
+        // components, which read these values from the shared view scope (data
+        // passed to the view does not propagate into nested Blade components).
+        // Mirror what NotificationMailer / the core informational-email jobs
+        // share, otherwise the layout renders with undefined $username /
+        // $userEmail. See flarum/framework#4774. An explicit title also avoids
+        // inheriting a stale title from an earlier email on the shared view
+        // factory (see flarum/framework#4767).
+        $view->share([
+            'forumTitle' => $this->settings->get('forum_title'),
+            'userEmail' => $email,
+            'username' => $username,
+            'title' => $blueprint->getEmailSubject($translator),
+        ]);
 
         $mailer->send(
             $blueprint->getEmailViews(),

--- a/extensions/gdpr/tests/integration/api/ErasureConfirmationEmailTest.php
+++ b/extensions/gdpr/tests/integration/api/ErasureConfirmationEmailTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Gdpr\Models\ErasureRequest;
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
+
+class ErasureConfirmationEmailTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-gdpr');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'user5', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'user5@machine.local', 'is_email_confirmed' => 1, 'joined_at' => Carbon::now(), 'last_seen_at' => Carbon::now()],
+            ],
+            Group::class => [
+                ['id' => 4, 'name_singular' => 'mod', 'name_plural' => 'mods'],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 4],
+            ],
+            'group_permission' => [
+                ['permission' => 'processErasure', 'group_id' => 4],
+            ],
+            'gdpr_erasure' => [
+                ['id' => 2, 'user_id' => 5, 'verification_token' => '123abc', 'status' => 'user_confirmed', 'reason' => 'forget me', 'created_at' => Carbon::now(), 'user_confirmed_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    /**
+     * Swap in a transport that records every sent message, so we can inspect
+     * the rendered email. Returns the array the captured messages land in.
+     *
+     * @return \ArrayObject<int, RawMessage>
+     */
+    private function captureSentMail(): \ArrayObject
+    {
+        $captured = new \ArrayObject();
+
+        $transport = new class($captured) implements TransportInterface {
+            public function __construct(private \ArrayObject $captured)
+            {
+            }
+
+            public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+            {
+                $this->captured[] = $message;
+
+                return new SentMessage($message, $envelope ?? Envelope::create($message));
+            }
+
+            public function __toString(): string
+            {
+                return 'capture';
+            }
+        };
+
+        $container = $this->app()->getContainer();
+        $container->instance('symfony.mailer.transport', $transport);
+        $container->forgetInstance('mailer');
+
+        return $captured;
+    }
+
+    private function processAnonymization(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/user-erasure-requests/2', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'processorComment' => 'done',
+                            'processedMode' => ErasureRequest::MODE_ANONYMIZATION,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function anonymization_confirmation_email_renders_with_shared_view_data()
+    {
+        $captured = $this->captureSentMail();
+
+        $this->processAnonymization();
+
+        // Find the completion email (sent to the user's original address).
+        $email = null;
+        foreach ($captured as $message) {
+            if ($message instanceof Email) {
+                foreach ($message->getTo() as $address) {
+                    if ($address->getAddress() === 'user5@machine.local') {
+                        $email = $message;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $this->assertNotNull($email, 'Erasure completion email was not sent to the user.');
+
+        $rendered = ((string) $email->getHtmlBody()).((string) $email->getTextBody());
+
+        // The shared email layout/components render the recipient address in
+        // their footer (via `$userEmail`) and the greeting (via `$username`).
+        // Both only appear when the sender shares that view data — the bug in
+        // flarum/framework#4774 was that the erasure job did not, so the layout
+        // rendered with undefined variables.
+        $this->assertStringContainsString('user5@machine.local', $rendered);
+        $this->assertStringContainsString('user5', $rendered);
+    }
+}


### PR DESCRIPTION
Fixes #4774

Processing a GDPR erasure/anonymisation request logged two errors (`Undefined variable $forumTitle`, `Undefined variable $username`) while rendering the completion email, even though the action itself succeeded.

## Cause
`ErasureJob::sendUserConfirmation()` sends the completion email directly through the core `Mailer` (deliberately — so the locale captured *before* the user's preferences are wiped is preserved). It passed only the blueprint's `getData()` (`username`, `mode`) to the view.

The email is rendered through the shared email layout and `x-mail::html.*` components. **Blade components have isolated scope** — data passed to the top-level view does not propagate into nested components; only `view->share()`d data does. The layout reads `$username` (unguarded) and the information component reads `$userEmail` (unguarded), so the render hit undefined variables. Every other email works because its sender shares this data — `NotificationMailer`, `SendInformationalEmailJob`, `SendAbandonedExtensionsEmailJob`.

This is independent of #4786 (which only added the locale capture); the direct send predates it and the report is older.

## Fix
Share the same per-send view data the core senders provide before sending: `forumTitle`, `userEmail`, `username`, and an explicit `title`. The explicit title also avoids inheriting a stale title from an earlier email on the shared view factory (per #4767). Keeps the direct-`Mailer` send (and its locale handling) intact rather than rerouting through `NotificationMailer` (which would generate an unsubscribe token / read wiped preferences).

## Testing
Added `tests/integration/api/ErasureConfirmationEmailTest.php`: processes an anonymisation request, captures the sent email via a spy transport, and asserts the rendered body contains the recipient address (footer `$userEmail`) and username. Fails before the fix (empty `$userEmail` in the rendered footer), passes after. Full GDPR api/forum/console suites pass.

## Credit
Reported by @GreXXL in #4774.