### PR TITLE
[2.x] feat: audit queue pause and resume

### DIFF
--- a/extensions/audit/extend.php
+++ b/extensions/audit/extend.php
@@ -18,11 +18,11 @@ use Flarum\Extension\Event as ExtensionEvent;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Group\Event as GroupEvent;
 use Flarum\Http\Event\DeveloperTokenCreated;
-use Illuminate\Queue\Events\QueuePaused;
-use Illuminate\Queue\Events\QueueResumed;
 use Flarum\Post\Event as PostEvent;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Settings\Event as SettingsEvent;
+use Illuminate\Queue\Events\QueuePaused;
+use Illuminate\Queue\Events\QueueResumed;
 
 // Register usage examples and help for each search gambit so the audit browser can show
 // clickable hints and a syntax help panel. Kept next to the gambit registration below;

--- a/extensions/audit/extend.php
+++ b/extensions/audit/extend.php
@@ -18,6 +18,8 @@ use Flarum\Extension\Event as ExtensionEvent;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Group\Event as GroupEvent;
 use Flarum\Http\Event\DeveloperTokenCreated;
+use Illuminate\Queue\Events\QueuePaused;
+use Illuminate\Queue\Events\QueueResumed;
 use Flarum\Post\Event as PostEvent;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Settings\Event as SettingsEvent;
@@ -66,6 +68,22 @@ return [
         ->register('cache_cleared')
         ->listen(ClearingCache::class, 'cache_cleared', function () {
             return [];
+        }),
+
+    // Queue pausing is a privileged, operationally significant action. Both
+    // the admin UI and the CLI commands route through QueueFactory, which
+    // dispatches these Illuminate events, so listening here captures every
+    // pause channel and records the queue name that was paused (including
+    // extension-defined queues and the "*" wildcard used by "pause all").
+    (new Audit())
+        ->group(null)
+        ->register('queue.paused')
+        ->register('queue.resumed')
+        ->listen(QueuePaused::class, 'queue.paused', function ($event) {
+            return ['connection' => $event->connection, 'queue' => $event->queue];
+        })
+        ->listen(QueueResumed::class, 'queue.resumed', function ($event) {
+            return ['connection' => $event->connection, 'queue' => $event->queue];
         }),
 
     (new Audit())

--- a/extensions/audit/js/src/common/components/AuditItem.tsx
+++ b/extensions/audit/js/src/common/components/AuditItem.tsx
@@ -295,6 +295,9 @@ export default class AuditItem implements ClassComponent<AuditItemAttrs> {
         reason: payload.reason ? <code>{payload.reason}</code> : <em>{app.translator.trans(translationPrefix + 'noReason')}</em>,
 
         deleted_count: payload.deleted_count,
+
+        connection: payload.connection ? <code>{payload.connection}</code> : undefined,
+        queue: payload.queue ? <code>{payload.queue}</code> : undefined,
       };
 
       formattedPayload = app.translator.trans(translationKeyForPayload, parameters);

--- a/extensions/audit/locale/en.yml
+++ b/extensions/audit/locale/en.yml
@@ -90,6 +90,9 @@ flarum-audit:
                 disabled: Disabled extension {package}
                 enabled: Enabled extension {package}
                 uninstalled: Uninstalled extension {package}
+            queue:
+                paused: Paused queue processing on {queue} ({connection})
+                resumed: Resumed queue processing on {queue} ({connection})
             group:
                 created: Created group {name}
                 deleted: Deleted group {name}

--- a/extensions/audit/tests/integration/CoreQueueTest.php
+++ b/extensions/audit/tests/integration/CoreQueueTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Audit\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Events\QueuePaused;
+use Illuminate\Queue\Events\QueueResumed;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Pausing/resuming a queue is a privileged, operationally significant action
+ * (jobs silently stop flowing), so it is audited. Both the admin UI endpoint
+ * and the CLI commands funnel through QueueFactory, which dispatches these
+ * Illuminate events — so listening to the events captures every pause channel
+ * and records the exact queue name that was paused, including named queues
+ * added by extensions and the wildcard ("*") used by "pause all".
+ */
+class CoreQueueTest extends TestCase
+{
+    private function events(): Dispatcher
+    {
+        return $this->app()->getContainer()->make(Dispatcher::class);
+    }
+
+    #[Test]
+    public function pausing_a_queue_is_logged_with_the_queue_name()
+    {
+        $this->events()->dispatch(new QueuePaused('redis', 'media'));
+
+        $log = AuditLog::query()->where('action', 'queue.paused')->first();
+
+        $this->assertNotNull($log, 'A queue.paused entry should be logged');
+        $this->assertSame(['connection' => 'redis', 'queue' => 'media'], $log->payload);
+    }
+
+    #[Test]
+    public function resuming_a_queue_is_logged_with_the_queue_name()
+    {
+        $this->events()->dispatch(new QueueResumed('redis', 'media'));
+
+        $log = AuditLog::query()->where('action', 'queue.resumed')->first();
+
+        $this->assertNotNull($log, 'A queue.resumed entry should be logged');
+        $this->assertSame(['connection' => 'redis', 'queue' => 'media'], $log->payload);
+    }
+
+    #[Test]
+    public function a_wildcard_pause_all_is_logged_as_the_wildcard_queue()
+    {
+        $this->events()->dispatch(new QueuePaused('flarum', '*'));
+
+        $log = AuditLog::query()->where('action', 'queue.paused')->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('*', $log->payload['queue']);
+    }
+}

--- a/extensions/audit/tests/integration/CoreQueueTest.php
+++ b/extensions/audit/tests/integration/CoreQueueTest.php
@@ -38,7 +38,7 @@ class CoreQueueTest extends TestCase
         $log = AuditLog::query()->where('action', 'queue.paused')->first();
 
         $this->assertNotNull($log, 'A queue.paused entry should be logged');
-        $this->assertSame(['connection' => 'redis', 'queue' => 'media'], $log->payload);
+        $this->assertEquals(['connection' => 'redis', 'queue' => 'media'], $log->payload);
     }
 
     #[Test]
@@ -49,7 +49,7 @@ class CoreQueueTest extends TestCase
         $log = AuditLog::query()->where('action', 'queue.resumed')->first();
 
         $this->assertNotNull($log, 'A queue.resumed entry should be logged');
-        $this->assertSame(['connection' => 'redis', 'queue' => 'media'], $log->payload);
+        $this->assertEquals(['connection' => 'redis', 'queue' => 'media'], $log->payload);
     }
 
     #[Test]


### PR DESCRIPTION
Audits the queue pause/resume actions added in #4841.

## Why

Pausing or resuming a queue is a privileged, operationally significant action — jobs silently stop or resume flowing (emails, notifications, search indexing, etc.). It belongs in the audit log alongside the setting and permission changes flarum/audit already records, so an operator can answer "who paused the queue, when, and did anyone resume it".

## How

flarum/audit registers two actions (`queue.paused`, `queue.resumed`) and listens to Illuminate's `QueuePaused` / `QueueResumed` events. Both the admin UI endpoint and the CLI `queue:pause`/`queue:resume` commands route through `QueueFactory`, which dispatches these events — so listening to the event captures **every** pause channel with no per-entry-point wiring, and any future channel is covered automatically.

The recorded payload carries the connection and queue name, so:
- named queues added by extensions (e.g. Horizon supervisor queues) are logged accurately, and
- the `*` wildcard used by "pause all" is logged as such.

The log-viewer label renders the connection and queue (added to the audit item's parameter allowlist — which deliberately does not spread the raw payload).

## Notes

- `pauseFor()` (timed pause) is not exposed in the UI or CLI, only permanent pause/resume, so there's no silent-expiry gap in practice.
- CLI-triggered pauses have no HTTP actor, so they log with a system (null) actor — correct, as there's no user.

## Tests

New `CoreQueueTest` (in the audit suite, mirroring `CoreCacheTest`): a `QueuePaused`/`QueueResumed` event produces the corresponding audit entry with the queue name in the payload, including the wildcard case. Full audit suite green, PHPStan clean.

Depends on #4841 (already merged to 2.x).