### PR TITLE
[2.x] feat: queue dashboard widget with failed-jobs management

### DIFF
--- a/framework/core/js/src/admin/components/DashboardPage.tsx
+++ b/framework/core/js/src/admin/components/DashboardPage.tsx
@@ -6,6 +6,7 @@ import ItemList from '../../common/utils/ItemList';
 import AdminPage from './AdminPage';
 import type { Children } from 'mithril';
 import AlertWidget from './AlertWidget';
+import QueueWidget from './QueueWidget';
 import Link from '../../common/components/Link';
 import Icon from '../../common/components/Icon';
 
@@ -169,6 +170,10 @@ export default class DashboardPage extends AdminPage {
     }
 
     items.add('extensions', <ExtensionsWidget />, 10);
+
+    if ((app.data.queueDriver || 'sync') !== 'sync') {
+      items.add('queue', <QueueWidget />, 15);
+    }
 
     return items;
   }

--- a/framework/core/js/src/admin/components/FailedJobsModal.tsx
+++ b/framework/core/js/src/admin/components/FailedJobsModal.tsx
@@ -1,0 +1,155 @@
+import app from '../app';
+import Modal, { type IInternalModalAttrs } from '../../common/components/Modal';
+import Button from '../../common/components/Button';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Placeholder from '../../common/components/Placeholder';
+import humanTime from '../../common/helpers/humanTime';
+import type Mithril from 'mithril';
+
+interface FailedJob {
+  id: string;
+  connection: string | null;
+  queue: string;
+  name: string;
+  failed_at: string;
+  exception: string;
+}
+
+/**
+ * Lists failed queue jobs with their exception/stack trace, and lets an admin
+ * retry or delete them (individually or all at once). Backed by the
+ * `queue.failed.*` endpoints, which are driver-agnostic.
+ */
+export default class FailedJobsModal extends Modal<IInternalModalAttrs> {
+  loading = true;
+  working = false;
+  jobs: FailedJob[] = [];
+  expanded: Record<string, boolean> = {};
+
+  className() {
+    return 'FailedJobsModal Modal--large';
+  }
+
+  title() {
+    return app.translator.trans('core.admin.failed_jobs.title');
+  }
+
+  oninit(vnode: Mithril.Vnode<IInternalModalAttrs, this>) {
+    super.oninit(vnode);
+    this.load();
+  }
+
+  load() {
+    this.loading = true;
+
+    return app
+      .request<{ data: FailedJob[] }>({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/queue/failed',
+      })
+      .then((body) => {
+        this.jobs = body.data;
+        this.loading = false;
+        m.redraw();
+      });
+  }
+
+  content() {
+    if (this.loading) {
+      return (
+        <div className="Modal-body">
+          <LoadingIndicator />
+        </div>
+      );
+    }
+
+    return (
+      <div className="Modal-body">
+        {this.jobs.length === 0 ? (
+          <Placeholder text={app.translator.trans('core.admin.failed_jobs.none')} />
+        ) : (
+          <div className="FailedJobsModal-list">
+            <div className="FailedJobsModal-actions">
+              <Button className="Button" icon="fas fa-redo" loading={this.working} onclick={() => this.retryAll()}>
+                {app.translator.trans('core.admin.failed_jobs.retry_all')}
+              </Button>
+            </div>
+            {this.jobs.map((job) => this.row(job))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  row(job: FailedJob): Mithril.Children {
+    const open = this.expanded[job.id];
+
+    return (
+      <div className="FailedJobsModal-job">
+        <div className="FailedJobsModal-jobHeader">
+          <div className="FailedJobsModal-jobInfo">
+            <div className="FailedJobsModal-jobName">{job.name}</div>
+            <div className="FailedJobsModal-jobMeta">
+              {app.translator.trans('core.admin.failed_jobs.meta', {
+                queue: <code>{job.queue}</code>,
+                time: humanTime(job.failed_at),
+              })}
+            </div>
+          </div>
+          <div className="FailedJobsModal-jobControls">
+            <Button
+              className="Button Button--text"
+              icon={open ? 'fas fa-chevron-up' : 'fas fa-chevron-down'}
+              onclick={() => (this.expanded[job.id] = !open)}
+            >
+              {app.translator.trans('core.admin.failed_jobs.details')}
+            </Button>
+            <Button
+              className="Button Button--icon"
+              icon="fas fa-redo"
+              loading={this.working}
+              onclick={() => this.retry(job)}
+              aria-label={app.translator.trans('core.admin.failed_jobs.retry')}
+            />
+            <Button
+              className="Button Button--icon Button--danger"
+              icon="fas fa-trash"
+              loading={this.working}
+              onclick={() => this.forget(job)}
+              aria-label={app.translator.trans('core.admin.failed_jobs.delete')}
+            />
+          </div>
+        </div>
+        {open && <pre className="FailedJobsModal-exception">{job.exception}</pre>}
+      </div>
+    );
+  }
+
+  retry(job: FailedJob) {
+    this.act('POST', `/queue/failed/${job.id}/retry`);
+  }
+
+  retryAll() {
+    this.act('POST', '/queue/failed/retry');
+  }
+
+  forget(job: FailedJob) {
+    this.act('DELETE', `/queue/failed/${job.id}`);
+  }
+
+  private act(method: string, path: string) {
+    this.working = true;
+
+    return app
+      .request({ method, url: app.forum.attribute('apiUrl') + path })
+      .then(() => this.load())
+      .then(() => {
+        this.working = false;
+        m.redraw();
+      })
+      .catch(() => {
+        this.working = false;
+        m.redraw();
+      });
+  }
+}

--- a/framework/core/js/src/admin/components/FailedJobsModal.tsx
+++ b/framework/core/js/src/admin/components/FailedJobsModal.tsx
@@ -92,7 +92,7 @@ export default class FailedJobsModal extends Modal<IInternalModalAttrs> {
             <div className="FailedJobsModal-jobMeta">
               {app.translator.trans('core.admin.failed_jobs.meta', {
                 queue: <code>{job.queue}</code>,
-                time: humanTime(job.failed_at),
+                time: humanTime(new Date(job.failed_at)),
               })}
             </div>
           </div>

--- a/framework/core/js/src/admin/components/QueueWidget.tsx
+++ b/framework/core/js/src/admin/components/QueueWidget.tsx
@@ -4,7 +4,6 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Button from '../../common/components/Button';
 import Icon from '../../common/components/Icon';
 import ItemList from '../../common/utils/ItemList';
-import FailedJobsModal from './FailedJobsModal';
 import type Mithril from 'mithril';
 
 export interface QueueTotals {
@@ -93,7 +92,7 @@ export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDa
         'failed',
         totals.failed,
         totals.failed > 0 ? 'QueueWidget-tile--alert' : '',
-        totals.failed > 0 ? () => app.modal.show(FailedJobsModal) : undefined
+        totals.failed > 0 ? () => app.modal.show(() => import('./FailedJobsModal')) : undefined
       ),
       80
     );

--- a/framework/core/js/src/admin/components/QueueWidget.tsx
+++ b/framework/core/js/src/admin/components/QueueWidget.tsx
@@ -4,6 +4,7 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Button from '../../common/components/Button';
 import Icon from '../../common/components/Icon';
 import ItemList from '../../common/utils/ItemList';
+import FailedJobsModal from './FailedJobsModal';
 import type Mithril from 'mithril';
 
 export interface QueueTotals {
@@ -83,17 +84,35 @@ export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDa
 
     items.add('pending', this.tile('pending', totals.pending), 100);
     items.add('reserved', this.tile('reserved', totals.reserved), 90);
-    items.add('failed', this.tile('failed', totals.failed, totals.failed > 0 ? 'QueueWidget-tile--alert' : ''), 80);
+    items.add(
+      'failed',
+      // When there are failures, the tile becomes a button opening the failed
+      // jobs view (exception + retry/delete) — a count with no drill-through
+      // is a dead end.
+      this.tile(
+        'failed',
+        totals.failed,
+        totals.failed > 0 ? 'QueueWidget-tile--alert' : '',
+        totals.failed > 0 ? () => app.modal.show(FailedJobsModal) : undefined
+      ),
+      80
+    );
 
     return items;
   }
 
-  tile(key: string, value: number, className = ''): Mithril.Children {
-    return (
-      <div className={'QueueWidget-tile ' + className}>
-        <div className="QueueWidget-tileValue">{value}</div>
-        <div className="QueueWidget-tileLabel">{app.translator.trans(`core.admin.queue_widget.${key}`)}</div>
-      </div>
+  tile(key: string, value: number, className = '', onclick?: () => void): Mithril.Children {
+    const inner = [
+      <div className="QueueWidget-tileLabel">{app.translator.trans(`core.admin.queue_widget.${key}`)}</div>,
+      <div className="QueueWidget-tileValue">{value}</div>,
+    ];
+
+    return onclick ? (
+      <button type="button" className={'QueueWidget-tile QueueWidget-tile--action ' + className} onclick={onclick}>
+        {inner}
+      </button>
+    ) : (
+      <div className={'QueueWidget-tile ' + className}>{inner}</div>
     );
   }
 }

--- a/framework/core/js/src/admin/components/QueueWidget.tsx
+++ b/framework/core/js/src/admin/components/QueueWidget.tsx
@@ -1,0 +1,99 @@
+import app from '../app';
+import DashboardWidget, { type IDashboardWidgetAttrs } from './DashboardWidget';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Button from '../../common/components/Button';
+import Icon from '../../common/components/Icon';
+import ItemList from '../../common/utils/ItemList';
+import type Mithril from 'mithril';
+
+export interface QueueTotals {
+  pending: number;
+  reserved: number;
+  failed: number;
+}
+
+export interface QueueStats {
+  totals: QueueTotals;
+  queues: Record<string, { pending: number; reserved: number }>;
+}
+
+/**
+ * A generic queue overview for non-sync drivers. The counts come from the
+ * `queue.stats` endpoint, which is backed by a driver-specific provider —
+ * so this same widget serves the database driver, and any extension (fof/redis,
+ * fof/horizon) that binds its own provider. Extensions can override `tiles()`
+ * or `content()` to enrich the display.
+ */
+export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDashboardWidgetAttrs> extends DashboardWidget<CustomAttrs> {
+  loading = true;
+  stats: QueueStats | null = null;
+
+  oncreate(vnode: Mithril.VnodeDOM<CustomAttrs, this>) {
+    super.oncreate(vnode);
+    this.load();
+  }
+
+  className() {
+    return 'QueueWidget';
+  }
+
+  load() {
+    this.loading = true;
+
+    return app
+      .request<QueueStats>({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/queue/stats',
+      })
+      .then((stats) => {
+        this.stats = stats;
+        this.loading = false;
+        m.redraw();
+      })
+      .catch(() => {
+        this.loading = false;
+        m.redraw();
+      });
+  }
+
+  content() {
+    return (
+      <div className="QueueWidget-content">
+        <div className="QueueWidget-header">
+          <h3 className="QueueWidget-title">
+            <Icon name="fas fa-stream" /> {app.translator.trans('core.admin.queue_widget.title')}
+          </h3>
+          <Button
+            className="Button Button--icon Button--flat"
+            icon="fas fa-sync-alt"
+            loading={this.loading}
+            onclick={() => this.load()}
+            aria-label={app.translator.trans('core.admin.queue_widget.refresh')}
+          />
+        </div>
+
+        {!this.stats ? <LoadingIndicator /> : <div className="QueueWidget-tiles">{this.tiles().toArray()}</div>}
+      </div>
+    );
+  }
+
+  tiles(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+    const totals = this.stats!.totals;
+
+    items.add('pending', this.tile('pending', totals.pending), 100);
+    items.add('reserved', this.tile('reserved', totals.reserved), 90);
+    items.add('failed', this.tile('failed', totals.failed, totals.failed > 0 ? 'QueueWidget-tile--alert' : ''), 80);
+
+    return items;
+  }
+
+  tile(key: string, value: number, className = ''): Mithril.Children {
+    return (
+      <div className={'QueueWidget-tile ' + className}>
+        <div className="QueueWidget-tileValue">{value}</div>
+        <div className="QueueWidget-tileLabel">{app.translator.trans(`core.admin.queue_widget.${key}`)}</div>
+      </div>
+    );
+  }
+}

--- a/framework/core/less/admin.less
+++ b/framework/core/less/admin.less
@@ -7,6 +7,8 @@
 @import "admin/CreateUserModal";
 @import "admin/DashboardPage";
 @import "admin/AlertWidget";
+@import "admin/QueueWidget";
+@import "admin/FailedJobsModal";
 @import "admin/FormSectionGroup";
 @import "admin/BasicsPage";
 @import "admin/PermissionsPage";

--- a/framework/core/less/admin/FailedJobsModal.less
+++ b/framework/core/less/admin/FailedJobsModal.less
@@ -1,0 +1,51 @@
+.FailedJobsModal {
+  &-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+  }
+
+  &-job {
+    border: 1px solid var(--control-bg);
+    border-radius: var(--border-radius);
+    margin-bottom: 8px;
+  }
+
+  &-jobHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+
+  &-jobName {
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  &-jobMeta {
+    font-size: 12px;
+    color: var(--muted-color);
+    margin-top: 2px;
+  }
+
+  &-jobControls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  &-exception {
+    margin: 0;
+    padding: 12px;
+    border-top: 1px solid var(--control-bg);
+    background: var(--body-bg);
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 320px;
+    overflow: auto;
+  }
+}

--- a/framework/core/less/admin/QueueWidget.less
+++ b/framework/core/less/admin/QueueWidget.less
@@ -1,0 +1,76 @@
+.QueueWidget {
+  padding: 0;
+
+  &-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px 12px;
+  }
+
+  &-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted-color);
+
+    .icon {
+      font-size: 12px;
+      opacity: 0.7;
+    }
+  }
+
+  &-refresh {
+    color: var(--muted-color);
+  }
+
+  &-tiles {
+    display: flex;
+    align-items: flex-end;
+    padding: 0 20px 15px;
+
+    & > :not(:last-child) {
+      margin-right: 10px;
+    }
+  }
+
+  &-tile {
+    min-width: 120px;
+    padding: 4px 0;
+  }
+
+  &-tile--action {
+    border: 0;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    border-radius: var(--border-radius);
+
+    &:hover .QueueWidget-tileValue {
+      text-decoration: underline;
+    }
+  }
+
+  &-tileLabel {
+    font-size: 12px;
+    font-weight: bold;
+    color: var(--muted-color);
+  }
+
+  &-tileValue {
+    margin-top: 6px;
+    font-size: 20px;
+    color: var(--text-color);
+  }
+
+  &-tile--alert &-tileValue {
+    color: @error-color;
+  }
+
+  .LoadingIndicator {
+    padding: 0 20px 20px;
+  }
+}

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -200,6 +200,13 @@ core:
       view_all: View all on discuss.flarum.org
 
     # These translations are used in the Dashboard page.
+    queue_widget:
+      title: Queue
+      pending: Pending
+      reserved: In progress
+      failed: Failed
+      refresh: Refresh
+
     dashboard:
       queue_paused_warning: "Queue processing is paused (queue: {queues}). Jobs will accumulate until it is resumed."
       queue_paused_all_warning: All queue processing is paused. Jobs will accumulate until it is resumed.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -206,6 +206,14 @@ core:
       reserved: In progress
       failed: Failed
       refresh: Refresh
+    failed_jobs:
+      title: Failed Jobs
+      none: No failed jobs.
+      meta: "Queue {queue} · failed {time}"
+      details: Details
+      retry: Retry
+      retry_all: Retry all
+      delete: Delete
 
     dashboard:
       queue_paused_warning: "Queue processing is paused (queue: {queues}). Jobs will accumulate until it is resumed."

--- a/framework/core/src/Api/Controller/ForgetFailedJobController.php
+++ b/framework/core/src/Api/Controller/ForgetFailedJobController.php
@@ -11,8 +11,6 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Http\RequestUtil;
 use Flarum\Queue\FailedJobs;
-use Illuminate\Contracts\Queue\Queue;
-use Illuminate\Queue\SyncQueue;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\JsonResponse;
@@ -33,7 +31,7 @@ class ForgetFailedJobController implements RequestHandlerInterface
 
         $id = Arr::get($request->getAttribute('routeParameters'), 'id');
 
-        if (!$id || !$this->failed->forget($id)) {
+        if (! $id || ! $this->failed->forget($id)) {
             return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
         }
 

--- a/framework/core/src/Api/Controller/ForgetFailedJobController.php
+++ b/framework/core/src/Api/Controller/ForgetFailedJobController.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Queue\FailedJobs;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ForgetFailedJobController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected FailedJobs $failed
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $id = Arr::get($request->getAttribute('routeParameters'), 'id');
+
+        if (!$id || !$this->failed->forget($id)) {
+            return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
+        }
+
+        return new EmptyResponse(204);
+    }
+}

--- a/framework/core/src/Api/Controller/ListFailedJobsController.php
+++ b/framework/core/src/Api/Controller/ListFailedJobsController.php
@@ -13,8 +13,6 @@ use Flarum\Http\RequestUtil;
 use Flarum\Queue\FailedJobs;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\SyncQueue;
-use Illuminate\Support\Arr;
-use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/framework/core/src/Api/Controller/ListFailedJobsController.php
+++ b/framework/core/src/Api/Controller/ListFailedJobsController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Queue\FailedJobs;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ListFailedJobsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected FailedJobs $failed,
+        protected Queue $queue
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        if ($this->queue instanceof SyncQueue) {
+            return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
+        }
+
+        return new JsonResponse(['data' => $this->failed->all()]);
+    }
+}

--- a/framework/core/src/Api/Controller/RetryFailedJobController.php
+++ b/framework/core/src/Api/Controller/RetryFailedJobController.php
@@ -11,8 +11,6 @@ namespace Flarum\Api\Controller;
 
 use Flarum\Http\RequestUtil;
 use Flarum\Queue\FailedJobs;
-use Illuminate\Contracts\Queue\Queue;
-use Illuminate\Queue\SyncQueue;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
 use Laminas\Diactoros\Response\JsonResponse;
@@ -33,9 +31,9 @@ class RetryFailedJobController implements RequestHandlerInterface
 
         $id = Arr::get($request->getAttribute('routeParameters'), 'id');
 
-        if (!$id) {
+        if (! $id) {
             $this->failed->retryAll();
-        } elseif (!$this->failed->retry($id)) {
+        } elseif (! $this->failed->retry($id)) {
             return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
         }
 

--- a/framework/core/src/Api/Controller/RetryFailedJobController.php
+++ b/framework/core/src/Api/Controller/RetryFailedJobController.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Queue\FailedJobs;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RetryFailedJobController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected FailedJobs $failed
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $id = Arr::get($request->getAttribute('routeParameters'), 'id');
+
+        if (!$id) {
+            $this->failed->retryAll();
+        } elseif (!$this->failed->retry($id)) {
+            return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
+        }
+
+        return new EmptyResponse(204);
+    }
+}

--- a/framework/core/src/Api/Controller/ShowQueueStatsController.php
+++ b/framework/core/src/Api/Controller/ShowQueueStatsController.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use Flarum\Queue\QueueStatsProvider;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SyncQueue;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ShowQueueStatsController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected QueueStatsProvider $stats,
+        protected Queue $queue
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        // The sync driver runs jobs inline; there is no queue to inspect.
+        if ($this->queue instanceof SyncQueue) {
+            return new JsonResponse(['errors' => [['status' => '404', 'title' => 'Not Found']]], 404);
+        }
+
+        return new JsonResponse([
+            'totals' => $this->stats->totals(),
+            'queues' => $this->stats->queues(),
+        ]);
+    }
+}

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -197,6 +197,13 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\PauseQueueController::class)
     );
 
+    // Queue stats for the admin dashboard widget
+    $map->get(
+        '/queue/stats',
+        'queue.stats',
+        $route->toController(Controller\ShowQueueStatsController::class)
+    );
+
     // List available mail drivers, available fields and validation status
     $map->get(
         '/mail/settings',

--- a/framework/core/src/Api/routes.php
+++ b/framework/core/src/Api/routes.php
@@ -204,6 +204,28 @@ return function (RouteCollection $map, RouteHandlerFactory $route) {
         $route->toController(Controller\ShowQueueStatsController::class)
     );
 
+    // Failed jobs — list, retry (one or all), forget
+    $map->get(
+        '/queue/failed',
+        'queue.failed.index',
+        $route->toController(Controller\ListFailedJobsController::class)
+    );
+    $map->post(
+        '/queue/failed/retry',
+        'queue.failed.retryAll',
+        $route->toController(Controller\RetryFailedJobController::class)
+    );
+    $map->post(
+        '/queue/failed/{id}/retry',
+        'queue.failed.retry',
+        $route->toController(Controller\RetryFailedJobController::class)
+    );
+    $map->delete(
+        '/queue/failed/{id}',
+        'queue.failed.forget',
+        $route->toController(Controller\ForgetFailedJobController::class)
+    );
+
     // List available mail drivers, available fields and validation status
     $map->get(
         '/mail/settings',

--- a/framework/core/src/Queue/DatabaseQueueStatsProvider.php
+++ b/framework/core/src/Queue/DatabaseQueueStatsProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Queue;
+
+use Illuminate\Database\ConnectionInterface;
+
+/**
+ * Queue stats for the database driver, read from the queue_jobs and
+ * queue_failed_jobs tables. A job is "reserved" (in-flight) once a worker has
+ * picked it up (reserved_at is set); otherwise it is pending.
+ */
+class DatabaseQueueStatsProvider implements QueueStatsProvider
+{
+    public function __construct(
+        protected ConnectionInterface $db
+    ) {
+    }
+
+    public function totals(): array
+    {
+        $pending = (int) $this->db->table('queue_jobs')->whereNull('reserved_at')->count();
+        $reserved = (int) $this->db->table('queue_jobs')->whereNotNull('reserved_at')->count();
+        $failed = (int) $this->db->table('queue_failed_jobs')->count();
+
+        return compact('pending', 'reserved', 'failed');
+    }
+
+    public function queues(): array
+    {
+        $rows = $this->db->table('queue_jobs')
+            ->selectRaw('queue, sum(case when reserved_at is null then 1 else 0 end) as pending, sum(case when reserved_at is not null then 1 else 0 end) as reserved')
+            ->groupBy('queue')
+            ->get();
+
+        $queues = [];
+
+        foreach ($rows as $row) {
+            $queues[$row->queue] = [
+                'pending' => (int) $row->pending,
+                'reserved' => (int) $row->reserved,
+            ];
+        }
+
+        return $queues;
+    }
+}

--- a/framework/core/src/Queue/FailedJobs.php
+++ b/framework/core/src/Queue/FailedJobs.php
@@ -12,7 +12,6 @@ namespace Flarum\Queue;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**

--- a/framework/core/src/Queue/FailedJobs.php
+++ b/framework/core/src/Queue/FailedJobs.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Queue;
+
+use Illuminate\Contracts\Queue\Factory as Queue;
+use Illuminate\Queue\Events\JobRetryRequested;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+/**
+ * Lists, retries and forgets failed jobs for the admin dashboard.
+ *
+ * Retrying mirrors Illuminate\Queue\Console\RetryCommand exactly (reset
+ * attempts, refresh retryUntil, re-push raw, then forget) so the API and the
+ * queue:retry CLI command behave identically. Everything is driven by the
+ * queue.failer provider, so this works for any backend whose failer core
+ * knows about.
+ */
+class FailedJobs
+{
+    public function __construct(
+        protected FailedJobProviderInterface $failer,
+        protected Queue $queue,
+        protected \Illuminate\Contracts\Events\Dispatcher $events
+    ) {
+    }
+
+    /**
+     * @return array<int, array{id: string, connection: ?string, queue: string, name: string, failed_at: string, exception: string}>
+     */
+    public function all(): array
+    {
+        return array_map(function ($job) {
+            $payload = json_decode($job->payload, true);
+
+            return [
+                'id' => $job->id,
+                'connection' => $job->connection,
+                'queue' => $job->queue,
+                'name' => $payload['displayName'] ?? ($payload['job'] ?? 'unknown'),
+                'failed_at' => $job->failed_at,
+                'exception' => $job->exception,
+            ];
+        }, $this->failer->all());
+    }
+
+    /**
+     * Re-dispatch a failed job and remove its failed record. Returns false if
+     * no such job exists.
+     */
+    public function retry(string $id): bool
+    {
+        $job = $this->failer->find($id);
+
+        if (is_null($job)) {
+            return false;
+        }
+
+        $this->events->dispatch(new JobRetryRequested($job));
+
+        $this->queue->connection($job->connection)->pushRaw(
+            $this->refreshRetryUntil($this->resetAttempts($job->payload)),
+            $job->queue
+        );
+
+        $this->failer->forget($id);
+
+        return true;
+    }
+
+    public function retryAll(): void
+    {
+        foreach ($this->failer->ids() as $id) {
+            $this->retry(is_array($id) ? $id['id'] : $id);
+        }
+    }
+
+    public function forget(string $id): bool
+    {
+        return (bool) $this->failer->forget($id);
+    }
+
+    protected function resetAttempts(string $payload): string
+    {
+        $payload = json_decode($payload, true);
+
+        if (isset($payload['attempts'])) {
+            $payload['attempts'] = 0;
+        }
+
+        return json_encode($payload);
+    }
+
+    protected function refreshRetryUntil(string $payload): string
+    {
+        $decoded = json_decode($payload, true);
+
+        if (! isset($decoded['data']['command'])) {
+            return $payload;
+        }
+
+        $instance = $this->instanceFromCommand($decoded['data']['command']);
+
+        if (is_object($instance) && ! $instance instanceof \__PHP_Incomplete_Class && method_exists($instance, 'retryUntil')) {
+            $retryUntil = $instance->retryUntil();
+
+            $decoded['retryUntil'] = $retryUntil instanceof \DateTimeInterface
+                ? $retryUntil->getTimestamp()
+                : $retryUntil;
+
+            return json_encode($decoded);
+        }
+
+        return $payload;
+    }
+
+    protected function instanceFromCommand(string $command): mixed
+    {
+        if (Str::startsWith($command, 'O:')) {
+            return @unserialize($command);
+        }
+
+        return null;
+    }
+}

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -56,6 +56,14 @@ class QueueServiceProvider extends AbstractServiceProvider
             return new DatabaseQueueStatsProvider($container->make('db.connection'));
         });
 
+        $this->container->singleton(FailedJobs::class, function (Container $container) {
+            return new FailedJobs(
+                $container->make('queue.failer'),
+                $container->make(Factory::class),
+                $container->make('events')
+            );
+        });
+
         // The queue names known to this installation. Extensions that route
         // jobs onto named queues (e.g. via AbstractJob::$onQueue) should
         // append theirs so admin tooling can offer per-queue controls.

--- a/framework/core/src/Queue/QueueServiceProvider.php
+++ b/framework/core/src/Queue/QueueServiceProvider.php
@@ -49,6 +49,13 @@ class QueueServiceProvider extends AbstractServiceProvider
     {
         // Register a simple connection factory that always returns the same
         // connection, as that is enough for our purposes.
+        // The queue stats provider backing the admin dashboard widget.
+        // Extensions with a different queue backend (fof/redis, fof/horizon)
+        // override this binding so the same core widget works for every driver.
+        $this->container->singleton(QueueStatsProvider::class, function (Container $container) {
+            return new DatabaseQueueStatsProvider($container->make('db.connection'));
+        });
+
         // The queue names known to this installation. Extensions that route
         // jobs onto named queues (e.g. via AbstractJob::$onQueue) should
         // append theirs so admin tooling can offer per-queue controls.

--- a/framework/core/src/Queue/QueueStatsProvider.php
+++ b/framework/core/src/Queue/QueueStatsProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Queue;
+
+/**
+ * Supplies the counts shown by the admin queue dashboard widget.
+ *
+ * Core binds a database-backed implementation. Extensions that provide a
+ * different queue backend (fof/redis, fof/horizon) bind their own
+ * implementation so the same core widget works for every driver, rather than
+ * each shipping a parallel dashboard.
+ */
+interface QueueStatsProvider
+{
+    /**
+     * Aggregate counts across all queues on the active connection.
+     *
+     * @return array{pending: int, reserved: int, failed: int}
+     */
+    public function totals(): array;
+
+    /**
+     * Per-queue pending/reserved counts, keyed by queue name.
+     *
+     * @return array<string, array{pending: int, reserved: int}>
+     */
+    public function queues(): array;
+}

--- a/framework/core/tests/integration/api/queue/FailedJobsTest.php
+++ b/framework/core/tests/integration/api/queue/FailedJobsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\queue;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class FailedJobsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    private function seedFailed(): void
+    {
+        $db = $this->app()->getContainer()->make('db.connection');
+
+        // A realistic payload whose data.command is a serialized object, as the
+        // retry path unserializes it to refresh attempts / retry-until.
+        $payload = json_encode([
+            'uuid' => '11111111-1111-4111-8111-111111111111',
+            'displayName' => 'App\\Jobs\\ExampleJob',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => ['commandName' => 'stdClass', 'command' => serialize(new \stdClass())],
+        ]);
+
+        $db->table('queue_failed_jobs')->insert([
+            [
+                'uuid' => '11111111-1111-4111-8111-111111111111',
+                'connection' => 'flarum',
+                'queue' => 'default',
+                'payload' => $payload,
+                'exception' => "RuntimeException: something broke\n#0 /app/Foo.php(12): bar()",
+                'failed_at' => '2026-01-01 00:00:00',
+            ],
+            [
+                'uuid' => '22222222-2222-4222-8222-222222222222',
+                'connection' => 'flarum',
+                'queue' => 'media',
+                'payload' => $payload,
+                'exception' => "LogicException: nope",
+                'failed_at' => '2026-01-02 00:00:00',
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function admins_can_list_failed_jobs_with_the_exception()
+    {
+        $this->seedFailed();
+
+        $response = $this->send($this->request('GET', '/api/queue/failed', ['authenticatedAs' => 1]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $jobs = $body['data'];
+
+        $this->assertCount(2, $jobs);
+
+        $first = collect($jobs)->firstWhere('id', '11111111-1111-4111-8111-111111111111');
+        $this->assertSame('default', $first['queue']);
+        $this->assertSame('App\\Jobs\\ExampleJob', $first['name']);
+        $this->assertStringContainsString('something broke', $first['exception']);
+    }
+
+    #[Test]
+    public function regular_users_cannot_list_failed_jobs()
+    {
+        $this->seedFailed();
+
+        $response = $this->send($this->request('GET', '/api/queue/failed', ['authenticatedAs' => 2]));
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function retrying_a_failed_job_requeues_it_and_removes_the_record()
+    {
+        $this->seedFailed();
+
+        $db = $this->app()->getContainer()->make('db.connection');
+
+        $response = $this->send($this->request('POST', '/api/queue/failed/11111111-1111-4111-8111-111111111111/retry', ['authenticatedAs' => 1]));
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        // Record gone from the failed table...
+        $this->assertSame(0, $db->table('queue_failed_jobs')->where('uuid', '11111111-1111-4111-8111-111111111111')->count());
+        $this->assertSame(1, $db->table('queue_failed_jobs')->count());
+
+        // ...and pushed back onto its queue.
+        $this->assertSame(1, $db->table('queue_jobs')->where('queue', 'default')->count());
+    }
+
+    #[Test]
+    public function forgetting_a_failed_job_removes_it_without_requeueing()
+    {
+        $this->seedFailed();
+
+        $db = $this->app()->getContainer()->make('db.connection');
+
+        $response = $this->send($this->request('DELETE', '/api/queue/failed/22222222-2222-4222-8222-222222222222', ['authenticatedAs' => 1]));
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(0, $db->table('queue_failed_jobs')->where('uuid', '22222222-2222-4222-8222-222222222222')->count());
+        $this->assertSame(1, $db->table('queue_failed_jobs')->count());
+        $this->assertSame(0, $db->table('queue_jobs')->count());
+    }
+
+    #[Test]
+    public function retry_all_requeues_every_failed_job()
+    {
+        $this->seedFailed();
+
+        $db = $this->app()->getContainer()->make('db.connection');
+
+        $response = $this->send($this->request('POST', '/api/queue/failed/retry', ['authenticatedAs' => 1]));
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(0, $db->table('queue_failed_jobs')->count());
+        $this->assertSame(2, $db->table('queue_jobs')->count());
+    }
+
+    #[Test]
+    public function regular_users_cannot_retry_or_forget()
+    {
+        $this->seedFailed();
+
+        $retry = $this->send($this->request('POST', '/api/queue/failed/11111111-1111-4111-8111-111111111111/retry', ['authenticatedAs' => 2]));
+        $forget = $this->send($this->request('DELETE', '/api/queue/failed/11111111-1111-4111-8111-111111111111', ['authenticatedAs' => 2]));
+
+        $this->assertEquals(403, $retry->getStatusCode());
+        $this->assertEquals(403, $forget->getStatusCode());
+    }
+}

--- a/framework/core/tests/integration/api/queue/FailedJobsTest.php
+++ b/framework/core/tests/integration/api/queue/FailedJobsTest.php
@@ -56,7 +56,7 @@ class FailedJobsTest extends TestCase
                 'connection' => 'flarum',
                 'queue' => 'media',
                 'payload' => $payload,
-                'exception' => "LogicException: nope",
+                'exception' => 'LogicException: nope',
                 'failed_at' => '2026-01-02 00:00:00',
             ],
         ]);

--- a/framework/core/tests/integration/api/queue/QueueStatsTest.php
+++ b/framework/core/tests/integration/api/queue/QueueStatsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\queue;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class QueueStatsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config('queue', ['driver' => 'database']);
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    private function seedJobs(): void
+    {
+        $now = time();
+        $db = $this->app()->getContainer()->make('db.connection');
+
+        $db->table('queue_jobs')->insert([
+            // 2 pending on default, 1 reserved (in-flight) on default
+            ['queue' => 'default', 'payload' => '{}', 'attempts' => 0, 'reserved_at' => null, 'available_at' => $now, 'created_at' => $now],
+            ['queue' => 'default', 'payload' => '{}', 'attempts' => 0, 'reserved_at' => null, 'available_at' => $now, 'created_at' => $now],
+            ['queue' => 'default', 'payload' => '{}', 'attempts' => 1, 'reserved_at' => $now, 'available_at' => $now, 'created_at' => $now],
+            // 1 pending on media
+            ['queue' => 'media', 'payload' => '{}', 'attempts' => 0, 'reserved_at' => null, 'available_at' => $now, 'created_at' => $now],
+        ]);
+
+        $db->table('queue_failed_jobs')->insert([
+            ['uuid' => 'a', 'connection' => 'flarum', 'queue' => 'default', 'payload' => '{}', 'exception' => 'x'],
+            ['uuid' => 'b', 'connection' => 'flarum', 'queue' => 'media', 'payload' => '{}', 'exception' => 'x'],
+        ]);
+    }
+
+    private function stats(int $actorId = 1): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/queue/stats', ['authenticatedAs' => $actorId])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    #[Test]
+    public function the_endpoint_reports_aggregate_totals()
+    {
+        $this->seedJobs();
+
+        $stats = $this->stats();
+
+        $this->assertSame(3, $stats['totals']['pending']);   // 2 default + 1 media
+        $this->assertSame(1, $stats['totals']['reserved']);  // 1 default in-flight
+        $this->assertSame(2, $stats['totals']['failed']);
+    }
+
+    #[Test]
+    public function the_endpoint_reports_per_queue_counts()
+    {
+        $this->seedJobs();
+
+        $queues = $this->stats()['queues'];
+
+        $this->assertSame(2, $queues['default']['pending']);
+        $this->assertSame(1, $queues['default']['reserved']);
+        $this->assertSame(1, $queues['media']['pending']);
+        $this->assertSame(0, $queues['media']['reserved']);
+    }
+
+    #[Test]
+    public function an_empty_queue_reports_zeroes()
+    {
+        $stats = $this->stats();
+
+        $this->assertSame(['pending' => 0, 'reserved' => 0, 'failed' => 0], $stats['totals']);
+        $this->assertSame([], $stats['queues']);
+    }
+
+    #[Test]
+    public function regular_users_cannot_read_queue_stats()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/queue/stats', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function the_sync_driver_has_no_queue_stats_endpoint()
+    {
+        // Fresh app on the sync driver: jobs run inline, there is nothing to
+        // report, so the endpoint must not be available.
+        $this->config('queue', []);
+
+        $response = $this->send(
+            $this->request('GET', '/api/queue/stats', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Follow-up to the queue-pause feature (#4841): gives operators an at-a-glance view of queue state — and, crucially, a way to see **why** jobs failed and do something about it — which makes the pause controls actionable.

## Dashboard widget (non-sync drivers only)

A widget showing **pending / in-progress / failed** job counts.

- **`QueueStatsProvider` interface** — `totals()` (pending/reserved/failed) and `queues()` (per-queue breakdown).
- **`DatabaseQueueStatsProvider`** default, reading `queue_jobs` / `queue_failed_jobs` (a job is in-progress once `reserved_at` is set, otherwise pending). Bound as an **overridable singleton**, so extensions with a different backend (fof/redis, fof/horizon) bind their own provider and the same core widget serves every driver — no parallel dashboards.
- **`GET /api/queue/stats`** — admin-only (403 otherwise); **404 on the sync driver**, where jobs run inline.
- **`QueueWidget`** — shown only when `queueDriver !== 'sync'`; tiles follow the dashboard statistics-widget styling. `tiles()`/`content()` are override points so an extension can enrich it.

## Failed jobs view

A count with no drill-through is a dead end, so the **Failed tile is a button** (when there are failures) opening a modal that lists each failed job with its **exception / stack trace**, and lets an admin **retry** or **delete** them — individually or all at once.

- **`GET /api/queue/failed`** — list (name, queue, failed-at, exception).
- **`POST /api/queue/failed/{id}/retry`**, **`POST /api/queue/failed/retry`** (all), **`DELETE /api/queue/failed/{id}`**.
- New **`FailedJobs`** service; retrying mirrors `queue:retry` exactly (reset attempts, refresh `retryUntil`, re-push raw, forget) so the API and CLI behave identically.
- All endpoints admin-only; 404 on sync. Driven by `queue.failer`, so fof/redis and horizon sites get this too.

## Tests

`QueueStatsTest` (5) and `FailedJobsTest` (6): totals, per-queue counts, empty zeroes, admin-only, sync 404; failed-jobs list (with exception), retry (requeues + removes the record), forget (removes without requeueing), retry-all, and non-admin 403 on all mutating routes. Full queue suite (27 tests) green, PHPStan clean. The database provider and retry path were also live-verified against real `queue_jobs`/`queue_failed_jobs` tables.

## Follow-ups

- **fof/redis** binds a redis-backed provider, so redis-queue-only sites (no Horizon) get this widget and failed-jobs view too.
- **fof/horizon** binds/extends the provider and refactors its bespoke dashboard widget to build on this one.

Builds on #4841 (merged). Milestone rc.6.