### PR TITLE
[2.x] fix: blank index title control when no nav item is active

### DIFF
--- a/extensions/tags/js/src/forum/addTagFilter.tsx
+++ b/extensions/tags/js/src/forum/addTagFilter.tsx
@@ -87,6 +87,16 @@ export default function addTagFilter() {
     }
   });
 
+  // Name the current tag in the index title control. The nav dropdown only falls
+  // back to this label when none of its items is active, so it surfaces exactly
+  // when the current tag has no item in the sidebar nav, which is the case for
+  // any secondary tag outside the 3 most discussed ones.
+  extend(IndexPage.prototype, 'view', function () {
+    const tag = app.currentTag();
+
+    if (tag) app.current.set('titleControlLabel', tag.name());
+  });
+
   // If currently viewing a tag, restyle the 'new discussion' button to use
   // the tag's color, and disable if the user isn't allowed to edit.
   extend(IndexSidebar.prototype, 'items', function (items) {

--- a/framework/core/js/src/forum/components/IndexSidebar.tsx
+++ b/framework/core/js/src/forum/components/IndexSidebar.tsx
@@ -47,12 +47,18 @@ export default class IndexSidebar<CustomAttrs extends IndexSidebarAttrs = IndexS
       </Button>
     );
 
+    // `SelectDropdown` labels its button with the active child, and falls back to
+    // `defaultLabel` when none of them is active. That happens whenever a page
+    // filters the discussion list without contributing a nav item of its own, so
+    // such a page can name itself here by setting `titleControlLabel` on
+    // `app.current`. Otherwise we are on the unfiltered index.
     items.add(
       'nav',
       <SelectDropdown
         buttonClassName="Button"
         className="App-titleControl"
         accessibleToggleLabel={app.translator.trans('core.forum.index.toggle_sidenav_dropdown_accessible_label')}
+        defaultLabel={app.current.get('titleControlLabel') ?? app.translator.trans('core.forum.index.all_discussions_link')}
       >
         {this.navItems().toArray()}
       </SelectDropdown>

--- a/framework/core/js/tests/integration/forum/components/IndexSidebar.test.ts
+++ b/framework/core/js/tests/integration/forum/components/IndexSidebar.test.ts
@@ -1,0 +1,58 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import IndexSidebar from '../../../../src/forum/components/IndexSidebar';
+import { app } from '../../../../src/forum';
+import mq from 'mithril-query';
+import m from 'mithril';
+
+beforeAll(() => bootstrapForum());
+
+const titleControlLabel = (sidebar: any): string | undefined =>
+  sidebar.rootEl.querySelector('.App-titleControl > .Dropdown-toggle .Button-labelText')?.textContent;
+
+const navItemLabel = (sidebar: any, item: string): string | undefined =>
+  sidebar.rootEl.querySelector(`.Dropdown-menu .item-${item} .Button-labelText`)?.textContent;
+
+describe('IndexSidebar', () => {
+  beforeAll(() => app.boot());
+
+  afterEach(() => app.current.set('titleControlLabel', undefined));
+
+  test('renders', () => {
+    const sidebar = mq(IndexSidebar, {});
+
+    expect(sidebar).toHaveElement('.App-titleControl');
+  });
+
+  test('labels the title control with the index link when no nav item is active', () => {
+    const sidebar = mq(IndexSidebar, {});
+
+    expect(titleControlLabel(sidebar)).toBeTruthy();
+    expect(titleControlLabel(sidebar)).toBe(navItemLabel(sidebar, 'allDiscussions'));
+  });
+
+  test('labels the title control from app.current when a page provides a label', () => {
+    app.current.set('titleControlLabel', 'Support');
+
+    const sidebar = mq(IndexSidebar, {});
+
+    expect(titleControlLabel(sidebar)).toBe('Support');
+  });
+
+  test('prefers an active nav item over the label from app.current', () => {
+    class SidebarWithActiveItem extends IndexSidebar {
+      navItems() {
+        const items = super.navItems();
+
+        items.add('active', m('button', { active: true }, 'Active item'), 200);
+
+        return items;
+      }
+    }
+
+    app.current.set('titleControlLabel', 'Support');
+
+    const sidebar = mq(SidebarWithActiveItem, {});
+
+    expect(titleControlLabel(sidebar)).toBe('Active item');
+  });
+});


### PR DESCRIPTION
Fixes #4819

### What / why

On phone-width viewports the index toolbar title (the nav `SelectDropdown`, `App-titleControl`) renders blank on tag pages whenever the current tag has no item in the index sidebar nav. In practice that means any secondary tag that is not among the 3 most discussed secondary tags, so the set of affected tags shifts as discussion counts change and the bug looks random from an admin's point of view.

### Root cause

`SelectDropdown.getButtonContent()` uses the label of the first active child and falls back to `attrs.defaultLabel`. `defaultLabel` is declared required on `ISelectDropdownAttrs`, but the nav dropdown built in `IndexSidebar.items()` never passed one. When no child is active the label collapses to nothing and only the sort caret is left.

Tags is what exposes it: `addTagList` adds primary tags plus the top 3 secondary tags by `discussionCount()`, so a tag outside those filters contributes no nav item and nothing is active.

### Fix

Two parts, following the approach agreed in review:

**Core.** `IndexSidebar` now passes a `defaultLabel` to the nav `SelectDropdown`, read from the current page with the index's own link as the fallback:

```jsx
defaultLabel={app.current.get('titleControlLabel') ?? app.translator.trans('core.forum.index.all_discussions_link')}
```

This resolves the empty-label case for any consumer, not just tags. A page that filters the discussion list without contributing a nav item can name itself by setting `titleControlLabel` on `app.current`, which is the existing channel a page uses to hand context to other components. Anything that does not falls back to "All Discussions".

**Tags.** On a tag page, set `app.current.set('titleControlLabel', tag.name())`. Because `getButtonContent()` only reaches for `defaultLabel` when no child is active, this surfaces the tag name precisely in the unlisted-tag case, while a listed tag still wins through its own active item.

The change is label-only, so nothing is added to the sidebar, and it needs no `override()`. `addTagList` is untouched.

On ordering: the tags side sets the label from an `extend` on `IndexPage.prototype.view`. That runs after the original `view()` returns, but `view()` only returns a `PageStructure` vnode holding a bound `sidebar` callback, so `IndexSidebar.view()` (and therefore `items()`) does not run until later in the diff. The label is always set before it is read. Stale labels are not a concern either, since `DefaultResolver.makeKey()` keys on route name plus route params, so any tag-to-tag or tag-to-index navigation re-creates the page and with it `app.current`.

### Testing

New `framework/core/js/tests/integration/forum/components/IndexSidebar.test.ts` covers the title control: that it renders, that it falls back to the index link when no nav item is active, that it uses `titleControlLabel` when a page sets one, and that an active nav item still beats `titleControlLabel`. The two behavioural cases fail on `2.x` without the `IndexSidebar` change and pass with it.

Also verified by hand on a 2.x-dev install with 4 secondary tags at descending discussion counts (4/3/2/1), Chromium at 390x844:

- Before: the 4th-ranked tag's page shows an empty toolbar title with only the sort caret.
- After: it shows the tag name. A top-3 tag page renders byte-identically to before, and the index still shows "All Discussions".
- At 1280px the tag page and the index render byte-identically before and after, confirming the sidebar is unchanged: the unlisted tag is still absent from it.

Client-side navigation was checked separately, since the ordering argument above only matters on a route change rather than a fresh load. Driving the router through listed tag, unlisted tag, listed tag, unlisted tag, index, unlisted tag, listed tag gives the correct title at every step, and the unlisted tag never gains a nav item.

No `js/dist` in the diff, per the contributing docs.
