### PR TITLE
[1.x] fix: Handle network connection loss in the frontend

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -266,6 +266,19 @@ export default class Application {
    */
   private requestErrorAlert: number | null = null;
 
+  /**
+   * The key for the Alert that was shown as a result of an AJAX request
+   * failing at the network level (status 0). Unlike other request error
+   * alerts, only one of these is shown at a time.
+   */
+  protected networkErrorAlert: number | null = null;
+
+  /**
+   * The key for the Alert that is shown while the browser reports being
+   * offline.
+   */
+  protected offlineAlert: number | null = null;
+
   initialRoute!: string;
 
   public load(payload: Application['data']) {
@@ -301,6 +314,8 @@ export default class Application {
     this.session = new Session(this.store.getById<User>('users', String(this.data.session.userId)) ?? null, this.data.session.csrfToken);
 
     this.mount();
+
+    this.registerConnectivityListeners();
 
     this.initialRoute = window.location.href;
 
@@ -519,6 +534,11 @@ export default class Application {
 
     if (this.requestErrorAlert) this.alerts.dismiss(this.requestErrorAlert);
 
+    if (this.networkErrorAlert) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
     return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler));
   }
 
@@ -531,6 +551,20 @@ export default class Application {
 
     let content;
     switch (error.status) {
+      // Status 0 means the request failed at the network level: the client is
+      // offline, DNS resolution failed, the origin was unreachable, or the
+      // response was blocked by CORS. Aborted requests never get here, as
+      // Mithril leaves their promises unsettled.
+      case 0:
+        if (navigator.onLine === false) {
+          content = app.translator.trans('core.lib.error.offline_message');
+        } else if (this.requestWasCrossOrigin(error)) {
+          content = app.translator.trans('core.lib.error.generic_cross_origin_message');
+        } else {
+          content = app.translator.trans('core.lib.error.network_message');
+        }
+        break;
+
       case 422:
         content = formattedErrors
           .map((detail) => [detail, <br />])
@@ -615,11 +649,76 @@ export default class Application {
       }
 
       if (e.alert) {
-        this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
+        if (e.status === 0) {
+          // A connection problem produces a single alert, even if several
+          // parallel requests fail at once.
+          if (!this.connectionAlertActive()) {
+            this.networkErrorAlert = this.alerts.show(e.alert, e.alert.content);
+          }
+        } else {
+          this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
+        }
       }
     } else {
       throw e;
     }
+  }
+
+  /**
+   * Whether an alert about a connection problem (a network-level request
+   * failure or the browser being offline) is currently being shown.
+   */
+  protected connectionAlertActive(): boolean {
+    const activeAlerts = this.alerts.getActiveAlerts();
+
+    return (
+      (this.networkErrorAlert !== null && this.networkErrorAlert in activeAlerts) || (this.offlineAlert !== null && this.offlineAlert in activeAlerts)
+    );
+  }
+
+  /**
+   * Register listeners to proactively notify the user when the browser goes
+   * offline and when connectivity is restored.
+   */
+  protected registerConnectivityListeners(): void {
+    window.addEventListener('offline', () => this.connectionLost());
+    window.addEventListener('online', () => this.connectionRestored());
+  }
+
+  /**
+   * Show a persistent (but dismissible) alert while the browser reports being
+   * offline.
+   */
+  protected connectionLost(): void {
+    if (this.offlineAlert !== null && this.offlineAlert in this.alerts.getActiveAlerts()) return;
+
+    // The offline alert supersedes any alert shown for a failed request.
+    if (this.networkErrorAlert !== null) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
+    this.offlineAlert = this.alerts.show({ type: 'error', dismissible: true }, app.translator.trans('core.lib.error.offline_message'));
+  }
+
+  /**
+   * Dismiss any connection problem alerts and briefly confirm to the user
+   * that connectivity has been restored.
+   */
+  protected connectionRestored(): void {
+    if (this.networkErrorAlert !== null) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
+    if (this.offlineAlert === null) return;
+
+    this.alerts.dismiss(this.offlineAlert);
+    this.offlineAlert = null;
+
+    const confirmationAlert = this.alerts.show({ type: 'success' }, app.translator.trans('core.lib.connection_restored_message'));
+
+    setTimeout(() => this.alerts.dismiss(confirmationAlert), 10000);
   }
 
   private showDebug(error: RequestError, formattedError: string[]) {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -280,15 +280,18 @@ export default class Application {
   protected offlineAlert: number | null = null;
 
   /**
-   * GET requests that failed because the browser was offline. They are
-   * retried, and their original promises settled, once connectivity is
-   * restored.
+   * GET requests that failed because the browser was offline, keyed by
+   * method, URL and params. They are retried, and their original promises
+   * settled, once connectivity is restored. Identical requests (e.g. from a
+   * polling extension) share one entry and are retried only once.
    */
-  protected deferredRequests: {
-    options: FlarumRequestOptions<any>;
-    resolve: (value: any) => void;
-    reject: (error: unknown) => void;
-  }[] = [];
+  protected deferredRequests: Map<
+    string,
+    {
+      options: FlarumRequestOptions<any>;
+      settlers: { resolve: (value: any) => void; reject: (error: unknown) => void }[];
+    }
+  > = new Map();
 
   initialRoute!: string;
 
@@ -583,8 +586,23 @@ export default class Application {
     this.connectionLost();
 
     return new Promise((resolve, reject) => {
-      this.deferredRequests.push({ options: originalOptions, resolve, reject });
+      const key = this.deferredRequestKey(originalOptions);
+      const deferred = this.deferredRequests.get(key);
+
+      if (deferred) {
+        deferred.settlers.push({ resolve, reject });
+      } else {
+        this.deferredRequests.set(key, { options: originalOptions, settlers: [{ resolve, reject }] });
+      }
     });
+  }
+
+  /**
+   * The identity of a request for deferral purposes: requests with the same
+   * key are considered identical and are retried only once.
+   */
+  protected deferredRequestKey(options: FlarumRequestOptions<any>): string {
+    return [options.method ?? 'GET', options.url, JSON.stringify(options.params ?? null)].join(' ');
   }
 
   /**
@@ -757,11 +775,14 @@ export default class Application {
       this.networkErrorAlert = null;
     }
 
-    const deferred = this.deferredRequests;
-    this.deferredRequests = [];
+    const deferred = Array.from(this.deferredRequests.values());
+    this.deferredRequests = new Map();
 
-    deferred.forEach(({ options, resolve, reject }) => {
-      this.request(options).then(resolve, reject);
+    deferred.forEach(({ options, settlers }) => {
+      this.request(options).then(
+        (response) => settlers.forEach(({ resolve }) => resolve(response)),
+        (error) => settlers.forEach(({ reject }) => reject(error))
+      );
     });
 
     if (this.offlineAlert === null) return;

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -279,6 +279,17 @@ export default class Application {
    */
   protected offlineAlert: number | null = null;
 
+  /**
+   * GET requests that failed because the browser was offline. They are
+   * retried, and their original promises settled, once connectivity is
+   * restored.
+   */
+  protected deferredRequests: {
+    options: FlarumRequestOptions<any>;
+    resolve: (value: any) => void;
+    reject: (error: unknown) => void;
+  }[] = [];
+
   initialRoute!: string;
 
   public load(payload: Application['data']) {
@@ -539,7 +550,41 @@ export default class Application {
       this.networkErrorAlert = null;
     }
 
-    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler));
+    return m.request(options).catch((e) => {
+      if (this.shouldDeferRequest(e, originalOptions)) {
+        return this.deferRequest(originalOptions);
+      }
+
+      return this.requestErrorCatch(e, originalOptions.errorHandler);
+    });
+  }
+
+  /**
+   * Whether a failed request should be held back and retried once
+   * connectivity is restored, instead of being rejected.
+   *
+   * Only GET requests that failed at the network level while the browser
+   * reported being offline qualify: they are safe to repeat, and the
+   * `online` event provides a reliable signal to retry them.
+   */
+  protected shouldDeferRequest(error: unknown, originalOptions: FlarumRequestOptions<any>): boolean {
+    return (
+      error instanceof RequestError && error.status === 0 && navigator.onLine === false && (originalOptions.method ?? 'GET').toUpperCase() === 'GET'
+    );
+  }
+
+  /**
+   * Hold a request that failed while offline. The returned promise settles
+   * with the result of retrying the request once connectivity is restored.
+   */
+  protected deferRequest<ResponseType>(originalOptions: FlarumRequestOptions<ResponseType>): Promise<ResponseType> {
+    // Make sure the offline alert is showing, in case the page was loaded
+    // while already offline and no `offline` event was ever fired.
+    this.connectionLost();
+
+    return new Promise((resolve, reject) => {
+      this.deferredRequests.push({ options: originalOptions, resolve, reject });
+    });
   }
 
   /**
@@ -702,14 +747,22 @@ export default class Application {
   }
 
   /**
-   * Dismiss any connection problem alerts and briefly confirm to the user
-   * that connectivity has been restored.
+   * Dismiss any connection problem alerts, retry requests that were deferred
+   * while offline, and briefly confirm to the user that connectivity has
+   * been restored.
    */
   protected connectionRestored(): void {
     if (this.networkErrorAlert !== null) {
       this.alerts.dismiss(this.networkErrorAlert);
       this.networkErrorAlert = null;
     }
+
+    const deferred = this.deferredRequests;
+    this.deferredRequests = [];
+
+    deferred.forEach(({ options, resolve, reject }) => {
+      this.request(options).then(resolve, reject);
+    });
 
     if (this.offlineAlert === null) return;
 

--- a/framework/core/js/tests/unit/common/Application.test.ts
+++ b/framework/core/js/tests/unit/common/Application.test.ts
@@ -2,6 +2,7 @@ import app from '../../../src/forum/app';
 import RequestError from '../../../src/common/utils/RequestError';
 import extractText from '../../../src/common/utils/extractText';
 import { jest } from '@jest/globals';
+import m from 'mithril';
 import type Mithril from 'mithril';
 
 const trans = (key: string) => extractText(app.translator.trans(key));
@@ -25,11 +26,17 @@ function setOnline(value: boolean): void {
   Object.defineProperty(window.navigator, 'onLine', { value, configurable: true });
 }
 
+function flushPromises(): Promise<void> {
+  // A macrotask runs after all pending promise chains, however deep.
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   app.alerts.clear();
   (app as any).requestErrorAlert = null;
   (app as any).networkErrorAlert = null;
   (app as any).offlineAlert = null;
+  (app as any).deferredRequests = [];
   setOnline(true);
 });
 
@@ -189,5 +196,91 @@ describe('Application reacts to browser connectivity events', () => {
     window.dispatchEvent(new Event('online'));
 
     expect(activeAlerts()).toHaveLength(0);
+  });
+});
+
+describe('Application defers GET requests that fail while offline', () => {
+  let requestSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    requestSpy = jest.spyOn(m, 'request');
+  });
+
+  afterEach(() => {
+    requestSpy.mockRestore();
+  });
+
+  it('holds a failed GET request and resolves it once the connection is restored', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolved = jest.fn();
+    const rejected = jest.fn();
+    app.request({ url: '/api/test' }).then(resolved, rejected);
+
+    await flushPromises();
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+    expect(activeAlerts().some((alert) => alert.text === trans('core.lib.error.offline_message'))).toBe(true);
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).toHaveBeenCalledWith(response);
+    expect(rejected).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-GET request that fails while offline', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    await expect(app.request({ url: '/api/test', method: 'POST' })).rejects.toBeInstanceOf(RequestError);
+  });
+
+  it('rejects a GET request that fails at the network level while the browser reports being online', async () => {
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    await expect(app.request({ url: '/api/test' })).rejects.toBeInstanceOf(RequestError);
+    expect(activeAlerts().some((alert) => alert.text === trans('core.lib.error.network_message'))).toBe(true);
+  });
+
+  it('re-defers a retried GET request that fails while still offline', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolved = jest.fn();
+    const rejected = jest.fn();
+    app.request({ url: '/api/test' }).then(resolved, rejected);
+
+    await flushPromises();
+
+    // The browser briefly reports being online, but the retry fails while
+    // offline again: the request must stay deferred, not reject.
+    requestSpy.mockImplementationOnce(() => {
+      setOnline(false);
+      return Promise.reject(makeError(0));
+    });
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).toHaveBeenCalledWith(response);
+    expect(rejected).not.toHaveBeenCalled();
   });
 });

--- a/framework/core/js/tests/unit/common/Application.test.ts
+++ b/framework/core/js/tests/unit/common/Application.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
   (app as any).requestErrorAlert = null;
   (app as any).networkErrorAlert = null;
   (app as any).offlineAlert = null;
-  (app as any).deferredRequests = [];
+  (app as any).deferredRequests = new Map();
   setOnline(true);
 });
 
@@ -282,5 +282,57 @@ describe('Application defers GET requests that fail while offline', () => {
 
     expect(resolved).toHaveBeenCalledWith(response);
     expect(rejected).not.toHaveBeenCalled();
+  });
+
+  it('retries identical deferred requests only once, settling every caller', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    // A polling extension fires the same request on every tick while offline.
+    const resolved = [jest.fn(), jest.fn(), jest.fn()];
+    resolved.forEach((callback) => void app.request({ url: '/api/stats', params: { period: 'day' } }).then(callback));
+
+    await flushPromises();
+
+    expect(requestSpy).toHaveBeenCalledTimes(3);
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    // One retry for the three identical requests, resolving all callers.
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    resolved.forEach((callback) => expect(callback).toHaveBeenCalledWith(response));
+  });
+
+  it('retries distinct deferred requests separately', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolvedA = jest.fn();
+    const resolvedB = jest.fn();
+    app.request({ url: '/api/discussions' }).then(resolvedA);
+    app.request({ url: '/api/posts' }).then(resolvedB);
+
+    await flushPromises();
+
+    const responseA = { data: 'discussions' };
+    const responseB = { data: 'posts' };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(responseA));
+    requestSpy.mockImplementationOnce(() => Promise.resolve(responseB));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    expect(resolvedA).toHaveBeenCalledWith(responseA);
+    expect(resolvedB).toHaveBeenCalledWith(responseB);
   });
 });

--- a/framework/core/js/tests/unit/common/Application.test.ts
+++ b/framework/core/js/tests/unit/common/Application.test.ts
@@ -1,0 +1,193 @@
+import app from '../../../src/forum/app';
+import RequestError from '../../../src/common/utils/RequestError';
+import extractText from '../../../src/common/utils/extractText';
+import { jest } from '@jest/globals';
+import type Mithril from 'mithril';
+
+const trans = (key: string) => extractText(app.translator.trans(key));
+
+function makeError(status: number, responseText: string | null = null, url: string = '/api/test'): RequestError {
+  return new RequestError(status, responseText, { url, method: 'GET' } as any, { status } as XMLHttpRequest);
+}
+
+function catchError(error: RequestError, customErrorHandler?: (e: RequestError) => void): Promise<void> {
+  return (app as any).requestErrorCatch(error, customErrorHandler).catch(() => {});
+}
+
+function activeAlerts(): { text: string; attrs: Record<string, unknown> }[] {
+  return Object.values(app.alerts.getActiveAlerts()).map((state) => ({
+    text: extractText(state.children as Mithril.Children),
+    attrs: state.attrs as Record<string, unknown>,
+  }));
+}
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true });
+}
+
+beforeEach(() => {
+  app.alerts.clear();
+  (app as any).requestErrorAlert = null;
+  (app as any).networkErrorAlert = null;
+  (app as any).offlineAlert = null;
+  setOnline(true);
+});
+
+describe('Application#requestErrorCatch handles network-level failures', () => {
+  it('shows a dedicated connection alert for a network-level failure (status 0)', async () => {
+    await catchError(makeError(0));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.network_message'));
+  });
+
+  it('shows an offline message when the browser reports being offline', async () => {
+    setOnline(false);
+
+    await catchError(makeError(0));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('still shows the cross-origin message for a failed cross-origin request', async () => {
+    await catchError(makeError(0, null, 'https://other-origin.example.com/api/test'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.generic_cross_origin_message'));
+  });
+
+  it('prefers the offline message over the cross-origin one while offline', async () => {
+    setOnline(false);
+
+    await catchError(makeError(0, null, 'https://other-origin.example.com/api/test'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('shows only one alert for multiple network-level failures', async () => {
+    await catchError(makeError(0));
+    await catchError(makeError(0));
+    await catchError(makeError(0));
+
+    expect(activeAlerts()).toHaveLength(1);
+  });
+
+  it('rejects with the original RequestError', async () => {
+    const error = makeError(0);
+
+    await expect((app as any).requestErrorCatch(error, undefined)).rejects.toBe(error);
+  });
+
+  it('respects a custom error handler instead of showing an alert', async () => {
+    const customErrorHandler = jest.fn();
+    const error = makeError(0);
+
+    await catchError(error, customErrorHandler);
+
+    expect(customErrorHandler).toHaveBeenCalledWith(error);
+    expect(activeAlerts()).toHaveLength(0);
+    expect(error.alert).not.toBeNull();
+  });
+});
+
+describe('Application#requestErrorCatch keeps existing behavior for server responses', () => {
+  it('shows the generic message for a 500 response', async () => {
+    await catchError(makeError(500, 'Internal Server Error'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.generic_message'));
+  });
+
+  it('shows validation error details for a 422 response', async () => {
+    const responseText = JSON.stringify({ errors: [{ detail: 'The title is required.' }] });
+
+    await catchError(makeError(422, responseText));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe('The title is required.');
+  });
+
+  it('shows one alert per error for consecutive server errors', async () => {
+    await catchError(makeError(500, 'Internal Server Error'));
+    await catchError(makeError(500, 'Internal Server Error'));
+
+    expect(activeAlerts()).toHaveLength(2);
+  });
+});
+
+describe('Application reacts to browser connectivity events', () => {
+  it('shows a dismissible offline alert when the browser goes offline', () => {
+    window.dispatchEvent(new Event('offline'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+    expect(alerts[0].attrs.type).toBe('error');
+    expect(alerts[0].attrs.dismissible).toBe(true);
+  });
+
+  it('shows only one alert for repeated offline events', () => {
+    window.dispatchEvent(new Event('offline'));
+    window.dispatchEvent(new Event('offline'));
+
+    expect(activeAlerts()).toHaveLength(1);
+  });
+
+  it('replaces a request failure alert with the offline alert when the browser goes offline', async () => {
+    await catchError(makeError(0));
+    window.dispatchEvent(new Event('offline'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('dismisses the offline alert and confirms once the connection is restored', () => {
+    jest.useFakeTimers();
+
+    try {
+      window.dispatchEvent(new Event('offline'));
+      window.dispatchEvent(new Event('online'));
+
+      const alerts = activeAlerts();
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].text).toBe(trans('core.lib.connection_restored_message'));
+
+      jest.runAllTimers();
+
+      expect(activeAlerts()).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('dismisses a request failure alert once the connection is restored', async () => {
+    await catchError(makeError(0));
+
+    jest.useFakeTimers();
+
+    try {
+      window.dispatchEvent(new Event('online'));
+
+      jest.runAllTimers();
+
+      expect(activeAlerts()).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not show a confirmation when the connection was never lost', () => {
+    window.dispatchEvent(new Event('online'));
+
+    expect(activeAlerts()).toHaveLength(0);
+  });
+});

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -620,6 +620,7 @@ core:
 
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
+    connection_restored_message: Your connection has been restored.
     debug_button: Debug
 
     # These translations are used in the Alert component.
@@ -661,7 +662,9 @@ core:
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       generic_cross_origin_message: "Oops! Something went wrong during a cross-origin request. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
+      network_message: Something seems to be wrong with your connection. Please check your network and try again.
       not_found_message: The requested resource was not found.
+      offline_message: You appear to be offline. Please check your connection and try again.
       payload_too_large_message: The request payload was too large.
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.


### PR DESCRIPTION
## Problem

All frontend XHR goes through `Application#request()`. When a request fails at the network level — the user is offline, DNS fails, the origin is unreachable — the rejection carries `status === 0`, which `requestErrorCatch()` has no branch for. Users get the generic *"Oops! Something went wrong. Please reload the page and try again."* alert, which wrongly suggests a server-side bug and prompts bug reports for what is a client connectivity issue.

Core also makes no use of the browser's `online`/`offline` events, so users get no proactive indication that they've gone offline, and content that failed to load while offline stays missing until a full page reload.

This was discussed with @imorland and is contributed as three self-contained commits.

## What this PR does

**1. Classify network-level failures (`status === 0`)** — `requestErrorCatch` now shows a dedicated translated alert: an offline-specific message when `navigator.onLine === false`, otherwise a generic connection-problem message. The existing cross-origin special case is preserved inside the new branch. Parallel failures produce a single alert instead of one per request. Aborted requests cannot trigger this: Mithril (2.0.4) wraps `xhr.abort` and leaves aborted promises unsettled, so they never reach the error handler by construction.

**2. `online`/`offline` events + automatic retry** — going offline shows a persistent, dismissible alert; reconnecting clears all connection alerts and shows a brief confirmation. Additionally, a **GET** request that fails while the browser reports being offline is not rejected: its promise is held open, and the request is re-issued when the `online` event fires, settling the original promise with the retry's result. Content that failed to load while offline (post stream pages, discussion lists) appears automatically on reconnection with no changes to calling code. Only GETs qualify — writes keep failing fast, so nothing can be submitted twice. A network failure while the browser reports being *online* still rejects exactly as before, so no promise can wait for an `online` event that will never come.

**3. Deduplicate deferred requests** — deferred requests are keyed by method + URL + params; identical requests queued while offline are retried with a single request whose result settles every caller's promise. This matters in practice: e.g. FoF Horizon's admin stats widget polls a GET every 5 seconds, which would otherwise replay dozens of identical requests on reconnection.

New locale keys: `core.lib.error.network_message`, `core.lib.error.offline_message`, `core.lib.connection_restored_message` (English only).

## Behavior notes

- `customErrorHandler` and rejection propagation are unchanged for every status except the offline-GET deferral case; regression tests cover 422/500/cross-origin.
- A survey of core, bundled extensions, and popular FoF extensions found no GET call sites whose `errorHandler`/`.catch` logic would be adversely affected by deferral — GET failure handling in the wild is loading-flag resets, which now correctly keep spinners visible until the content self-heals.

## Testing

- 22 new Jest unit tests (`tests/unit/common/Application.test.ts`): status-0 classification (online/offline/cross-origin), alert dedup, custom-error-handler contract, 422/500 regression guards, connectivity events, deferral + resolution on reconnect, re-deferral while still offline, retry dedup.
- Manual smoke test on a local 1.x forum: offline request failure → single dedicated alert; reply while offline → alert + composer content preserved; reconnect → offline alert cleared, confirmation shown, deferred content loads without reload; 422/500 render as on `1.x`.

## Screenshot
<img width="502" height="79" alt="image" src="https://github.com/user-attachments/assets/e85e38d3-8a9d-4d58-9ae4-9fc96fc6fb52" />
<img width="300" height="92" alt="image" src="https://github.com/user-attachments/assets/62b6de4e-af7a-4b19-86e5-6ae05a363c31" />


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
