### PR TITLE
[2.x] fix: queue:resume with no argument clears every pause

### DIFF
--- a/framework/core/src/Queue/Console/ResumeCommand.php
+++ b/framework/core/src/Queue/Console/ResumeCommand.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Queue\Console;
 
+use Flarum\Queue\QueueFactory;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\Queue;
@@ -21,14 +22,33 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'queue:resume')]
 class ResumeCommand extends Command
 {
-    protected $signature = 'queue:resume {queue=default : The name of the queue to resume, optionally prefixed with a connection (connection:queue)} {--all : Resume all queues on the connection}';
+    protected $signature = 'queue:resume {queue? : The queue to resume, optionally prefixed with a connection (connection:queue). Omit to resume all paused queues} {--all : Resume all queues on the connection}';
 
     protected $description = 'Resume processing of jobs on a paused queue';
 
     public function handle(Factory $factory, Queue $connection): int
     {
+        $connectionName = $connection->getConnectionName();
+
+        // A bare `queue:resume` (and --all) means "get jobs flowing again":
+        // clear the wildcard pause and every individually paused queue.
+        // Otherwise the admin footgun returns — "pause all" sets the wildcard
+        // key, which a resume targeting only `default` would silently leave in
+        // place.
+        if (! $this->argument('queue')) {
+            $paused = $factory instanceof QueueFactory ? $factory->pausedQueues($connectionName) : [];
+
+            foreach (array_merge(['*'], $paused) as $queue) {
+                $factory->resume($connectionName, $queue);
+            }
+
+            $this->components->info("Job processing on connection [{$connectionName}] has been resumed.");
+
+            return 0;
+        }
+
         [$connectionName, $queue] = $this->option('all')
-            ? [$connection->getConnectionName(), '*']
+            ? [$connectionName, '*']
             : $this->parseQueue($this->argument('queue'), $connection);
 
         $factory->resume($connectionName, $queue);

--- a/framework/core/tests/integration/queue/QueuePauseTest.php
+++ b/framework/core/tests/integration/queue/QueuePauseTest.php
@@ -199,6 +199,50 @@ class QueuePauseTest extends ConsoleTestCase
     }
 
     #[Test]
+    public function a_bare_resume_clears_a_wildcard_pause()
+    {
+        // The operator footgun: pausing everything (e.g. the "pause all" admin
+        // toggle, or `queue:pause --all`) sets the wildcard key, but a plain
+        // `queue:resume` used to only clear the `default` key — leaving the
+        // queue paused with no obvious reason. A bare resume means "get jobs
+        // flowing again", so it must clear whatever pause is in effect.
+        $this->runCommand(['command' => 'queue:pause', '--all' => true]);
+
+        $this->assertTrue($this->factory()->isPaused('flarum', 'default'));
+
+        $this->runCommand(['command' => 'queue:resume']);
+
+        $this->assertFalse($this->factory()->isPaused('flarum', 'default'));
+        $this->assertFalse($this->factory()->isPaused('flarum', 'anything'));
+        $this->assertSame([], $this->factory()->pausedQueues('flarum'));
+    }
+
+    #[Test]
+    public function a_bare_resume_clears_every_individually_paused_queue()
+    {
+        $this->runCommand(['command' => 'queue:pause', 'queue' => 'default']);
+        $this->runCommand(['command' => 'queue:pause', 'queue' => 'media']);
+
+        $this->runCommand(['command' => 'queue:resume']);
+
+        $this->assertSame([], $this->factory()->pausedQueues('flarum'));
+    }
+
+    #[Test]
+    public function resuming_a_named_queue_still_targets_only_that_queue()
+    {
+        $this->runCommand(['command' => 'queue:pause', 'queue' => 'default']);
+        $this->runCommand(['command' => 'queue:pause', 'queue' => 'media']);
+
+        $this->runCommand(['command' => 'queue:resume', 'queue' => 'media']);
+
+        $this->assertTrue($this->factory()->isPaused('flarum', 'default'));
+        $this->assertFalse($this->factory()->isPaused('flarum', 'media'));
+
+        $this->factory()->resume('flarum', 'default');
+    }
+
+    #[Test]
     public function pausing_all_queues_pauses_any_queue_name()
     {
         $factory = $this->factory();


### PR DESCRIPTION
Follow-up to the pausable-queues feature (#4841), fixing an operator footgun found in testing.

## Problem

Pausing everything — the admin **"pause all"** toggle on the Advanced page, or `queue:pause --all` — sets the wildcard pause key (`{connection}:*`). But a plain `queue:resume` only cleared the `default` key. So an operator who paused all queues from the UI and then ran the natural `flarum queue:resume` on the CLI was left with the queue **still paused and no obvious reason why** — the wildcard key was untouched.

Verified live: UI "pause all" → `pausedQueues() === ['*']` → bare `queue:resume` → still `['*']`.

## Fix

A bare `queue:resume` (no queue argument) now means "get jobs flowing again": it clears the wildcard pause **and** every individually paused queue on the connection. The queue argument is made genuinely optional so "no target" is distinguishable from an explicit `default`.

Unchanged: passing a queue name resumes only that queue; `--all` still targets the wildcard; `queue:pause` with no argument still pauses only `default` (pausing everything on a bare pause would be too aggressive — the asymmetry is intentional).

The admin UI toggle was already symmetric (it resumes with the same queue value it paused with), so this only affects the CLI path.

## Tests

3 new integration tests: bare resume clears a wildcard pause, bare resume clears every individually-paused queue, and a named resume still targets only that queue. Full suite 746 green, PHPStan clean. Live-verified: UI pause-all → bare CLI resume now clears it (`[]`).