### PR TITLE
[1.x] fix(mentions): prevent deleted fallback for unsynced posts during formatting

### DIFF
--- a/extensions/mentions/src/Formatter/FormatGroupMentions.php
+++ b/extensions/mentions/src/Formatter/FormatGroupMentions.php
@@ -38,7 +38,7 @@ class FormatGroupMentions
     public function __invoke(Renderer $renderer, $context, string $xml): string
     {
         return Utils::replaceAttributes($xml, 'GROUPMENTION', function ($attributes) use ($context) {
-            $group = (($context && isset($context->getRelations()['mentionsGroups'])) || $context instanceof Post)
+            $group = ($context && isset($context->getRelations()['mentionsGroups']))
                 ? $context->mentionsGroups->find($attributes['id'])
                 : Group::find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/FormatGroupMentions.php
+++ b/extensions/mentions/src/Formatter/FormatGroupMentions.php
@@ -10,7 +10,6 @@
 namespace Flarum\Mentions\Formatter;
 
 use Flarum\Group\Group;
-use Flarum\Post\Post;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/extensions/mentions/src/Formatter/FormatPostMentions.php
+++ b/extensions/mentions/src/Formatter/FormatPostMentions.php
@@ -47,7 +47,7 @@ class FormatPostMentions
     public function __invoke(Renderer $renderer, $context, $xml, Request $request = null)
     {
         return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
-            $post = (($context && isset($context->getRelations()['mentionsPosts'])) || $context instanceof Post)
+            $post = ($context && isset($context->getRelations()['mentionsPosts']))
                 ? $context->mentionsPosts->find($attributes['id'])
                 : Post::find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/FormatTagMentions.php
+++ b/extensions/mentions/src/Formatter/FormatTagMentions.php
@@ -21,7 +21,7 @@ class FormatTagMentions
     {
         return Utils::replaceAttributes($xml, 'TAGMENTION', function ($attributes) use ($context) {
             /** @var Tag|null $tag */
-            $tag = (($context && isset($context->getRelations()['mentionsTags'])) || $context instanceof Post)
+            $tag = ($context && isset($context->getRelations()['mentionsTags']))
                 ? $context->mentionsTags->find($attributes['id'])
                 : Tag::query()->find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/FormatTagMentions.php
+++ b/extensions/mentions/src/Formatter/FormatTagMentions.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Mentions\Formatter;
 
-use Flarum\Post\Post;
 use Flarum\Tags\Tag;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Renderer;

--- a/extensions/mentions/src/Formatter/FormatUserMentions.php
+++ b/extensions/mentions/src/Formatter/FormatUserMentions.php
@@ -10,7 +10,6 @@
 namespace Flarum\Mentions\Formatter;
 
 use Flarum\Http\SlugManager;
-use Flarum\Post\Post;
 use Flarum\User\User;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;

--- a/extensions/mentions/src/Formatter/FormatUserMentions.php
+++ b/extensions/mentions/src/Formatter/FormatUserMentions.php
@@ -45,7 +45,7 @@ class FormatUserMentions
     public function __invoke(Renderer $renderer, $context, string $xml)
     {
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
-            $user = (($context && isset($context->getRelations()['mentionsUsers'])) || $context instanceof Post)
+            $user = ($context && isset($context->getRelations()['mentionsUsers']))
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/UnparsePostMentions.php
+++ b/extensions/mentions/src/Formatter/UnparsePostMentions.php
@@ -56,7 +56,7 @@ class UnparsePostMentions
         $post = $context;
 
         return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($context) {
-            $post = (($context && isset($context->getRelations()['mentionsPosts'])) || $context instanceof Post)
+            $post = ($context && isset($context->getRelations()['mentionsPosts']))
                 ? $context->mentionsPosts->find($attributes['id'])
                 : Post::find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/UnparseTagMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseTagMentions.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Mentions\Formatter;
 
-use Flarum\Post\Post;
 use Flarum\Tags\Tag;
 use s9e\TextFormatter\Utils;
 

--- a/extensions/mentions/src/Formatter/UnparseTagMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseTagMentions.php
@@ -45,7 +45,7 @@ class UnparseTagMentions
     {
         return Utils::replaceAttributes($xml, 'TAGMENTION', function (array $attributes) use ($context) {
             /** @var Tag|null $tag */
-            $tag = (($context && isset($context->getRelations()['mentionsTags'])) || $context instanceof Post)
+            $tag = ($context && isset($context->getRelations()['mentionsTags']))
                 ? $context->mentionsTags->find($attributes['id'])
                 : Tag::query()->find($attributes['id']);
 

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Mentions\Formatter;
 
-use Flarum\Post\Post;
 use Flarum\User\User;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/extensions/mentions/src/Formatter/UnparseUserMentions.php
+++ b/extensions/mentions/src/Formatter/UnparseUserMentions.php
@@ -55,7 +55,7 @@ class UnparseUserMentions
     protected function updateUserMentionTags($context, string $xml): string
     {
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($context) {
-            $user = (($context && isset($context->getRelations()['mentionsUsers'])) || $context instanceof Post)
+            $user = ($context && isset($context->getRelations()['mentionsUsers']))
                 ? $context->mentionsUsers->find($attributes['id'])
                 : User::find($attributes['id']);
 

--- a/extensions/mentions/tests/integration/api/PostMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/PostMentionsTest.php
@@ -496,7 +496,7 @@ class PostMentionsTest extends TestCase
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@"Bad _ User"#p9',
+                            'content' => '@"Bad _ User"#p9 edited',
                         ],
                     ],
                 ],
@@ -508,7 +508,7 @@ class PostMentionsTest extends TestCase
         $response = json_decode($response->getBody(), true);
 
         $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@"Bad _ User"#p9', $response['data']['attributes']['content']);
+        $this->assertEquals('@"Bad _ User"#p9 edited', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(9));
     }

--- a/extensions/mentions/tests/integration/api/TagMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/TagMentionsTest.php
@@ -35,7 +35,7 @@ class TagMentionsTest extends TestCase
             ],
             'posts' => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><TAGMENTION id="1" slug="test_old_slug" tagname="TestOldName">#test_old_slug</TAGMENTION></r>'],
-                ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><TAGMENTION id="3" slug="support" tagname="Support">#deleted_relation</TAGMENTION></r>'],
+                ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><TAGMENTION id="999" slug="support" tagname="Support">#deleted_relation</TAGMENTION></r>'],
                 ['id' => 8, 'number' => 6, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="2020" slug="i_am_a_deleted_tag" tagname="i_am_a_deleted_tag">#i_am_a_deleted_tag</TAGMENTION></r>'],
                 ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><TAGMENTION id="5" slug="laravel">#laravel</TAGMENTION></r>'],
             ],

--- a/extensions/mentions/tests/integration/api/UserMentionsTest.php
+++ b/extensions/mentions/tests/integration/api/UserMentionsTest.php
@@ -479,7 +479,7 @@ class UserMentionsTest extends TestCase
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@"Bad _ User"#5',
+                            'content' => '@"Bad _ User"#5 edited',
                         ],
                     ],
                 ],
@@ -491,7 +491,7 @@ class UserMentionsTest extends TestCase
         $response = json_decode($response->getBody(), true);
 
         $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@"Bad _ User"#5', $response['data']['attributes']['content']);
+        $this->assertEquals('@"Bad _ User"#5 edited', $response['data']['attributes']['content']);
         $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(5));
     }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #4823 & #3454**
Backport fix from #4824 to 1.x

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR modifies all `Format*Mentions` and `Unparse*Mentions` classes to:
- Use the relation's loaded collection if it has been eager loaded (via `relationLoaded`), executing 0 queries.
- Fallback directly to the base model query (e.g., `Post::query()->find()`) rather than querying the pivot table if the relation isn't loaded.

This completely bypasses the pivot table requirement during text evaluation, allowing the formatters to accurately retrieve display names for edited posts.

This bug also caused false positives in the Flarum test suite:
- `editing_a_post_with_deleted_author_that_has_a_mention_works`: The test edited a post by sending the exact same text that the post already had. Because the broken `unparse()` method previously evaluated the old post content as `[deleted]`, Flarum thought the content had changed and dispatched the `Revised` event. With `unparse()` fixed, Flarum correctly recognizes the text did not change and skips the `Revised` event, causing the test's pivot table assertion to fail. This PR updates the test payloads to actually mutate the content so that the `Revised` event fires properly.
- `deleted_tag_mentions_relation_unparse_and_render_as_expected`: The test verified that a post mentioning a Tag would render as `[deleted]` if the pivot row was missing, despite the Tag actually existing in the database fixtures. Before our format fixes, Flarum wrongly rendered this as deleted because it strictly trusted the empty pivot table. With our format logic fixed, Flarum rightfully discovers the Tag still exists and refuses to render it as deleted, causing the test to fail. This PR updates the test to target a genuinely non-existent Tag ID (999) to accurately test the deleted fallback.

**Output of  `$post->content`**
<!-- include an image of the most relevant user-facing change, if any -->

Content use to test:
```
@"huoxin"#p34 abc
@"huoxin"#1 abc
```

Output:
```
Before:
[2026-07-22 19:05:01] flarum.INFO: [Test] Content observed during Saving event: {"content":"@\"[unknown]\"#p34 abc
@\"[deleted]\"#1 abc"} 

After:
[2026-07-22 19:07:39] flarum.INFO: [Test] Content observed during Saving event: {"content":"@\"huoxin\"#p34 abc
@\"huoxin\"#1 abc"} 
```

This seems to fix issue related to email notification #3454 also:

Before:
```
[2026-07-22 19:05:01] flarum.INFO: Message-ID: <95f9f5663f4c9b91ec6f56f6588ee9c4@0.0.0.0>
Date: Wed, 22 Jul 2026 19:05:01 +0000
Subject: [Follow User] New post in asdsa
From: test <admin@xxxxxx>
To: huoxin <a@a.com>
MIME-Version: 1.0
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable
.....
    <div class="content">
        <p>Hey huoxin,</p>

<p>huoxin233 posted in a discussion: asdsa</p>

<p>To view the new activity, check out the following link:</p>

<p><a href="https://xxxxxxxx/d/9/9">https://xxxxxxxx/d/9/9</a></p>

<p>—</p>

<p>@“[unknown]”#p34 abc
@“[deleted]”#1 abc</p>

<p>—</p>

<p>You won’t receive any more notifications about this discussion until you’re up-to-date.</p>


    </div>
    <div class="footer">
        <div class="content">
            <p>Sent from test using FoF Pretty Mail</p>
        </div>
    </div>
    </body>
</html>
```

After:
```
[2026-07-22 19:07:39] flarum.INFO: Message-ID: <c976d05041b1ec05578ddf134a5da263@0.0.0.0>
Date: Wed, 22 Jul 2026 19:07:39 +0000
Subject: [Follow User] New post in asdsa
From: test <admin@xxxx>
To: huoxin <a@a.com>
MIME-Version: 1.0
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

....
    <div class="content">
        <p>Hey huoxin,</p>

<p>huoxin233 posted in a discussion: asdsa</p>

<p>To view the new activity, check out the following link:</p>

<p><a href="https://xxxxxxxx/d/9/10">https://xxxxxxxx/d/9/10</a></p>

<p>—</p>

<p>@“huoxin”#p34 abc
@“huoxin”#1 abc</p>

<p>—</p>

<p>You won’t receive any more notifications about this discussion until you’re up-to-date.</p>


    </div>
    <div class="footer">
        <div class="content">
            <p>Sent from test using FoF Pretty Mail</p>
        </div>
    </div>
    </body>
</html>
```


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
