### PR TITLE
[2.x] fix: Cache permissions per group set instead of per User instance

### DIFF
--- a/extensions/tags/tests/integration/api/discussions/TagFilterTest.php
+++ b/extensions/tags/tests/integration/api/discussions/TagFilterTest.php
@@ -291,10 +291,12 @@ class TagFilterTest extends TestCase
     {
         $this->useIdWithSlugDriver();
 
-        // Resolving more slugs must not cost more queries: a batch driver resolves
-        // them together, so a 3-slug filter issues the same number of queries as a
-        // 1-slug filter. An N+1 (per-slug fromSlug) would make the counts diverge.
-        $countQueriesFor = function (string $filter): int {
+        // A batch driver resolves all slugs in the filter together, so a request
+        // must issue exactly one slug-resolution query no matter how many slugs
+        // the filter contains. An N+1 (per-slug fromSlug) would issue one per
+        // slug. Total query counts are not comparable across the two requests:
+        // they return different result sets, whose serialization costs differ.
+        $countResolutionQueriesFor = function (string $filter): int {
             $db = $this->database();
             $db->flushQueryLog();
             $db->enableQueryLog();
@@ -304,19 +306,36 @@ class TagFilterTest extends TestCase
                     ->withQueryParams(['filter' => ['tag' => $filter]])
             );
 
-            $count = count($db->getQueryLog());
+            $count = 0;
+
+            foreach ($db->getQueryLog() as $query) {
+                // Normalize identifier quoting across database drivers.
+                $sql = str_replace(['"', '`'], '', $query['query']);
+
+                // The batch lookup constrains the *unqualified* id column
+                // (visibility scope first, then the requested IDs); lazy
+                // single-tag loads and scoped parent loads qualify it
+                // as tags.id, and eager loads join through discussion_tag.
+                if (str_starts_with($sql, 'select * from tags where id in')) {
+                    $count++;
+                }
+            }
+
             $db->flushQueryLog();
 
             return $count;
         };
 
-        $oneSlug = $countQueriesFor('1');
-        $threeSlugs = $countQueriesFor('1,2,6');
+        $this->assertSame(
+            1,
+            $countResolutionQueriesFor('1'),
+            'Resolving 1 slug must take exactly one tag-lookup query.'
+        );
 
         $this->assertSame(
-            $oneSlug,
-            $threeSlugs,
-            "Batch slug resolution should be query-count flat: 1 slug took $oneSlug queries, 3 slugs took $threeSlugs."
+            1,
+            $countResolutionQueriesFor('1,2,6'),
+            'Resolving 3 slugs must still take exactly one tag-lookup query, not one per slug.'
         );
     }
 }

--- a/extensions/tags/tests/integration/api/discussions/TagFilterTest.php
+++ b/extensions/tags/tests/integration/api/discussions/TagFilterTest.php
@@ -307,6 +307,7 @@ class TagFilterTest extends TestCase
             );
 
             $count = 0;
+            $tags = $db->getTablePrefix().'tags';
 
             foreach ($db->getQueryLog() as $query) {
                 // Normalize identifier quoting across database drivers.
@@ -316,7 +317,7 @@ class TagFilterTest extends TestCase
                 // (visibility scope first, then the requested IDs); lazy
                 // single-tag loads and scoped parent loads qualify it
                 // as tags.id, and eager loads join through discussion_tag.
-                if (str_starts_with($sql, 'select * from tags where id in')) {
+                if (str_starts_with($sql, "select * from $tags where id in")) {
                     $count++;
                 }
             }

--- a/framework/core/src/Api/Controller/SetPermissionController.php
+++ b/framework/core/src/Api/Controller/SetPermissionController.php
@@ -10,6 +10,7 @@
 namespace Flarum\Api\Controller;
 
 use Flarum\Group\Permission;
+use Flarum\Group\PermissionCache;
 use Flarum\Http\RequestUtil;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -19,6 +20,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SetPermissionController implements RequestHandlerInterface
 {
+    public function __construct(
+        protected PermissionCache $permissionCache
+    ) {
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         RequestUtil::getActor($request)->assertAdmin();
@@ -35,6 +41,10 @@ class SetPermissionController implements RequestHandlerInterface
                 'group_id' => $groupId
             ];
         }, $groupIds));
+
+        // These writes go through the query builder, so no model events fire —
+        // reset the shared permission cache explicitly.
+        $this->permissionCache->flush();
 
         return new EmptyResponse(204);
     }

--- a/framework/core/src/Group/GroupServiceProvider.php
+++ b/framework/core/src/Group/GroupServiceProvider.php
@@ -11,11 +11,28 @@ namespace Flarum\Group;
 
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Group\Access\ScopeGroupVisibility;
+use Illuminate\Contracts\Container\Container;
 
 class GroupServiceProvider extends AbstractServiceProvider
 {
-    public function boot(): void
+    public function register(): void
+    {
+        $this->container->singleton(PermissionCache::class);
+    }
+
+    public function boot(Container $container): void
     {
         Group::registerVisibilityScoper(new ScopeGroupVisibility(), 'view');
+
+        // Keep the shared permission cache in sync with model-level permission
+        // changes. (The admin permission endpoint writes through the query
+        // builder and flushes the cache itself.)
+        Permission::saved(fn (Permission $permission) => $container->make(PermissionCache::class)->forgetGroup($permission->group_id));
+        Permission::deleted(fn (Permission $permission) => $container->make(PermissionCache::class)->forgetGroup($permission->group_id));
+
+        // A deleted group's memberships cascade away, so fresh users get a new
+        // group set (and cache key) anyway — but drop its cached sets so its
+        // permissions cannot be served to any lingering instances.
+        Group::deleted(fn (Group $group) => $container->make(PermissionCache::class)->forgetGroup($group->id));
     }
 }

--- a/framework/core/src/Group/PermissionCache.php
+++ b/framework/core/src/Group/PermissionCache.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Group;
+
+/**
+ * Caches the permission lists of group-ID sets for the lifetime of the
+ * application instance.
+ *
+ * The permissions a user has are fully determined by the set of group IDs
+ * they belong to, so users sharing a group set can share one `group_permission`
+ * load. Without this, any code that checks an ability against each serialized
+ * user — extension serializer flags, policies, visibility scopers — issues one
+ * identical query per user instance.
+ *
+ * The cache is a container singleton, so its lifetime is one request under
+ * PHP-FPM. Entries are invalidated when permissions change: per affected group
+ * for model writes, and wholesale for the admin permission endpoint (which
+ * writes through the query builder and bypasses model events). Code that
+ * modifies the `group_permission` table directly should call `flush()`.
+ */
+class PermissionCache
+{
+    /**
+     * Permission lists keyed by sorted group-ID set.
+     *
+     * @var array<string, string[]>
+     */
+    protected array $permissions = [];
+
+    /**
+     * @param int[] $groupIds
+     * @return string[]|null
+     */
+    public function get(array $groupIds): ?array
+    {
+        return $this->permissions[$this->key($groupIds)] ?? null;
+    }
+
+    /**
+     * @param int[] $groupIds
+     * @param string[] $permissions
+     */
+    public function put(array $groupIds, array $permissions): void
+    {
+        $this->permissions[$this->key($groupIds)] = $permissions;
+    }
+
+    /**
+     * Forget every cached set that contains the given group, e.g. because the
+     * group's permissions changed or the group was deleted.
+     */
+    public function forgetGroup(int $groupId): void
+    {
+        foreach (array_keys($this->permissions) as $key) {
+            if (in_array((string) $groupId, explode(',', $key), true)) {
+                unset($this->permissions[$key]);
+            }
+        }
+    }
+
+    public function flush(): void
+    {
+        $this->permissions = [];
+    }
+
+    /**
+     * @param int[] $groupIds
+     */
+    protected function key(array $groupIds): string
+    {
+        $groupIds = array_values(array_unique(array_map('intval', $groupIds)));
+
+        sort($groupIds);
+
+        return implode(',', $groupIds);
+    }
+}

--- a/framework/core/src/User/User.php
+++ b/framework/core/src/User/User.php
@@ -17,6 +17,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Foundation\EventGeneratorTrait;
 use Flarum\Group\Group;
 use Flarum\Group\Permission;
+use Flarum\Group\PermissionCache;
 use Flarum\Http\AccessToken;
 use Flarum\Notification\Notification;
 use Flarum\Post\Post;
@@ -134,6 +135,11 @@ class User extends AbstractModel
     protected static Access\Gate $gate;
 
     /**
+     * The shared per-group-set permission cache.
+     */
+    protected static ?PermissionCache $permissionCache = null;
+
+    /**
      * Callbacks to check passwords.
      *
      * @var callable[]
@@ -179,6 +185,11 @@ class User extends AbstractModel
     public static function setGate(Access\Gate $gate): void
     {
         static::$gate = $gate;
+    }
+
+    public static function setPermissionCache(PermissionCache $cache): void
+    {
+        static::$permissionCache = $cache;
     }
 
     public static function setDisplayNameDriver(DisplayNameDriver $driver): void
@@ -621,10 +632,11 @@ class User extends AbstractModel
     }
 
     /**
-     * Define the relationship with the permissions of all the groups that
-     * the user is in.
+     * The IDs of the groups the user's permissions are drawn from.
+     *
+     * @return int[]
      */
-    public function permissions(): Builder
+    public function permissionGroupIds(): array
     {
         $groupIds = [Group::GUEST_ID];
 
@@ -640,18 +652,42 @@ class User extends AbstractModel
             $groupIds = $processor($this, $groupIds);
         }
 
-        return Permission::query()->whereIn('group_id', $groupIds);
+        return $groupIds;
+    }
+
+    /**
+     * Define the relationship with the permissions of all the groups that
+     * the user is in.
+     */
+    public function permissions(): Builder
+    {
+        return Permission::query()->whereIn('group_id', $this->permissionGroupIds());
     }
 
     /**
      * Get a list of permissions that the user has.
+     *
+     * Permissions depend only on the set of groups the user belongs to, so
+     * they are shared through a per-group-set cache: users with the same
+     * groups reuse one `group_permission` load instead of querying once per
+     * User instance.
      *
      * @return string[]
      */
     public function getPermissions(): array
     {
         if (is_null($this->permissions)) {
-            $this->permissions = $this->permissions()->pluck('permission')->all();
+            $groupIds = $this->permissionGroupIds();
+
+            $permissions = static::$permissionCache?->get($groupIds);
+
+            if (is_null($permissions)) {
+                $permissions = Permission::query()->whereIn('group_id', $groupIds)->pluck('permission')->all();
+
+                static::$permissionCache?->put($groupIds, $permissions);
+            }
+
+            $this->permissions = $permissions;
         }
 
         return $this->permissions;

--- a/framework/core/src/User/UserServiceProvider.php
+++ b/framework/core/src/User/UserServiceProvider.php
@@ -15,6 +15,7 @@ use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Foundation\ContainerUtil;
 use Flarum\Group\Access\GroupPolicy;
 use Flarum\Group\Group;
+use Flarum\Group\PermissionCache;
 use Flarum\Http\Access\AccessTokenPolicy;
 use Flarum\Http\AccessToken;
 use Flarum\Post\Access\PostPolicy;
@@ -136,6 +137,7 @@ class UserServiceProvider extends AbstractServiceProvider
         User::setHasher($container->make('hash'));
         User::setPasswordCheckers($container->make('flarum.user.password_checkers'));
         User::setGate($container->makeWith(Access\Gate::class, ['policyClasses' => $container->make('flarum.policies')]));
+        User::setPermissionCache($container->make(PermissionCache::class));
         User::setDisplayNameDriver($container->make('flarum.user.display_name.driver'));
         User::setAvatarDriver($container->make('flarum.user.avatar.driver'));
 

--- a/framework/core/tests/integration/user/GroupPermissionCacheTest.php
+++ b/framework/core/tests/integration/user/GroupPermissionCacheTest.php
@@ -1,0 +1,284 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\user;
+
+use Flarum\Group\Group;
+use Flarum\Group\Permission;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The permissions granted to a user depend only on the set of group IDs the
+ * user belongs to, yet they were loaded (and memoized) per User instance. Any
+ * code path that checks an ability against each serialized user — extension
+ * serializer flags, policies, visibility scopers — therefore issued one
+ * identical `group_permission` query per user.
+ *
+ * These tests pin the fix: permissions are cached per group-ID set for the
+ * lifetime of the app instance, and invalidated when permissions change.
+ */
+class GroupPermissionCacheTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $users = [];
+        $groupUser = [];
+
+        // Four users sharing one custom group.
+        for ($i = 0; $i < 4; $i++) {
+            $userId = 10 + $i;
+            $users[] = [
+                'id' => $userId,
+                'username' => 'shared'.$userId,
+                'email' => 'shared'.$userId.'@machine.local',
+                'is_email_confirmed' => 1,
+                'password' => 'foobar',
+            ];
+            $groupUser[] = ['user_id' => $userId, 'group_id' => 5];
+        }
+
+        // One user in an additional group — a distinct group set.
+        $users[] = [
+            'id' => 14,
+            'username' => 'distinct14',
+            'email' => 'distinct14@machine.local',
+            'is_email_confirmed' => 1,
+            'password' => 'foobar',
+        ];
+        $groupUser[] = ['user_id' => 14, 'group_id' => 5];
+        $groupUser[] = ['user_id' => 14, 'group_id' => 6];
+
+        // An unactivated user, who is treated as a guest.
+        $users[] = [
+            'id' => 15,
+            'username' => 'unconfirmed15',
+            'email' => 'unconfirmed15@machine.local',
+            'is_email_confirmed' => 0,
+            'password' => 'foobar',
+        ];
+
+        $this->prepareDatabase([
+            User::class => array_merge([$this->normalUser()], $users),
+            Group::class => [
+                ['id' => 5, 'name_singular' => 'Five', 'name_plural' => 'Fives'],
+                ['id' => 6, 'name_singular' => 'Six', 'name_plural' => 'Sixes'],
+            ],
+            'group_user' => $groupUser,
+            Permission::class => [
+                ['group_id' => 5, 'permission' => 'custom.five'],
+                ['group_id' => 6, 'permission' => 'custom.six'],
+            ],
+        ]);
+    }
+
+    private function countPermissionQueries(callable $callback): int
+    {
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $callback();
+
+        $count = 0;
+
+        foreach ($db->getQueryLog() as $query) {
+            if (stripos($query['query'], 'group_permission') !== false) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    #[Test]
+    public function users_sharing_a_group_set_trigger_a_single_permission_query()
+    {
+        $this->app();
+
+        $queries = $this->countPermissionQueries(function () {
+            foreach ([10, 11, 12, 13] as $id) {
+                // A fresh instance per user, as relationship hydration produces
+                // during serialization — the per-instance memo cannot help here.
+                $user = User::query()->findOrFail($id);
+
+                $this->assertContains('custom.five', $user->getPermissions());
+            }
+        });
+
+        $this->assertSame(1, $queries, 'Users sharing one group set must share one group_permission query.');
+    }
+
+    #[Test]
+    public function distinct_group_sets_are_each_loaded_once()
+    {
+        $this->app();
+
+        $queries = $this->countPermissionQueries(function () {
+            $shared = User::query()->findOrFail(10);
+            $this->assertContains('custom.five', $shared->getPermissions());
+
+            $distinct = User::query()->findOrFail(14);
+            $permissions = $distinct->getPermissions();
+            $this->assertContains('custom.five', $permissions);
+            $this->assertContains('custom.six', $permissions);
+
+            // Same set as user 10 again — must reuse the cached load.
+            $sharedAgain = User::query()->findOrFail(11);
+            $this->assertContains('custom.five', $sharedAgain->getPermissions());
+        });
+
+        $this->assertSame(2, $queries, 'Each distinct group set must be loaded exactly once.');
+    }
+
+    #[Test]
+    public function permission_changes_are_visible_to_fresh_instances()
+    {
+        $this->app();
+
+        // Warm whatever caching is in place.
+        User::query()->findOrFail(10)->getPermissions();
+
+        Permission::unguarded(fn () => Permission::query()->create(['group_id' => 5, 'permission' => 'custom.granted-later']));
+
+        $this->assertContains(
+            'custom.granted-later',
+            User::query()->findOrFail(11)->getPermissions(),
+            'A permission granted after the first load must be visible to fresh instances.'
+        );
+    }
+
+    #[Test]
+    public function revoked_permissions_disappear_for_fresh_instances()
+    {
+        $this->app();
+
+        $this->assertContains('custom.five', User::query()->findOrFail(10)->getPermissions());
+
+        Permission::query()->where('group_id', 5)->where('permission', 'custom.five')->first()->delete();
+
+        $this->assertNotContains(
+            'custom.five',
+            User::query()->findOrFail(11)->getPermissions(),
+            'A revoked permission must not be served from a stale cache.'
+        );
+    }
+
+    #[Test]
+    public function permission_changes_only_invalidate_the_affected_group_sets()
+    {
+        $this->app();
+
+        // Warm both cached sets: {guest, member, 5} and {guest, member, 5, 6}.
+        User::query()->findOrFail(10)->getPermissions();
+        User::query()->findOrFail(14)->getPermissions();
+
+        // Change a permission of group 6 — only the set containing group 6
+        // should be invalidated.
+        Permission::unguarded(fn () => Permission::query()->create(['group_id' => 6, 'permission' => 'custom.six-later']));
+
+        $queries = $this->countPermissionQueries(function () {
+            // Untouched set: must be served from cache, no new query.
+            $this->assertNotContains('custom.six-later', User::query()->findOrFail(11)->getPermissions());
+        });
+
+        $this->assertSame(0, $queries, 'A permission change to another group must not evict unrelated cached sets.');
+
+        $queries = $this->countPermissionQueries(function () {
+            // Affected set: must be reloaded and reflect the change.
+            $this->assertContains('custom.six-later', User::query()->findOrFail(14)->getPermissions());
+        });
+
+        $this->assertSame(1, $queries, 'The affected set must be reloaded exactly once.');
+    }
+
+    #[Test]
+    public function group_membership_changes_take_effect_for_fresh_instances()
+    {
+        $this->app();
+
+        // Warm the {guest, member, 5} set.
+        $this->assertNotContains('custom.six', User::query()->findOrFail(10)->getPermissions());
+
+        // Add the user to group 6: their group set — and thus their cache key —
+        // changes, so no invalidation is needed for correctness.
+        $this->database()->table('group_user')->insert(['user_id' => 10, 'group_id' => 6]);
+
+        $this->assertContains(
+            'custom.six',
+            User::query()->findOrFail(10)->getPermissions(),
+            'A membership change must be reflected immediately via the changed group set.'
+        );
+    }
+
+    #[Test]
+    public function deleting_a_group_removes_its_permissions_for_fresh_instances()
+    {
+        $this->app();
+
+        // Warm the {guest, member, 5, 6} set.
+        $this->assertContains('custom.six', User::query()->findOrFail(14)->getPermissions());
+
+        Group::query()->findOrFail(6)->delete();
+
+        $this->assertNotContains(
+            'custom.six',
+            User::query()->findOrFail(14)->getPermissions(),
+            'Permissions of a deleted group must not survive via a stale cache.'
+        );
+    }
+
+    #[Test]
+    public function the_admin_permission_endpoint_invalidates_the_cache()
+    {
+        $this->app();
+
+        // Warm the {guest, member, 5} set.
+        $this->assertNotContains('custom.endpoint', User::query()->findOrFail(10)->getPermissions());
+
+        // The endpoint writes through the query builder (no model events), so
+        // it must reset the cache itself.
+        $response = $this->send(
+            $this->request('POST', '/api/permission', [
+                'authenticatedAs' => 1,
+                'json' => ['permission' => 'custom.endpoint', 'groupIds' => [5]],
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $this->assertContains(
+            'custom.endpoint',
+            User::query()->findOrFail(11)->getPermissions(),
+            'A permission granted through the admin endpoint must be visible immediately.'
+        );
+    }
+
+    #[Test]
+    public function unactivated_users_share_the_guest_permission_load()
+    {
+        $this->app();
+
+        $queries = $this->countPermissionQueries(function () {
+            $unconfirmed = User::query()->findOrFail(15);
+            $permissions = $unconfirmed->getPermissions();
+
+            // No member/custom-group permissions for an unactivated account.
+            $this->assertNotContains('custom.five', $permissions);
+        });
+
+        $this->assertSame(1, $queries);
+    }
+}


### PR DESCRIPTION
Part of the warm-session responsiveness work: every interaction on a moderator-facing view was paying a per-user `group_permission` query.

## Problem

A user's permissions depend only on the **set of group IDs** they belong to, but `User::getPermissions()` loaded and memoized them **per User instance**. Any code that checks an ability against each serialized user — extension serializer flags (`can*`), policies, visibility scopers — issued one identical query per user instance:

- On a moderator's 20-item discussion list, **60 of 61** `group_permission` queries had byte-identical bindings (`[2,3,8]` — everyone in the same groups).
- The pattern isn't one bad extension: with the four biggest offenders disabled, a different extension's per-user `can()` still produced 30 identical queries. The instance memo can't help — 31 distinct instances, users even hydrated twice via different relationships.
- 1.x behaves identically (`getPermissions()` is unchanged there) — this is longstanding, not a 2.x regression, but 2.x-era extensions exercise it much harder.

## Change

A container-scoped `PermissionCache` keyed by the **sorted group-ID set**, layered under the existing instance memo. Group processors keep working — they feed the computed set that forms the key. `permissions()` still returns the same relationship builder; the group-ID computation is extracted into `permissionGroupIds()`.

**Invalidation** (each scenario covered by a test):
- `Permission` saves/deletes forget **only** the cached sets containing the affected group.
- `Group` deletion forgets its sets (memberships cascade, so fresh instances get a new key regardless).
- `SetPermissionController` writes through the query builder — no model events — so it **flushes explicitly**.
- Group-membership changes need no invalidation: they change the key, not the value.

Cache lifetime is the app instance (one request under FPM). In a long-running process, a permission changed by *another* process isn't seen until restart — same staleness class as other boot-time state; same-process changes are fully covered by the hooks above.

## Measured impact (dev forum, admin viewing 20-discussion list)

| | before | after |
|---|---|---|
| `group_permission` queries | 61 | **2** |
| total request queries (full extension set) | 207 | **149** |
| total (core + minimal extensions) | 66 | **37** |

The remaining per-user queries belong to individual extensions (their own tables) and are being addressed separately.

## Tests

`GroupPermissionCacheTest` (9 tests, TDD — the query-count assertions fail against the previous code): shared set → one query; distinct sets → one each; targeted invalidation (a change to group B leaves group A's entry cached — proven by query count — and reloads only B's set); grant/revoke visibility; membership changes; group deletion; the admin endpoint path; unactivated-user guest set.

Full core integration suite (726) and unit suite (366) pass; PHPStan clean.
