### PR TITLE
[2.1] feat: Email bounce & complaint handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,9 @@
         "symfony/mime": "^7.0",
         "symfony/polyfill-intl-messageformatter": "^1.27",
         "symfony/postmark-mailer": "^7.0",
+        "symfony/remote-event": "^7.0",
         "symfony/translation": "^7.0",
+        "symfony/webhook": "^7.0",
         "symfony/yaml": "^7.0",
         "wikimedia/less.php": "^5.3"
     },

--- a/extensions/gdpr/extend.php
+++ b/extensions/gdpr/extend.php
@@ -33,7 +33,8 @@ return [
     (new Extend\Notification())
         ->type(Notifications\ExportAvailableBlueprint::class, ['alert', 'email'])
         ->type(Notifications\ConfirmErasureBlueprint::class, ['email'])
-        ->type(Notifications\ErasureRequestCancelledBlueprint::class, ['alert', 'email']),
+        ->type(Notifications\ErasureRequestCancelledBlueprint::class, ['alert', 'email'])
+        ->beforeSending(FilterAnonymizedRecipients::class),
 
     (new Extend\Model(User::class))
         ->cast('anonymized', 'boolean')

--- a/extensions/gdpr/resources/locale/en.yml
+++ b/extensions/gdpr/resources/locale/en.yml
@@ -69,6 +69,10 @@ flarum-gdpr:
                 export_description: Retrieves the user's avatar from the filesystem and includes it in the export.
             discussions:
                 export_description: Exports all discussions the user has started. Data restricted to title and creation date.
+            emailbounceevents:
+                anonymize_description: Removes the email address from the user's email bounce history, keeping anonymous records for statistics.
+                delete_description: Deletes the user's email bounce history.
+                export_description: Exports the user's email bounce and spam-complaint history.
             forum:
                 export_description: Exports the forum title, url, username, email and the current date.
             default_user_action: "No action, handled by default user table data handling."

--- a/extensions/gdpr/src/Data/EmailBounceEvents.php
+++ b/extensions/gdpr/src/Data/EmailBounceEvents.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Data;
+
+use Flarum\Mail\EmailBounceEvent;
+use Illuminate\Support\Arr;
+
+/**
+ * Handles the user's email bounce/complaint history for GDPR export and
+ * erasure. The event rows store the recipient email address (PII), so on
+ * erasure that address must be scrubbed; the rows themselves are retained
+ * (email nulled) so aggregate bounce statistics stay meaningful.
+ */
+class EmailBounceEvents extends Type
+{
+    public static function piiFields(): array
+    {
+        return ['email'];
+    }
+
+    public function export(): ?array
+    {
+        $exportData = [];
+
+        EmailBounceEvent::query()
+            ->where('user_id', $this->user->id)
+            ->each(function (EmailBounceEvent $event) use (&$exportData) {
+                $exportData[] = [
+                    "email-bounce-events/event-{$event->id}.json" => $this->encodeForExport(
+                        Arr::except($event->toArray(), ['user_id'])
+                    ),
+                ];
+            });
+
+        return $exportData;
+    }
+
+    /**
+     * Strip the PII (email address and any provider reason text) from the
+     * user's bounce events, but keep the rows so historical bounce volume and
+     * "recovered" counts remain accurate.
+     */
+    public function anonymize(): void
+    {
+        EmailBounceEvent::query()
+            ->where('user_id', $this->user->id)
+            ->update([
+                'email' => '',
+                'reason' => null,
+            ]);
+    }
+
+    public function delete(): void
+    {
+        EmailBounceEvent::query()
+            ->where('user_id', $this->user->id)
+            ->delete();
+    }
+}

--- a/extensions/gdpr/src/DataProcessor.php
+++ b/extensions/gdpr/src/DataProcessor.php
@@ -29,6 +29,7 @@ final class DataProcessor
         Data\Posts::class => null,
         Data\Tokens::class => null,
         Data\Discussions::class => null,
+        Data\EmailBounceEvents::class => null,
         Data\User::class => null, // Ought to be last at all times.
     ];
 

--- a/extensions/gdpr/src/FilterAnonymizedRecipients.php
+++ b/extensions/gdpr/src/FilterAnonymizedRecipients.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr;
+
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\User\User;
+
+/**
+ * Removes anonymized (erased) users from notification recipients. Their email
+ * address is a non-routable placeholder and they have no reason to receive
+ * notifications, so mailing them only wastes sends and risks bounces.
+ */
+class FilterAnonymizedRecipients
+{
+    /**
+     * @param User[] $recipients
+     * @return User[]
+     */
+    public function __invoke(BlueprintInterface $blueprint, array $recipients): array
+    {
+        return array_values(array_filter($recipients, fn (User $user) => ! $user->anonymized));
+    }
+}

--- a/extensions/gdpr/tests/integration/api/DeleteUserTest.php
+++ b/extensions/gdpr/tests/integration/api/DeleteUserTest.php
@@ -171,4 +171,57 @@ class DeleteUserTest extends TestCase
         $this->assertEquals('/data/attributes/mode', $data['errors'][0]['source']['pointer']);
         $this->assertStringContainsString('invalid-mode', $data['errors'][0]['detail']);
     }
+
+    #[Test]
+    public function anonymization_scrubs_email_from_bounce_events_but_keeps_the_row()
+    {
+        $this->database()->table('email_bounce_events')->insert([
+            'email' => 'normal@machine.local',
+            'user_id' => 2,
+            'type' => 'bounce',
+            'reason' => 'Mailbox does not exist',
+            'created_at' => \Carbon\Carbon::now(),
+        ]);
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/users/2', [
+                'authenticatedAs' => 1,
+                'json' => ['gdprMode' => ErasureRequest::MODE_ANONYMIZATION],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $event = \Flarum\Mail\EmailBounceEvent::where('user_id', 2)->first();
+
+        // Row is retained (for statistics) but the PII email is scrubbed.
+        $this->assertNotNull($event, 'The bounce event row should be kept.');
+        $this->assertSame('', $event->email);
+        $this->assertNull($event->reason);
+        $this->assertEquals(2, $event->user_id);
+    }
+
+    #[Test]
+    public function deletion_removes_bounce_events()
+    {
+        $this->setting('flarum-gdpr.allow-deletion', true);
+
+        $this->database()->table('email_bounce_events')->insert([
+            'email' => 'normal@machine.local',
+            'user_id' => 2,
+            'type' => 'bounce',
+            'reason' => 'Mailbox does not exist',
+            'created_at' => \Carbon\Carbon::now(),
+        ]);
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/users/2', [
+                'authenticatedAs' => 1,
+                'json' => ['gdprMode' => ErasureRequest::MODE_DELETION],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(0, \Flarum\Mail\EmailBounceEvent::where('user_id', 2)->count());
+    }
 }

--- a/extensions/gdpr/tests/integration/api/ListDataTypesControllerTest.php
+++ b/extensions/gdpr/tests/integration/api/ListDataTypesControllerTest.php
@@ -53,7 +53,7 @@ class ListDataTypesControllerTest extends TestCase
 
         $body = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertCount(6, $body['data']);
+        $this->assertCount(7, $body['data']);
 
         $this->assertEquals(Forum::class, $body['data'][0]['id']);
         $this->assertEquals(Forum::exportDescription(), $body['data'][0]['attributes']['exportDescription']);

--- a/extensions/gdpr/tests/unit/FilterAnonymizedRecipientsTest.php
+++ b/extensions/gdpr/tests/unit/FilterAnonymizedRecipientsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\tests\unit;
+
+use Flarum\Gdpr\FilterAnonymizedRecipients;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Testing\unit\TestCase;
+use Flarum\User\User;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+class FilterAnonymizedRecipientsTest extends TestCase
+{
+    private function user(bool $anonymized): User
+    {
+        $user = m::mock(User::class)->makePartial();
+        $user->anonymized = $anonymized;
+
+        return $user;
+    }
+
+    #[Test]
+    public function anonymized_users_are_removed_and_others_kept(): void
+    {
+        $normal = $this->user(false);
+        $anon = $this->user(true);
+
+        $filter = new FilterAnonymizedRecipients();
+        $result = $filter(m::mock(BlueprintInterface::class), [$normal, $anon]);
+
+        $this->assertSame([$normal], $result);
+    }
+
+    #[Test]
+    public function returns_all_when_none_anonymized(): void
+    {
+        $a = $this->user(false);
+        $b = $this->user(false);
+
+        $filter = new FilterAnonymizedRecipients();
+
+        $this->assertSame([$a, $b], $filter(m::mock(BlueprintInterface::class), [$a, $b]));
+    }
+}

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -89,8 +89,10 @@
         "symfony/mime": "^7.0",
         "symfony/polyfill-intl-messageformatter": "^1.27",
         "symfony/postmark-mailer": "^7.0",
+        "symfony/remote-event": "^7.0",
         "symfony/translation": "^7.0",
         "symfony/translation-contracts": "^2.5",
+        "symfony/webhook": "^7.0",
         "symfony/yaml": "^7.0",
         "wikimedia/less.php": "^5.3"
     },

--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -2,6 +2,7 @@ import app from '../../admin/app';
 import StatusWidget from './StatusWidget';
 import ExtensionsWidget from './ExtensionsWidget';
 import AnnouncementsWidget from './AnnouncementsWidget';
+import EmailBounceWidget from './EmailBounceWidget';
 import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { Children } from 'mithril';
@@ -112,6 +113,11 @@ export default class DashboardPage extends AdminPage {
 
     if (!app.data.announcementsDisabled) {
       items.add('announcements', <AnnouncementsWidget />, 70);
+    }
+
+    // Only when the active mail driver can actually report bounces.
+    if (app.forum.attribute('mailDriverSupportsBounceReporting')) {
+      items.add('emailBounces', <EmailBounceWidget />, 60);
     }
 
     items.add('extensions', <ExtensionsWidget />, 10);

--- a/framework/core/js/src/admin/components/EmailBounceWidget.tsx
+++ b/framework/core/js/src/admin/components/EmailBounceWidget.tsx
@@ -1,0 +1,143 @@
+import app from '../../admin/app';
+import DashboardWidget from './DashboardWidget';
+import type { IDashboardWidgetAttrs } from './DashboardWidget';
+import type Mithril from 'mithril';
+import Icon from '../../common/components/Icon';
+import Button from '../../common/components/Button';
+import Tooltip from '../../common/components/Tooltip';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Link from '../../common/components/Link';
+
+interface BounceStats {
+  hour: number;
+  week: number;
+  month: number;
+  total: number;
+  affected: number;
+  recovered: number;
+  configured: boolean;
+}
+
+export default class EmailBounceWidget extends DashboardWidget {
+  stats: BounceStats | null = null;
+  loading = false;
+  loadError = false;
+
+  oninit(vnode: Mithril.Vnode<IDashboardWidgetAttrs, this>) {
+    super.oninit(vnode);
+    this.load();
+  }
+
+  className() {
+    return 'EmailBounceWidget';
+  }
+
+  async load() {
+    this.loading = true;
+    this.loadError = false;
+    m.redraw();
+
+    try {
+      const data = (await app.request({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/mail/bounce-stats',
+      })) as unknown as BounceStats;
+      this.stats = data;
+    } catch (e) {
+      this.loadError = true;
+    } finally {
+      this.loading = false;
+      m.redraw();
+    }
+  }
+
+  content() {
+    return (
+      <>
+        <div className="EmailBounceWidget-header">
+          <h2 className="EmailBounceWidget-title">
+            <Icon name="fas fa-envelope-open-text" />
+            {app.translator.trans('core.admin.email_bounces.title')}
+            <Tooltip text={app.translator.trans('core.admin.email_bounces.about')}>
+              <span className="EmailBounceWidget-info">
+                <Icon name="fas fa-info-circle" />
+              </span>
+            </Tooltip>
+          </h2>
+          <div className="EmailBounceWidget-controls">
+            <Tooltip text={app.translator.trans('core.admin.email_bounces.refresh')}>
+              <Button
+                className="Button Button--icon"
+                icon={this.loading ? 'fas fa-sync-alt fa-spin' : 'fas fa-sync-alt'}
+                disabled={this.loading}
+                onclick={() => this.load()}
+              />
+            </Tooltip>
+          </div>
+        </div>
+        {this.body()}
+      </>
+    );
+  }
+
+  body(): Mithril.Children {
+    if (this.loading && !this.stats) {
+      return <LoadingIndicator />;
+    }
+
+    if (this.loadError) {
+      return <p className="EmailBounceWidget-error">{app.translator.trans('core.admin.email_bounces.load_error')}</p>;
+    }
+
+    if (!this.stats) {
+      return null;
+    }
+
+    // Event-volume counts over each time window.
+    const periods: Array<{ key: keyof BounceStats; label: string }> = [
+      { key: 'hour', label: app.translator.trans('core.admin.email_bounces.period_hour', {}, true) },
+      { key: 'week', label: app.translator.trans('core.admin.email_bounces.period_week', {}, true) },
+      { key: 'month', label: app.translator.trans('core.admin.email_bounces.period_month', {}, true) },
+      { key: 'total', label: app.translator.trans('core.admin.email_bounces.period_total', {}, true) },
+    ];
+
+    return (
+      <div className="EmailBounceWidget-body">
+        {!this.stats.configured && (
+          <div className="EmailBounceWidget-notConfigured">
+            <Icon name="fas fa-exclamation-triangle" />
+            <span>
+              {app.translator.trans('core.admin.email_bounces.not_configured', {
+                a: <Link href={app.route('mail')} />,
+              })}
+            </span>
+          </div>
+        )}
+        <div className="EmailBounceWidget-figures">
+          {periods.map((period) => (
+            <div className="EmailBounceWidget-figure" key={period.key}>
+              <div className="EmailBounceWidget-figureCount">{this.stats![period.key].toLocaleString()}</div>
+              <div className="EmailBounceWidget-figureLabel">{period.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Current status: how many addresses are still broken vs recovered. */}
+        <div className="EmailBounceWidget-status">
+          <span className="EmailBounceWidget-status-affected">
+            {app.translator.trans('core.admin.email_bounces.affected', { count: this.stats.affected })}
+          </span>
+          <span className="EmailBounceWidget-status-recovered">
+            {app.translator.trans('core.admin.email_bounces.recovered', { count: this.stats.recovered })}
+          </span>
+        </div>
+
+        {this.stats.affected > 0 && (
+          <Link className="EmailBounceWidget-viewAll" href={app.route('users', { filter: 'is:bounced' })}>
+            {app.translator.trans('core.admin.email_bounces.view_affected')}
+          </Link>
+        )}
+      </div>
+    );
+  }
+}

--- a/framework/core/js/src/admin/components/MailPage.tsx
+++ b/framework/core/js/src/admin/components/MailPage.tsx
@@ -17,15 +17,18 @@ export interface MailSettings {
       fields: Record<string, any>;
       sending: boolean;
       errors: any[];
+      canReceiveWebhooks: boolean;
+      canProvisionWebhooks: boolean;
     };
   };
 }
 
 export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   sendingTest = false;
-  status?: { sending: boolean; errors: any };
+  status?: { sending: boolean; errors: any; canReceiveWebhooks: boolean; canProvisionWebhooks: boolean };
   driverFields?: Record<string, any>;
   testEmailSuccessAlert?: AlertIdentifier;
+  provisioningWebhook = false;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
@@ -45,7 +48,7 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
   refresh() {
     this.loading = true;
 
-    this.status = { sending: false, errors: {} };
+    this.status = { sending: false, errors: {}, canReceiveWebhooks: false, canProvisionWebhooks: false };
 
     app
       .request<MailSettings>({
@@ -56,6 +59,8 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
         this.driverFields = response.data.attributes.fields;
         this.status!.sending = response.data.attributes.sending;
         this.status!.errors = response.data.attributes.errors;
+        this.status!.canReceiveWebhooks = response.data.attributes.canReceiveWebhooks;
+        this.status!.canProvisionWebhooks = response.data.attributes.canProvisionWebhooks;
 
         this.loading = false;
         m.redraw();
@@ -86,7 +91,32 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
             </Button>
           </FieldSet>
         </Form>
+        {this.status!.canReceiveWebhooks && this.bounceHandlingForm()}
       </>
+    );
+  }
+
+  bounceHandlingForm(): Mithril.Children {
+    return (
+      <Form>
+        <FieldSet
+          label={app.translator.trans('core.admin.email.bounce_handling_heading')}
+          className="FieldSet--col MailPage-MailSettings"
+          description={app.translator.trans('core.admin.email.bounce_handling_text')}
+        >
+          {this.buildSettingComponent({
+            type: 'bool',
+            setting: 'mail_suppress_bounced',
+            label: app.translator.trans('core.admin.email.suppress_bounced_label'),
+            help: app.translator.trans('core.admin.email.suppress_bounced_help'),
+          })}
+          {this.status!.canProvisionWebhooks && (
+            <Button className="Button" disabled={this.provisioningWebhook || this.isChanged()} onclick={() => this.provisionWebhook()}>
+              {app.translator.trans('core.admin.email.register_webhook_button')}
+            </Button>
+          )}
+        </FieldSet>
+      </Form>
     );
   }
 
@@ -225,6 +255,28 @@ export default class MailPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
       })
       .catch((error) => {
         this.sendingTest = false;
+        m.redraw();
+        throw error;
+      });
+  }
+
+  provisionWebhook() {
+    if (this.provisioningWebhook) return;
+
+    this.provisioningWebhook = true;
+
+    app
+      .request({
+        method: 'POST',
+        url: app.forum.attribute('apiUrl') + '/mail/webhook/provision',
+      })
+      .then(() => {
+        this.provisioningWebhook = false;
+        app.alerts.show({ type: 'success' }, app.translator.trans('core.admin.email.register_webhook_success'));
+        m.redraw();
+      })
+      .catch((error) => {
+        this.provisioningWebhook = false;
         m.redraw();
         throw error;
       });

--- a/framework/core/js/src/admin/components/UserListPage.tsx
+++ b/framework/core/js/src/admin/components/UserListPage.tsx
@@ -1,4 +1,5 @@
 import Mithril from 'mithril';
+import dayjs from 'dayjs';
 
 import app from '../../admin/app';
 
@@ -82,6 +83,13 @@ export default class UserListPage extends AdminPage {
 
   oninit(vnode: Mithril.Vnode<IPageAttrs, this>) {
     super.oninit(vnode);
+
+    // Allow deep-linking to a pre-filled search, e.g. from the dashboard
+    // bounce widget linking to `is:bounced`.
+    const filter = m.route.param('filter');
+    if (filter) {
+      this.query = filter;
+    }
 
     // Get page query value from URL
     const page = parseInt(m.route.param('page'));
@@ -376,6 +384,36 @@ export default class UserListPage extends AdminPage {
       },
       70
     );
+
+    // Only meaningful when the active mail driver can actually report bounces.
+    // With drivers that can't (e.g. SMTP/Sendmail), every user would read the
+    // same and imply monitoring that isn't happening — so we omit the column.
+    if (app.forum.attribute('mailDriverSupportsBounceReporting')) {
+      columns.add(
+        'emailBounced',
+        {
+          name: app.translator.trans('core.admin.users.grid.columns.email_bounced.title'),
+          content: (user: User) => {
+            const bouncedAt = user.emailBouncedAt();
+
+            if (!bouncedAt) {
+              // Absence of a reported bounce — NOT a positive "delivered"
+              // signal, so we render a neutral dash rather than "OK".
+              return <span className="UserList-emailDelivery-ok">—</span>;
+            }
+
+            return (
+              <span className="UserList-emailDelivery-bounced" title={dayjs(bouncedAt).format('LLL')}>
+                {user.emailBounceReason() || app.translator.trans('core.admin.users.grid.columns.email_bounced.bounced')}
+                {' — '}
+                {dayjs(bouncedAt).fromNow()}
+              </span>
+            );
+          },
+        },
+        65
+      );
+    }
 
     columns.add(
       'userActions',

--- a/framework/core/js/src/common/GambitManager.ts
+++ b/framework/core/js/src/common/GambitManager.ts
@@ -5,6 +5,7 @@ import HiddenGambit from './query/discussions/HiddenGambit';
 import UnreadGambit from './query/discussions/UnreadGambit';
 import EmailGambit from './query/users/EmailGambit';
 import GroupGambit from './query/users/GroupGambit';
+import BouncedGambit from './query/users/BouncedGambit';
 import DiscussionGambit from './query/discussions/DiscussionGambit';
 
 /**
@@ -17,7 +18,7 @@ export default class GambitManager {
   gambits: Record<string, Array<new () => IGambit>> = {
     discussions: [AuthorGambit, CreatedGambit, HiddenGambit, UnreadGambit],
     posts: [AuthorGambit, DiscussionGambit],
-    users: [EmailGambit, GroupGambit],
+    users: [EmailGambit, GroupGambit, BouncedGambit],
   };
 
   public apply(type: string, filter: Record<string, any>): Record<string, any> {

--- a/framework/core/js/src/common/models/User.tsx
+++ b/framework/core/js/src/common/models/User.tsx
@@ -26,6 +26,13 @@ export default class User extends Model {
     return Model.attribute<boolean | undefined>('isEmailConfirmed').call(this);
   }
 
+  emailBouncedAt() {
+    return Model.attribute('emailBouncedAt', Model.transformDate).call(this) as Date | null | undefined;
+  }
+  emailBounceReason() {
+    return Model.attribute<string | null | undefined>('emailBounceReason').call(this);
+  }
+
   password() {
     return Model.attribute<string | undefined>('password').call(this);
   }

--- a/framework/core/js/src/common/query/users/BouncedGambit.ts
+++ b/framework/core/js/src/common/query/users/BouncedGambit.ts
@@ -1,0 +1,17 @@
+import app from '../../app';
+import { BooleanGambit } from '../IGambit';
+
+export default class BouncedGambit extends BooleanGambit {
+  key(): string {
+    return app.translator.trans('core.lib.gambits.users.bounced.key', {}, true);
+  }
+
+  filterKey(): string {
+    return 'bounced';
+  }
+
+  enabled(): boolean {
+    // Only meaningful to admins, who can see bounce state and manage users.
+    return !!app.session.user?.isAdmin();
+  }
+}

--- a/framework/core/js/src/forum/components/Notices.tsx
+++ b/framework/core/js/src/forum/components/Notices.tsx
@@ -40,6 +40,26 @@ export default class Notices extends Component {
       );
     }
 
+    if (user && user.emailBouncedAt()) {
+      items.add(
+        'emailBounced',
+        <Alert
+          type="error"
+          dismissible={false}
+          controls={[
+            <Button className="Button Button--link" onclick={() => app.modal.show(() => import('./ChangeEmailModal'))}>
+              {app.translator.trans('core.forum.user_email_bounced.update_button')}
+            </Button>,
+          ]}
+          className="Alert--emailBounced"
+          containerClassName="container"
+        >
+          {app.translator.trans('core.forum.user_email_bounced.alert_message', { email: <strong>{user.email()}</strong> })}
+        </Alert>,
+        95
+      );
+    }
+
     if (app.data.bisecting) {
       items.add(
         'bisecting',

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -6,6 +6,7 @@
 @import "admin/AdvancedPage";
 @import "admin/CreateUserModal";
 @import "admin/DashboardPage";
+@import "admin/EmailBounceWidget";
 @import "admin/AlertWidget";
 @import "admin/FormSectionGroup";
 @import "admin/BasicsPage";

--- a/framework/core/less/admin/EmailBounceWidget.less
+++ b/framework/core/less/admin/EmailBounceWidget.less
@@ -1,0 +1,128 @@
+.EmailBounceWidget {
+  padding: 0;
+}
+
+.EmailBounceWidget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 20px;
+}
+
+.EmailBounceWidget-controls {
+  > .Button {
+    margin-left: 8px;
+  }
+}
+
+.EmailBounceWidget-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 20px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-color);
+
+  .icon {
+    font-size: 12px;
+    opacity: 0.7;
+  }
+}
+
+.EmailBounceWidget-info {
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  opacity: 0.4;
+  font-size: 11px;
+  transition: opacity 0.15s;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.EmailBounceWidget-body {
+  padding: 0 20px 16px;
+}
+
+.EmailBounceWidget-figures {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.EmailBounceWidget-figure {
+  text-align: center;
+  padding: 12px 8px;
+  border-radius: var(--border-radius);
+  background: var(--control-bg);
+}
+
+.EmailBounceWidget-figureCount {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.EmailBounceWidget-figureLabel {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--muted-color);
+}
+
+.EmailBounceWidget-notConfigured {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius);
+  background: var(--alert-warning-bg, fade(#f5a623, 12%));
+  color: var(--alert-warning-color, inherit);
+  font-size: 13px;
+
+  .icon {
+    color: #f5a623;
+  }
+}
+
+.EmailBounceWidget-status {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  margin-top: 12px;
+  font-size: 13px;
+
+  &-affected {
+    font-weight: 600;
+  }
+
+  &-recovered {
+    color: var(--muted-color);
+
+    &::before {
+      content: "·";
+      margin-right: 6px;
+    }
+  }
+}
+
+.EmailBounceWidget-viewAll {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.EmailBounceWidget-error {
+  padding: 0 20px 16px;
+  color: var(--muted-color);
+}
+
+@media @phone {
+  .EmailBounceWidget-figures {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -284,6 +284,8 @@ core:
     # These translations are used in the email page of the admin interface.
     email:
       addresses_heading: Addresses
+      bounce_handling_heading: Bounce Handling
+      bounce_handling_text: "When your mail provider reports that an address permanently bounced or was marked as spam, Flarum can flag the affected user and optionally stop emailing them, protecting your sender reputation."
       description: "Configure the driver, settings and addresses your forum will use to send email."
       driver_heading: Choose a Driver
       driver_label: Driver
@@ -302,6 +304,8 @@ core:
       mail_mailgun_domain_label: Domain
       mail_mailgun_region_label: Region
       mail_mailgun_secret_label: Secret key
+      mail_mailgun_webhook_signing_key_label: Webhook signing key
+      mail_mailgun_webhook_signing_key_help: "Mailgun's HTTP webhook signing key, used to verify incoming bounce/complaint webhooks. Found in your Mailgun dashboard under Settings → Webhooks. Required for bounce handling."
       mail_password_label: => core.ref.password
       mail_port_label: Port
       mail_postmark_message_stream_label: Message stream
@@ -310,16 +314,36 @@ core:
       mail_smtp_verify_peer_help: "Verify the server's SSL certificate when using TLS or SSL encryption. Disable only if your mail server uses a self-signed certificate."
       mail_username_label: => core.ref.username
       mailgun_heading: Mailgun Settings
+      mailgun_description: "Send email via Mailgun's HTTP API. Enter the domain and secret key from your Mailgun account, and choose the region matching your domain."
       postmark_heading: Postmark Settings
       postmark_description: "Send email via Postmark's HTTP API. Optionally specify a message stream to use a non-default stream."
       not_sending_message: Flarum currently does not send emails. This can be due to the selected driver, or errors in its configuration.
+      register_webhook_button: Register webhook with provider
+      register_webhook_success: "Webhook registered with your mail provider."
       send_test_mail_button: Send
       send_test_mail_heading: Send Test Mail
       send_test_mail_success: "Test mail sent successfully!"
       send_test_mail_text: "This will send an email using the above configuration to your email, {email}."
       smtp_heading: SMTP Settings
       smtp_description: "Configure SMTP connection settings. Common configurations: Port 587 with TLS, or Port 465 with SSL."
+      suppress_bounced_label: Stop emailing bounced addresses
+      suppress_bounced_help: "When enabled, users whose address has bounced or filed a spam complaint will be skipped when sending notification emails, until they update and confirm their address."
       title: => core.ref.email
+
+    # These translations are used in the email bounces dashboard widget.
+    email_bounces:
+      title: Email Bounces
+      about: "Bounce and spam-complaint events reported by your mail provider, counted over each period. Includes events for users who have since fixed their address."
+      refresh: Refresh
+      load_error: Could not load bounce statistics. Please try again later.
+      period_hour: Past hour
+      period_week: Past week
+      period_month: Past month
+      period_total: All time
+      affected: "{count, plural, =0 {No addresses currently affected} one {# address currently affected} other {# addresses currently affected}}"
+      recovered: "{count, plural, =0 {none recovered} one {# recovered} other {# recovered}}"
+      not_configured: "Bounce handling isn't fully set up, so no bounces will be received. <a>Check your email settings.</a>"
+      view_affected: View affected users
 
     # These translations are used on default extension pages.
     extension:
@@ -484,6 +508,10 @@ core:
             title: => core.ref.email
             visibility_hide: Hide email address
             visibility_show: Show email address
+
+          email_bounced:
+            title: Email delivery
+            bounced: Delivery failed
 
           group_badges:
             no_badges: None
@@ -800,6 +828,10 @@ core:
       toggle_dropdown_accessible_label: Toggle user controls dropdown menu
 
     # These translations are used in the alert that is shown when a new user has not confirmed their email address.
+    user_email_bounced:
+      alert_message: We couldn't deliver email to {email}. Please update your email address so you don't miss important notifications.
+      update_button: Update Email
+
     user_email_confirmation:
       alert_message: => core.ref.confirmation_email_sent
       resend_button: Resend Confirmation Email
@@ -886,6 +918,8 @@ core:
           key: discussion
           hint: the ID of the discussion
       users:
+        bounced:
+          key: bounced
         email:
           key: email
           hint: example@machine.local

--- a/framework/core/migrations/2026_07_23_000000_add_email_bounce_to_users.php
+++ b/framework/core/migrations/2026_07_23_000000_add_email_bounce_to_users.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('users', function (Blueprint $table) {
+            $table->timestamp('email_bounced_at')->nullable()->after('is_email_confirmed');
+            $table->string('email_bounce_reason')->nullable()->after('email_bounced_at');
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('users', function (Blueprint $table) {
+            $table->dropColumn(['email_bounced_at', 'email_bounce_reason']);
+        });
+    },
+];

--- a/framework/core/migrations/2026_07_23_000001_create_email_bounce_events_table.php
+++ b/framework/core/migrations/2026_07_23_000001_create_email_bounce_events_table.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return Migration::createTable(
+    'email_bounce_events',
+    function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('email');
+        // Nullable: the address may not map to a user, and the user may later
+        // be deleted/anonymized without losing the historical event.
+        $table->unsignedInteger('user_id')->nullable();
+        $table->string('type'); // 'bounce' | 'complaint'
+        $table->string('reason')->nullable();
+        $table->timestamp('created_at');
+
+        $table->index('created_at');
+        $table->index('user_id');
+
+        $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+    }
+);

--- a/framework/core/src/Api/Controller/ProvisionMailWebhookController.php
+++ b/framework/core/src/Api/Controller/ProvisionMailWebhookController.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Http\UrlGenerator;
+use Flarum\Mail\ProvisionsWebhooks;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Registers or unregisters the delivery-event webhook with the active mail
+ * driver's provider, so the admin never has to visit the provider dashboard.
+ */
+class ProvisionMailWebhookController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected Container $container,
+        protected SettingsRepositoryInterface $settings,
+        protected UrlGenerator $url,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $driver = $this->container->make('flarum.mail.configured_driver');
+
+        if (! $driver instanceof ProvisionsWebhooks) {
+            return new JsonResponse([
+                'error' => 'The active mail driver does not support webhook provisioning.',
+            ], 422);
+        }
+
+        $webhookUrl = $this->url->to('forum')->route('mailWebhook', [
+            'driver' => $this->settings->get('mail_driver'),
+        ]);
+
+        $unregister = (bool) Arr::get($request->getParsedBody(), 'unregister', false);
+
+        try {
+            if ($unregister) {
+                $driver->unregisterWebhook($this->settings, $webhookUrl);
+            } else {
+                $driver->registerWebhook($this->settings, $webhookUrl);
+            }
+        } catch (\Throwable $e) {
+            return new JsonResponse([
+                'error' => $e->getMessage(),
+            ], 502);
+        }
+
+        return new JsonResponse([
+            'registered' => ! $unregister,
+            'url' => $webhookUrl,
+        ]);
+    }
+}

--- a/framework/core/src/Api/Controller/ShowEmailBounceStatsController.php
+++ b/framework/core/src/Api/Controller/ShowEmailBounceStatsController.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Carbon\Carbon;
+use Flarum\Http\RequestUtil;
+use Flarum\Mail\EmailBounceEvent;
+use Flarum\Mail\HandlesWebhooks;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use Illuminate\Contracts\Container\Container;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Returns counts of bounce/complaint events grouped by how recently they
+ * occurred. These are true event counts from the historical log, so they
+ * reflect volume over each window even after affected users fix their address.
+ */
+class ShowEmailBounceStatsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected Container $container,
+        protected SettingsRepositoryInterface $settings,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $now = Carbon::now();
+
+        return new JsonResponse([
+            'hour' => $this->countSince($now->copy()->subHour()),
+            'week' => $this->countSince($now->copy()->subWeek()),
+            'month' => $this->countSince($now->copy()->subMonth()),
+            'total' => EmailBounceEvent::count(),
+            // Whether the inbound return path is actually usable: the driver
+            // can receive webhooks AND a signing secret is configured (without
+            // it, incoming webhooks are rejected and no bounces are recorded).
+            'configured' => $this->webhookConfigured(),
+            // Users still flagged as bounced right now (unresolved).
+            'affected' => User::whereNotNull('email_bounced_at')->count(),
+            // Users who had a bounce event but are no longer flagged — i.e.
+            // they fixed their address. Distinct users, from the event log.
+            'recovered' => EmailBounceEvent::query()
+                ->whereNotNull('user_id')
+                ->whereIn('user_id', User::whereNull('email_bounced_at')->select('id'))
+                ->distinct()
+                ->count('user_id'),
+        ]);
+    }
+
+    protected function countSince(Carbon $since): int
+    {
+        return EmailBounceEvent::where('created_at', '>=', $since)->count();
+    }
+
+    protected function webhookConfigured(): bool
+    {
+        $driver = $this->container->make('flarum.mail.configured_driver');
+
+        // The driver decides what "configured" means for its provider (Mailgun
+        // needs a signing key; Postmark needs nothing beyond IP verification).
+        return $driver instanceof HandlesWebhooks
+            && $driver->webhookConfigured($this->settings);
+    }
+}

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -17,7 +17,9 @@ use Flarum\Foundation\Application;
 use Flarum\Foundation\Config;
 use Flarum\Group\Group;
 use Flarum\Http\UrlGenerator;
+use Flarum\Mail\HandlesWebhooks;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -37,6 +39,7 @@ class ForumResource extends AbstractResource implements Findable
         protected UrlGenerator $url,
         protected SettingsRepositoryInterface $settings,
         protected Config $config,
+        protected Container $container,
         Factory $filesystemFactory
     ) {
         $this->assetsFilesystem = $filesystemFactory->disk('flarum-assets');
@@ -140,6 +143,9 @@ class ForumResource extends AbstractResource implements Findable
             Schema\Str::make('version')
                 ->visible(fn ($model, Context $context) => $context->getActor()->can('administrate'))
                 ->get(fn () => Application::VERSION),
+            Schema\Boolean::make('mailDriverSupportsBounceReporting')
+                ->visible(fn ($model, Context $context) => $context->getActor()->can('administrate'))
+                ->get(fn () => $this->container->make('flarum.mail.configured_driver') instanceof HandlesWebhooks),
 
             Schema\Relationship\ToMany::make('groups')
                 ->includable()

--- a/framework/core/src/Api/Resource/MailSettingResource.php
+++ b/framework/core/src/Api/Resource/MailSettingResource.php
@@ -13,6 +13,8 @@ use Flarum\Api\Endpoint;
 use Flarum\Api\Resource\Contracts\Findable;
 use Flarum\Api\Schema;
 use Flarum\Mail\DriverInterface;
+use Flarum\Mail\HandlesWebhooks;
+use Flarum\Mail\ProvisionsWebhooks;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory;
@@ -83,6 +85,10 @@ class MailSettingResource extends AbstractResource implements Findable
 
                     return $configured->validate($this->settings, $this->validator);
                 }),
+            Schema\Boolean::make('canReceiveWebhooks')
+                ->get(fn () => $this->container->make('flarum.mail.configured_driver') instanceof HandlesWebhooks),
+            Schema\Boolean::make('canProvisionWebhooks')
+                ->get(fn () => $this->container->make('flarum.mail.configured_driver') instanceof ProvisionsWebhooks),
         ];
     }
 }

--- a/framework/core/src/Api/Resource/UserResource.php
+++ b/framework/core/src/Api/Resource/UserResource.php
@@ -214,6 +214,27 @@ class UserResource extends AbstractDatabaseResource
                         $user->activate();
                     }
                 }),
+
+            Schema\DateTime::make('emailBouncedAt')
+                // Visible to the user themselves (so the forum can prompt them
+                // to fix their address) and to admins who can edit credentials.
+                ->visible(function (User $user, Context $context) {
+                    return $context->getActor()->id === $user->id
+                        || $context->getActor()->can('editCredentials', $user);
+                })
+                // Admins can clear a bounce flag (e.g. a provider glitch) by
+                // writing null; they cannot set an arbitrary bounce timestamp.
+                ->writable(fn (User $user, Context $context) => $context->getActor()->isAdmin())
+                ->set(function (User $user, $value, Context $context) {
+                    if (empty($value)) {
+                        $user->clearEmailBounce();
+                    }
+                }),
+
+            Schema\Str::make('emailBounceReason')
+                // Reason is only exposed to admins; the user just needs to know
+                // that delivery failed, not the raw provider message.
+                ->visible(fn (User $user, Context $context) => $context->getActor()->can('editCredentials', $user)),
             Schema\Str::make('password')
                 ->requiredOnCreateWithout(['token'])
                 ->validationMessages([

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -204,6 +204,20 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\SendTestMailController::class)
     );
 
+    // Register/unregister the delivery-event webhook with the mail provider
+    $map->post(
+        '/mail/webhook/provision',
+        'mailWebhook.provision',
+        $route->toController(Controller\ProvisionMailWebhookController::class)
+    );
+
+    // Email bounce counts for the admin dashboard widget
+    $map->get(
+        '/mail/bounce-stats',
+        'mailBounceStats',
+        $route->toController(Controller\ShowEmailBounceStatsController::class)
+    );
+
     // Trigger a sync of the abandoned extensions list
     $map->post(
         '/extensions/abandoned/sync',

--- a/framework/core/src/Forum/routes.php
+++ b/framework/core/src/Forum/routes.php
@@ -120,4 +120,10 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         'savePassword',
         $route->toController(Controller\SavePasswordController::class)
     );
+
+    $map->post(
+        '/mail/webhook[/{driver}]',
+        'mailWebhook',
+        $route->toController(\Flarum\Mail\WebhookController::class)
+    );
 };

--- a/framework/core/src/Http/HttpServiceProvider.php
+++ b/framework/core/src/Http/HttpServiceProvider.php
@@ -27,7 +27,9 @@ class HttpServiceProvider extends AbstractServiceProvider
     public function register(): void
     {
         $this->container->singleton('flarum.http.csrfExemptPaths', function () {
-            return ['token', 'registration-token'];
+            // 'mailWebhook' is authenticated by the provider's request signature,
+            // not a session, so it cannot supply a CSRF token.
+            return ['token', 'registration-token', 'mailWebhook'];
         });
 
         $this->container->bind(Middleware\CheckCsrfToken::class, function (Container $container) {

--- a/framework/core/src/Mail/EmailBounceEvent.php
+++ b/framework/core/src/Mail/EmailBounceEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Database\AbstractModel;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A historical record of a single bounce or complaint event reported by the
+ * mail provider. Unlike the flag on the user, these rows persist even after
+ * the user fixes their address, so they can be counted as true event volume.
+ *
+ * @property int $id
+ * @property string $email
+ * @property int|null $user_id
+ * @property string $type
+ * @property string|null $reason
+ * @property \Carbon\Carbon $created_at
+ * @property-read \Flarum\User\User|null $user
+ */
+class EmailBounceEvent extends AbstractModel
+{
+    public const TYPE_BOUNCE = 'bounce';
+    public const TYPE_COMPLAINT = 'complaint';
+
+    protected $table = 'email_bounce_events';
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'user_id' => 'int',
+        'created_at' => 'datetime',
+    ];
+
+    protected $fillable = ['email', 'user_id', 'type', 'reason', 'created_at'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/framework/core/src/Mail/Event/EmailBounced.php
+++ b/framework/core/src/Mail/Event/EmailBounced.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail\Event;
+
+use Flarum\User\User;
+
+/**
+ * Fired when a mail driver reports that a message to an address permanently
+ * failed to deliver (a hard bounce). Transient/soft failures do NOT fire this.
+ */
+class EmailBounced
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly string $reason,
+        public readonly ?User $recipient = null,
+        public readonly array $raw = [],
+    ) {
+    }
+}

--- a/framework/core/src/Mail/Event/EmailComplained.php
+++ b/framework/core/src/Mail/Event/EmailComplained.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail\Event;
+
+use Flarum\User\User;
+
+/**
+ * Fired when a mail driver reports that a recipient marked a message as spam
+ * (a complaint). Treated at least as seriously as a hard bounce.
+ */
+class EmailComplained
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly string $reason,
+        public readonly ?User $recipient = null,
+        public readonly array $raw = [],
+    ) {
+    }
+}

--- a/framework/core/src/Mail/HandlesWebhooks.php
+++ b/framework/core/src/Mail/HandlesWebhooks.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+
+/**
+ * An optional capability for {@see DriverInterface} implementations whose
+ * provider can push delivery events (bounces, complaints) to Flarum via an
+ * inbound webhook.
+ *
+ * This is intentionally a separate interface, not part of DriverInterface, so
+ * that adding bounce handling never breaks third-party drivers that do not
+ * implement it.
+ *
+ * @public
+ */
+interface HandlesWebhooks
+{
+    /**
+     * The Symfony request parser for this provider. The parser is fully
+     * responsible for **authenticating** the request and normalising the
+     * payload into a {@see \Symfony\Component\RemoteEvent\RemoteEvent}.
+     *
+     * Verification is provider-specific and lives entirely in the parser — it
+     * may check an HMAC signature (Mailgun), an IP allowlist (Postmark, Brevo),
+     * or an SNS certificate (SES). Callers MUST NOT attempt to verify the
+     * request themselves; they should call {@see RequestParserInterface::parse()}
+     * and treat a thrown {@see \Symfony\Component\Webhook\Exception\RejectWebhookException}
+     * as a rejection, and a `null` return as "verified but no actionable event"
+     * (e.g. an SES/SNS subscription-confirmation handshake).
+     */
+    public function getWebhookRequestParser(SettingsRepositoryInterface $settings): RequestParserInterface;
+
+    /**
+     * The secret passed to the parser's `parse()` call, if this provider uses
+     * one. Return null when the provider authenticates by other means (e.g.
+     * Postmark's IP allowlist) — this is a valid, fully-supported state, NOT a
+     * misconfiguration. Providers that require a secret (e.g. Mailgun) reject
+     * the request from within their own parser when it is missing.
+     */
+    public function getWebhookSigningSecret(SettingsRepositoryInterface $settings): ?string;
+
+    /**
+     * Whether inbound webhooks can actually be received and trusted with the
+     * current settings. Drivers that require configuration the admin must
+     * supply (e.g. Mailgun's signing key) should return false until it is set,
+     * so the UI can warn that no bounces will arrive. Drivers that need no such
+     * config (e.g. Postmark, verified by IP) should simply return true.
+     */
+    public function webhookConfigured(SettingsRepositoryInterface $settings): bool;
+}

--- a/framework/core/src/Mail/Listener/StampBouncedUser.php
+++ b/framework/core/src/Mail/Listener/StampBouncedUser.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail\Listener;
+
+use Carbon\Carbon;
+use Flarum\Mail\EmailBounceEvent;
+use Flarum\Mail\Event\EmailBounced;
+use Flarum\Mail\Event\EmailComplained;
+use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * Reacts to bounce/complaint events by (a) logging a historical event row —
+ * which persists even after the user fixes their address — and (b) flagging
+ * the affected user so mail can be suppressed and the state surfaced to admins.
+ */
+class StampBouncedUser
+{
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen(EmailBounced::class, [$this, 'whenEmailBounced']);
+        $events->listen(EmailComplained::class, [$this, 'whenEmailComplained']);
+    }
+
+    public function whenEmailBounced(EmailBounced $event): void
+    {
+        $this->record($event->email, $event->recipient, EmailBounceEvent::TYPE_BOUNCE, $event->reason ?: 'bounced');
+    }
+
+    public function whenEmailComplained(EmailComplained $event): void
+    {
+        $this->record($event->email, $event->recipient, EmailBounceEvent::TYPE_COMPLAINT, $event->reason ?: 'complaint');
+    }
+
+    protected function record(string $email, ?User $user, string $type, string $reason): void
+    {
+        $now = Carbon::now();
+
+        // Always log the event, even if the address maps to no user.
+        EmailBounceEvent::create([
+            'email' => $email,
+            'user_id' => $user?->id,
+            'type' => $type,
+            'reason' => $reason,
+            'created_at' => $now,
+        ]);
+
+        if ($user === null) {
+            return;
+        }
+
+        $user->email_bounced_at = $now;
+        $user->email_bounce_reason = $reason;
+        $user->save();
+    }
+}

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -109,6 +109,8 @@ class MailServiceProvider extends AbstractServiceProvider
     ): void {
         $events->listen(MessageSending::class, MutateEmail::class);
 
+        $events->subscribe(Listener\StampBouncedUser::class);
+
         // Resolve the logo URL via the flarum-assets disk so it stays correct on
         // installs whose assets are served from a remote bucket / CDN — same path
         // ForumResource::getLogoUrl() uses for the frontend.

--- a/framework/core/src/Mail/MailgunDriver.php
+++ b/framework/core/src/Mail/MailgunDriver.php
@@ -10,15 +10,26 @@
 namespace Flarum\Mail;
 
 use Flarum\Settings\SettingsRepositoryInterface;
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\MessageBag;
+use Symfony\Component\Mailer\Bridge\Mailgun\RemoteEvent\MailgunPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
+use Symfony\Component\Mailer\Bridge\Mailgun\Webhook\MailgunRequestParser;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
 
-class MailgunDriver implements DriverInterface
+class MailgunDriver implements DriverInterface, HandlesWebhooks, ProvisionsWebhooks
 {
     use ValidatesMailSettings;
+
+    /**
+     * Delivery-event webhook types Flarum registers with Mailgun. We only care
+     * about permanent (hard) failures and complaints; temporary failures are
+     * deliberately excluded so we never suppress over a transient problem.
+     */
+    protected const WEBHOOK_EVENTS = ['permanent_fail', 'complained'];
 
     public function availableSettings(): array
     {
@@ -29,6 +40,7 @@ class MailgunDriver implements DriverInterface
                 'api.mailgun.net' => 'US',
                 'api.eu.mailgun.net' => 'EU',
             ],
+            'mail_mailgun_webhook_signing_key' => '', // HTTP webhook signing key (verifies inbound webhooks)
         ];
     }
 
@@ -56,5 +68,77 @@ class MailgunDriver implements DriverInterface
             $settings->get('mail_mailgun_secret'),
             $settings->get('mail_mailgun_domain')
         ));
+    }
+
+    public function getWebhookRequestParser(SettingsRepositoryInterface $settings): RequestParserInterface
+    {
+        return new MailgunRequestParser(new MailgunPayloadConverter());
+    }
+
+    public function getWebhookSigningSecret(SettingsRepositoryInterface $settings): ?string
+    {
+        return $settings->get('mail_mailgun_webhook_signing_key') ?: null;
+    }
+
+    public function webhookConfigured(SettingsRepositoryInterface $settings): bool
+    {
+        // Mailgun verifies inbound webhooks with the signing key, so without it
+        // every webhook is rejected — treat as not configured.
+        return $this->getWebhookSigningSecret($settings) !== null;
+    }
+
+    public function registerWebhook(SettingsRepositoryInterface $settings, string $url): void
+    {
+        $client = $this->apiClient($settings);
+
+        // Mailgun keys webhooks by event type, so we PUT each type to make the
+        // call idempotent: updating the URL if the webhook exists, creating it
+        // if it doesn't. Only a 404 is expected/handled — any other non-2xx
+        // (401 bad key, 400 bad payload, …) throws so the caller can surface a
+        // real error instead of reporting a false success.
+        foreach (self::WEBHOOK_EVENTS as $event) {
+            $response = $client->request('PUT', "webhooks/$event", [
+                'form_params' => ['url' => $url],
+                'http_errors' => false,
+            ]);
+
+            $status = $response->getStatusCode();
+
+            if ($status === 404) {
+                // Webhook doesn't exist yet — create it (throws on failure).
+                $client->request('POST', 'webhooks', [
+                    'form_params' => ['id' => $event, 'url' => $url],
+                ]);
+            } elseif ($status < 200 || $status >= 300) {
+                throw new \RuntimeException(sprintf(
+                    'Mailgun rejected the webhook registration for "%s" (HTTP %d): %s',
+                    $event,
+                    $status,
+                    (string) $response->getBody()
+                ));
+            }
+        }
+    }
+
+    public function unregisterWebhook(SettingsRepositoryInterface $settings, string $url): void
+    {
+        $client = $this->apiClient($settings);
+
+        foreach (self::WEBHOOK_EVENTS as $event) {
+            $client->request('DELETE', "webhooks/$event", [
+                'http_errors' => false,
+            ]);
+        }
+    }
+
+    protected function apiClient(SettingsRepositoryInterface $settings): Client
+    {
+        $region = $settings->get('mail_mailgun_region') ?: 'api.mailgun.net';
+        $domain = $settings->get('mail_mailgun_domain');
+
+        return new Client([
+            'base_uri' => "https://$region/v3/domains/$domain/",
+            'auth' => ['api', $settings->get('mail_mailgun_secret')],
+        ]);
     }
 }

--- a/framework/core/src/Mail/PostmarkDriver.php
+++ b/framework/core/src/Mail/PostmarkDriver.php
@@ -12,11 +12,14 @@ namespace Flarum\Mail;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\MessageBag;
+use Symfony\Component\Mailer\Bridge\Postmark\RemoteEvent\PostmarkPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
 
-class PostmarkDriver implements DriverInterface
+class PostmarkDriver implements DriverInterface, HandlesWebhooks
 {
     use ValidatesMailSettings;
 
@@ -59,5 +62,26 @@ class PostmarkDriver implements DriverInterface
             null,
             $options
         ));
+    }
+
+    public function getWebhookRequestParser(SettingsRepositoryInterface $settings): RequestParserInterface
+    {
+        // Postmark authenticates inbound webhooks by verifying the request
+        // originates from its published IP range (handled inside the parser's
+        // request matcher), not by a shared secret.
+        return new PostmarkRequestParser(new PostmarkPayloadConverter());
+    }
+
+    public function getWebhookSigningSecret(SettingsRepositoryInterface $settings): ?string
+    {
+        // Postmark does not use a signing secret; verification is IP-based.
+        return null;
+    }
+
+    public function webhookConfigured(SettingsRepositoryInterface $settings): bool
+    {
+        // Postmark needs no extra webhook config — verification is by IP, and
+        // the admin registers the URL in Postmark's dashboard.
+        return true;
     }
 }

--- a/framework/core/src/Mail/ProvisionsWebhooks.php
+++ b/framework/core/src/Mail/ProvisionsWebhooks.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+
+/**
+ * An optional add-on to {@see HandlesWebhooks} for drivers whose provider
+ * exposes an API to register the webhook, so an admin never has to configure
+ * it manually in the provider's dashboard.
+ *
+ * @public
+ */
+interface ProvisionsWebhooks
+{
+    /**
+     * Register (or update) the delivery-event webhook with the provider,
+     * pointing it at the given Flarum webhook URL. Must be idempotent.
+     *
+     * @throws \Exception if provisioning fails (e.g. bad credentials); the
+     *         caller is responsible for surfacing the error to the admin.
+     */
+    public function registerWebhook(SettingsRepositoryInterface $settings, string $url): void;
+
+    /**
+     * Remove the webhook previously registered for the given Flarum webhook
+     * URL. Should not throw if the webhook does not exist.
+     */
+    public function unregisterWebhook(SettingsRepositoryInterface $settings, string $url): void;
+}

--- a/framework/core/src/Mail/WebhookController.php
+++ b/framework/core/src/Mail/WebhookController.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Mail\Event\EmailBounced;
+use Flarum\Mail\Event\EmailComplained;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\UserRepository;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+/**
+ * Receives inbound delivery-event webhooks (bounces, complaints) from the
+ * active mail driver's provider, verifies them, and dispatches the
+ * corresponding Flarum event so listeners can react.
+ */
+class WebhookController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected Container $container,
+        protected SettingsRepositoryInterface $settings,
+        protected UserRepository $users,
+        protected Dispatcher $events,
+        protected LoggerInterface $logger,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $driver = $this->container->make('flarum.mail.configured_driver');
+
+        // Only the active driver, and only if it can receive webhooks, is
+        // allowed to process them. Anything else is a silent no-op.
+        if (! $driver instanceof HandlesWebhooks) {
+            return new EmptyResponse(404);
+        }
+
+        $requested = Arr::get($request->getQueryParams(), 'driver');
+        $active = $this->settings->get('mail_driver');
+
+        if ($requested !== null && $requested !== $active) {
+            return new EmptyResponse(404);
+        }
+
+        $parser = $driver->getWebhookRequestParser($this->settings);
+        $symfonyRequest = $this->toSymfonyRequest($request);
+
+        // The parser owns ALL verification — HMAC signature (Mailgun), IP
+        // allowlist (Postmark/Brevo), or SNS certificate (SES). We never verify
+        // here, and we must NOT assume a secret is what authenticates: some
+        // providers legitimately have no secret. Pass whatever the driver
+        // supplies (or an empty string); drivers that require it enforce that
+        // themselves and reject via RejectWebhookException.
+        $secret = $driver->getWebhookSigningSecret($this->settings) ?? '';
+
+        try {
+            $event = $parser->parse($symfonyRequest, $secret);
+        } catch (RejectWebhookException $e) {
+            return new EmptyResponse($e->getStatusCode());
+        }
+
+        // A null return means the request was verified and handled but carried
+        // no event we act on — e.g. an SES/SNS subscription-confirmation
+        // handshake, or an event type we ignore. Acknowledge with a 200 either
+        // way so the provider stops retrying.
+        if ($event !== null) {
+            foreach (is_array($event) ? $event : [$event] as $remoteEvent) {
+                $this->handleEvent($remoteEvent);
+            }
+        }
+
+        return new EmptyResponse(200);
+    }
+
+    protected function handleEvent(object $event): void
+    {
+        $email = null;
+        $reason = '';
+
+        if ($event instanceof MailerDeliveryEvent) {
+            // Only permanent failures suppress. DEFERRED (transient),
+            // DELIVERED and RECEIVED are ignored.
+            if (! in_array($event->getName(), [MailerDeliveryEvent::BOUNCE, MailerDeliveryEvent::DROPPED], true)) {
+                return;
+            }
+
+            $email = $event->getRecipientEmail();
+            $reason = $event->getReason();
+            $recipient = $email ? $this->users->findByEmail($email) : null;
+
+            $this->events->dispatch(new EmailBounced($email, $reason, $recipient, $event->getPayload()));
+
+            return;
+        }
+
+        if ($event instanceof MailerEngagementEvent && $event->getName() === MailerEngagementEvent::SPAM) {
+            $email = $event->getRecipientEmail();
+            $recipient = $email ? $this->users->findByEmail($email) : null;
+
+            $this->events->dispatch(new EmailComplained($email, 'complaint', $recipient, $event->getPayload()));
+        }
+    }
+
+    /**
+     * Build the Symfony HttpFoundation request the driver's parser expects,
+     * preserving the method, headers and raw body needed for signature
+     * verification. Avoids pulling in the PSR-7 <-> Symfony bridge dependency.
+     */
+    protected function toSymfonyRequest(ServerRequestInterface $request): SymfonyRequest
+    {
+        $server = [];
+
+        foreach ($request->getHeaders() as $name => $values) {
+            $server['HTTP_'.strtoupper(str_replace('-', '_', $name))] = implode(', ', $values);
+        }
+
+        $server['REQUEST_METHOD'] = $request->getMethod();
+        $server['CONTENT_TYPE'] = $request->getHeaderLine('Content-Type');
+
+        // Preserve the client IP so parsers that verify by IP allowlist
+        // (e.g. Postmark, Brevo) can resolve it via Request::getClientIp().
+        // Flarum's ProcessIp middleware stashes the resolved IP on the
+        // 'ipAddress' attribute; fall back to the raw REMOTE_ADDR.
+        $ip = $request->getAttribute('ipAddress')
+            ?? Arr::get($request->getServerParams(), 'REMOTE_ADDR');
+
+        if ($ip !== null) {
+            $server['REMOTE_ADDR'] = $ip;
+        }
+
+        return new SymfonyRequest(
+            query: $request->getQueryParams(),
+            request: [],
+            attributes: [],
+            cookies: [],
+            files: [],
+            server: $server,
+            content: $this->rawBody($request),
+        );
+    }
+
+    /**
+     * The raw request body as a JSON string. Reads the body stream directly,
+     * but falls back to re-encoding the already-parsed body if an upstream
+     * middleware has consumed the (non-rewindable) stream first — which is
+     * what happens inside Flarum's middleware stack.
+     */
+    protected function rawBody(ServerRequestInterface $request): string
+    {
+        $body = $request->getBody();
+
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+
+        $content = (string) $body;
+
+        if ($content === '' && is_array($parsed = $request->getParsedBody())) {
+            $content = (string) json_encode($parsed);
+        }
+
+        return $content;
+    }
+}

--- a/framework/core/src/Notification/Driver/EmailNotificationDriver.php
+++ b/framework/core/src/Notification/Driver/EmailNotificationDriver.php
@@ -12,6 +12,7 @@ namespace Flarum\Notification\Driver;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Job\SendEmailNotificationJob;
 use Flarum\Notification\MailableInterface;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Queue\Queue;
 use ReflectionClass;
@@ -19,7 +20,8 @@ use ReflectionClass;
 readonly class EmailNotificationDriver implements NotificationDriverInterface
 {
     public function __construct(
-        private Queue $queue
+        private Queue $queue,
+        private SettingsRepositoryInterface $settings,
     ) {
     }
 
@@ -37,7 +39,13 @@ readonly class EmailNotificationDriver implements NotificationDriverInterface
      */
     protected function mailNotifications(MailableInterface&BlueprintInterface $blueprint, array $recipients): void
     {
+        $suppressBounced = (bool) $this->settings->get('mail_suppress_bounced');
+
         foreach ($recipients as $user) {
+            if ($suppressBounced && $user->hasBouncedEmail()) {
+                continue;
+            }
+
             if ($user->shouldEmail($blueprint::getType())) {
                 $this->queue->push(new SendEmailNotificationJob($blueprint, $user));
             }

--- a/framework/core/src/Search/SearchServiceProvider.php
+++ b/framework/core/src/Search/SearchServiceProvider.php
@@ -84,6 +84,7 @@ class SearchServiceProvider extends AbstractServiceProvider
                 UserSearcher::class => [
                     UserFilter\EmailFilter::class,
                     UserFilter\GroupFilter::class,
+                    UserFilter\BouncedFilter::class,
                 ],
                 GroupSearcher::class => [
                     GroupFilter\HiddenFilter::class,

--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -25,6 +25,7 @@ class SettingsServiceProvider extends AbstractServiceProvider
                 'theme_primary_color' => '#4D698E',
                 'theme_secondary_color' => '#4D698E',
                 'mail_format' => 'multipart',
+                'mail_suppress_bounced' => false,
                 'fontawesome_source' => 'local',
                 'maintenance_mode' => 'none',
                 'show_language_selector' => true,

--- a/framework/core/src/User/Search/Filter/BouncedFilter.php
+++ b/framework/core/src/User/Search/Filter/BouncedFilter.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\User\Search\Filter;
+
+use Flarum\Search\Database\DatabaseSearchState;
+use Flarum\Search\Filter\FilterInterface;
+use Flarum\Search\SearchState;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Filters users by whether their email address has bounced or been marked as
+ * spam. Used via the `bounced` gambit, e.g. `is:bounced`.
+ *
+ * @implements FilterInterface<DatabaseSearchState>
+ */
+class BouncedFilter implements FilterInterface
+{
+    public function getFilterKey(): string
+    {
+        return 'bounced';
+    }
+
+    public function filter(SearchState $state, string|array $value, bool $negate): void
+    {
+        if (! $state->getActor()->hasPermission('user.editCredentials')) {
+            return;
+        }
+
+        $this->constrain($state->getQuery(), $negate);
+    }
+
+    protected function constrain(Builder $query, bool $negate): void
+    {
+        // is:bounced   -> email_bounced_at IS NOT NULL (bounced users)
+        // -is:bounced  -> email_bounced_at IS NULL     (everyone else)
+        $query->whereNull('email_bounced_at', 'and', ! $negate);
+    }
+}

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -47,6 +47,8 @@ use Illuminate\Support\Arr;
  * @property string $display_name
  * @property string $email
  * @property bool $is_email_confirmed
+ * @property \Carbon\Carbon|null $email_bounced_at
+ * @property string|null $email_bounce_reason
  * @property string $password
  * @property string|null $avatar_url
  * @property bool $has_avatar_2x
@@ -85,6 +87,7 @@ class User extends AbstractModel
         'last_seen_at' => 'datetime',
         'marked_all_as_read_at' => 'datetime',
         'read_notifications_at' => 'datetime',
+        'email_bounced_at' => 'datetime',
     ];
 
     /**
@@ -216,8 +219,32 @@ class User extends AbstractModel
         if ($email !== $this->email) {
             $this->email = $email;
 
+            // A new address supersedes any bounce recorded against the old one.
+            $this->clearEmailBounce();
+
             $this->raise(new EmailChanged($this));
         }
+
+        return $this;
+    }
+
+    /**
+     * Has mail to this user's address been reported as permanently
+     * undeliverable (a hard bounce) or been marked as spam by the recipient?
+     */
+    public function hasBouncedEmail(): bool
+    {
+        return $this->email_bounced_at !== null;
+    }
+
+    /**
+     * Clear any recorded bounce/complaint state, e.g. once the user has
+     * updated and re-confirmed their address, or an admin has cleared it.
+     */
+    public function clearEmailBounce(): static
+    {
+        $this->email_bounced_at = null;
+        $this->email_bounce_reason = null;
 
         return $this;
     }

--- a/framework/core/tests/integration/mail/PostmarkWebhookBounceTest.php
+++ b/framework/core/tests/integration/mail/PostmarkWebhookBounceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\mail;
+
+use Flarum\Mail\EmailBounceEvent;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
+
+/**
+ * Drives a real Postmark webhook through the actual /mail/webhook route.
+ * Postmark has NO signing secret — it is authenticated by verifying the
+ * request originates from Postmark's published IP range. This exercises the
+ * secret-less, IP-verified path end to end.
+ */
+class PostmarkWebhookBounceTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setting('mail_driver', 'postmark');
+        $this->setting('mail_postmark_token', 'token-abc');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                [
+                    'id' => 3,
+                    'username' => 'bouncer',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email' => 'bouncer@example.com',
+                    'is_email_confirmed' => 1,
+                ],
+            ],
+        ]);
+    }
+
+    private function postmarkPayload(string $recordType, string $recipient): array
+    {
+        $date = '2026-07-23T12:00:00Z';
+
+        return [
+            'RecordType' => $recordType,
+            'MessageID' => 'msg-1',
+            'Recipient' => $recipient,
+            'Email' => $recipient,
+            'Description' => 'The server was unable to deliver your message',
+            'Type' => 'HardBounce',
+            'TypeCode' => 1,
+            // The converter reads a record-type-specific timestamp field.
+            'BouncedAt' => $date,
+            'DeliveredAt' => $date,
+            'ReceivedAt' => $date,
+            'ChangedAt' => $date,
+        ];
+    }
+
+    /**
+     * Build the request manually so we can set REMOTE_ADDR to a Postmark IP —
+     * the request() helper hardcodes empty server params, and Postmark's parser
+     * verifies the source IP.
+     */
+    private function postWebhook(array $payload, ?string $ip = null)
+    {
+        $ip ??= PostmarkRequestParser::PROVIDER_IPS[0];
+
+        $body = new Stream('php://temp', 'wb+');
+        $body->write(json_encode($payload));
+        $body->rewind();
+
+        $request = (new ServerRequest(['REMOTE_ADDR' => $ip], [], '/mail/webhook/postmark', 'POST'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($body)
+            ->withParsedBody($payload);
+
+        return $this->send($request);
+    }
+
+    #[Test]
+    public function bounce_from_a_postmark_ip_flags_the_user(): void
+    {
+        $response = $this->postWebhook($this->postmarkPayload('Bounce', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertTrue(User::find(3)->hasBouncedEmail());
+        $this->assertEquals(1, EmailBounceEvent::where('email', 'bouncer@example.com')->count());
+    }
+
+    #[Test]
+    public function spam_complaint_from_a_postmark_ip_flags_the_user(): void
+    {
+        $response = $this->postWebhook($this->postmarkPayload('SpamComplaint', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue(User::find(3)->hasBouncedEmail());
+    }
+
+    #[Test]
+    public function request_from_a_non_postmark_ip_is_rejected(): void
+    {
+        $response = $this->postWebhook($this->postmarkPayload('Bounce', 'bouncer@example.com'), '10.0.0.1');
+
+        // IpsRequestMatcher fails -> RejectWebhookException(406).
+        $this->assertEquals(406, $response->getStatusCode());
+        $this->assertFalse(User::find(3)->hasBouncedEmail());
+    }
+
+    #[Test]
+    public function a_delivered_event_does_not_flag(): void
+    {
+        $response = $this->postWebhook($this->postmarkPayload('Delivery', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertFalse(User::find(3)->hasBouncedEmail());
+    }
+}

--- a/framework/core/tests/integration/mail/WebhookBounceTest.php
+++ b/framework/core/tests/integration/mail/WebhookBounceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\mail;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Drives a real, correctly-signed Mailgun webhook payload through the actual
+ * /mail/webhook route and asserts the affected user is flagged. Exercises the
+ * whole chain: route -> WebhookController -> Symfony parser (signature check +
+ * normalisation) -> EmailBounced/EmailComplained event -> StampBouncedUser.
+ */
+class WebhookBounceTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const SIGNING_KEY = 'test-webhook-signing-key';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setting('mail_driver', 'mailgun');
+        $this->setting('mail_mailgun_secret', 'key-abc123');
+        $this->setting('mail_mailgun_domain', 'mg.example.com');
+        $this->setting('mail_mailgun_region', 'api.mailgun.net');
+        $this->setting('mail_mailgun_webhook_signing_key', self::SIGNING_KEY);
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                [
+                    'id' => 3,
+                    'username' => 'bouncer',
+                    // BCrypt hash for "too-obscure", as per normalUser().
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email' => 'bouncer@example.com',
+                    'is_email_confirmed' => 1,
+                ],
+            ],
+        ]);
+    }
+
+    private function signedPayload(string $event, string $recipient): array
+    {
+        $timestamp = '1700000000';
+        $token = 'abc123token';
+        $signature = hash_hmac('sha256', $timestamp.$token, self::SIGNING_KEY);
+
+        return [
+            'signature' => [
+                'timestamp' => $timestamp,
+                'token' => $token,
+                'signature' => $signature,
+            ],
+            'event-data' => [
+                'event' => $event,
+                'id' => 'evt-1',
+                'timestamp' => 1700000000.123456,
+                'recipient' => $recipient,
+                'severity' => 'permanent',
+                'delivery-status' => [
+                    'code' => 550,
+                    'description' => 'No such mailbox',
+                    'message' => 'No such mailbox',
+                ],
+                'reason' => 'bounce',
+            ],
+        ];
+    }
+
+    private function postWebhook(array $payload)
+    {
+        // Deliberately NOT bypassing CSRF: a real provider webhook cannot send a
+        // CSRF token, so the route must be exempt. This also guards that
+        // exemption against regressions.
+        return $this->send(
+            $this->request('POST', '/mail/webhook/mailgun', ['json' => $payload])
+        );
+    }
+
+    #[Test]
+    public function permanent_failure_flags_the_user(): void
+    {
+        $response = $this->postWebhook($this->signedPayload('failed', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $user = User::find(3);
+        $this->assertNotNull($user->email_bounced_at);
+        $this->assertTrue($user->hasBouncedEmail());
+    }
+
+    #[Test]
+    public function permanent_failure_logs_an_event_row(): void
+    {
+        $this->postWebhook($this->signedPayload('failed', 'bouncer@example.com'));
+
+        $event = \Flarum\Mail\EmailBounceEvent::where('email', 'bouncer@example.com')->first();
+
+        $this->assertNotNull($event, 'A bounce event row should have been logged.');
+        $this->assertEquals(\Flarum\Mail\EmailBounceEvent::TYPE_BOUNCE, $event->type);
+        $this->assertEquals(3, $event->user_id);
+    }
+
+    #[Test]
+    public function complaint_flags_the_user(): void
+    {
+        $response = $this->postWebhook($this->signedPayload('complained', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $this->assertTrue(User::find(3)->hasBouncedEmail());
+    }
+
+    #[Test]
+    public function a_bad_signature_is_rejected_and_does_not_flag(): void
+    {
+        $payload = $this->signedPayload('failed', 'bouncer@example.com');
+        $payload['signature']['signature'] = 'deadbeef';
+
+        $response = $this->postWebhook($payload);
+
+        $this->assertEquals(406, $response->getStatusCode());
+        $this->assertFalse(User::find(3)->hasBouncedEmail());
+    }
+
+    #[Test]
+    public function a_successful_delivery_does_not_flag(): void
+    {
+        $response = $this->postWebhook($this->signedPayload('delivered', 'bouncer@example.com'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertFalse(User::find(3)->hasBouncedEmail());
+    }
+}

--- a/framework/core/tests/integration/notification/SuppressBouncedTest.php
+++ b/framework/core/tests/integration/notification/SuppressBouncedTest.php
@@ -10,9 +10,9 @@
 namespace Flarum\Tests\integration\notification;
 
 use Carbon\Carbon;
+use Flarum\Extend;
 use Flarum\Locale\TranslatorInterface;
 use Flarum\Notification\Blueprint\BlueprintInterface;
-use Flarum\Extend;
 use Flarum\Notification\Driver\EmailNotificationDriver;
 use Flarum\Notification\MailableInterface;
 use Flarum\Settings\SettingsRepositoryInterface;

--- a/framework/core/tests/integration/notification/SuppressBouncedTest.php
+++ b/framework/core/tests/integration/notification/SuppressBouncedTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\notification;
+
+use Carbon\Carbon;
+use Flarum\Locale\TranslatorInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Extend;
+use Flarum\Notification\Driver\EmailNotificationDriver;
+use Flarum\Notification\MailableInterface;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Contracts\Queue\Queue;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Proves the bounce suppression gate in EmailNotificationDriver: when
+ * `mail_suppress_bounced` is on, users with a recorded bounce are skipped;
+ * when off (the default), behaviour is unchanged.
+ */
+class SuppressBouncedTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Register the test notification type with email enabled by default,
+        // so shouldEmail() is true unless the suppression gate skips the user.
+        $this->extend(
+            (new Extend\Notification())
+                ->type(SuppressTestBlueprint::class, ['email'])
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                // A user whose address has hard-bounced.
+                [
+                    'id' => 3,
+                    'username' => 'bounced',
+                    'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email' => 'bounced@machine.local',
+                    'is_email_confirmed' => 1,
+                    'email_bounced_at' => Carbon::now(),
+                    'email_bounce_reason' => 'No such mailbox',
+                ],
+            ],
+        ]);
+    }
+
+    private function driveWith(bool $suppress): int
+    {
+        $this->setting('mail_suppress_bounced', $suppress);
+
+        $pushCount = 0;
+        $queue = m::mock(Queue::class);
+        $queue->shouldReceive('push')->andReturnUsing(function () use (&$pushCount) {
+            $pushCount++;
+
+            return null;
+        });
+
+        $driver = new EmailNotificationDriver(
+            $queue,
+            $this->app()->getContainer()->make(SettingsRepositoryInterface::class),
+        );
+
+        // A bounced user (3) and a healthy user (2). Email is on by default for
+        // this registered type, so the ONLY thing that can skip the bounced
+        // user is the suppression gate.
+        $driver->send(new SuppressTestBlueprint(), [User::find(3), User::find(2)]);
+
+        return $pushCount;
+    }
+
+    #[Test]
+    public function bounced_user_is_skipped_when_suppression_is_enabled(): void
+    {
+        // Only the healthy user's email job should be queued.
+        $this->assertEquals(1, $this->driveWith(suppress: true));
+    }
+
+    #[Test]
+    public function bounced_user_is_still_emailed_when_suppression_is_disabled(): void
+    {
+        // Default behaviour: both users get a job, bounce state ignored.
+        $this->assertEquals(2, $this->driveWith(suppress: false));
+    }
+}
+
+class SuppressTestBlueprint implements BlueprintInterface, MailableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?\Flarum\Database\AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): ?array
+    {
+        return null;
+    }
+
+    public static function getType(): string
+    {
+        return 'suppressTest';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return 'suppressTestSubjectModel';
+    }
+
+    public function getEmailSubject(TranslatorInterface $translator): string
+    {
+        return 'Test';
+    }
+
+    public function getEmailViews(): array
+    {
+        return ['text' => 'unused', 'html' => 'unused'];
+    }
+}

--- a/framework/core/tests/unit/Mail/MailgunDriverTest.php
+++ b/framework/core/tests/unit/Mail/MailgunDriverTest.php
@@ -9,7 +9,9 @@
 
 namespace Flarum\Tests\unit\Mail;
 
+use Flarum\Mail\HandlesWebhooks;
 use Flarum\Mail\MailgunDriver;
+use Flarum\Mail\ProvisionsWebhooks;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\unit\TestCase;
 use Illuminate\Translation\ArrayLoader;
@@ -18,6 +20,7 @@ use Illuminate\Validation\Factory as ValidatorFactory;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunApiTransport;
+use Symfony\Component\Mailer\Bridge\Mailgun\Webhook\MailgunRequestParser;
 
 class MailgunDriverTest extends TestCase
 {
@@ -154,5 +157,53 @@ class MailgunDriverTest extends TestCase
         $transport = $this->driver->buildTransport($this->settings($this->validSettings()));
 
         $this->assertInstanceOf(MailgunApiTransport::class, $transport);
+    }
+
+    // -------------------------------------------------------------------------
+    // Webhook capability
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function driver_supports_webhook_capabilities(): void
+    {
+        $this->assertInstanceOf(HandlesWebhooks::class, $this->driver);
+        $this->assertInstanceOf(ProvisionsWebhooks::class, $this->driver);
+    }
+
+    #[Test]
+    public function available_settings_includes_webhook_signing_key(): void
+    {
+        $this->assertArrayHasKey('mail_mailgun_webhook_signing_key', $this->driver->availableSettings());
+    }
+
+    #[Test]
+    public function webhook_request_parser_is_the_mailgun_parser(): void
+    {
+        $parser = $this->driver->getWebhookRequestParser($this->settings($this->validSettings()));
+
+        $this->assertInstanceOf(MailgunRequestParser::class, $parser);
+    }
+
+    #[Test]
+    public function signing_secret_reads_the_dedicated_setting(): void
+    {
+        $settings = array_merge($this->validSettings(), ['mail_mailgun_webhook_signing_key' => 'sign-xyz']);
+
+        $this->assertSame('sign-xyz', $this->driver->getWebhookSigningSecret($this->settings($settings)));
+    }
+
+    #[Test]
+    public function signing_secret_is_null_when_unset(): void
+    {
+        $this->assertNull($this->driver->getWebhookSigningSecret($this->settings($this->validSettings())));
+    }
+
+    #[Test]
+    public function webhook_configured_requires_a_signing_key(): void
+    {
+        $this->assertFalse($this->driver->webhookConfigured($this->settings($this->validSettings())));
+
+        $withKey = array_merge($this->validSettings(), ['mail_mailgun_webhook_signing_key' => 'sign-xyz']);
+        $this->assertTrue($this->driver->webhookConfigured($this->settings($withKey)));
     }
 }

--- a/framework/core/tests/unit/Mail/PostmarkDriverTest.php
+++ b/framework/core/tests/unit/Mail/PostmarkDriverTest.php
@@ -9,7 +9,9 @@
 
 namespace Flarum\Tests\unit\Mail;
 
+use Flarum\Mail\HandlesWebhooks;
 use Flarum\Mail\PostmarkDriver;
+use Flarum\Mail\ProvisionsWebhooks;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\unit\TestCase;
 use Illuminate\Translation\ArrayLoader;
@@ -18,6 +20,7 @@ use Illuminate\Validation\Factory as ValidatorFactory;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
+use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 
 class PostmarkDriverTest extends TestCase
 {
@@ -156,5 +159,33 @@ class PostmarkDriverTest extends TestCase
 
         $this->assertInstanceOf(PostmarkApiTransport::class, $transport);
         $this->assertStringContainsString('outbound', (string) $transport);
+    }
+
+    // -------------------------------------------------------------------------
+    // Webhook capability
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function driver_handles_webhooks_but_does_not_provision_them(): void
+    {
+        $this->assertInstanceOf(HandlesWebhooks::class, $this->driver);
+        // Postmark webhooks are registered manually in its dashboard.
+        $this->assertNotInstanceOf(ProvisionsWebhooks::class, $this->driver);
+    }
+
+    #[Test]
+    public function webhook_request_parser_is_the_postmark_parser(): void
+    {
+        $parser = $this->driver->getWebhookRequestParser($this->settings($this->validSettings()));
+
+        $this->assertInstanceOf(PostmarkRequestParser::class, $parser);
+    }
+
+    #[Test]
+    public function has_no_signing_secret_and_is_configured_by_default(): void
+    {
+        // Postmark verifies by IP, not a secret — so no secret, yet ready.
+        $this->assertNull($this->driver->getWebhookSigningSecret($this->settings($this->validSettings())));
+        $this->assertTrue($this->driver->webhookConfigured($this->settings($this->validSettings())));
     }
 }


### PR DESCRIPTION
### The problem

When Flarum sends mail to an address that hard-bounces (mailbox doesn't exist, permanently rejected) or is marked as spam, Flarum currently has no idea. It keeps sending to that address indefinitely. Repeated delivery to dead addresses and to people who filed spam complaints is the single fastest way to damage a forum's sender reputation and get its domain throttled or blocklisted by the mail provider.

Two things that look like they'd help, but don't:

- **`EmailSendFailed`** only fires on *submission* failure (bad credentials, API rejects the request). A bounce happens **asynchronously**, minutes-to-hours after the provider already accepted the message — the transport never sees it.
- **`is_email_confirmed`** does not gate outbound mail at all (notifications gate solely on `shouldEmail()`), so it can't be repurposed for this.

Bounces are only knowable via the provider's **inbound webhook** — Mailgun, Postmark, etc. POST delivery events back to us.

### How this solves it

An abstract, provider-agnostic pipeline in core:

- **New opt-in driver capability interfaces** — `HandlesWebhooks` (receive + verify + parse inbound events) and `ProvisionsWebhooks` (register the webhook with the provider automatically). `DriverInterface` is untouched, so third-party mail drivers are unaffected.
- **A single inbound route** `POST /mail/webhook[/{driver}]` → `WebhookController` resolves the active driver, hands the request to its parser, and dispatches provider-neutral **`EmailBounced` / `EmailComplained`** events. Verification is owned entirely by each provider's parser (HMAC signature, IP allowlist, …) — the controller never assumes *how* a provider authenticates.
- Leverages **Symfony Mailer's webhook bridges** (`symfony/webhook` + `symfony/remote-event`, newly required) so signature/IP verification and payload normalisation come from Symfony, and the crucial **soft-vs-hard bounce distinction** (transient deferrals are ignored) is handled for us.

On top of the pipeline:

- **Bounce state on the user** (`email_bounced_at` + `email_bounce_reason`), plus a permanent **`email_bounce_events`** log so statistics survive a user fixing their address.
- **Suppression** of notification email to bounced/complained users, behind a **`mail_suppress_bounced` setting that defaults off** — no behaviour change unless an admin opts in. Transactional mail (e.g. email confirmation) is deliberately *not* suppressed, so users can still recover.
- **In-app notice** prompting affected users to update their email; it clears automatically once they do.
- **Admin visibility** — an "Email delivery" column and `is:bounced` filter on the user list (shown only when the active driver can report bounces), and a **dashboard widget** with bounce volume over time plus currently-affected / recovered counts, warning when the return path isn't configured.
- **GDPR-aware** — the bundled GDPR extension scrubs the email from bounce-event rows on anonymisation (deletes them on erasure), and anonymised users are filtered out of all notifications so their placeholder addresses never generate mail.

### Drivers

Implemented for the two core drivers that support it: **Mailgun** (HMAC-signed webhooks + automatic provisioning) and **Postmark** (IP-verified webhooks; URL registered manually in the Postmark dashboard). SMTP and Sendmail have no feedback channel and are unaffected.

The interface is deliberately shaped to fit providers that verify by shared secret, IP allowlist, or SNS certificate, so additional drivers can implement it without core changes. **Longer term, the Mailgun and Postmark drivers may be split out of core into their own extensions**, and dedicated provider extensions are already planned (`fof/ses-mail`, `fof/brevo-mail`) which will build on these same interfaces.

### Notes

- Targeting **2.1**: this adds new public API surface (the capability interfaces, events, route, settings) and one behaviour-changing (opt-in, default-off) setting, so it is not for the 2.0 RC line.
- A **documentation PR will follow** once the 2.1 cycle begins.

### Reviewing

- The capability interfaces are the public contract — `Flarum\Mail\HandlesWebhooks` / `Flarum\Mail\ProvisionsWebhooks`.
- `WebhookController` is the security-sensitive entry point: verification is delegated to each driver's parser, and the route is CSRF-exempt by design (the provider signature / source IP is the authentication).
