### PR TITLE
[2.x] Fix notifications endpoint 400 on invalid `subject.discussion` default include

### DIFF
--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -19,6 +19,7 @@ use Flarum\Notification\NotificationRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
+use Tobyz\JsonApiServer\Schema\Field\Relationship;
 
 /**
  * @extends AbstractDatabaseResource<Notification>
@@ -66,16 +67,25 @@ class NotificationResource extends AbstractDatabaseResource
 
     public function endpoints(): array
     {
+        // Eager-load the subject's discussion only when at least one subject
+        // type actually exposes a `discussion` relationship. Gating on the
+        // number of subject types instead would add an invalid `subject.discussion`
+        // default include when the extra types have no such relationship (e.g. a
+        // User-subject notification like flarum/mentions' `userMentioned` on a
+        // forum with no Post-subject notification type), which the include
+        // validator then rejects with a 400 on the endpoint's own default.
+        $defaultInclude = array_filter([
+            'fromUser',
+            'subject',
+            $this->initialized && $this->subjectsHaveDiscussionRelationship()
+                ? 'subject.discussion'
+                : null,
+        ]);
+
         return [
             Endpoint\Show::make()
                 ->authenticated()
-                ->defaultInclude(array_filter([
-                    'fromUser',
-                    'subject',
-                    $this->initialized && count($this->subjectTypes()) > 1
-                        ? 'subject.discussion'
-                        : null,
-                ])),
+                ->defaultInclude($defaultInclude),
             Endpoint\Update::make()
                 ->authenticated(),
             Endpoint\Index::make()
@@ -86,13 +96,7 @@ class NotificationResource extends AbstractDatabaseResource
                     // Invalidate new notification count cache since read_notifications_at changed
                     $this->cache->forget("user.{$actor->id}.new_notification_count");
                 })
-                ->defaultInclude(array_filter([
-                    'fromUser',
-                    'subject',
-                    $this->initialized && count($this->subjectTypes()) > 1
-                        ? 'subject.discussion'
-                        : null,
-                ]))
+                ->defaultInclude($defaultInclude)
                 ->paginate(),
         ];
     }
@@ -132,5 +136,28 @@ class NotificationResource extends AbstractDatabaseResource
         return $this->api->typesForModels(
             (new Notification())->getSubjectModels()
         );
+    }
+
+    /**
+     * Whether any registered notification subject type exposes an includable
+     * `discussion` relationship, making `subject.discussion` a valid include.
+     */
+    protected function subjectsHaveDiscussionRelationship(): bool
+    {
+        foreach ($this->subjectTypes() as $type) {
+            $resource = $this->api->getResource($type);
+
+            if (! $resource instanceof AbstractResource) {
+                continue;
+            }
+
+            foreach ($resource->resolveFields() as $field) {
+                if ($field instanceof Relationship && $field->includable && $field->name === 'discussion') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/framework/core/tests/integration/api/notifications/ListTest.php
+++ b/framework/core/tests/integration/api/notifications/ListTest.php
@@ -10,7 +10,11 @@
 namespace Flarum\Tests\integration\api\notifications;
 
 use Carbon\Carbon;
+use Flarum\Database\AbstractModel;
 use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Notification;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -85,5 +89,111 @@ class ListTest extends TestCase
 
         $this->assertNotContains('1', $ids);
         $this->assertEmpty($ids);
+    }
+
+    #[Test]
+    public function index_does_not_fail_when_a_subject_type_has_no_discussion_relationship()
+    {
+        // Registering a notification type whose subject (User) has no discussion
+        // relationship must not make the endpoint reject its own default include.
+        // Before the fix, `subject.discussion` was added purely because more than
+        // one subject type was registered, and the include validator then threw
+        // "Invalid include [subject.discussion]" (a 400) for every request.
+        $this->extend(
+            (new Extend\Notification())->type(UserSubjectBlueprint::class, ['alert'])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function subject_discussion_is_still_included_when_a_subject_type_has_a_discussion_relationship()
+    {
+        // A Post subject does have a discussion relationship, so `subject.discussion`
+        // remains a valid default include and the discussion is still eager-loaded.
+        $this->extend(
+            (new Extend\Notification())->type(PostSubjectBlueprint::class, ['alert'])
+        );
+
+        $this->prepareDatabase([
+            Notification::class => [
+                ['id' => 2, 'user_id' => 2, 'from_user_id' => 1, 'type' => 'postSubjectBlueprint', 'subject_id' => 1, 'read_at' => null, 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $included = array_map(fn ($resource) => $resource['type'].':'.$resource['id'], $body['included'] ?? []);
+
+        $this->assertContains('discussions:1', $included, 'The post subject\'s discussion should be eager-loaded.');
+    }
+}
+
+class UserSubjectBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): mixed
+    {
+        return [];
+    }
+
+    public static function getType(): string
+    {
+        return 'userSubjectBlueprint';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return User::class;
+    }
+}
+
+class PostSubjectBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): mixed
+    {
+        return [];
+    }
+
+    public static function getType(): string
+    {
+        return 'postSubjectBlueprint';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return Post::class;
     }
 }


### PR DESCRIPTION
Fixes #4815

## Changes proposed in this pull request

`NotificationResource` added `subject.discussion` to the notifications endpoints' default include whenever more than one notification subject type was registered:

```php
$this->initialized && count($this->subjectTypes()) > 1
    ? 'subject.discussion'
    : null,
```

That nested include is only valid when at least one subject type actually exposes an includable `discussion` relationship. The include validator validates default includes too, so when the subject collection is, for example, `{discussions, users}` (neither of which has a `discussion` relationship), it rejects the endpoint's own default include:

```json
{"errors":[{"status":"400","code":"validation_error","title":"Bad Request","detail":"Invalid include [subject.discussion]","source":{"parameter":"include"}}]}
```

Because `NotificationListState` sends no explicit `include` and relies on the server default, this returns `400` for every user and breaks the notifications dropdown and page. `User` subjects are not exotic: `flarum/mentions` ships `UserMentionedBlueprint`; it only stays safe because it also ships `PostMentionedBlueprint`, and `Post` has a `discussion` relationship. Any forum with a `User`-subject (or `Group`-subject) notification type and no `Post`-subject type present hits this.

This PR gates the include on whether a subject type genuinely exposes an includable `discussion` relationship, instead of on the subject-type count. The include is preserved exactly where it matters (Post subjects) and dropped only when it would be invalid.

## Reviewers should focus on

- `subjectsHaveDiscussionRelationship()` resolves each subject type's resource and checks its fields for an includable `discussion` relationship. This uses `resolveFields()` (which applies field extenders), guarded by an `instanceof AbstractResource` check.

## Verified

Reproduced and fixed on a fresh `2.0.0-rc.5` install (MariaDB):

| Registered subject types | `GET /api/notifications` before | after |
| --- | --- | --- |
| `{discussions}` (core only) | 200 | 200 |
| `{discussions, users}` | **400** | 200 |
| `{discussions, users, posts}` | 200 | 200 |

Two regression tests are added to `notifications/ListTest`: one asserting the endpoint no longer 400s when a subject type has no discussion relationship, and one asserting the discussion is still eager-loaded when a discussion-bearing subject type is present. The existing notification tests still pass.
