### PR TITLE
[2.x] perf: Prefetch the post stream chunks after boot

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -184,6 +184,20 @@ export default class Application {
   initializers: ItemList<(app: this) => void> = new ItemList();
 
   /**
+   * An ordered list of chunk loaders to prefetch once the app is idle after
+   * booting.
+   *
+   * Lazily-loaded (code-split) components add a network round-trip the first
+   * time their route is visited. Registering their loader here warms the chunk
+   * in the background so that, by the time the user navigates to it, the
+   * dynamic import resolves from cache instead of blocking on a request.
+   *
+   * Each item is a thunk that triggers the load — a function returning the
+   * dynamic import of the chunk (the same loader passed to a lazy route).
+   */
+  prefetch: ItemList<() => Promise<unknown>> = new ItemList();
+
+  /**
    * The app's session.
    *
    * Stores info about the current user.

--- a/framework/core/js/src/common/utils/drainPrefetchQueue.ts
+++ b/framework/core/js/src/common/utils/drainPrefetchQueue.ts
@@ -1,0 +1,47 @@
+import type ItemList from './ItemList';
+
+/**
+ * Schedule a callback to run when the browser is idle, falling back to a short
+ * timeout where `requestIdleCallback` is unavailable (e.g. Safari).
+ */
+function whenIdle(callback: () => void): void {
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(callback);
+  } else {
+    setTimeout(callback, 200);
+  }
+}
+
+/**
+ * Warm the app's registered prefetch chunks in the background, once the browser
+ * is idle.
+ *
+ * Loaders run one at a time, each waiting for the next idle period, so that
+ * prefetching never competes with rendering or user interaction. Failures are
+ * swallowed: a prefetch is a best-effort optimisation, and the real `import()`
+ * on navigation will surface any genuine load error.
+ *
+ * @see Application.prefetch
+ */
+export default function drainPrefetchQueue(prefetch: ItemList<() => Promise<unknown>>): void {
+  const loaders = prefetch.toArray();
+
+  if (loaders.length === 0) return;
+
+  let index = 0;
+
+  const next = () => {
+    if (index >= loaders.length) return;
+
+    const loader = loaders[index++];
+
+    // Best-effort: ignore errors, then queue the next loader for the following
+    // idle period.
+    Promise.resolve()
+      .then(loader)
+      .catch(() => {})
+      .then(() => whenIdle(next));
+  };
+
+  whenIdle(next);
+}

--- a/framework/core/js/src/forum/ForumApplication.tsx
+++ b/framework/core/js/src/forum/ForumApplication.tsx
@@ -24,6 +24,7 @@ import type Discussion from '../common/models/Discussion';
 import type NotificationModel from '../common/models/Notification';
 import type PostModel from '../common/models/Post';
 import extractText from '../common/utils/extractText';
+import drainPrefetchQueue from '../common/utils/drainPrefetchQueue';
 import Notices from './components/Notices';
 import Footer from './components/Footer';
 import SearchManager from '../common/SearchManager';
@@ -142,6 +143,10 @@ export default class ForumApplication extends Application {
         $('.App').addClass('mobile-safari');
       });
     }
+
+    // Once the app is mounted, warm any registered code-split chunks in the
+    // background so later navigations don't pay for them on the critical path.
+    drainPrefetchQueue(this.prefetch);
   }
 
   /**

--- a/framework/core/js/src/forum/routes.ts
+++ b/framework/core/js/src/forum/routes.ts
@@ -40,6 +40,12 @@ export default function (app: ForumApplication) {
     'user.security': { path: '/u/:username/security', component: () => import('./components/UserSecurityPage'), resolverClass: UserPageResolver },
     notifications: { path: '/notifications', component: () => import('./components/NotificationsPage') },
   };
+
+  // Warm the post stream chunks in the background once the app is idle. Opening
+  // a discussion is the most common navigation, so having these cached avoids a
+  // request on the critical path when the user clicks through to one.
+  app.prefetch.add('postStream', () => import('./components/PostStream'), 100);
+  app.prefetch.add('postStreamScrubber', () => import('./components/PostStreamScrubber'), 100);
 }
 
 export function makeRouteHelpers(app: ForumApplication) {

--- a/framework/core/js/tests/unit/common/utils/drainPrefetchQueue.test.ts
+++ b/framework/core/js/tests/unit/common/utils/drainPrefetchQueue.test.ts
@@ -1,0 +1,127 @@
+import { jest } from '@jest/globals';
+import drainPrefetchQueue from '../../../../src/common/utils/drainPrefetchQueue';
+import ItemList from '../../../../src/common/utils/ItemList';
+
+type Loader = () => Promise<unknown>;
+
+function queueOf(...loaders: Loader[]): ItemList<Loader> {
+  const list = new ItemList<Loader>();
+  loaders.forEach((loader, i) => list.add(`loader${i}`, loader, -i));
+  return list;
+}
+
+/**
+ * `drainPrefetchQueue` schedules work via `requestIdleCallback` (or a
+ * `setTimeout` fallback). We install a synchronous stub for the idle callback
+ * so the queue drains deterministically within the test.
+ */
+describe('drainPrefetchQueue', () => {
+  let originalRIC: typeof window.requestIdleCallback | undefined;
+
+  const useSyncIdle = () => {
+    (window as any).requestIdleCallback = (cb: () => void) => {
+      cb();
+      return 0;
+    };
+  };
+
+  beforeEach(() => {
+    originalRIC = window.requestIdleCallback;
+  });
+
+  afterEach(() => {
+    if (originalRIC) {
+      window.requestIdleCallback = originalRIC;
+    } else {
+      delete (window as any).requestIdleCallback;
+    }
+    jest.useRealTimers();
+  });
+
+  test('does nothing for an empty queue', () => {
+    const ric = jest.fn();
+    (window as any).requestIdleCallback = ric;
+
+    drainPrefetchQueue(new ItemList<Loader>());
+
+    expect(ric).not.toHaveBeenCalled();
+  });
+
+  test('runs every registered loader', async () => {
+    useSyncIdle();
+
+    const a = jest.fn(() => Promise.resolve());
+    const b = jest.fn(() => Promise.resolve());
+    const c = jest.fn(() => Promise.resolve());
+
+    drainPrefetchQueue(queueOf(a, b, c));
+    // Let the promise chain settle between loaders.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(c).toHaveBeenCalledTimes(1);
+  });
+
+  test('runs loaders one at a time, waiting for each idle period', async () => {
+    const idleCallbacks: Array<() => void> = [];
+    (window as any).requestIdleCallback = (cb: () => void) => {
+      idleCallbacks.push(cb);
+      return 0;
+    };
+
+    const a = jest.fn(() => Promise.resolve());
+    const b = jest.fn(() => Promise.resolve());
+
+    drainPrefetchQueue(queueOf(a, b));
+
+    // First idle period scheduled, nothing run yet.
+    expect(idleCallbacks).toHaveLength(1);
+    expect(a).not.toHaveBeenCalled();
+
+    // Fire the first idle period → first loader runs, next idle scheduled.
+    idleCallbacks.shift()!();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).not.toHaveBeenCalled();
+    expect(idleCallbacks).toHaveLength(1);
+
+    // Fire the second idle period → second loader runs.
+    idleCallbacks.shift()!();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test('a rejected loader does not stop the rest', async () => {
+    useSyncIdle();
+
+    const failing = jest.fn(() => Promise.reject(new Error('chunk load failed')));
+    const after = jest.fn(() => Promise.resolve());
+
+    drainPrefetchQueue(queueOf(failing, after));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(failing).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to setTimeout when requestIdleCallback is unavailable', async () => {
+    delete (window as any).requestIdleCallback;
+    jest.useFakeTimers();
+
+    const a = jest.fn(() => Promise.resolve());
+
+    drainPrefetchQueue(queueOf(a));
+
+    // Nothing runs synchronously; it is queued behind the timeout.
+    expect(a).not.toHaveBeenCalled();
+
+    jest.runOnlyPendingTimers();
+    // Flush the microtask that invokes the loader.
+    await Promise.resolve();
+
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Opening a discussion is the most common navigation in the forum, but `PostStream` and `PostStreamScrubber` are code-split. The first time a user opens a discussion in a session, the browser must fetch those chunks over the network before the post stream can render — an extra round-trip on the hottest path, which reads as the forum "feeling slow" even on a fast connection.

The chunks are small (~17KB raw, ~4KB gzipped combined), so the cost isn't the bytes — it's the request latency gating the spinner on the route users hit most.

## Change

Add an `app.prefetch` registry — an `ItemList` of chunk loaders — that is drained in the background once the app has booted and the browser is idle (`requestIdleCallback`, with a `setTimeout` fallback). Core seeds it with the post stream chunks.

By the time the user opens a discussion, the dynamic `import()` resolves from the module cache instead of blocking on a request. Loaders run one at a time between idle periods, so prefetching never competes with rendering or interaction; a failed prefetch is ignored, since the real import on navigation surfaces any genuine error.

This keeps the code-splitting benefit (the chunks stay out of the main bundle) while removing the round-trip from the critical path for in-session navigation.

## Extensibility

`app.prefetch` is a normal `ItemList`, so extensions can register their own chunks to warm, and reorder or remove core's:

```js
app.prefetch.add('acme.customPage', () => import('./components/CustomPage'));
```

Documented in flarum/docs (code-splitting guide).

## Tests

Unit tests for the drain utility cover: empty queue is a no-op, every loader runs, loaders run one-at-a-time per idle period, a rejected loader doesn't stop the rest, and the `setTimeout` fallback path.

Verified at runtime against a live forum (headless Chrome): the post stream chunks are fetched right after the index page loads — before any discussion is opened — so the subsequent discussion open resolves them from cache.

## Not included (follow-ups)

- **Direct landings on `/d/:id`** (shared links, SEO traffic) still pay the chunk request, because the idle prefetch hasn't run yet when the page boots straight into a discussion. The proper fix there is a server-emitted `<link rel="modulepreload">` for the discussion chunks, which can build on `Document`'s existing preload mechanism.
- Registering the other split forum pages (settings, notifications, etc.) for prefetch.
