### PR TITLE
[2.x] fix(core): bind the database transactions manager

### DIFF
--- a/framework/core/src/Database/DatabaseServiceProvider.php
+++ b/framework/core/src/Database/DatabaseServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Capsule\Manager;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -48,6 +49,14 @@ class DatabaseServiceProvider extends AbstractServiceProvider
             $manager->addConnection($config, 'flarum');
 
             return $manager;
+        });
+
+        // Bind the transactions manager so connections receive it during
+        // configuration (Illuminate's DatabaseManager::configure() attaches it
+        // whenever `db.transactions` is bound). Without it, Connection::afterCommit()
+        // throws. See flarum/framework#4787.
+        $this->container->singleton('db.transactions', function () {
+            return new DatabaseTransactionsManager;
         });
 
         $this->container->singleton(ConnectionResolverInterface::class, function (Container $container) {

--- a/framework/core/tests/integration/database/AfterCommitTest.php
+++ b/framework/core/tests/integration/database/AfterCommitTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\database;
+
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\DatabaseTransactionsManager;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use RuntimeException;
+
+/**
+ * Regression test for flarum/framework#4787.
+ *
+ * Flarum's DatabaseServiceProvider historically omitted the `db.transactions`
+ * binding, so connections never received a DatabaseTransactionsManager and any
+ * call to Connection::afterCommit() threw "Transactions Manager has not been
+ * set." Binding it lets Illuminate's DatabaseManager::configure() attach the
+ * manager to every connection.
+ *
+ * Note: the integration harness wraps each test in an open transaction that is
+ * rolled back on tearDown, so a registered afterCommit callback is (correctly)
+ * deferred to that never-committed transaction and cannot be observed firing
+ * here. These tests therefore assert the wiring the fix establishes and that
+ * afterCommit no longer throws; the callback-execution semantics themselves are
+ * Illuminate's own, guaranteed once a manager is attached.
+ */
+class AfterCommitTest extends TestCase
+{
+    private function connection(): ConnectionInterface
+    {
+        return $this->app()->getContainer()->make(ConnectionInterface::class);
+    }
+
+    #[Test]
+    public function transactions_manager_is_bound(): void
+    {
+        $this->assertInstanceOf(
+            DatabaseTransactionsManager::class,
+            $this->app()->getContainer()->make('db.transactions')
+        );
+    }
+
+    #[Test]
+    public function connection_receives_the_transactions_manager(): void
+    {
+        $connection = $this->connection();
+
+        $property = new ReflectionProperty(Connection::class, 'transactionsManager');
+        $property->setAccessible(true);
+
+        $this->assertInstanceOf(
+            DatabaseTransactionsManager::class,
+            $property->getValue($connection),
+            'The connection should have a transactions manager attached by DatabaseManager::configure().'
+        );
+    }
+
+    #[Test]
+    public function after_commit_does_not_throw(): void
+    {
+        $connection = $this->connection();
+
+        try {
+            // Registered against the harness's open transaction, so it is
+            // deferred (not run) rather than throwing.
+            $connection->afterCommit(function () {
+                // no-op
+            });
+        } catch (RuntimeException $e) {
+            $this->fail('Connection::afterCommit() threw: '.$e->getMessage());
+        }
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
Fixes #4787 (2.x only)

### Problem

Calling `Connection::afterCommit()` on any Flarum connection throws:

```
RuntimeException: Transactions Manager has not been set.
```

This breaks extensions that rely on transaction-safe deferral (run a side effect — event, notification, queued job — only after the surrounding transaction commits).

### Cause

Illuminate's `DatabaseManager::configure()` attaches a transactions manager to every connection **only if `db.transactions` is bound**:

```php
if ($this->app->bound('db.transactions')) {
    $connection->setTransactionManager($this->app['db.transactions']);
}
```

Flarum's `DatabaseServiceProvider` is a hand-rolled, minimal Capsule setup (not Laravel's full database provider) and never bound `db.transactions`. The manager (added to Laravel in 8.x for the after-commit feature) was simply never picked up — and core never used `afterCommit`, so the gap went unnoticed.

### Fix

Bind `Illuminate\Database\DatabaseTransactionsManager` as `db.transactions`, so `configure()` attaches it to connections — matching Laravel's own provider:

```php
$this->container->singleton('db.transactions', function () {
    return new DatabaseTransactionsManager;
});
```

### Notes

- **Additive / RC-safe.** It enables a previously-throwing method; no behaviour changes for code that doesn't call `afterCommit` (model events are not deferred unless a caller opts in). An `afterCommit` with no active transaction runs immediately (Laravel semantics).
- **No `DB` facade.** This is a container binding; `afterCommit` is called on the injected `ConnectionInterface`, consistent with Flarum's DI approach.
- Complements Flarum's existing `AbstractModel::afterSave()` deferral: `afterSave` fires during the model save (inside any enclosing transaction, i.e. not commit-safe), whereas `afterCommit` fires only after the outermost transaction commits (and is discarded on rollback).

### Testing

`tests/integration/database/AfterCommitTest.php`: asserts `db.transactions` is bound, that the connection receives the manager (via `DatabaseManager::configure()`), and that `afterCommit()` no longer throws.

The integration harness wraps each test in a transaction that is rolled back on teardown, so a registered `afterCommit` callback is correctly deferred to that never-committed transaction and can't be observed firing in-test — hence the wiring-focused assertions. The callback-execution semantics themselves are Illuminate's, guaranteed once the manager is attached (verified here).