### PR TITLE
[2.x] fix(core): notifications index 400 on invalid default include + n+1

### DIFF
--- a/framework/core/src/Api/Resource/NotificationResource.php
+++ b/framework/core/src/Api/Resource/NotificationResource.php
@@ -13,12 +13,17 @@ use Flarum\Api\Context;
 use Flarum\Api\Endpoint;
 use Flarum\Api\Schema;
 use Flarum\Bus\Dispatcher;
+use Flarum\Discussion\Discussion;
 use Flarum\Notification\Command\ReadNotification;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationRepository;
+use Flarum\Post\Post;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Tobyz\JsonApiServer\Pagination\OffsetPagination;
+use Tobyz\JsonApiServer\Schema\Field\Relationship;
 
 /**
  * @extends AbstractDatabaseResource<Notification>
@@ -66,16 +71,28 @@ class NotificationResource extends AbstractDatabaseResource
 
     public function endpoints(): array
     {
+        // Eager-load the subject's discussion only when at least one subject
+        // type actually exposes a `discussion` relationship. Gating on the
+        // number of subject types instead would add an invalid
+        // `subject.discussion` default include when the extra types have no such
+        // relationship (e.g. a User-subject notification like flarum/mentions'
+        // `userMentioned` on a forum with no Post-subject notification type),
+        // which the include validator then rejects with a 400 on the endpoint's
+        // own default.
+        $defaultInclude = array_filter([
+            'fromUser',
+            'subject',
+            $this->initialized && $this->subjectsHaveDiscussionRelationship()
+                ? 'subject.discussion'
+                : null,
+        ]);
+
         return [
             Endpoint\Show::make()
                 ->authenticated()
-                ->defaultInclude(array_filter([
-                    'fromUser',
-                    'subject',
-                    $this->initialized && count($this->subjectTypes()) > 1
-                        ? 'subject.discussion'
-                        : null,
-                ])),
+                ->defaultInclude($defaultInclude)
+                ->eagerLoad('fromUser')
+                ->eagerLoadWhere('subject', $this->eagerLoadSubject(...)),
             Endpoint\Update::make()
                 ->authenticated(),
             Endpoint\Index::make()
@@ -86,15 +103,71 @@ class NotificationResource extends AbstractDatabaseResource
                     // Invalidate new notification count cache since read_notifications_at changed
                     $this->cache->forget("user.{$actor->id}.new_notification_count");
                 })
-                ->defaultInclude(array_filter([
-                    'fromUser',
-                    'subject',
-                    $this->initialized && count($this->subjectTypes()) > 1
-                        ? 'subject.discussion'
-                        : null,
-                ]))
+                ->defaultInclude($defaultInclude)
+                ->eagerLoad('fromUser')
+                ->eagerLoadWhere('subject', $this->eagerLoadSubject(...))
                 ->paginate(),
         ];
+    }
+
+    /**
+     * Eager-load the polymorphic subject's own `state`/`discussion.state` so the
+     * notifications index does not issue a query per row for them (n+1).
+     */
+    protected function eagerLoadSubject(Relation $query): void
+    {
+        if ($query instanceof MorphTo) {
+            $query->morphWith($this->subjectMorphWith());
+        }
+    }
+
+    /**
+     * The nested relationships to eager-load per subject model type.
+     *
+     * @return array<class-string, string[]>
+     */
+    protected function subjectMorphWith(): array
+    {
+        $map = [];
+
+        foreach (array_unique((new Notification())->getSubjectModels()) as $class) {
+            if (is_a($class, Discussion::class, true)) {
+                $map[$class] = ['state'];
+            } elseif (is_a($class, Post::class, true)) {
+                $map[$class] = ['discussion.state'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Whether any registered notification subject type exposes an includable
+     * `discussion` relationship, making `subject.discussion` a valid include.
+     */
+    protected function subjectsHaveDiscussionRelationship(): bool
+    {
+        foreach ($this->subjectTypes() as $type) {
+            // typesForModels() yields null for a subject model that has no
+            // registered API resource; there is nothing to inspect for those.
+            if ($type === null) {
+                continue;
+            }
+
+            $resource = $this->api->getResource($type);
+
+            if (! $resource instanceof AbstractResource) {
+                continue;
+            }
+
+            foreach ($resource->resolveFields() as $field) {
+                if ($field instanceof Relationship && $field->includable && $field->name === 'discussion') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public function fields(): array

--- a/framework/core/tests/integration/api/notifications/ListTest.php
+++ b/framework/core/tests/integration/api/notifications/ListTest.php
@@ -10,7 +10,11 @@
 namespace Flarum\Tests\integration\api\notifications;
 
 use Carbon\Carbon;
+use Flarum\Database\AbstractModel;
 use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Notification\AlertableInterface;
+use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\Notification;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -85,5 +89,179 @@ class ListTest extends TestCase
 
         $this->assertNotContains('1', $ids);
         $this->assertEmpty($ids);
+    }
+
+    #[Test]
+    public function index_does_not_fail_when_a_subject_type_has_no_discussion_relationship()
+    {
+        // Registering a notification type whose subject (User) has no discussion
+        // relationship must not make the endpoint reject its own default include.
+        // Before the fix, `subject.discussion` was added purely because more than
+        // one subject type was registered, and the include validator then threw
+        // "Invalid include [subject.discussion]" (a 400) for every request.
+        $this->extend(
+            (new Extend\Notification())->type(UserSubjectBlueprint::class, ['alert'])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    #[Test]
+    public function subject_discussion_is_still_included_when_a_subject_type_has_a_discussion_relationship()
+    {
+        // A Post subject does have a discussion relationship, so `subject.discussion`
+        // remains a valid default include and the discussion is still eager-loaded.
+        $this->extend(
+            (new Extend\Notification())->type(PostSubjectBlueprint::class, ['alert'])
+        );
+
+        $this->prepareDatabase([
+            Notification::class => [
+                ['id' => 2, 'user_id' => 2, 'from_user_id' => 1, 'type' => 'postSubjectBlueprint', 'subject_id' => 1, 'read_at' => null, 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), true);
+        $included = array_map(fn ($resource) => $resource['type'].':'.$resource['id'], $body['included'] ?? []);
+
+        $this->assertContains('discussions:1', $included, 'The post subject\'s discussion should be eager-loaded.');
+    }
+
+    #[Test]
+    public function subject_discussion_state_is_batch_loaded_without_an_n_plus_one()
+    {
+        // With Post-subject notifications, each notification's subject.discussion
+        // exposes a per-actor `state`. It must be eager-loaded in a single batched
+        // query, not one query per notification (the n+1 this PR also mitigates).
+        $this->extend(
+            (new Extend\Notification())->type(PostSubjectBlueprint::class, ['alert'])
+        );
+
+        $count = 8;
+        $discussions = [];
+        $posts = [];
+        $notifications = [];
+        $discussionUser = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $id = 10 + $i;
+            $discussions[] = ['id' => $id, 'title' => 'D'.$id, 'comment_count' => 1, 'user_id' => 2, 'first_post_id' => $id];
+            $posts[] = ['id' => $id, 'discussion_id' => $id, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>x</p></t>'];
+            $notifications[] = ['id' => $id, 'user_id' => 2, 'from_user_id' => 1, 'type' => 'postSubjectBlueprint', 'subject_id' => $id, 'read_at' => null, 'created_at' => Carbon::now()];
+            $discussionUser[] = ['user_id' => 2, 'discussion_id' => $id, 'last_read_post_number' => 1];
+        }
+
+        $this->prepareDatabase([
+            Discussion::class => $discussions,
+            Post::class => $posts,
+            Notification::class => $notifications,
+            'discussion_user' => $discussionUser,
+        ]);
+
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/notifications', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $batchedLoads = 0;
+        $individualLoads = 0;
+
+        foreach ($db->getQueryLog() as $query) {
+            if (stripos($query['query'], 'discussion_user') === false) {
+                continue;
+            }
+
+            if (stripos($query['query'], ' in (') !== false) {
+                $batchedLoads++;
+            } else {
+                $individualLoads++;
+            }
+        }
+
+        $db->disableQueryLog();
+
+        $this->assertSame(
+            0,
+            $individualLoads,
+            "Discussion states were loaded individually ($individualLoads times) instead of a single batched query — an n+1 on the notifications index."
+        );
+        $this->assertGreaterThanOrEqual(1, $batchedLoads, 'Expected the discussion states to be eager-loaded in a single batched query.');
+    }
+}
+
+class UserSubjectBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): mixed
+    {
+        return [];
+    }
+
+    public static function getType(): string
+    {
+        return 'userSubjectBlueprint';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return User::class;
+    }
+}
+
+class PostSubjectBlueprint implements BlueprintInterface, AlertableInterface
+{
+    public function getFromUser(): ?User
+    {
+        return null;
+    }
+
+    public function getSubject(): ?AbstractModel
+    {
+        return null;
+    }
+
+    public function getData(): mixed
+    {
+        return [];
+    }
+
+    public static function getType(): string
+    {
+        return 'postSubjectBlueprint';
+    }
+
+    public static function getSubjectModel(): string
+    {
+        return Post::class;
     }
 }


### PR DESCRIPTION
Fixes #4815

Combines #4816 and #4817 into a single change, with tests for both.

## Fixes

**400 on the notifications endpoint.** `NotificationResource` added `subject.discussion` to the default include whenever more than one subject type was registered. That include is only valid when a subject type actually exposes a `discussion` relationship. With subject types like `{discussions, users}` (neither has a `discussion` relationship) the include validator rejects the endpoint's own default include with:

```
Invalid include [subject.discussion]
```

Since the frontend sends no explicit include and relies on the default, this returns a 400 for every request and breaks the notifications dropdown and page. Any forum with a `User`- or `Group`-subject notification type and no `Post`-subject type present hits it.

The include is now gated on whether a subject type genuinely exposes an includable `discussion` relationship, rather than on the subject-type count.

**N+1 on the index.** The subject's `state` / `discussion.state` was lazy-loaded once per notification. It's now eager-loaded via `morphWith`, so it's a single batched query regardless of how many notifications are in the payload.

## Notes

- `subjectTypes()` can contain `null` for a subject model with no registered API resource; that case is now skipped rather than passed to `getResource()`.

## Tests

- The endpoint no longer 400s when a subject type has no `discussion` relationship.
- `subject.discussion` is still included when a subject type does have one.
- The subject discussion state is batch-loaded with no per-row query.

Supersedes #4816 (@karl-bullock) and #4817 (@DavideIadeluca); both are closed in favour of this.