### PR TITLE
[2.x] fix: PHPStan errors under phpstan 2.2.6 / illuminate 13.22

### DIFF
--- a/framework/core/src/Database/DatabaseServiceProvider.php
+++ b/framework/core/src/Database/DatabaseServiceProvider.php
@@ -106,7 +106,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
                     // For Eloquent builders, we need to access the connection through the query property
                     $connection = method_exists($this, 'getConnection')
                         ? $this->getConnection()
-                        : (property_exists($this, 'query') ? $this->query->getConnection() : null);
+                        : (method_exists($this, 'getQuery') ? $this->getQuery()->getConnection() : null);
 
                     if ($connection && $connection->getDriverName() === $driver) {
                         $callback($this);
@@ -122,7 +122,7 @@ class DatabaseServiceProvider extends AbstractServiceProvider
                     // For Eloquent builders, we need to access the connection through the query property
                     $connection = method_exists($this, 'getConnection')
                         ? $this->getConnection()
-                        : (property_exists($this, 'query') ? $this->query->getConnection() : null);
+                        : (method_exists($this, 'getQuery') ? $this->getQuery()->getConnection() : null);
 
                     if ($connection && $connection->getDriverName() !== $driver) {
                         $callback($this);


### PR DESCRIPTION
phpstan 2.2.6 with illuminate/database 13.22.0 (both released after 2.x's last green run) flag the two `when*`/`unless*` database driver macros in `DatabaseServiceProvider` for accessing the protected `$query` property on the `Builder|Query\Builder` union — failing Static Analysis on every 2.x push.

The access was runtime-legal (macro closures are scope-bound to the builder via `Closure::call()`), but read the property directly. This switches to the public `getQuery()` accessor, which resolves the same connection on every supported illuminate version.

Unblocks 2.x CI. Verified: PHPStan clean and the database integration tests pass against phpstan 2.2.6 / illuminate 13.22.0 locally.