### PR TITLE
[2.x] feat(core): Add database version requirements with recommended-version warnings

### DIFF
--- a/framework/core/js/src/admin/AdminApplication.tsx
+++ b/framework/core/js/src/admin/AdminApplication.tsx
@@ -56,6 +56,15 @@ export enum DatabaseDriver {
   SQLite = 'SQLite',
 }
 
+export interface DatabaseVersionStatus {
+  // A running install is always at or above the hard minimum, so the backend
+  // only ever reports these two states to the admin frontend.
+  status: 'ok' | 'below_recommended';
+  server: string;
+  version: string;
+  recommended: string;
+}
+
 export interface AdminApplicationData extends ApplicationData {
   extensions: Record<string, Extension>;
   installedPackages: string[];
@@ -80,6 +89,8 @@ export interface AdminApplicationData extends ApplicationData {
 
   dbDriver: DatabaseDriver;
   dbVersion: string;
+  dbDriverMismatch: string | null;
+  dbVersionStatus: DatabaseVersionStatus | null;
   dbOptions: Record<string, string>;
   phpVersion: string;
   queueDriver: string;

--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -108,6 +108,38 @@ export default class DashboardPage extends AdminPage {
       );
     }
 
+    // A running install can never be below the hard minimum — Flarum won't
+    // boot below it, and the installer refuses to proceed — so we only nudge
+    // when the version is below the recommended release.
+    const dbVersionStatus = app.data.dbVersionStatus;
+    if (dbVersionStatus && dbVersionStatus.status === 'below_recommended') {
+      items.add(
+        'db-version-warning',
+        <AlertWidget
+          className="DbVersionWarningWidget"
+          alert={{
+            type: 'warning',
+            dismissible: false,
+            title: app.translator.trans('core.admin.database-version-warning.below-recommended-label'),
+            icon: 'fas fa-database',
+          }}
+        >
+          {app.translator.trans('core.admin.database-version-warning.below-recommended-detail', {
+            server: dbVersionStatus.server,
+            version: dbVersionStatus.version,
+            recommended: dbVersionStatus.recommended,
+            link: ({ children }: { children: Children }) => (
+              <Link href="https://docs.flarum.org/2.x/install/#server-requirements" external={true} target="_blank">
+                <Icon name="fas fa-external-link-alt" />
+                {children}
+              </Link>
+            ),
+          })}
+        </AlertWidget>,
+        85
+      );
+    }
+
     items.add('status', <StatusWidget />, 80);
 
     if (!app.data.announcementsDisabled) {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -241,6 +241,12 @@ core:
         Using the wrong driver can cause subtle, hard-to-diagnose bugs. Set <code>'driver' => ''{actual}''</code> in the <code>database</code> section of your <code>config.php</code> file. See <link>Flarum docs</link> for more information.
       label: Database driver mismatch
 
+    # These translations are used in the database version warning widget.
+    database-version-warning:
+      below-recommended-detail: |
+        Your {server} server is running version <code>{version}</code>. This is supported, but Flarum recommends {server} <code>{recommended}</code> or later for the best performance and to stay on a maintained release. See <link>Flarum docs</link> for more information.
+      below-recommended-label: Database version outdated
+
     # These translations are used in the debug warning widget.
     debug-warning:
       detail: |

--- a/framework/core/src/Admin/Content/AdminPayload.php
+++ b/framework/core/src/Admin/Content/AdminPayload.php
@@ -78,6 +78,7 @@ class AdminPayload
         $document->payload['dbDriver'] = $this->appInfo->identifyDatabaseDriver();
         $document->payload['dbVersion'] = $this->appInfo->identifyDatabaseVersion();
         $document->payload['dbDriverMismatch'] = $this->appInfo->identifyDatabaseDriverMismatch();
+        $document->payload['dbVersionStatus'] = $this->appInfo->identifyDatabaseVersionStatus();
         $document->payload['dbOptions'] = $this->appInfo->identifyDatabaseOptions();
         $document->payload['debugEnabled'] = Arr::get($this->config, 'debug');
 

--- a/framework/core/src/Database/DatabaseRequirements.php
+++ b/framework/core/src/Database/DatabaseRequirements.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Database;
+
+use Illuminate\Support\Str;
+
+/**
+ * Database engine version requirements for this Flarum version.
+ *
+ * Two tiers per engine:
+ *  - MINIMUM: below this Flarum will not run. The installer refuses to proceed
+ *    and the admin dashboard shows a blocking error.
+ *  - RECOMMENDED: above the minimum but below this runs, but the admin is
+ *    warned to encourage upgrading to a modern, supported release.
+ *
+ * Centralised here so the installer, `ApplicationInfoProvider` and the admin
+ * surfaces share a single source of truth.
+ */
+class DatabaseRequirements
+{
+    /**
+     * Minimum MySQL version. The `JSON` column type, which Flarum relies on,
+     * was introduced in MySQL 5.7.8.
+     */
+    public const MYSQL_MINIMUM = '5.7.8';
+
+    /**
+     * Recommended MySQL version — a modern, supported release.
+     */
+    public const MYSQL_RECOMMENDED = '8.4.0';
+
+    /**
+     * Minimum MariaDB version. While JSON support arrived in 10.2.7, Flarum's
+     * migrations require features present from 10.3 onwards.
+     */
+    public const MARIADB_MINIMUM = '10.3.0';
+
+    /**
+     * Recommended MariaDB version — a modern, supported release.
+     */
+    public const MARIADB_RECOMMENDED = '11.8.0';
+
+    public const PGSQL_MINIMUM = '10.0.0';
+
+    /**
+     * Recommended PostgreSQL version. PostgreSQL supports each major release for
+     * five years; below this a release is (or is about to be) end-of-life, so we
+     * warn to encourage staying on a maintained release.
+     */
+    public const PGSQL_RECOMMENDED = '15.0';
+
+    public const SQLITE_MINIMUM = '3.35.0';
+
+    /**
+     * The result of comparing a version against the tiers.
+     */
+    public const OK = 'ok';
+    public const BELOW_MINIMUM = 'below_minimum';
+    public const BELOW_RECOMMENDED = 'below_recommended';
+
+    /**
+     * Whether a raw `VERSION()` string reports a MariaDB server.
+     */
+    public static function isMariaDb(string $rawVersion): bool
+    {
+        return Str::contains($rawVersion, 'MariaDB', ignoreCase: true);
+    }
+
+    /**
+     * Extract a dotted numeric version (e.g. "8.0.36" or "11.8.2") from a raw
+     * `VERSION()` string.
+     *
+     * MariaDB reports itself with a legacy "5.5.5-" compatibility prefix in
+     * some configurations (e.g. "5.5.5-10.11.6-MariaDB-..."). We strip that
+     * prefix before parsing so we read the real MariaDB version.
+     *
+     * The third segment is optional: since PostgreSQL 10, `SHOW server_version`
+     * reports a two-part `major.minor` string (e.g. "16.3"). MySQL and MariaDB
+     * always report all three parts, which the greedy match still captures.
+     */
+    public static function normaliseVersion(string $rawVersion, bool $isMariaDb): ?string
+    {
+        if ($isMariaDb && str_starts_with($rawVersion, '5.5.5-')) {
+            $rawVersion = substr($rawVersion, strlen('5.5.5-'));
+        }
+
+        if (preg_match('/(\d+\.\d+(?:\.\d+)?)/', $rawVersion, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * The minimum and recommended versions for a MySQL/MariaDB server.
+     *
+     * @return array{minimum: string, recommended: string}
+     */
+    public static function mysqlFamilyTiers(bool $isMariaDb): array
+    {
+        return $isMariaDb
+            ? ['minimum' => self::MARIADB_MINIMUM, 'recommended' => self::MARIADB_RECOMMENDED]
+            : ['minimum' => self::MYSQL_MINIMUM, 'recommended' => self::MYSQL_RECOMMENDED];
+    }
+
+    /**
+     * Compare a normalised version against a tier pair.
+     *
+     * @return self::OK|self::BELOW_MINIMUM|self::BELOW_RECOMMENDED
+     */
+    public static function compare(string $version, string $minimum, string $recommended): string
+    {
+        if (version_compare($version, $minimum, '<')) {
+            return self::BELOW_MINIMUM;
+        }
+
+        if (version_compare($version, $recommended, '<')) {
+            return self::BELOW_RECOMMENDED;
+        }
+
+        return self::OK;
+    }
+}

--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -10,6 +10,7 @@
 namespace Flarum\Foundation;
 
 use Carbon\Carbon;
+use Flarum\Database\DatabaseRequirements;
 use Flarum\Locale\Translator;
 use Flarum\User\SessionManager;
 use Illuminate\Console\Scheduling\Schedule;
@@ -124,6 +125,80 @@ class ApplicationInfoProvider
         $actual = $isMariaDb ? 'mariadb' : 'mysql';
 
         return $actual === $configured ? null : $actual;
+    }
+
+    /**
+     * Assess the running database version against Flarum's minimum and
+     * recommended tiers.
+     *
+     * MySQL, MariaDB and PostgreSQL each carry a two-tier requirement; SQLite
+     * (which only has a hard floor enforced at install time) returns null. The
+     * returned array mirrors what the admin frontend needs to render a warning
+     * consistent with the driver-mismatch alert.
+     *
+     * @return array{status: string, server: string, version: string, recommended: string}|null
+     */
+    public function identifyDatabaseVersionStatus(): ?array
+    {
+        $tuple = match ($this->config['database.driver']) {
+            'mysql', 'mariadb' => $this->mysqlFamilyVersionTuple(),
+            'pgsql' => $this->pgsqlVersionTuple(),
+            default => null,
+        };
+
+        if ($tuple === null || $tuple['version'] === null) {
+            return null;
+        }
+
+        return [
+            'status' => DatabaseRequirements::compare($tuple['version'], $tuple['minimum'], $tuple['recommended']),
+            'server' => $tuple['server'],
+            'version' => $tuple['version'],
+            'recommended' => $tuple['recommended'],
+        ];
+    }
+
+    /**
+     * @return array{server: string, version: ?string, minimum: string, recommended: string}
+     */
+    private function mysqlFamilyVersionTuple(): array
+    {
+        // Cache for 24 hours since the database version rarely changes. This is
+        // the unmodified VERSION() string (unlike flarum:db_version, which is
+        // trimmed for display) so we can correctly parse MariaDB's legacy
+        // "5.5.5-" compatibility prefix before comparing.
+        $raw = $this->cache->remember('flarum:db_version_raw', 86400, function () {
+            return $this->db->selectOne('select version() as version')->version;
+        });
+
+        $isMariaDb = DatabaseRequirements::isMariaDb($raw);
+        $tiers = DatabaseRequirements::mysqlFamilyTiers($isMariaDb);
+
+        return [
+            'server' => $isMariaDb ? 'MariaDB' : 'MySQL',
+            'version' => DatabaseRequirements::normaliseVersion($raw, $isMariaDb),
+            'minimum' => $tiers['minimum'],
+            'recommended' => $tiers['recommended'],
+        ];
+    }
+
+    /**
+     * @return array{server: string, version: ?string, minimum: string, recommended: string}
+     */
+    private function pgsqlVersionTuple(): array
+    {
+        // SHOW server_version returns a clean version (e.g. "15.3"), unlike
+        // SELECT version() which includes platform info.
+        $version = $this->cache->remember('flarum:db_version_pgsql', 86400, function () {
+            return Str::before($this->db->selectOne('show server_version')->server_version, ' ');
+        });
+
+        return [
+            'server' => 'PostgreSQL',
+            'version' => DatabaseRequirements::normaliseVersion($version, false),
+            'minimum' => DatabaseRequirements::PGSQL_MINIMUM,
+            'recommended' => DatabaseRequirements::PGSQL_RECOMMENDED,
+        ];
     }
 
     public function identifyDatabaseOptions(): array

--- a/framework/core/src/Foundation/Console/InfoCommand.php
+++ b/framework/core/src/Foundation/Console/InfoCommand.php
@@ -10,6 +10,7 @@
 namespace Flarum\Foundation\Console;
 
 use Flarum\Console\AbstractCommand;
+use Flarum\Database\DatabaseRequirements;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
 use Flarum\Foundation\ApplicationInfoProvider;
@@ -67,10 +68,17 @@ class InfoCommand extends AbstractCommand
         }
 
         $dbMismatch = $this->appInfo->identifyDatabaseDriverMismatch();
+        $dbVersionStatus = $this->appInfo->identifyDatabaseVersionStatus();
         $dbLine = '<info>'.$this->appInfo->identifyDatabaseDriver().' version:</info> '.$this->appInfo->identifyDatabaseVersion();
 
         if ($dbMismatch) {
             $dbLine .= " <error>(driver mismatch — config.php is set to '{$this->config['database.driver']}', but the server is {$dbMismatch})</error>";
+        }
+
+        // A booted Flarum is always at or above the hard minimum, so only the
+        // recommended-version nudge is meaningful here.
+        if ($dbVersionStatus && $dbVersionStatus['status'] === DatabaseRequirements::BELOW_RECOMMENDED) {
+            $dbLine .= " <comment>(below the recommended {$dbVersionStatus['server']} {$dbVersionStatus['recommended']})</comment>";
         }
 
         $this->output->writeln($dbLine);

--- a/framework/core/src/Install/Steps/ConnectToDatabase.php
+++ b/framework/core/src/Install/Steps/ConnectToDatabase.php
@@ -10,6 +10,7 @@
 namespace Flarum\Install\Steps;
 
 use Closure;
+use Flarum\Database\DatabaseRequirements;
 use Flarum\Install\DatabaseConfig;
 use Flarum\Install\Step;
 use Illuminate\Database\Connectors\MariaDbConnector;
@@ -55,15 +56,19 @@ readonly class ConnectToDatabase implements Step
     {
         $pdo = (new MySqlConnector)->connect($config);
 
-        $version = $pdo->query('SELECT VERSION()')->fetchColumn();
+        $raw = $pdo->query('SELECT VERSION()')->fetchColumn();
 
-        if (Str::contains($version, 'MariaDB')) {
-            if (version_compare($version, '10.3.0', '<')) {
-                throw new RangeException("MariaDB version ($version) too low. You need at least MariaDB 10.3");
+        if (DatabaseRequirements::isMariaDb($raw)) {
+            $version = DatabaseRequirements::normaliseVersion($raw, true) ?? $raw;
+
+            if (version_compare($version, DatabaseRequirements::MARIADB_MINIMUM, '<')) {
+                throw new RangeException("MariaDB version ($version) too low. You need at least MariaDB ".DatabaseRequirements::MARIADB_MINIMUM);
             }
         } else {
-            if (version_compare($version, '5.7.0', '<')) {
-                throw new RangeException("MySQL version ($version) too low. You need at least MySQL 5.7");
+            $version = DatabaseRequirements::normaliseVersion($raw, false) ?? $raw;
+
+            if (version_compare($version, DatabaseRequirements::MYSQL_MINIMUM, '<')) {
+                throw new RangeException("MySQL version ($version) too low. You need at least MySQL ".DatabaseRequirements::MYSQL_MINIMUM);
             }
         }
 
@@ -81,10 +86,11 @@ readonly class ConnectToDatabase implements Step
     {
         $pdo = (new MariaDbConnector())->connect($config);
 
-        $version = $pdo->query('SELECT VERSION()')->fetchColumn();
+        $raw = $pdo->query('SELECT VERSION()')->fetchColumn();
+        $version = DatabaseRequirements::normaliseVersion($raw, true) ?? $raw;
 
-        if (version_compare($version, '10.3.0', '<')) {
-            throw new RangeException("MariaDB version ($version) too low. You need at least MariaDB 10.3");
+        if (version_compare($version, DatabaseRequirements::MARIADB_MINIMUM, '<')) {
+            throw new RangeException("MariaDB version ($version) too low. You need at least MariaDB ".DatabaseRequirements::MARIADB_MINIMUM);
         }
 
         ($this->store)(
@@ -104,7 +110,7 @@ readonly class ConnectToDatabase implements Step
         $version = $pdo->query('SHOW server_version')->fetchColumn();
         $version = Str::before($version, ' ');
 
-        if (version_compare($version, '10.0.0', '<')) {
+        if (version_compare($version, DatabaseRequirements::PGSQL_MINIMUM, '<')) {
             throw new RangeException("PostgreSQL version ($version) too low. You need at least PostgreSQL 10");
         }
 
@@ -128,8 +134,8 @@ readonly class ConnectToDatabase implements Step
 
         $version = $pdo->query('SELECT sqlite_version()')->fetchColumn();
 
-        if (version_compare($version, '3.35.0', '<')) {
-            throw new RangeException("SQLite version ($version) too low. You need at least SQLite 3.35.0");
+        if (version_compare($version, DatabaseRequirements::SQLITE_MINIMUM, '<')) {
+            throw new RangeException("SQLite version ($version) too low. You need at least SQLite ".DatabaseRequirements::SQLITE_MINIMUM);
         }
 
         ($this->store)(

--- a/framework/core/tests/unit/Database/DatabaseRequirementsTest.php
+++ b/framework/core/tests/unit/Database/DatabaseRequirementsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Database;
+
+use Flarum\Database\DatabaseRequirements;
+use Flarum\Testing\unit\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class DatabaseRequirementsTest extends TestCase
+{
+    #[DataProvider('isMariaDbProvider')]
+    public function test_detects_mariadb(string $raw, bool $expected): void
+    {
+        $this->assertSame($expected, DatabaseRequirements::isMariaDb($raw));
+    }
+
+    public static function isMariaDbProvider(): array
+    {
+        return [
+            ['10.11.6-MariaDB-1:10.11.6+maria~ubu', true],
+            ['5.5.5-10.11.6-MariaDB', true],
+            ['8.0.36', false],
+            ['8.4.0-0ubuntu0.24.04.1', false],
+        ];
+    }
+
+    #[DataProvider('normaliseProvider')]
+    public function test_normalises_version(string $raw, bool $isMariaDb, ?string $expected): void
+    {
+        $this->assertSame($expected, DatabaseRequirements::normaliseVersion($raw, $isMariaDb));
+    }
+
+    public static function normaliseProvider(): array
+    {
+        return [
+            // Plain MySQL.
+            ['8.0.36', false, '8.0.36'],
+            ['8.4.0-0ubuntu0.24.04.1', false, '8.4.0'],
+            // MariaDB with a distribution suffix.
+            ['10.11.14-MariaDB-0+deb12u2', true, '10.11.14'],
+            // MariaDB's legacy "5.5.5-" compatibility prefix must be stripped
+            // so we read the real version, not 5.5.5.
+            ['5.5.5-10.11.6-MariaDB-1:10.11.6+maria~ubu', true, '10.11.6'],
+            // PostgreSQL 10+ reports a two-part major.minor version.
+            ['16.3', false, '16.3'],
+            ['15.13', false, '15.13'],
+            // Pre-10 PostgreSQL reported three parts.
+            ['9.6.24', false, '9.6.24'],
+            // Unparseable.
+            ['not-a-version', false, null],
+        ];
+    }
+
+    #[DataProvider('compareProvider')]
+    public function test_compares_against_tiers(string $version, string $minimum, string $recommended, string $expected): void
+    {
+        $this->assertSame($expected, DatabaseRequirements::compare($version, $minimum, $recommended));
+    }
+
+    public static function compareProvider(): array
+    {
+        return [
+            // Below the floor.
+            ['5.6.0', '5.7.8', '8.4.0', DatabaseRequirements::BELOW_MINIMUM],
+            ['5.7.7', '5.7.8', '8.4.0', DatabaseRequirements::BELOW_MINIMUM],
+            // At the floor, below recommended.
+            ['5.7.8', '5.7.8', '8.4.0', DatabaseRequirements::BELOW_RECOMMENDED],
+            ['8.0.36', '5.7.8', '8.4.0', DatabaseRequirements::BELOW_RECOMMENDED],
+            // At or above recommended.
+            ['8.4.0', '5.7.8', '8.4.0', DatabaseRequirements::OK],
+            ['9.0.0', '5.7.8', '8.4.0', DatabaseRequirements::OK],
+            // PostgreSQL two-part versions against the pgsql tiers.
+            ['14.11', '10.0.0', '15.0', DatabaseRequirements::BELOW_RECOMMENDED],
+            ['15.0', '10.0.0', '15.0', DatabaseRequirements::OK],
+            ['17.2', '10.0.0', '15.0', DatabaseRequirements::OK],
+        ];
+    }
+
+    public function test_mysql_family_tiers_switch_on_engine(): void
+    {
+        $mysql = DatabaseRequirements::mysqlFamilyTiers(false);
+        $this->assertSame(DatabaseRequirements::MYSQL_MINIMUM, $mysql['minimum']);
+        $this->assertSame(DatabaseRequirements::MYSQL_RECOMMENDED, $mysql['recommended']);
+
+        $mariadb = DatabaseRequirements::mysqlFamilyTiers(true);
+        $this->assertSame(DatabaseRequirements::MARIADB_MINIMUM, $mariadb['minimum']);
+        $this->assertSame(DatabaseRequirements::MARIADB_RECOMMENDED, $mariadb['recommended']);
+    }
+}


### PR DESCRIPTION
Mirrors the floor and recommended database versions from [fof/upgrade-advisor](https://github.com/FriendsOfFlarum/upgrade-advisor) into core, so the requirements are enforced at install time and surfaced in the admin panel.

## Changes

A new `Flarum\Database\DatabaseRequirements` centralises the per-engine thresholds (minimum + recommended) as a single source of truth, consumed by both the installer and the admin surfaces.

**Installer** (`ConnectToDatabase`) now reads its hard-fail floors from the shared constants:

| Engine | Minimum (fail) | Recommended (warn) |
| --- | --- | --- |
| MySQL | 5.7.8 (was 5.7.0) | 8.4.0 |
| MariaDB | 10.3.0 (unchanged) | 11.8.0 |
| PostgreSQL | 10.0.0 | 15.0 |
| SQLite | 3.35.0 | — |

It also uses the shared version normaliser so MariaDB's legacy `5.5.5-` compatibility prefix parses to the real version before comparison.

**Admin** — the dashboard and `php flarum info` now warn when the running MySQL/MariaDB/PostgreSQL version is below the recommended release, following the existing database-driver-mismatch pattern. A booted install is always at or above the hard minimum (Flarum won't run below it, and the installer refuses to proceed), so only the recommended tier is surfaced in the admin; the minimum tier only applies at install time.
