### PR TITLE
[1.x] fix(search): coalesce null query before gambits to avoid str_getcsv deprecation

### DIFF
--- a/framework/core/src/Search/AbstractSearcher.php
+++ b/framework/core/src/Search/AbstractSearcher.php
@@ -52,7 +52,7 @@ abstract class AbstractSearcher
 
         $search = new SearchState($query->getQuery(), $actor);
 
-        $this->gambits->apply($search, $criteria->query['q']);
+        $this->gambits->apply($search, $criteria->query['q'] ?? '');
         $this->applySort($search, $criteria->sort, $criteria->sortIsDefault);
         $this->applyOffset($search, $offset);
         $this->applyLimit($search, $limit + 1);

--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -64,7 +64,7 @@ class GambitManager
      */
     protected function explode($query)
     {
-        return str_getcsv($query ?? '', ' ');
+        return str_getcsv($query, ' ');
     }
 
     /**

--- a/framework/core/src/Search/GambitManager.php
+++ b/framework/core/src/Search/GambitManager.php
@@ -64,7 +64,7 @@ class GambitManager
      */
     protected function explode($query)
     {
-        return str_getcsv($query, ' ');
+        return str_getcsv($query ?? '', ' ');
     }
 
     /**

--- a/framework/core/tests/integration/api/users/ListTest.php
+++ b/framework/core/tests/integration/api/users/ListTest.php
@@ -320,15 +320,16 @@ class ListTest extends TestCase
      * to a fatal on stricter setups. Regression test for the gambit search
      * choking on a null `q`.
      *
-     * The handler only throws for that specific deprecation so it is not
-     * derailed by unrelated framework deprecations emitted during the request.
+     * The handler only throws for the "passing null" deprecation so it is not
+     * derailed by unrelated deprecations emitted during the request — including
+     * PHP 8.5's separate deprecation of str_getcsv()'s default $escape argument.
      *
      * @test
      */
     public function search_with_null_query_does_not_emit_deprecation()
     {
         set_error_handler(function ($errno, $errstr) {
-            if (strpos($errstr, 'str_getcsv') !== false) {
+            if (strpos($errstr, 'Passing null') !== false) {
                 throw new \ErrorException($errstr, 0, $errno);
             }
 

--- a/framework/core/tests/integration/api/users/ListTest.php
+++ b/framework/core/tests/integration/api/users/ListTest.php
@@ -313,4 +313,33 @@ class ListTest extends TestCase
         $data = json_decode($response->getBody()->getContents(), true)['data'];
         $this->assertEquals([], Arr::pluck($data, 'id'));
     }
+
+    /**
+     * A search with a null query (rather than a string) must not trip the
+     * "passing null to a non-nullable parameter" deprecation on PHP 8.1+, which
+     * escalates to a fatal on stricter setups. Regression test for the gambit
+     * search choking on a null `q`.
+     *
+     * @test
+     */
+    public function search_with_null_query_does_not_emit_deprecation()
+    {
+        set_error_handler(function ($errno, $errstr) {
+            throw new \ErrorException($errstr, 0, $errno);
+        }, E_DEPRECATED);
+
+        try {
+            $response = $this->send(
+                $this->request('GET', '/api/users', [
+                    'authenticatedAs' => 1,
+                ])->withQueryParams([
+                    'filter' => ['q' => null],
+                ])
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }

--- a/framework/core/tests/integration/api/users/ListTest.php
+++ b/framework/core/tests/integration/api/users/ListTest.php
@@ -316,16 +316,23 @@ class ListTest extends TestCase
 
     /**
      * A search with a null query (rather than a string) must not trip the
-     * "passing null to a non-nullable parameter" deprecation on PHP 8.1+, which
-     * escalates to a fatal on stricter setups. Regression test for the gambit
-     * search choking on a null `q`.
+     * `str_getcsv(): Passing null ...` deprecation on PHP 8.1+, which escalates
+     * to a fatal on stricter setups. Regression test for the gambit search
+     * choking on a null `q`.
+     *
+     * The handler only throws for that specific deprecation so it is not
+     * derailed by unrelated framework deprecations emitted during the request.
      *
      * @test
      */
     public function search_with_null_query_does_not_emit_deprecation()
     {
         set_error_handler(function ($errno, $errstr) {
-            throw new \ErrorException($errstr, 0, $errno);
+            if (strpos($errstr, 'str_getcsv') !== false) {
+                throw new \ErrorException($errstr, 0, $errno);
+            }
+
+            return false;
         }, E_DEPRECATED);
 
         try {


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

This fixed an issue I came across when:
- Use PHP 8.2+
- Navigate to users list
- Refresh page
- A deprecation warning shows saying $query should not be null.

I'm not 100% sure if this is actually core related or my extension issue, but I tested without search related extensions and it persists.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
