### PR TITLE
Seamless asset refresh instead of the reload prompt

### DIFF
--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -10,7 +10,6 @@ import CommentPost from './components/CommentPost';
 import DiscussionRenamedPost from './components/DiscussionRenamedPost';
 import routes, { ForumRoutes, makeRouteHelpers } from './routes';
 import Application, { ApplicationData } from '../common/Application';
-import Button from '../common/components/Button';
 import Navigation from '../common/components/Navigation';
 import NotificationListState from './states/NotificationListState';
 import GlobalSearchState from './states/GlobalSearchState';
@@ -152,15 +151,23 @@ export default class ForumApplication extends Application {
   }
 
   /**
-   * Whether we have already alerted the user that the forum's assets have been
-   * updated since they loaded the page. Ensures the prompt is shown only once.
+   * Whether newer assets have been detected since this page booted. Once set, the
+   * user's next navigation becomes a full page load so the fresh assets are picked
+   * up — see {@link checkAssetsRevision} and {@link refreshOnNextNavigation}.
    */
-  private assetsRevisionAlertShown = false;
+  private assetsRefreshPending = false;
 
   /**
-   * When the server reports an asset revision (on an API response) that differs
-   * from the one this page booted with, the forum's JS/CSS has been rebuilt since
-   * load. Prompt the user to reload to pick up the new assets, at most once.
+   * When the server reports an asset revision (on an API response, or one pushed
+   * by the realtime extension) that differs from the one this page booted with,
+   * the forum's JS/CSS has been rebuilt since load.
+   *
+   * Rather than interrupt with a reload prompt — which pops up mid-read or
+   * mid-compose, and fires for every visitor the moment an admin toggles an
+   * extension — we just remember it. The user's next real navigation then loads
+   * the fresh assets naturally, without ever interrupting a reading or typing
+   * session, and with no risk of discarding an open draft. (Approach proposed by
+   * @luceos.)
    *
    * Both values are produced server-side (see `AssetsRevision`), so they are
    * directly comparable regardless of which versioner the forum uses.
@@ -170,23 +177,68 @@ export default class ForumApplication extends Application {
   public checkAssetsRevision(serverRevision: string | null): void {
     const bootedRevision = this.data?.assetsRevision;
 
-    if (!serverRevision || !bootedRevision || serverRevision === bootedRevision || this.assetsRevisionAlertShown) {
+    if (!serverRevision || !bootedRevision || serverRevision === bootedRevision || this.assetsRefreshPending) {
       return;
     }
 
-    this.assetsRevisionAlertShown = true;
+    this.assetsRefreshPending = true;
+    this.refreshOnNextNavigation();
+  }
 
-    this.alerts.show(
-      {
-        type: 'warning',
-        dismissible: true,
-        controls: [
-          <Button className="Button Button--link" onclick={() => window.location.reload()}>
-            {app.translator.trans('core.lib.assets_updated.reload_button')}
-          </Button>,
-        ],
+  /**
+   * Turn the user's next navigation into a full page load, so it boots with the
+   * freshly-built assets. Runs in the capture phase (and stops propagation) so it
+   * takes over before the router's own `<Link>` click handling, but only for a
+   * plain left-click on an internal, same-origin link: modified clicks (open in
+   * new tab/window), `target="_blank"` / `download` links, in-page anchors and
+   * non-navigation schemes are all left untouched. Back/forward reloads too.
+   *
+   * Set up only once, lazily, the first time newer assets are detected.
+   */
+  private refreshOnNextNavigation(): void {
+    document.addEventListener(
+      'click',
+      (e) => {
+        if (!this.assetsRefreshPending || e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+          return;
+        }
+
+        const anchor = (e.target as HTMLElement | null)?.closest?.('a[href]') as HTMLAnchorElement | null;
+        if (!anchor || anchor.target === '_blank' || anchor.hasAttribute('download')) {
+          return;
+        }
+
+        const href = anchor.getAttribute('href') || '';
+        if (!href || href.startsWith('#') || /^(javascript|mailto|tel):/i.test(href)) {
+          return;
+        }
+
+        let url: URL;
+        try {
+          url = new URL(anchor.href, window.location.href);
+        } catch {
+          return;
+        }
+
+        // Same-origin only, and not a bare hash change on the current page.
+        if (url.origin !== window.location.origin) {
+          return;
+        }
+        if (url.pathname === window.location.pathname && url.search === window.location.search && url.hash) {
+          return;
+        }
+
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        window.location.assign(url.href);
       },
-      app.translator.trans('core.lib.assets_updated.message')
+      true
     );
+
+    window.addEventListener('popstate', () => {
+      if (this.assetsRefreshPending) {
+        window.location.reload();
+      }
+    });
   }
 }


### PR DESCRIPTION
### Background

When the forum's assets are rebuilt — a deploy, or simply an admin enabling/disabling an extension — every API response starts carrying a new `X-Flarum-Assets-Revision`. `ForumApplication.checkAssetsRevision` compares it to the revision the page booted with and, if it differs, immediately shows a dismissible **"A new version of this page is available — Reload"** alert.

Two problems with showing it right away:

- It appears **mid-read or mid-compose**, interrupting whatever the user was doing.
- Because an extension toggle rebuilds assets, it pops up for **every visitor on the forum at once** the moment an admin touches the admin area — which reads as the forum nagging everyone to reload.

### What this does

Implements the middle ground [**@luceos** proposed](https://github.com/flarum/framework) — don't interrupt, don't ignore. When newer assets are detected we just **remember** it (`assetsRefreshPending`) and say nothing. The user's **next real navigation** — clicking a link, opening a discussion, back/forward — is turned into a full page load, so the fresh assets are picked up naturally.

The result: an actively reading or typing user is **never interrupted**, there's no modal and no timing guesswork, no risk of discarding an open draft — and the very next navigation is already on the new assets.

### Details

- `checkAssetsRevision` now sets a flag and lazily wires up `refreshOnNextNavigation()` instead of showing the alert. It's still `public` so the realtime extension's pushed revision token flows through the same path.
- `refreshOnNextNavigation()` adds a **capture-phase** click listener (stops propagation so it runs before the router's `<Link>` handling) that only acts on a plain left-click of an **internal, same-origin** link. It deliberately leaves untouched: modified clicks (Ctrl/⌘/Shift/middle → open in new tab/window), `target="_blank"` / `download` links, in-page anchors (`#…`), `javascript:` / `mailto:` / `tel:` links, external links, and bare hash changes on the current page. `popstate` reloads too.
- Removed the now-unused `Button` import.

The `core.lib.assets_updated.message` / `.reload_button` locale strings are now unused. I left them in place to avoid churning existing translations — happy to remove them if you'd prefer.

### Testing

Verified against a forum whose assets were rebuilt after load:
- No alert appears; the flag is set instead.
- The next internal-link click / back-forward triggers a full page load onto the new assets, while modified clicks, new-tab/download, external, `#`, `javascript:` links, and same-page hash changes all behave normally.

I've also been running this as a userland extension (overriding the same method) on two production forums.