### PR TITLE
[2.x] fix(mentions): prevent deleted fallback for unsynced posts during formatting

### DIFF
--- a/extensions/mentions/src/Formatter/FormatGroupMentions.php
+++ b/extensions/mentions/src/Formatter/FormatGroupMentions.php
@@ -27,9 +27,7 @@ class FormatGroupMentions
         return Utils::replaceAttributes($xml, 'GROUPMENTION', function ($attributes) use ($context) {
             /** @var Group|null $group */
             $group = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsGroups') => $context->relationLoaded('mentionsGroups')
-                    ? $context->mentionsGroups->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsGroups()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsGroups') => $context->mentionsGroups->find($attributes['id']), // @phpstan-ignore-line
                 default => Group::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/FormatPostMentions.php
+++ b/extensions/mentions/src/Formatter/FormatPostMentions.php
@@ -33,9 +33,7 @@ class FormatPostMentions
         return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
             /** @var Post|null $post */
             $post = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsPosts') => $context->relationLoaded('mentionsPosts')
-                    ? $context->mentionsPosts->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsPosts()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsPosts') => $context->mentionsPosts->find($attributes['id']), // @phpstan-ignore-line
                 default => Post::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/FormatTagMentions.php
+++ b/extensions/mentions/src/Formatter/FormatTagMentions.php
@@ -22,9 +22,7 @@ class FormatTagMentions
         return Utils::replaceAttributes($xml, 'TAGMENTION', function ($attributes) use ($context) {
             /** @var Tag|null $tag */
             $tag = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsTags') => $context->relationLoaded('mentionsTags')
-                    ? $context->mentionsTags->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsTags()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsTags') => $context->mentionsTags->find($attributes['id']), // @phpstan-ignore-line
                 default => Tag::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/FormatUserMentions.php
+++ b/extensions/mentions/src/Formatter/FormatUserMentions.php
@@ -29,9 +29,7 @@ class FormatUserMentions
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
             /** @var User|null $user */
             $user = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsUsers') => $context->relationLoaded('mentionsUsers')
-                    ? $context->mentionsUsers->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsUsers()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsUsers') => $context->mentionsUsers->find($attributes['id']), // @phpstan-ignore-line
                 default => User::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/UnparsePostMentions.php
+++ b/extensions/mentions/src/Formatter/UnparsePostMentions.php
@@ -40,9 +40,7 @@ class UnparsePostMentions
         return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
             /** @var Post|null $post */
             $post = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsPosts') => $context->relationLoaded('mentionsPosts')
-                    ? $context->mentionsPosts->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsPosts()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsPosts') => $context->mentionsPosts->find($attributes['id']), // @phpstan-ignore-line
                 default => Post::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/UnparseTagMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseTagMentions.php
@@ -34,9 +34,7 @@ class UnparseTagMentions
         return Utils::replaceAttributes($xml, 'TAGMENTION', function (array $attributes) use ($context) {
             /** @var Tag|null $tag */
             $tag = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsTags') => $context->relationLoaded('mentionsTags')
-                    ? $context->mentionsTags->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsTags()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsTags') => $context->mentionsTags->find($attributes['id']), // @phpstan-ignore-line
                 default => Tag::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -40,9 +40,7 @@ class UnparseUserMentions
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
             /** @var User|null $user */
             $user = match (true) {
-                $context instanceof AbstractModel && $context->isRelation('mentionsUsers') => $context->relationLoaded('mentionsUsers')
-                    ? $context->mentionsUsers->find($attributes['id']) // @phpstan-ignore-line
-                    : $context->mentionsUsers()->find($attributes['id']), // @phpstan-ignore-line
+                $context instanceof AbstractModel && $context->relationLoaded('mentionsUsers') => $context->mentionsUsers->find($attributes['id']), // @phpstan-ignore-line
                 default => User::query()->find($attributes['id']),
             };
 

--- a/extensions/mentions/tests/integration/api/MentionsDuringSavingTest.php
+++ b/extensions/mentions/tests/integration/api/MentionsDuringSavingTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Event\Saving;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for https://github.com/flarum/framework/issues/4823.
+ *
+ * When `$post->content` is read during the `Saving` lifecycle event (before
+ * the post's mention pivot tables have been populated), the mention
+ * formatters must still resolve the mentioned entity by its own existence
+ * rather than the not-yet-synced pivot — otherwise the mention is wrongly
+ * unparsed to the `[deleted]` / `[unknown]` fallback text.
+ */
+class MentionsDuringSavingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * Content observed by the Saving listener, captured for assertion.
+     */
+    protected ?string $observedContent = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        $this->extend(
+            (new Extend\Event())
+                ->listen(Saving::class, function (Saving $event) {
+                    // Reading content here triggers unparse() while the post's
+                    // mention pivots are not yet synced — the #4823 scenario.
+                    $this->observedContent = $event->post->content;
+                })
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'mentioned_user', 'email' => 'mentioned_user@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Test discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Original</p></t>'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function user_mention_resolves_during_saving_of_a_new_post(): void
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"mentioned_user"#3',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['type' => 'discussions', 'id' => '1']],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
+
+        // The Saving listener must have seen the real mention, NOT the deleted
+        // fallback — this is the regression from #4823.
+        $this->assertNotNull($this->observedContent);
+        $this->assertStringContainsString('mentioned_user', $this->observedContent);
+        $this->assertStringNotContainsString('[deleted]', $this->observedContent);
+        $this->assertStringNotContainsString('[unknown]', $this->observedContent);
+    }
+
+    #[Test]
+    public function user_mention_resolves_during_saving_when_editing_a_post(): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"mentioned_user"#3 edited',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $this->assertNotNull($this->observedContent);
+        $this->assertStringContainsString('mentioned_user', $this->observedContent);
+        $this->assertStringNotContainsString('[deleted]', $this->observedContent);
+        $this->assertStringNotContainsString('[unknown]', $this->observedContent);
+    }
+}

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -480,7 +480,7 @@ class PostMentionsTest extends TestCase
                     'data' => [
                         'type' => 'posts',
                         'attributes' => [
-                            'content' => '@"Bad _ User"#p9',
+                            'content' => '@"Bad _ User"#p9 edited',
                         ],
                     ],
                 ],
@@ -494,7 +494,7 @@ class PostMentionsTest extends TestCase
         $response = json_decode($body, true);
 
         $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@"Bad _ User"#p9', $response['data']['attributes']['content']);
+        $this->assertEquals('@"Bad _ User"#p9 edited', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(9));
     }

--- a/extensions/mentions/tests/integration/api/TagMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/TagMentionsTest.php
@@ -40,7 +40,7 @@ class TagMentionsTest extends TestCase
             ],
             Post::class => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><TAGMENTION id="1" slug="test_old_slug" tagname="TestOldName">#test_old_slug</TAGMENTION></r>'],
-                ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><TAGMENTION id="3" slug="support" tagname="Support">#deleted_relation</TAGMENTION></r>'],
+                ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><TAGMENTION id="999" slug="support" tagname="Support">#deleted_relation</TAGMENTION></r>'],
                 ['id' => 8, 'number' => 6, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="2020" slug="i_am_a_deleted_tag" tagname="i_am_a_deleted_tag">#i_am_a_deleted_tag</TAGMENTION></r>'],
                 ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="5" slug="laravel">#laravel</TAGMENTION></r>'],
             ],

--- a/extensions/mentions/tests/integration/api/UserMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/UserMentionsTest.php
@@ -465,7 +465,7 @@ class UserMentionsTest extends TestCase
                     'data' => [
                         'type' => 'posts',
                         'attributes' => [
-                            'content' => '@"Bad _ User"#5',
+                            'content' => '@"Bad _ User"#5 edited',
                         ],
                     ],
                 ],
@@ -479,7 +479,7 @@ class UserMentionsTest extends TestCase
         $response = json_decode($body, true);
 
         $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@"Bad _ User"#5', $response['data']['attributes']['content']);
+        $this->assertEquals('@"Bad _ User"#5 edited', $response['data']['attributes']['content']);
         $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(5));
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4823**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR modifies all `Format*Mentions` and `Unparse*Mentions` classes to:
- Use the relation's loaded collection if it has been eager loaded (via `relationLoaded`), executing 0 queries.
- Fallback directly to the base model query (e.g., `Post::query()->find()`) rather than querying the pivot table if the relation isn't loaded.

This completely bypasses the pivot table requirement during text evaluation, allowing the formatters to accurately retrieve display names for edited posts.

This bug also caused false positives in the Flarum test suite:
- `editing_a_post_with_deleted_author_that_has_a_mention_works`: The test edited a post by sending the exact same text that the post already had. Because the broken `unparse()` method previously evaluated the old post content as `[deleted]`, Flarum thought the content had changed and dispatched the `Revised` event. With `unparse()` fixed, Flarum correctly recognizes the text did not change and skips the `Revised` event, causing the test's pivot table assertion to fail. This PR updates the test payloads to actually mutate the content so that the `Revised` event fires properly.
- `deleted_tag_mentions_relation_unparse_and_render_as_expected`: The test verified that a post mentioning a Tag would render as `[deleted]` if the pivot row was missing, despite the Tag actually existing in the database fixtures. Before our format fixes, Flarum wrongly rendered this as deleted because it strictly trusted the empty pivot table. With our format logic fixed, Flarum rightfully discovers the Tag still exists and refuses to render it as deleted, causing the test to fail. This PR updates the test to target a genuinely non-existent Tag ID (999) to accurately test the deleted fallback.


**Output of  `$post->content`**
<!-- include an image of the most relevant user-facing change, if any -->

Content use to test:
```
@"huoxin"#p89 abc
@"huoxin"#1 abc
```

Output:
```
Before:
[2026-07-22T18:44:19.913160+00:00] flarum.INFO: [Test] Content observed during Saving event: {"content":"@\"[unknown]\"#p89 abc
@\"[deleted]\"#1 abc"} 

After:
[2026-07-22T18:42:36.145018+00:00] flarum.INFO: [Test] Content observed during Saving event: {"content":"@\"huoxin\"#p89 abc
@\"huoxin\"#1 abc"} 
```

Also tested with email notification which relates to #3454, but was **not able to reproduce** the issue, the username is showing correctly before and after the fix:
```
Notification

Hey huoxin,

huoxin233 mentioned you in a post in cccddaaas.

https://xxxxx

---

@&quot;huoxin&quot;#p89 abc
@&quot;huoxin&quot;#1 abc

- The test team -
....
```


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
