### PR TITLE
[2.x] chore(ci): optional Redis/Valkey service in the reusable backend workflow

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -15,6 +15,24 @@ on:
         default: false
         required: false
 
+      enable_redis:
+        description: "Start a Redis-compatible service (127.0.0.1:6379) for backend tests?"
+        type: boolean
+        default: false
+        required: false
+
+      redis_variant:
+        description: "Which Redis-compatible server to start: 'redis' or 'valkey'."
+        type: string
+        default: 'redis'
+        required: false
+
+      redis_version:
+        description: "Image tag for the Redis/Valkey service, e.g. 'latest', '7.2', '8.0-alpine'."
+        type: string
+        default: 'latest'
+        required: false
+
       backend_directory:
         description: The directory of the project where backend code is located. This should contain a `composer.json` file, and is generally the root directory of the repo.
         type: string
@@ -191,6 +209,15 @@ jobs:
           - 5432
         options: >-
           --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: ${{ inputs.enable_redis && format('{0}:{1}', inputs.redis_variant == 'valkey' && 'valkey/valkey' || 'redis', inputs.redis_version) || '' }}
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping || valkey-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
Extensions with redis-backed integration tests (fof/horizon, and fof/redis once it grows a suite) currently cannot run them through the shared workflow — callers cannot add service containers to a reusable workflow's jobs, so their only options were forking the workflow or skipping tests.

## Changes

Three new `workflow_call` inputs:

- `enable_redis` (boolean, default `false`) — starts a Redis-compatible service on `127.0.0.1:6379` for the backend test matrix, health-checked like the existing DB services (empty-image skip pattern).
- `redis_variant` (string, default `'redis'`) — `'redis'` or `'valkey'`.
- `redis_version` (string, default `'latest'`) — image tag, e.g. `'7.2'`, `'8.0-alpine'`.

## Validation

Consumed live from FriendsOfFlarum/horizon#27, whose 16-test suite requires redis. Baseline failure without this change: all matrix jobs red with `RedisException: Connection refused` ([run](https://github.com/FriendsOfFlarum/horizon/actions/runs/30211165945)).

- `redis` variant (earlier revision of this branch, pinned image): all matrix + PHPStan jobs green — [run 30211981972](https://github.com/FriendsOfFlarum/horizon/actions/runs/30211981972)
- `valkey` variant (earlier revision, pinned image): all jobs green — [run 30213780964](https://github.com/FriendsOfFlarum/horizon/actions/runs/30213780964)
- Current revision (`redis` default, `latest` tag): all jobs green — [run 30213889533](https://github.com/FriendsOfFlarum/horizon/actions/runs/30213889533)
