### PR TITLE
[2.x] feat: Make the queue dashboard widget's tiles extensible

### DIFF
--- a/framework/core/js/src/admin/components/QueueWidget.tsx
+++ b/framework/core/js/src/admin/components/QueueWidget.tsx
@@ -100,9 +100,18 @@ export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDa
     return items;
   }
 
-  tile(key: string, value: number, className = '', onclick?: () => void): Mithril.Children {
+  /**
+   * Render a single tile.
+   *
+   * @param label   Either a tile key (resolved against this widget's own
+   *                translation namespace via `tileLabel()`) or ready-made
+   *                label content (a translated string / vnode). Extensions
+   *                subclassing this widget can pass their own label directly.
+   * @param value   The tile value — a number, string, or vnode.
+   */
+  tile(label: string | Mithril.Children, value: Mithril.Children, className = '', onclick?: () => void): Mithril.Children {
     const inner = [
-      <div className="QueueWidget-tileLabel">{app.translator.trans(`core.admin.queue_widget.${key}`)}</div>,
+      <div className="QueueWidget-tileLabel">{typeof label === 'string' ? this.tileLabel(label) : label}</div>,
       <div className="QueueWidget-tileValue">{value}</div>,
     ];
 
@@ -113,5 +122,13 @@ export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDa
     ) : (
       <div className={'QueueWidget-tile ' + className}>{inner}</div>
     );
+  }
+
+  /**
+   * Resolve a tile key to its label. Override in a subclass to source tile
+   * labels from an extension's own translation namespace.
+   */
+  tileLabel(key: string): Mithril.Children {
+    return app.translator.trans(`core.admin.queue_widget.${key}`);
   }
 }


### PR DESCRIPTION
## Why

Core's `QueueWidget` is designed to be subclassed by extensions that bind their own `QueueStatsProvider` (the class doc already says so). But its `tile()` helper was hardcoded to a numeric value and to core's own translation namespace, so a subclass couldn't render a non-numeric tile (a status label, a formatted duration) or use its own labels without reimplementing the tile markup.

fof/horizon is about to do exactly this — enrich the `/queue/stats` payload and render extra tiles (worker processes, throughput, longest wait, paused state) rather than ship a parallel widget. This unblocks that cleanly.

## What

Two small, backward-compatible changes to `QueueWidget`:

- **`tile()` value type** widened `number → Mithril.Children` — a tile can now show a number, string, or vnode.
- **`tile()` first argument** widened `string → string | Mithril.Children` — either a tile key (resolved via the new `tileLabel()`) or ready-made label content.
- **New `tileLabel(key)`** method resolving a key to its label (`core.admin.queue_widget.${key}` by default), overridable so a subclass sources labels from its own namespace.

Existing core tiles (`pending` / `reserved` / `failed`) are unchanged — they still pass a key string and a numeric value, both valid under the wider types. Purely additive.

## Verification

`check-typings` passes; `yarn format` clean. No behaviour change for core's own widget.