### PR TITLE
[2.x] fix(testing): Run after-commit callbacks inline in integration tests

### DIFF
--- a/framework/core/tests/integration/database/AfterCommitListenerTest.php
+++ b/framework/core/tests/integration/database/AfterCommitListenerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\database;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression test for flarum/framework#4814.
+ *
+ * Once `db.transactions` is bound (see AfterCommitTest / #4787), listeners
+ * implementing ShouldHandleEventsAfterCommit are deferred to the surrounding
+ * transaction's commit. The integration harness wraps each test in a
+ * transaction that is rolled back and never committed, so without special
+ * handling those listeners never run — making after-commit behaviour
+ * impossible to test. The testing harness runs these callbacks inline instead.
+ */
+class AfterCommitListenerTest extends TestCase
+{
+    #[Test]
+    public function after_commit_listener_runs_during_a_test(): void
+    {
+        AfterCommitListenerSpy::$ran = false;
+
+        $this->extend(
+            (new Extend\Event())->listen(AfterCommitListenerTestEvent::class, AfterCommitListenerSpy::class)
+        );
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(new AfterCommitListenerTestEvent());
+
+        $this->assertTrue(
+            AfterCommitListenerSpy::$ran,
+            'A ShouldHandleEventsAfterCommit listener should run during an integration test.'
+        );
+    }
+
+    #[Test]
+    public function after_commit_event_is_dispatched_during_a_test(): void
+    {
+        $ran = false;
+
+        $this->extend(
+            (new Extend\Event())->listen(AfterCommitDispatchableEvent::class, function () use (&$ran) {
+                $ran = true;
+            })
+        );
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(new AfterCommitDispatchableEvent());
+
+        $this->assertTrue(
+            $ran,
+            'A ShouldDispatchAfterCommit event should be dispatched during an integration test.'
+        );
+    }
+}
+
+class AfterCommitListenerTestEvent
+{
+}
+
+class AfterCommitDispatchableEvent implements ShouldDispatchAfterCommit
+{
+}
+
+class AfterCommitListenerSpy implements ShouldHandleEventsAfterCommit
+{
+    public static bool $ran = false;
+
+    public function handle(AfterCommitListenerTestEvent $event): void
+    {
+        static::$ran = true;
+    }
+}

--- a/framework/core/tests/integration/database/AfterCommitTest.php
+++ b/framework/core/tests/integration/database/AfterCommitTest.php
@@ -26,12 +26,15 @@ use RuntimeException;
  * set." Binding it lets Illuminate's DatabaseManager::configure() attach the
  * manager to every connection.
  *
- * Note: the integration harness wraps each test in an open transaction that is
- * rolled back on tearDown, so a registered afterCommit callback is (correctly)
- * deferred to that never-committed transaction and cannot be observed firing
- * here. These tests therefore assert the wiring the fix establishes and that
- * afterCommit no longer throws; the callback-execution semantics themselves are
- * Illuminate's own, guaranteed once a manager is attached.
+ * These tests assert the wiring the fix establishes: that `db.transactions` is
+ * bound and attached to the connection, and that `Connection::afterCommit()`
+ * no longer throws.
+ *
+ * The integration harness wraps each test in an open transaction that is rolled
+ * back on tearDown. So that after-commit listeners remain observable in tests
+ * rather than being discarded with that rollback, the harness runs their
+ * callbacks inline; see InlineTransactionsManager and AfterCommitListenerTest
+ * (flarum/framework#4814).
  */
 class AfterCommitTest extends TestCase
 {
@@ -70,8 +73,6 @@ class AfterCommitTest extends TestCase
         $connection = $this->connection();
 
         try {
-            // Registered against the harness's open transaction, so it is
-            // deferred (not run) rather than throwing.
             $connection->afterCommit(function () {
                 // no-op
             });
@@ -80,5 +81,20 @@ class AfterCommitTest extends TestCase
         }
 
         $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function after_commit_callback_runs_in_tests(): void
+    {
+        $ran = false;
+
+        // The test harness runs after-commit callbacks inline (see
+        // InlineTransactionsManager) so they don't get discarded with the
+        // harness's rolled-back transaction. See flarum/framework#4814.
+        $this->connection()->afterCommit(function () use (&$ran) {
+            $ran = true;
+        });
+
+        $this->assertTrue($ran, 'Connection::afterCommit() callback should run during a test.');
     }
 }

--- a/php-packages/testing/src/integration/Extend/BindInlineTransactionsManager.php
+++ b/php-packages/testing/src/integration/Extend/BindInlineTransactionsManager.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Testing\integration\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use Flarum\Testing\integration\Setup\InlineTransactionsManager;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+
+/**
+ * Rebind `db.transactions` to a manager that runs after-commit callbacks inline
+ * so they are observable in tests. Must be applied before the connection is
+ * first resolved (i.e. before BeginTransactionAndSetDatabase), because
+ * DatabaseManager::configure() attaches whatever `db.transactions` resolves to
+ * at that point.
+ *
+ * @see InlineTransactionsManager
+ * @see \Flarum\Tests\integration\database\AfterCommitListenerTest
+ */
+class BindInlineTransactionsManager implements ExtenderInterface
+{
+    public function extend(Container $container, ?Extension $extension = null): void
+    {
+        $manager = new InlineTransactionsManager();
+
+        $container->instance('db.transactions', $manager);
+
+        // The connection may already have been resolved (and had the original
+        // manager attached by DatabaseManager::configure()), so attach ours to
+        // it directly. This covers Connection::afterCommit() as well as the
+        // event dispatcher, which reads db.transactions live.
+        $connection = $container->make(ConnectionInterface::class);
+
+        if ($connection instanceof Connection) {
+            $connection->setTransactionManager($manager);
+        }
+    }
+}

--- a/php-packages/testing/src/integration/Setup/Bootstrapper.php
+++ b/php-packages/testing/src/integration/Setup/Bootstrapper.php
@@ -13,6 +13,7 @@ use Flarum\Foundation\Config;
 use Flarum\Foundation\InstalledSite;
 use Flarum\Foundation\Paths;
 use Flarum\Testing\integration\Extend\BeginTransactionAndSetDatabase;
+use Flarum\Testing\integration\Extend\BindInlineTransactionsManager;
 use Flarum\Testing\integration\Extend\OverrideExtensionManagerForTests;
 use Flarum\Testing\integration\Extend\SetSettingsBeforeBoot;
 use Flarum\Testing\integration\UsesTmpDir;
@@ -69,6 +70,9 @@ class Bootstrapper
 
         $extenders = array_merge([
             new OverrideExtensionManagerForTests($this->extensions),
+            // Must precede BeginTransactionAndSetDatabase: it resolves the
+            // connection, which is when the transactions manager is attached.
+            new BindInlineTransactionsManager(),
             new BeginTransactionAndSetDatabase(function (ConnectionInterface $db) {
                 $this->database = $db;
             }),

--- a/php-packages/testing/src/integration/Setup/InlineTransactionsManager.php
+++ b/php-packages/testing/src/integration/Setup/InlineTransactionsManager.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Testing\integration\Setup;
+
+use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Support\Collection;
+
+/**
+ * A transactions manager for the integration test harness.
+ *
+ * The harness wraps every test in a transaction that is rolled back (never
+ * committed) on tear-down. With the stock manager, callbacks registered via
+ * `Connection::afterCommit()` — including listeners implementing
+ * `ShouldHandleEventsAfterCommit` — are attached to that open transaction and
+ * discarded when it rolls back, so after-commit behaviour can never be
+ * observed in tests (flarum/framework#4814).
+ *
+ * By reporting no applicable pending transactions, `addCallback()` runs each
+ * callback immediately instead of deferring it. All other transaction
+ * bookkeeping is left intact, so `db.transactions` stays bound and
+ * `Connection::afterCommit()` still works (flarum/framework#4787).
+ */
+class InlineTransactionsManager extends DatabaseTransactionsManager
+{
+    public function callbackApplicableTransactions()
+    {
+        return new Collection();
+    }
+}


### PR DESCRIPTION
Fixes #4814.

Binding `db.transactions` (#4787) means listeners implementing `ShouldHandleEventsAfterCommit` — and events implementing `ShouldDispatchAfterCommit`, and any direct `Connection::afterCommit()` callback — are deferred to the surrounding transaction's commit. The integration harness wraps each test in a transaction that is rolled back and never committed, so those callbacks were attached to it and silently discarded. After-commit behaviour therefore could not be observed or asserted in integration tests, with no error.

The test harness now binds a `DatabaseTransactionsManager` subclass (`InlineTransactionsManager`) that reports no applicable pending transactions, so `addCallback()` runs each callback immediately instead of deferring it. `db.transactions` stays bound and attached to the connection, so `Connection::afterCommit()` still works and #4787 stays intact — `AfterCommitTest` continues to pass.

The manager is bound and attached to the connection via a `BindInlineTransactionsManager` extender that runs before the harness opens its transaction.

Covered by integration tests for all three paths: a direct `afterCommit()` callback, a `ShouldHandleEventsAfterCommit` listener, and a `ShouldDispatchAfterCommit` event.