### PR TITLE
[2.x] perf(core): mitigate n+1 on notifications index

### DIFF
--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -13,11 +13,14 @@ use Flarum\Api\Context;
 use Flarum\Api\Endpoint;
 use Flarum\Api\Schema;
 use Flarum\Bus\Dispatcher;
+use Flarum\Discussion\Discussion;
 use Flarum\Notification\Command\ReadNotification;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationRepository;
+use Flarum\Post\Post;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
 
 /**
@@ -93,8 +96,32 @@ class NotificationResource extends AbstractDatabaseResource
                         ? 'subject.discussion'
                         : null,
                 ]))
+                ->eagerLoad(['fromUser'])
+                ->eagerLoadWhere('subject', function ($query) {
+                    if ($query instanceof MorphTo) {
+                        $query->morphWith($this->subjectMorphWith());
+                    }
+                })
                 ->paginate(),
         ];
+    }
+
+    /**
+     * @return array<class-string, string[]>
+     */
+    protected function subjectMorphWith(): array
+    {
+        $map = [];
+
+        foreach (array_unique(Notification::getSubjectModels()) as $class) {
+            if (is_a($class, Discussion::class, true)) {
+                $map[$class] = ['state'];
+            } elseif (is_a($class, Post::class, true)) {
+                $map[$class] = ['discussion.state'];
+            }
+        }
+
+        return $map;
     }
 
     public function fields(): array


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
Review this along side #4816. Maybe take inspiration from both PR's and create a new PR yourself with a mixture of both fixes and close ours

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
