### PR TITLE
fix(core): block disabling the default language pack

### DIFF
--- a/framework/core/src/Extension/DefaultLanguagePackGuard.php
+++ b/framework/core/src/Extension/DefaultLanguagePackGuard.php
@@ -23,7 +23,7 @@ class DefaultLanguagePackGuard
 
     public function handle(Disabling $event): void
     {
-        if (! in_array('flarum-locale', $event->extension->extra)) {
+        if (! Arr::has($event->extension->extra, 'flarum-locale')) {
             return;
         }
 

--- a/framework/core/tests/unit/Extension/DefaultLanguagePackGuardTest.php
+++ b/framework/core/tests/unit/Extension/DefaultLanguagePackGuardTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Extension;
+
+use Flarum\Extension\DefaultLanguagePackGuard;
+use Flarum\Extension\Event\Disabling;
+use Flarum\Extension\Extension;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\Exception\PermissionDeniedException;
+use PHPUnit\Framework\Attributes\Test;
+
+class DefaultLanguagePackGuardTest extends TestCase
+{
+    private function guard(string $defaultLocale): DefaultLanguagePackGuard
+    {
+        $settings = $this->createStub(SettingsRepositoryInterface::class);
+        $settings->method('get')
+            ->willReturnCallback(function ($key, $default = null) use ($defaultLocale) {
+                return $key === 'default_locale' ? $defaultLocale : $default;
+            });
+
+        return new DefaultLanguagePackGuard($settings);
+    }
+
+    private function disabling(array $extra, string $name = 'flarum/lang-english'): Disabling
+    {
+        return new Disabling(new Extension('/tmp/ext', [
+            'name' => $name,
+            'extra' => $extra,
+        ]));
+    }
+
+    #[Test]
+    public function it_blocks_disabling_the_default_language_pack()
+    {
+        $this->expectException(PermissionDeniedException::class);
+
+        $this->guard('en')->handle(
+            $this->disabling(['flarum-locale' => ['code' => 'en', 'title' => 'English']])
+        );
+    }
+
+    #[Test]
+    public function it_allows_disabling_a_non_default_language_pack()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->guard('en')->handle(
+            $this->disabling(['flarum-locale' => ['code' => 'fr', 'title' => 'French']])
+        );
+    }
+
+    #[Test]
+    public function it_allows_disabling_a_non_language_pack_extension()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->guard('en')->handle(
+            $this->disabling(['flarum-extension' => ['title' => 'Some Extension']], 'acme/some-extension')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #623 (re-opens the intent — the guard added for it never actually fires).

### Changes proposed in this pull request

`DefaultLanguagePackGuard` is meant to stop an admin from disabling the language pack that `default_locale` points to. Its guard used `in_array('flarum-locale', $extension->extra)`, which searches the **values** of the composer `extra` object — those values are arrays (`branch-alias`, `flarum-extension`, `flarum-locale`, …), so the string is never found, the check is always `false`, and the guard returns early. The protection was dead code: the default language pack could be disabled freely.

The very next line already treats `flarum-locale` as a **key** via `Arr::get($extra, 'flarum-locale.code')`, so this switches the check to `Arr::has($extension->extra, 'flarum-locale')`.

### Reviewers should focus on

- `DefaultLanguagePackGuard::handle()` — the key-vs-value lookup.

### Confirmed

- [x] Backend changes — added DB-free unit tests (`tests/unit/Extension/DefaultLanguagePackGuardTest.php`): default pack blocked, non-default pack allowed, non-language-pack extension allowed.
- [x] Frontend changes — N/A. Translations — N/A.

### Testing

`composer test:unit` — the new tests fail before the change (exception not thrown) and pass after; full unit suite green (344 tests).

_Prepared with AI assistance (Claude) and reviewed/verified by me._
