### PR TITLE
[2.x] chore(ci): Fix PHP-version matrix, drop unused Xdebug, and modernise workflow actions

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -34,6 +34,12 @@ on:
         # Keep PHP versions synced with build-install-packages.yml
         default: '["8.3", "8.4", "8.5"]'
 
+      latest_php:
+        description: The latest PHP version to test with. DB-specific jobs run only on this version. Keep in sync with the last entry of php_versions.
+        type: string
+        required: false
+        default: '8.5'
+
       php_extensions:
         description: PHP extensions to install.
         type: string
@@ -103,25 +109,25 @@ jobs:
             driver: pgsql
 
           # Include Database prefix tests with only one PHP version (latest).
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
+          - php: ${{ inputs.latest_php }}
             service: 'mysql:5.7'
             db: MySQL 5.7
             driver: mysql
             prefix: flarum_
             prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
+          - php: ${{ inputs.latest_php }}
             service: mariadb
             db: MariaDB
             driver: mariadb
             prefix: flarum_
             prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
+          - php: ${{ inputs.latest_php }}
             service: 'sqlite:3'
             db: SQLite
             driver: sqlite
             prefix: flarum_
             prefixStr: (prefix)
-          - php: ${{ fromJSON(inputs.php_versions)[3] }}
+          - php: ${{ inputs.latest_php }}
             service: 'postgres:10'
             db: PostgreSQL 10
             driver: pgsql
@@ -132,30 +138,26 @@ jobs:
         # - MySQL 8.0 runs on all PHP versions (primary DB for PHP version coverage)
         # - All other DBs run on latest PHP only (DB-specific bugs don't depend on PHP version)
         # - MySQL 5.7 also runs on latest PHP only (floor version coverage)
+        #
+        # This excludes every non-latest PHP version for those DBs, leaving only
+        # `latest_php`. The list must cover all `php_versions` entries EXCEPT the
+        # last one, so keep it in sync when `php_versions` changes size.
         exclude:
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: 'mysql:5.7'
           - php: ${{ fromJSON(inputs.php_versions)[1] }}
             service: 'mysql:5.7'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: 'mysql:5.7'
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: mariadb
           - php: ${{ fromJSON(inputs.php_versions)[1] }}
             service: mariadb
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
-            service: mariadb
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: 'sqlite:3'
           - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'sqlite:3'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
             service: 'sqlite:3'
           - php: ${{ fromJSON(inputs.php_versions)[0] }}
             service: 'postgres:10'
           - php: ${{ fromJSON(inputs.php_versions)[1] }}
-            service: 'postgres:10'
-          - php: ${{ fromJSON(inputs.php_versions)[2] }}
             service: 'postgres:10'
 
     services:
@@ -201,7 +203,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -209,7 +211,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          # Coverage is not collected or uploaded anywhere, and Xdebug slows the
+          # test suite considerably, so leave it disabled.
+          coverage: none
           extensions: ${{ inputs.php_extensions }}
           tools: phpunit, composer:v2
           ini-values: ${{ matrix.php_ini_values }}
@@ -256,13 +260,13 @@ jobs:
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.event_name != 'pull_request')
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: none
           extensions: ${{ inputs.php_extensions }}
           tools: phpunit, composer:v2
           ini-values: ${{ matrix.php_ini_values }}

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -79,7 +79,7 @@ on:
         description: The node version to use for the workflow.
         type: number
         required: false
-        default: 20
+        default: 24
 
       js_package_manager:
         description: "Enable TypeScript?"
@@ -136,12 +136,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.git_actor_token != '' && secrets.git_actor_token || secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.js_package_manager }}

--- a/.github/workflows/REUSABLE_frontend.yml
+++ b/.github/workflows/REUSABLE_frontend.yml
@@ -164,7 +164,7 @@ jobs:
         working-directory: ${{ inputs.frontend_directory }}
 
       - name: JS Checks & Production Build
-        uses: flarum/action-build@v4.1
+        uses: flarum/action-build@v5
         with:
           build_script: ${{ inputs.build_script }}
           build_typings_script: ${{ inputs.build_typings_script }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Prepare release
         uses: flarum/action-release@master
         with:


### PR DESCRIPTION
Modernises the reusable CI workflows: fixes a latent bug in the backend test matrix, drops unused Xdebug instrumentation, and brings the actions and runtimes up to date.

## Backend test matrix

When #4468 reduced `php_versions` from four entries to three, the matrix kept referencing index `[3]` for the latest PHP version (now out of bounds, resolving to an empty string) and excluding indices `[0]`, `[1]` and `[2]`.

This did **not** break the build — `shivammathur/setup-php` falls back to the runner's default PHP when given an empty version, which on `ubuntu-latest` happens to be the intended latest (8.5), so those jobs still ran on the right version. But the job labels read `PHP  /` (blank), and the matrix silently depended on the runner default matching the intended latest — it would test the wrong version if that ever diverged.

- Add a `latest_php` input and use it for the database-specific jobs instead of a hardcoded, length-dependent array index. (GitHub Actions expressions don't support arithmetic inside the index operator, so an index-safe inline expression isn't possible.)
- Correct the `exclude` list to drop only the non-latest PHP versions.

Resulting matrix (unchanged in shape, now with explicit PHP versions):
- MySQL 8.0 on all PHP versions (8.3, 8.4, 8.5) — PHP version coverage
- MySQL 5.7, MariaDB, PostgreSQL, SQLite on latest PHP only (+ prefix variants)

## Speed: drop unused Xdebug coverage

The test and PHPStan jobs enabled `coverage: xdebug`, but coverage is never collected or uploaded anywhere. Xdebug still slows execution when merely loaded. Set `coverage: none`.

Measured effect (single run, so ± CI variance): the critical-path job — the whole workflow's wall-clock, since all matrix jobs run concurrently — dropped from ~778s to ~650s (**−16%, ~2 min**). Other jobs improved ~3–10%, which doesn't change wall-clock but frees runners sooner.

## Action & runtime updates

- `actions/checkout` and `actions/setup-node`: **v4 → v7**; pinned the remaining `@master` / `@v3` references (backend PHPStan checkout, prepare-release checkout).
- Frontend workflow Node default: **20 → 24** (Node 20 is EOL). Incidentally cut the frontend build step ~18% (~40s), likely from V8 improvements across the major.
- `flarum/action-build`: **@v4.1 → @v5**. v5 moves the action to the node24 runtime and fixes committing gitignored `dist` output (flarum/action-build#15). Verified: the frontend job on this branch runs cleanly against `action-build@v5`.

## Not included

- Runners stay on x86 `ubuntu-latest`. ARM (`ubuntu-24.04-arm`) was measured and gave no wall-clock benefit (public repo → x86 is free and equally fast), and the MySQL 5.7 service image has no arm64 manifest.
- No further test-suite parallelisation. ~90% of each job is test/build execution, so deeper wall-clock gains would require splitting or speeding up the suites themselves — left as a possible follow-up.
