### PR TITLE
[2.x] feat(core): add tinker command for an interactive REPL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "pusher/pusher-php-server": "^7.2",
+        "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
         "sycho/sourcemap": "^2.0.0",
         "symfony/config": "^7.0",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -79,6 +79,7 @@
         "psr/http-message": "^1.1",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
+        "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
         "sycho/sourcemap": "^2.0.0",
         "symfony/config": "^7.0",

--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -71,6 +71,7 @@ class ConsoleServiceProvider extends AbstractServiceProvider
                 ScheduleRunCommand::class,
                 ToggleExtensionCommand::class,
                 BisectCommand::class,
+                TinkerCommand::class,
                 ConvertAvatarsToWebpCommand::class,
                 BackfillAvatarVariantsCommand::class,
                 // Used internally to create DB dumps before major releases.

--- a/framework/core/src/Console/ModelAliasAutoloader.php
+++ b/framework/core/src/Console/ModelAliasAutoloader.php
@@ -186,7 +186,7 @@ class ModelAliasAutoloader
     protected static function findComposerLoader(): ?ClassLoader
     {
         foreach (spl_autoload_functions() as $function) {
-            if (is_array($function) && ($function[0] ?? null) instanceof ClassLoader) {
+            if (is_array($function) && $function[0] instanceof ClassLoader) {
                 return $function[0];
             }
         }

--- a/framework/core/src/Console/ModelAliasAutoloader.php
+++ b/framework/core/src/Console/ModelAliasAutoloader.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Console;
+
+use Composer\Autoload\ClassLoader;
+use Flarum\Database\AbstractModel;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Lets tinker users reference Eloquent models by their short name — e.g.
+ * `User::find(1)` instead of `Flarum\User\User::find(1)`.
+ *
+ * Registered as a fallback autoloader, so it only runs when PHP fails to
+ * resolve a class by its given (short) name. On the first miss it indexes every
+ * registered PSR-4 root (core, extensions, and other Composer packages) by
+ * short name; when a bare name is requested it aliases the matching Eloquent
+ * model into the global namespace. This means third-party extension models are
+ * covered automatically, with no hardcoded list. The index is built once and
+ * cached for the lifetime of the shell.
+ */
+class ModelAliasAutoloader
+{
+    /**
+     * Short name => list of fully-qualified model class names.
+     *
+     * @var array<string, list<class-string>>|null
+     */
+    protected ?array $index = null;
+
+    /**
+     * Short names we have already aliased, so we don't do the work twice.
+     *
+     * @var array<string, true>
+     */
+    protected array $aliased = [];
+
+    public function __construct(
+        protected ClassLoader $loader,
+        protected \Closure $writeln
+    ) {
+    }
+
+    public static function register(\Closure $writeln): ?self
+    {
+        $loader = static::findComposerLoader();
+
+        if ($loader === null) {
+            return null;
+        }
+
+        $instance = new static($loader, $writeln);
+
+        // Append (prepend = false) so this only fires after every real
+        // autoloader has failed to find the (short) class name.
+        spl_autoload_register([$instance, 'load'], true, false);
+
+        return $instance;
+    }
+
+    /**
+     * Remove this autoloader. Safe to call more than once.
+     */
+    public function unregister(): void
+    {
+        spl_autoload_unregister([$this, 'load']);
+    }
+
+    /**
+     * Laravel facades that don't exist in Flarum, mapped to the hint we show
+     * when someone reaches for them out of habit. Flarum doesn't register
+     * Laravel's facades, so these resolve to nothing without a nudge.
+     *
+     * @var array<string, string>
+     */
+    protected array $facadeHints = [
+        'DB' => 'Flarum does not register Laravel facades. Use the <comment>$db</comment> variable instead, e.g. <comment>$db->table(\'users\')->count()</comment>.',
+        'Cache' => 'Flarum does not register Laravel facades. Resolve the cache with <comment>resolve(Illuminate\Contracts\Cache\Store::class)</comment>.',
+        'Event' => 'Flarum does not register Laravel facades. Use the <comment>$events</comment> variable instead.',
+        'Schema' => 'Flarum does not register Laravel facades. Use <comment>$db->getSchemaBuilder()</comment> instead.',
+        'Queue' => 'Flarum does not register Laravel facades. Resolve the queue with <comment>resolve(Illuminate\Contracts\Queue\Queue::class)</comment>.',
+    ];
+
+    public function load(string $class): void
+    {
+        // Only bare, unqualified names are candidates for aliasing.
+        if (str_contains($class, '\\') || isset($this->aliased[$class])) {
+            return;
+        }
+
+        // Candidate FQNs that share this short name (derived from filenames,
+        // no classes loaded yet). Only these get the expensive model check.
+        $candidates = $this->buildIndex()[$class] ?? [];
+
+        $models = array_values(array_filter($candidates, function (string $fqn) {
+            return class_exists($fqn) && is_subclass_of($fqn, AbstractModel::class);
+        }));
+
+        if (count($models) === 1) {
+            // Guard against re-aliasing (class_alias warns and returns false if
+            // the name already exists), e.g. when the command runs more than
+            // once in one process, or a real global class of this name exists.
+            if (! class_exists($class, false)) {
+                class_alias($models[0], $class);
+            }
+
+            $this->aliased[$class] = true;
+
+            return;
+        }
+
+        if (count($models) > 1) {
+            ($this->writeln)(sprintf(
+                "<comment>%s</comment> is ambiguous. Use the full name:\n  %s",
+                $class,
+                implode("\n  ", $models)
+            ));
+
+            return;
+        }
+
+        // No model claimed this name — if it's a Laravel facade someone reached
+        // for out of habit, nudge them towards the Flarum equivalent.
+        if (isset($this->facadeHints[$class])) {
+            ($this->writeln)("<comment>$class</comment>: {$this->facadeHints[$class]}");
+        }
+    }
+
+    /**
+     * @return array<string, list<class-string>>
+     */
+    protected function buildIndex(): array
+    {
+        if ($this->index !== null) {
+            return $this->index;
+        }
+
+        $this->index = [];
+
+        foreach ($this->loader->getPrefixesPsr4() as $prefix => $dirs) {
+            foreach ($dirs as $dir) {
+                if (! is_dir($dir)) {
+                    continue;
+                }
+
+                $this->scanDirectory($prefix, $dir);
+            }
+        }
+
+        return $this->index;
+    }
+
+    protected function scanDirectory(string $prefix, string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = substr($file->getPathname(), strlen($dir) + 1);
+            $class = $prefix.str_replace(['/', '.php'], ['\\', ''], $relative);
+
+            $short = strrchr($class, '\\');
+            $short = $short === false ? $class : substr($short, 1);
+
+            // Index by filename only — no classes are loaded here. The actual
+            // "is this an Eloquent model?" check happens in load(), and only
+            // for the few candidates that share the requested short name.
+            $this->index[$short][] = $class;
+        }
+    }
+
+    protected static function findComposerLoader(): ?ClassLoader
+    {
+        foreach (spl_autoload_functions() as $function) {
+            if (is_array($function) && ($function[0] ?? null) instanceof ClassLoader) {
+                return $function[0];
+            }
+        }
+
+        return null;
+    }
+}

--- a/framework/core/src/Console/TinkerCommand.php
+++ b/framework/core/src/Console/TinkerCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Console;
+
+use Flarum\Extension\ExtensionManager;
+use Flarum\Foundation\Application;
+use Flarum\Foundation\Paths;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionInterface;
+use Psy\Configuration;
+use Psy\Shell;
+use Psy\VersionUpdater\Checker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+class TinkerCommand extends AbstractCommand
+{
+    public function __construct(
+        protected Container $container,
+        protected Paths $paths
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('tinker')
+            ->setDescription('Interact with your Flarum installation through an interactive PHP shell (REPL)')
+            ->addOption('execute', 'e', InputOption::VALUE_REQUIRED, 'Execute the given code, print the result, and exit (non-interactive)');
+    }
+
+    protected function fire(): int
+    {
+        $code = $this->input->getOption('execute');
+
+        // Keep PsySH's runtime files (and command history) inside Flarum's
+        // storage directory. The default location relies on a writable $HOME /
+        // system temp dir, which often isn't available for the web/CLI user on
+        // a server — and getRuntimeDir() throws outright if it can't be created.
+        $runtimeDir = $this->paths->storage.'/tmp/psysh';
+
+        // Mirror the console's own colour decision (TTY detection plus the
+        // --ansi / --no-ansi flags) onto PsySH. Its default `auto` mode does
+        // its own detection, which loses colour whenever output isn't a direct
+        // TTY (e.g. through Docker) and ignores --ansi; deferring to Symfony's
+        // decision gives colour interactively and clean text when piped.
+        $colorMode = $this->output->isDecorated()
+            ? Configuration::COLOR_MODE_FORCED
+            : Configuration::COLOR_MODE_DISABLED;
+
+        $config = new Configuration([
+            'updateCheck' => Checker::NEVER,
+            'runtimeDir' => $runtimeDir,
+            'historyFile' => $runtimeDir.'/history',
+            'colorMode' => $colorMode,
+            'prompt' => 'flarum> ',
+            'startupMessage' => implode("\n", [
+                '<info>Flarum '.Application::VERSION.' tinker — interactive shell.</info>',
+                '<info>Available: <comment>$container</comment>, <comment>$settings</comment>, <comment>$db</comment>, <comment>$events</comment>, <comment>$extensions</comment>, <comment>resolve()</comment>, and models by short name (e.g. <comment>User::find(1)</comment>).</info>',
+                '<info>Type <comment>flarum</comment> for this list again, or <comment>help</comment> for shell commands. Docs: <comment>https://docs.flarum.org/2.x/console#tinker</comment></info>',
+            ]),
+        ]);
+
+        // When code is executed non-interactively, don't try to source ~/.psysh
+        // config or write history — just run and exit cleanly.
+        if ($code !== null) {
+            $config->setInteractiveMode(Configuration::INTERACTIVE_MODE_DISABLED);
+        }
+
+        $shell = new Shell($config);
+        $shell->setScopeVariables([
+            'container' => $this->container,
+            'settings' => $this->container->make(SettingsRepositoryInterface::class),
+            'db' => $this->container->make(ConnectionInterface::class),
+            'events' => $this->container->make(Dispatcher::class),
+            'extensions' => $this->container->make(ExtensionManager::class),
+        ]);
+
+        // Add an in-shell `flarum` command that reprints the available
+        // variables and helpers; it also shows up in PsySH's `help` list.
+        $shell->addCommand(new TinkerHelpCommand);
+
+        // Allow referencing Eloquent models by their short name, e.g.
+        // `User::find(1)` instead of `Flarum\User\User::find(1)`.
+        $aliasLoader = ModelAliasAutoloader::register(fn (string $message) => $this->output->writeln($message));
+
+        if ($aliasLoader === null && $code === null) {
+            $this->output->writeln('<comment>Note: could not locate the Composer autoloader, so referencing models by their short name is unavailable. Use fully-qualified class names instead.</comment>');
+        }
+
+        try {
+            // With --execute, run the snippet, print its return value, and exit
+            // instead of dropping into the interactive prompt. This is the
+            // reliable way to run tinker non-interactively (e.g. in scripts) —
+            // piping code into stdin is unreliable because of how the REPL
+            // buffers input.
+            if ($code !== null) {
+                // execute() doesn't set up the shell's output the way run()
+                // does, so give it PsySH's configured output first.
+                $shell->setOutput($config->getOutput());
+
+                // Pass throwExceptions so a failing snippet surfaces a non-zero
+                // exit code (important for scripting/CI) rather than being
+                // swallowed.
+                try {
+                    $result = $shell->execute($code, true);
+                } catch (\Throwable $e) {
+                    $this->error($e->getMessage());
+
+                    return Command::FAILURE;
+                }
+
+                // Write the result through the command's own output (rather than
+                // PsySH's raw STDOUT stream) so it's consistent with every other
+                // Flarum command and can be captured or redirected.
+                $this->output->writeln('=> '.$config->getPresenter()->present($result));
+
+                return Command::SUCCESS;
+            }
+
+            return $shell->run();
+        } finally {
+            // Don't leave the fallback autoloader registered after the shell
+            // exits — matters when the command runs more than once in a single
+            // process (e.g. integration tests).
+            $aliasLoader?->unregister();
+        }
+    }
+}

--- a/framework/core/src/Console/TinkerHelpCommand.php
+++ b/framework/core/src/Console/TinkerHelpCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Console;
+
+use Psy\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * An in-shell `flarum` command that reprints the Flarum-specific context
+ * (scope variables, short-name model aliasing, docs link). This is the same
+ * information shown in the startup banner, made available on demand for once
+ * the banner has scrolled out of view. It is listed automatically by PsySH's
+ * built-in `help` command.
+ */
+class TinkerHelpCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('flarum')
+            ->setDefinition([])
+            ->setDescription('Show Flarum tinker help (available variables and helpers).')
+            ->setHelp('Show the Flarum-specific variables and helpers available in this shell.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln([
+            '<info>Flarum tinker</info>',
+            '',
+            '  <comment>$container</comment>    The application (service container)',
+            '  <comment>$settings</comment>     The settings repository',
+            '  <comment>$db</comment>           The database connection',
+            '  <comment>$events</comment>       The event dispatcher',
+            '  <comment>$extensions</comment>   The extension manager',
+            '  <comment>resolve(...)</comment>  Resolve any other binding from the container',
+            '',
+            '  Eloquent models can be referenced by their short name, e.g. <comment>User::find(1)</comment>.',
+            '',
+            '  Docs: <comment>https://docs.flarum.org/2.x/console#tinker</comment>',
+        ]);
+
+        return self::SUCCESS;
+    }
+}

--- a/framework/core/tests/integration/console/TinkerCommandTest.php
+++ b/framework/core/tests/integration/console/TinkerCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class TinkerCommandTest extends ConsoleTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * Run a command and return both its output and exit code, since the base
+     * helper discards the code and the --execute contract depends on it.
+     *
+     * @return array{output: string, status: int}
+     */
+    protected function runCommandWithStatus(array $inputArray): array
+    {
+        $output = new BufferedOutput();
+        $status = $this->console()->run(new ArrayInput($inputArray), $output);
+
+        return ['output' => trim($output->fetch()), 'status' => $status];
+    }
+
+    #[Test]
+    public function execute_option_evaluates_code_and_succeeds()
+    {
+        $result = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => '1 + 1',
+        ]);
+
+        $this->assertStringContainsString('2', $result['output']);
+        $this->assertEquals(Command::SUCCESS, $result['status']);
+    }
+
+    #[Test]
+    public function execute_option_returns_failure_when_code_throws()
+    {
+        $result = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => 'throw new \Exception("boom")',
+        ]);
+
+        // The error is surfaced...
+        $this->assertStringContainsString('boom', $result['output']);
+        // ...and the exit code is non-zero, so scripts can detect the failure.
+        $this->assertEquals(Command::FAILURE, $result['status']);
+    }
+
+    #[Test]
+    public function models_can_be_referenced_by_short_name()
+    {
+        $result = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => 'User::where("username", "normal")->exists()',
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $result['status']);
+        // Resolving the seeded user by short-name `User` proves the alias
+        // autoloader mapped it to Flarum\User\User without a qualified name.
+        $this->assertStringContainsString('true', $result['output']);
+    }
+
+    #[Test]
+    public function reaching_for_a_laravel_facade_shows_a_hint()
+    {
+        $result = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => 'DB::table("users")',
+        ]);
+
+        $this->assertStringContainsString('$db', $result['output']);
+    }
+
+    #[Test]
+    public function command_can_run_more_than_once_in_one_process()
+    {
+        // The model-alias autoloader must be unregistered between runs;
+        // otherwise the second run re-aliases `User` and PHP warns. Running
+        // twice here would surface that as an error/leak.
+        $first = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => 'User::count()',
+        ]);
+        $second = $this->runCommandWithStatus([
+            'command' => 'tinker',
+            '--execute' => 'User::count()',
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $first['status']);
+        $this->assertEquals(Command::SUCCESS, $second['status']);
+    }
+}


### PR DESCRIPTION
Adds a `php flarum tinker` command that opens an interactive PHP shell (a REPL, powered by [PsySH](https://psysh.org/)) with the application fully booted. It lets maintainers and extension developers inspect and manipulate a forum's data and services directly from the terminal, instead of writing a throwaway bootstrap script.

### What it provides

- The following are available in scope: `$container`, `$settings`, `$db`, `$events`, `$extensions`, plus `resolve()` for any other binding.
- Eloquent models can be referenced by their short name — `User::find(1)` instead of `Flarum\User\User::find(1)`. This works for core **and** installed-extension models, via a fallback autoloader that indexes registered PSR-4 roots on first use (no hardcoded list).
- Since Flarum doesn't register Laravel's facades, reaching for one out of habit (e.g. `DB::table(...)`) prints a hint pointing at the Flarum equivalent rather than a bare "class not found".
- A `--execute` (`-e`) option runs a single snippet non-interactively and exits with a non-zero status if it throws, so it can be used in scripts.
- PsySH runtime/history files are kept inside `storage/`, so it doesn't depend on a writable `$HOME` on the server. Colour output follows the console's `--ansi`/`--no-ansi` decision.

Adds `psy/psysh` as a dependency.

Documentation: flarum/docs#548