### PR TITLE
[2.x] chore(deps): pin axios to patched 0.33.x to clear advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     ],
     "scripts": {
         "audit-fix": "npx yarn-audit-fix"
+    },
+    "resolutions": {
+        "axios": "^0.33.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,12 +1962,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+axios@^0.24.0, axios@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.33.0.tgz#91fc5e231db5b81ab6474c0a945a603c55601f6e"
+  integrity sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==
   dependencies:
-    follow-redirects "^1.14.4"
+    follow-redirects "^1.15.4"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.5.0, babel-jest@^29.7.0:
   version "29.7.0"
@@ -2890,12 +2892,12 @@ focus-trap@^6.7.1:
   dependencies:
     tabbable "^5.3.3"
 
-follow-redirects@^1.14.4:
+follow-redirects@^1.15.4:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
@@ -4433,6 +4435,11 @@ prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
### Problem

`axios@0.24.0` is the single largest cluster of open Dependabot alerts on `2.x` (SSRF, CSRF token leakage, ReDoS, etc.).

It is a **purely transitive, dev-only** dependency — `yarn why axios` shows the only consumer is **`bundlewatch`** (the CI bundle-size tool in `framework/core/js` devDependencies). axios is never bundled or shipped to end users.

### Fix

`bundlewatch` still declares `axios@^0.24.0`, so pin axios via a root `resolutions` entry to `^0.33.0` — the maintained, **security-patched 0.x line** (0.30–0.33 are backport releases specifically for transitive 0.x consumers). This keeps the 0.x API `bundlewatch` expects while clearing the advisories, without forcing a risky 1.x major bump on a tool that uses the old API.

```json
"resolutions": {
  "axios": "^0.33.0"
}
```

### Verification

- `yarn why axios` → resolves to `axios@0.33.0`; no package remains installed at 0.24 (only bundlewatch's requirement *range* text stays, satisfied by 0.33.0).
- `bundlewatch` still loads (`require('bundlewatch')` OK).
- Lockfile change is scoped to axios + its transitive deps; no other packages affected. No compiled assets committed.