### PR TITLE
[2.x] fix(core): render abandoned-extensions email body

### DIFF
--- a/framework/core/tests/integration/mail/AbandonedExtensionsEmailBodyTest.php
+++ b/framework/core/tests/integration/mail/AbandonedExtensionsEmailBodyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\mail;
+
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\View\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression test: the abandoned-extensions notification email rendered with an
+ * empty body (only greeting + sign-off). The notify templates passed their body
+ * via `<x-slot:content>`, but the shared `x-mail::*.information` component renders
+ * `{!! $body ?? $slot ?? '' !!}` — it reads a `body` slot (or the default slot),
+ * never `content`, so the body was silently dropped. Affected both HTML and plain.
+ */
+class AbandonedExtensionsEmailBodyTest extends TestCase
+{
+    private function viewFactory(): Factory
+    {
+        return $this->app()->getContainer()->make(Factory::class);
+    }
+
+    /**
+     * Render the two views exactly as SendAbandonedExtensionsEmailJob does:
+     * share forumTitle/userEmail/username, pass extensionLines as view data.
+     *
+     * @return array{html: string, text: string}
+     */
+    private function render(array $extensionLines): array
+    {
+        $view = $this->viewFactory();
+
+        $view->share([
+            'forumTitle' => 'Test Forum',
+            'userEmail' => 'admin@example.com',
+            'username' => 'Admin',
+        ]);
+
+        return [
+            'html' => $view->make('mail::html.abandoned_extensions.notify', compact('extensionLines'))->render(),
+            'text' => $view->make('mail::plain.abandoned_extensions.notify', compact('extensionLines'))->render(),
+        ];
+    }
+
+    #[Test]
+    public function html_email_contains_the_extension_lines(): void
+    {
+        $lines = ['Example Extension (fof/example)', 'Another Extension (acme/another)'];
+
+        $rendered = $this->render($lines)['html'];
+
+        foreach ($lines as $line) {
+            $this->assertStringContainsString($line, $rendered, 'The HTML email body should list the abandoned extensions.');
+        }
+    }
+
+    #[Test]
+    public function plain_email_contains_the_extension_lines(): void
+    {
+        $lines = ['Example Extension (fof/example)', 'Another Extension (acme/another)'];
+
+        $rendered = $this->render($lines)['text'];
+
+        foreach ($lines as $line) {
+            $this->assertStringContainsString($line, $rendered, 'The plain-text email body should list the abandoned extensions.');
+        }
+    }
+}

--- a/framework/core/views/email/html/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/html/abandoned_extensions/notify.blade.php
@@ -1,5 +1,5 @@
 <x-mail::html.information>
-    <x-slot:content>
+    <x-slot:body>
         <p>{{ $translator->trans('core.email.abandoned_extensions.body_intro') }}</p>
         <ul>
             @foreach ($extensionLines as $line)
@@ -7,5 +7,5 @@
             @endforeach
         </ul>
         <p>{{ $translator->trans('core.email.abandoned_extensions.body_outro') }}</p>
-    </x-slot:content>
+    </x-slot:body>
 </x-mail::html.information>

--- a/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
+++ b/framework/core/views/email/plain/abandoned_extensions/notify.blade.php
@@ -1,5 +1,5 @@
 <x-mail::plain.information>
-<x-slot:content>
+<x-slot:body>
 {{ $translator->trans('core.email.abandoned_extensions.body_intro') }}
 
 @foreach ($extensionLines as $line)
@@ -7,5 +7,5 @@
 @endforeach
 
 {{ $translator->trans('core.email.abandoned_extensions.body_outro') }}
-</x-slot:content>
+</x-slot:body>
 </x-mail::plain.information>


### PR DESCRIPTION
### Problem

The abandoned-extensions notification email renders with an **empty body** — only the greeting and sign-off appear, no intro/extension list/outro. Affects both the HTML and plain versions.

### Cause

`abandoned_extensions/notify.blade.php` passes its body via `<x-slot:content>`:

```blade
<x-mail::html.information>
    <x-slot:content> …intro, extension list, outro… </x-slot:content>
</x-mail::html.information>
```

But the shared `x-mail::html.information` / `x-mail::plain.information` component renders its body as:

```blade
{!! $body ?? $slot ?? '' !!}
```

i.e. it reads a named **`body`** slot, or the **default** slot — never `content`. So the `content` slot is silently dropped and the body renders empty. The greeting/sign-off come from the outer `x-mail::html` layout, which is why those still show.

Every other informational email (e.g. all four GDPR emails) correctly passes its body via `<x-slot:body>`; the abandoned-extensions templates were the lone exception.

### Fix

Rename the slot from `content` to `body` in both notify templates. No logic/data changes.

### Testing

`tests/integration/mail/AbandonedExtensionsEmailBodyTest.php` renders both templates the way `SendAbandonedExtensionsEmailJob` does and asserts the extension lines appear in the HTML **and** plain output. Fails before the fix (empty body), passes after. Full mail suite passes.