### PR TITLE
[2.x] chore(flags): dispatch model events when flags are deleted

### DIFF
--- a/extensions/flags/extend.php
+++ b/extensions/flags/extend.php
@@ -22,7 +22,7 @@ use Flarum\Flags\Event\Deleting as FlagDeleting;
 use Flarum\Flags\Flag;
 use Flarum\Flags\Listener;
 use Flarum\Forum\Content\AssertRegistered;
-use Flarum\Post\Event\Deleted;
+use Flarum\Post\Event\Deleting as PostDeleting;
 use Flarum\Post\Post;
 use Flarum\Realtime\Extend\Realtime as RealtimeExtend;
 use Flarum\User\User;
@@ -66,7 +66,7 @@ return [
         ->serializeToForum('guidelinesUrl', 'flarum-flags.guidelines_url'),
 
     (new Extend\Event())
-        ->listen(Deleted::class, Listener\DeleteFlags::class),
+        ->listen(PostDeleting::class, Listener\DeleteFlags::class),
 
     (new Extend\ModelVisibility(Flag::class))
         ->scope(ScopeFlagVisibility::class),

--- a/extensions/flags/src/AuditIntegration.php
+++ b/extensions/flags/src/AuditIntegration.php
@@ -10,15 +10,14 @@
 namespace Flarum\Flags;
 
 use Flarum\Audit\AuditLogger;
-use Flarum\Post\Post;
+use Flarum\Flags\Event\Dismissed;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * Audit log integration for flarum/flags.
  *
- * Stateful: hooks the Flag model and a HasMany macro to detect flag dismissals. Wired into
+ * Hooks the Flag model's created event and the Dismissed event. Wired into
  * flarum/audit through the Flarum\Audit\Extend\Audit extender's `using()` escape hatch, behind
  * an Extend\Conditional so it's only active when flarum-audit is installed.
  */
@@ -35,36 +34,15 @@ class AuditIntegration
         // listener isn't bound to the model's static dispatcher.
         $container->make(Dispatcher::class)->listen('eloquent.created: '.Flag::class, [$this, 'flagCreated']);
 
-        // We don't use the FlagsWillBeDeleted event as extensions might still prevent deletion at that
-        // point. This macro must stay a closure: it relies on $this being rebound to the HasMany
-        // instance at call time. It registers on the HasMany class (not a model instance), so it is
-        // not part of the serialized model graph that tripped the static model-event closures.
-        HasMany::macro('delete', function () {
-            /** @var HasMany $this */
-            $parent = $this->getParent();
+        $container->make(Dispatcher::class)->listen(Dismissed::class, [$this, 'flagsDismissed']);
+    }
 
-            // Because flarum/flags calls this every time a post is deleted, we need to check if there were actual flags.
-            $post = ($parent instanceof Post && $this->getQuery()->getModel() instanceof Flag && $this->getQuery()->count())
-                ? $parent
-                : null;
-
-            // Replicates code from Relation::__call
-            $result = $this->forwardCallTo($this->getQuery(), 'delete', func_get_args());
-
-            if ($post) {
-                AuditLogger::log('post.dismissed_flags', [
-                    'discussion_id' => $post->discussion->id,
-                    'post_id' => $post->id,
-                ]);
-            }
-
-            // Replicates code from Relation::__call
-            if ($result === $this->getQuery()) {
-                return $this;
-            }
-
-            return $result;
-        });
+    public function flagsDismissed(Dismissed $event): void
+    {
+        AuditLogger::log('post.dismissed_flags', [
+            'discussion_id' => $event->post->discussion->id,
+            'post_id' => $event->post->id,
+        ]);
     }
 
     public function flagCreated(Flag $flag): void

--- a/extensions/flags/src/Command/DeleteFlagsHandler.php
+++ b/extensions/flags/src/Command/DeleteFlagsHandler.php
@@ -34,7 +34,7 @@ class DeleteFlagsHandler
             $this->events->dispatch(new Deleting($flag, $actor, $command->data));
         }
 
-        $post->flags()->delete();
+        $post->flags->each->delete();
 
         return $post;
     }

--- a/extensions/flags/src/Command/DeleteFlagsHandler.php
+++ b/extensions/flags/src/Command/DeleteFlagsHandler.php
@@ -10,6 +10,7 @@
 namespace Flarum\Flags\Command;
 
 use Flarum\Flags\Event\Deleting;
+use Flarum\Flags\Event\Dismissed;
 use Flarum\Post\Post;
 use Flarum\Post\PostRepository;
 use Illuminate\Events\Dispatcher;
@@ -30,11 +31,17 @@ class DeleteFlagsHandler
 
         $actor->assertCan('viewFlags', $post->discussion);
 
-        foreach ($post->flags as $flag) {
+        $flags = $post->flags;
+
+        foreach ($flags as $flag) {
             $this->events->dispatch(new Deleting($flag, $actor, $command->data));
         }
 
-        $post->flags->each->delete();
+        $flags->each->delete();
+
+        if ($flags->isNotEmpty()) {
+            $this->events->dispatch(new Dismissed($post, $flags, $actor, $command->data));
+        }
 
         return $post;
     }

--- a/extensions/flags/src/Event/Dismissed.php
+++ b/extensions/flags/src/Event/Dismissed.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Flags\Event;
+
+use Flarum\Flags\Flag;
+use Flarum\Post\Post;
+use Flarum\User\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Dispatched once after all of a post's flags have been dismissed,
+ * covering the whole batch — unlike Deleting, which fires per flag.
+ */
+class Dismissed
+{
+    /**
+     * @param Collection<int, Flag> $flags
+     */
+    public function __construct(
+        public Post $post,
+        public Collection $flags,
+        public User $actor,
+        public array $data = []
+    ) {
+    }
+}

--- a/extensions/flags/src/Event/Dismissed.php
+++ b/extensions/flags/src/Event/Dismissed.php
@@ -14,10 +14,6 @@ use Flarum\Post\Post;
 use Flarum\User\User;
 use Illuminate\Support\Collection;
 
-/**
- * Dispatched once after all of a post's flags have been dismissed,
- * covering the whole batch — unlike Deleting, which fires per flag.
- */
 class Dismissed
 {
     /**

--- a/extensions/flags/src/Listener/DeleteFlags.php
+++ b/extensions/flags/src/Listener/DeleteFlags.php
@@ -9,12 +9,12 @@
 
 namespace Flarum\Flags\Listener;
 
-use Flarum\Post\Event\Deleted;
+use Flarum\Post\Event\Deleting;
 
 class DeleteFlags
 {
-    public function handle(Deleted $event): void
+    public function handle(Deleting $event): void
     {
-        $event->post->flags()->delete();
+        $event->post->flags->each->delete();
     }
 }

--- a/extensions/flags/tests/integration/AuditTest.php
+++ b/extensions/flags/tests/integration/AuditTest.php
@@ -35,7 +35,7 @@ class AuditTest extends TestCase
 
         $this->prepareDatabase([
             Discussion::class => [
-                ['id' => 10, 'title' => 'A', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 1, 'comment_count' => 2],
+                ['id' => 10, 'title' => 'A', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 1, 'last_post_id' => 2, 'last_post_number' => 2, 'comment_count' => 2],
             ],
             Post::class => [
                 ['id' => 1, 'number' => 1, 'discussion_id' => 10, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>A</p></t>'],
@@ -117,5 +117,18 @@ class AuditTest extends TestCase
             'discussion_id' => 10,
             'post_id' => 2,
         ]);
+    }
+
+    #[Test]
+    public function deletingFlaggedPostDoesntLogFlagDismissal()
+    {
+        /*
+         * Deleting a flagged post is not a dismissal: the flags were acted upon,
+         * not dismissed. Actual dismissals all go through the flags.delete
+         * endpoint (the frontend dismisses alongside every destructive control).
+         */
+        $this->sendSuccessfulRequest('DELETE', '/api/posts/2', [], 204);
+
+        $this->assertLogDoesntExist('post.dismissed_flags');
     }
 }

--- a/extensions/flags/tests/integration/DeleteFlagsOnPostDeletionTest.php
+++ b/extensions/flags/tests/integration/DeleteFlagsOnPostDeletionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Flags\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Flags\Flag;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class DeleteFlagsOnPostDeletionTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-flags');
+
+        $date = Carbon::parse('2021-01-01T12:00:00+00:00');
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 10, 'title' => 'A', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 1, 'last_post_id' => 2, 'last_post_number' => 2, 'comment_count' => 2],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 10, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>A</p></t>'],
+                ['id' => 2, 'number' => 2, 'discussion_id' => 10, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>B</p></t>'],
+            ],
+            Flag::class => [
+                ['id' => 20, 'post_id' => 2],
+                ['id' => 21, 'post_id' => 2],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function deleting_a_flagged_post_fires_model_events_for_its_flags()
+    {
+        $deleted = [];
+
+        // The listener must delete the flags through Eloquent before the post row
+        // is gone — otherwise the flags.post_id cascade removes them at the
+        // database level and this event never fires.
+        $this->extend((new Extend\Event())->listen('eloquent.deleted: '.Flag::class, function (Flag $flag) use (&$deleted) {
+            $deleted[] = $flag->id;
+        }));
+
+        $response = $this->send($this->request('DELETE', '/api/posts/2', ['authenticatedAs' => 1]));
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertEqualsCanonicalizing([20, 21], $deleted);
+        $this->assertSame(0, Flag::query()->count());
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
No eloquent model events being dispatched when a flag gets deleted

**Changes proposed in this pull request:**
* Change how flags are deleted. With the new approach model events are fired after each delete, allowing Observers to hook into this.
* This in turn also allows the Audit Integration to loose some complexity with the macro 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
