### PR TITLE
[2.x] fix(approval): scope the unapproved fade to text, not the whole post

### DIFF
--- a/extensions/approval/less/forum.less
+++ b/extensions/approval/less/forum.less
@@ -1,5 +1,16 @@
 .Post--unapproved {
-  opacity: 0.5;
+  .Post-header, .Post-header a,
+  .PostUser .PostUser-name, .PostUser .PostUser-name a {
+    color: var(--muted-more-color);
+  }
+  .Post-body,
+  .Post-footer,
+  .Post-side > *,
+  .PostUser-badges,
+  .EventPost-icon,
+  .EventPost-info {
+    opacity: 0.5;
+  }
 }
 .DiscussionListItem--unapproved {
   .DiscussionListItem--hidden();

--- a/extensions/approval/less/forum.less
+++ b/extensions/approval/less/forum.less
@@ -1,17 +1,50 @@
+// A pending post reads as de-emphasised in its entirety, as it always has. What
+// it must NOT do is carry `opacity` on the <article>: a value below 1 gives the
+// post its own stacking context, and nothing rendered inside it can escape that
+// — not with z-index, not with position: fixed. Every popup the post owns (the
+// user card and the meta dropdown in the header, the controls dropdown in the
+// actions) is drawn as part of that faded group, and the posts after it in the
+// stream paint over the top. The controls menu then cannot be clicked at all,
+// because the clicks land on the post underneath (#4505, and the same root
+// cause behind #4453, #4212, #3031, #950).
+//
+// So the fade is applied to the elements themselves rather than to their common
+// ancestor, and each popup's own container is left out of it. Every part of the
+// post a reader can see while its menus are closed is still at half strength.
 .Post--unapproved {
-  .Post-header, .Post-header a,
-  .PostUser .PostUser-name, .PostUser .PostUser-name a {
+  .Post-header,
+  .Post-header a,
+  .PostUser .PostUser-name,
+  .PostUser .PostUser-name a {
     color: var(--muted-more-color);
   }
+
   .Post-body,
   .Post-footer,
-  .Post-side > *,
   .PostUser-badges,
   .EventPost-icon,
   .EventPost-info {
     opacity: 0.5;
   }
+
+  // The avatar, not the link wrapping it: on 2.x the user card is a sibling
+  // inside the header, but keeping the fade on the image itself holds for any
+  // theme that moves the card inside that link.
+  .Post-avatar,
+  .PostUser-avatar {
+    opacity: 0.5;
+  }
+
+  // Reply, Like, and the controls toggle. Reached one level at a time so the
+  // menu the toggle opens, which is a sibling of it inside .Dropdown, keeps its
+  // own opacity. Fading .Post-actions wholesale would take the menu with it and
+  // put us back where we started.
+  .Post-actions > ul > li > .Button,
+  .Post-controls > .Dropdown-toggle {
+    opacity: 0.5;
+  }
 }
+
 .DiscussionListItem--unapproved {
   .DiscussionListItem--hidden();
 }


### PR DESCRIPTION
`.Post--unapproved` puts `opacity: 0.5` on the whole `<article>`, which gives the post its own stacking context. Everything that pops out of the post is then stuck inside it. The controls dropdown, the post-meta modal and the user card all render at half opacity, and anything that follows the post in the stream paints over them. The practical effect is that the controls menu on a pending post can't be clicked, because the clicks land on the post underneath.

To reproduce, with Approval enabled:

1. Post a reply, then set `is_approved = 0` on its row in the `posts` table
2. Make sure there is another post after it in the stream
3. Open the controls menu on the pending post

This is the same bug #4453 dealt with, moved rather than removed. Before that PR the opacity sat on `.Post-header`, which trapped the user card. Moving it up to the article freed the card, but pulled `.Post-actions` into the fade for the first time. The wider version of this has been open as flarum/issue-archive#328 since 2016, with #950 and #3031 closed as duplicates of it, and #4212 closed by #4453.

The fix mutes the header with `color` and applies the fade to the elements themselves rather than to their common ancestor, leaving out only each popup's own container. The action buttons are reached one level at a time (`.Post-actions > ul > li > .Button`, `.Post-controls > .Dropdown-toggle`) so that the menu the toggle opens keeps its own opacity: it is a sibling of the toggle inside `.Dropdown`, not a child of it.

**A pending post looks the same as it does today.** Everything visible while the menus are closed stays at half strength, including the avatar and the action buttons. Measured effective opacity on 2.0.0-rc.5, with `.Post-actions` forced visible since core hides it until hover:

| | article | avatar | body | Reply / Like | controls toggle | open controls menu |
| --- | --- | --- | --- | --- | --- | --- |
| current `2.x` | 0.5 | 0.5 | 0.5 | 0.5 | 0.5 | **0.5, and behind later posts** |
| this PR | 1 | 0.5 | 0.5 | 0.5 | 0.5 | **1** |

Checked on 2.0.0-rc.5 against a comment post, a discussion's opening post, and an unapproved event post.

1.x has the same root cause but breaks differently. The controls menu is fine there, and it's the user card and post-meta modal that suffer. The equivalent change fixes it, so I'm happy to open a 1.x PR if that's wanted.

Fixes #4505

