### PR TITLE
[2.x] chore: prepare 2.0.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [v2.0.0-rc.5](https://github.com/flarum/framework/compare/v2.0.0-rc.4...v2.0.0-rc.5)
+
+### Added
+
+- (markdown) continue lists when pressing Enter in the Markdown editor by @linkrobins [#4778]
+
+### Changed
+
+- (deps) remove redundant nested lockfiles for gdpr/realtime by @imorland [#4801]
+
+### Fixed
+
+- (core) set an explicit title on notification emails so it can't leak by @imorland [#4768]
+- (core) register a default for the `show_language_selector` setting by @imorland [#4792]
+- (core) reject oversized-dimension images before decoding by @imorland [#4794]
+- (core) return an empty page instead of a 500 when `page[limit]=0` is requested by @linkrobins [#4775]
+- (core) bind the database transactions manager by @imorland [#4800]
+- (core) render the abandoned-extensions email body by @imorland [#4804]
+- (core) fix iPad/touch devices requiring a double-tap in the discussion list by @imorland [#4556]
+- (a11y) add a `role` attribute to `PostStream` items by @claudiushenrichs [#4780]
+- (messages) use the correct route name in the dialogs dropdown by @imorland [#4791]
+- (tags) show a friendly model name for the tag slug driver setting by @imorland [#4793]
+- (tags) update tag metadata when a pending discussion is approved by @linkrobins [#4777]
+- (gdpr) send the erasure completion email in the user's locale by @grimur82 [#4786]
+- (gdpr) share view data for the erasure completion email by @imorland [#4798]
+- (realtime) recover desktop tabs after silent socket loss and catch up on missed events by @ekumanov [#4718]
+
+### Security
+
+- (core) harden avatar-from-URL fetch with a streaming cap, resolution guard, and link-local block by @imorland [#4795]
+- (deps) pin axios to patched 0.33.x to clear advisories by @imorland [#4802]
+- (deps) bump vulnerable transitive dev deps (minimatch, serialize-javascript) by @imorland [#4803]
+
+### Performance
+
+- (likes) don't default-include post likes on the discussion index by @imorland [#4796]
+- (core) eager-load discussion state on the posts endpoint by @imorland [#4797]
+
+### Documentation
+
+- (core) update the Laravel version in PHP docblocks by @DavideIadeluca [#4762]
+
 ## [v2.0.0-rc.4](https://github.com/flarum/framework/compare/v2.0.0-rc.3...v2.0.0-rc.4)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- (audit) move the bundled third-party integrations out to their own extensions by @imorland [#4807]
 - (audit) remove the clarkwinkelmann-author-change integration (replaced by fof/author-change) by @imorland [#4806]
 - (deps) remove redundant nested lockfiles for gdpr/realtime by @imorland [#4801]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- (audit) remove the clarkwinkelmann-author-change integration (replaced by fof/author-change) by @imorland [#4806]
 - (deps) remove redundant nested lockfiles for gdpr/realtime by @imorland [#4801]
 
 ### Fixed

--- a/extensions/akismet/composer.json
+++ b/extensions/akismet/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "flarum/approval": "^2.0"
     },
     "autoload": {

--- a/extensions/approval/composer.json
+++ b/extensions/approval/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "flarum/flags": "^2.0"
     },
     "autoload": {

--- a/extensions/audit/composer.json
+++ b/extensions/audit/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "ext-json": "*"
     },
     "autoload": {

--- a/extensions/bbcode/composer.json
+++ b/extensions/bbcode/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/embed/composer.json
+++ b/extensions/embed/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/emoji/composer.json
+++ b/extensions/emoji/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/flags/composer.json
+++ b/extensions/flags/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/gdpr/composer.json
+++ b/extensions/gdpr/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "nelexa/zip": "^4.0.2"
     },
     "autoload": {
@@ -91,8 +91,8 @@
         "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "require-dev": {
-        "flarum/testing": "^2.0.0-rc.4",
-        "flarum/phpstan": "^2.0.0-rc.4",
+        "flarum/testing": "^2.0.0-rc.5",
+        "flarum/phpstan": "^2.0.0-rc.5",
         "flarum/audit": "*"
     }
 }

--- a/extensions/lang-english/composer.json
+++ b/extensions/lang-english/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "MIT",
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/likes/composer.json
+++ b/extensions/likes/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/lock/composer.json
+++ b/extensions/lock/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/markdown/composer.json
+++ b/extensions/markdown/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "extra": {
         "branch-alias": {

--- a/extensions/mentions/composer.json
+++ b/extensions/mentions/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/messages/composer.json
+++ b/extensions/messages/composer.json
@@ -7,7 +7,7 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "authors": [
         {

--- a/extensions/nicknames/composer.json
+++ b/extensions/nicknames/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/package-manager/composer.json
+++ b/extensions/package-manager/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/flarum/extension-manager"
     },
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "composer/composer": "^2.7"
     },
     "require-dev": {

--- a/extensions/pusher/composer.json
+++ b/extensions/pusher/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "pusher/pusher-php-server": "^7.2"
     },
     "require-dev": {

--- a/extensions/realtime/composer.json
+++ b/extensions/realtime/composer.json
@@ -24,7 +24,7 @@
     ],
     "type": "flarum-extension",
     "require": {
-        "flarum/core": "^2.0.0-rc.4",
+        "flarum/core": "^2.0.0-rc.5",
         "plesk/ratchetphp": "v1.0.4",
         "pusher/pusher-php-server": "^7.2.0"
     },

--- a/extensions/statistics/composer.json
+++ b/extensions/statistics/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/sticky/composer.json
+++ b/extensions/sticky/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/subscriptions/composer.json
+++ b/extensions/subscriptions/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/suspend/composer.json
+++ b/extensions/suspend/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/extensions/tags/composer.json
+++ b/extensions/tags/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0-rc.4"
+        "flarum/core": "^2.0.0-rc.5"
     },
     "autoload": {
         "psr-4": {

--- a/framework/core/src/Foundation/Application.php
+++ b/framework/core/src/Foundation/Application.php
@@ -27,7 +27,7 @@ class Application extends IlluminateContainer implements LaravelApplication
      *
      * @var string
      */
-    public const VERSION = '2.0.0-rc.4';
+    public const VERSION = '2.0.0-rc.5';
 
     protected bool $booted = false;
 


### PR DESCRIPTION
Release prep for 2.0.0-rc.5.

- **Changelog** — adds the `v2.0.0-rc.5` section covering all merged PRs in [milestone 66](https://github.com/flarum/framework/milestone/66?closed=1) (Added / Changed / Fixed / Security / Performance / Documentation), including the audit third-party integration work (#4806, #4807).
- **Version bump** — `Application::VERSION` → `2.0.0-rc.5`.
- **Dependency constraints** — bump `^2.0.0-rc.4` → `^2.0.0-rc.5` across all bundled extensions' `composer.json` (`flarum/core`, and `flarum/testing`/`flarum/phpstan` where pinned).