### PR TITLE
[2.x] feat: Support testing against multiple Redis clients in reusable backend workflow

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -33,6 +33,18 @@ on:
         default: 'latest'
         required: false
 
+      redis_clients:
+        description: >-
+          JSON array of Redis client libraries to run the test matrix against.
+          Only meaningful when `enable_redis` is true. 'phpredis' loads the
+          native `redis` PHP extension; 'predis' relies on the pure-PHP client.
+          Default is a single empty entry, which adds no client dimension and
+          leaves the matrix unchanged for repos that don't need to distinguish
+          clients. Set to e.g. '["phpredis", "predis"]' to test both.
+        type: string
+        default: '[""]'
+        required: false
+
       backend_directory:
         description: The directory of the project where backend code is located. This should contain a `composer.json` file, and is generally the root directory of the repo.
         type: string
@@ -106,6 +118,10 @@ jobs:
         service: ${{ fromJSON(inputs.db_versions) }}
         prefix: ['']
         php_ini_values: [inputs.php_ini_values]
+        # Redis client library to exercise. Defaults to a single empty entry
+        # (no extra dimension); repos that enable_redis can opt into testing
+        # both 'phpredis' and 'predis' via the `redis_clients` input.
+        redis_client: ${{ fromJSON(inputs.redis_clients) }}
 
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
@@ -222,7 +238,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    name: 'PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}'
+    name: "PHP ${{ matrix.php }} / ${{ matrix.db }} ${{ matrix.prefixStr }}${{ matrix.redis_client && format(' [{0}]', matrix.redis_client) || '' }}"
 
     if: >-
       inputs.enable_backend_testing &&
@@ -241,7 +257,11 @@ jobs:
           # Coverage is not collected or uploaded anywhere, and Xdebug slows the
           # test suite considerably, so leave it disabled.
           coverage: none
-          extensions: ${{ inputs.php_extensions }}
+          # Append the native `redis` extension only for the phpredis matrix
+          # leg. The predis leg deliberately omits it so fof/redis (and any
+          # redis-enabled repo) falls back to the pure-PHP client, exercising
+          # both code paths.
+          extensions: ${{ inputs.php_extensions }}${{ matrix.redis_client == 'phpredis' && ', redis' || '' }}
           tools: phpunit, composer:v2
           ini-values: ${{ matrix.php_ini_values }}
 


### PR DESCRIPTION
## Why

Redis-backed extensions (e.g. `fof/redis`) support two client libraries — the native **phpredis** extension and the pure-PHP **predis**. The two disagree on some command signatures (a concrete example: `PUBSUB NUMSUB` wants an *array* of channels on phpredis but a *string* on predis), so a change correct for one client can silently regress the other. CI currently can't distinguish them: whichever client happens to be present is the only one exercised.

## What

Adds an **opt-in** way for a caller of `REUSABLE_backend.yml` to run its test matrix against both clients:

- New `redis_clients` input — a JSON array, e.g. `'["phpredis", "predis"]'`.
- New `redis_client` matrix axis populated from it.
- The `Setup PHP` step appends the native `redis` extension **only** on the `phpredis` leg; the `predis` leg omits it so the extension falls back to the pure-PHP client.
- Job names gain a `[phpredis]` / `[predis]` suffix so the legs are distinguishable in the checks UI.

## Blast radius

The input defaults to `'[""]'` — a single empty entry. That adds **no** matrix dimension, appends **no** extension, and adds **no** name suffix, so every existing consumer of the reusable workflow is completely unchanged. Only repos that both set `enable_redis` and list clients opt in.

## Validation

- `actionlint` clean on the changed workflow (the one remaining finding, `matrix.php_ini_values` in the phpstan job, pre-dates this change).
- Verified locally against a real Valkey with both clients: the client-branching is genuinely required — a phpredis-only fix fails the predis leg and vice-versa; only the correct per-client form passes both.

The first consumer will be `fof/redis`, whose `backend.yml` sets `redis_clients: '["phpredis", "predis"]'` (separate PR, pinned to `@2.x` — this needs to merge first for that to run).