### PR TITLE
[2.x] feat: Add header extension seams to the queue dashboard widget

### DIFF
--- a/framework/core/js/src/admin/components/QueueWidget.tsx
+++ b/framework/core/js/src/admin/components/QueueWidget.tsx
@@ -62,19 +62,44 @@ export default class QueueWidget<CustomAttrs extends IDashboardWidgetAttrs = IDa
         <div className="QueueWidget-header">
           <h3 className="QueueWidget-title">
             <Icon name="fas fa-stream" /> {app.translator.trans('core.admin.queue_widget.title')}
+            {this.titleItems().toArray()}
           </h3>
-          <Button
-            className="Button Button--icon Button--flat"
-            icon="fas fa-sync-alt"
-            loading={this.loading}
-            onclick={() => this.load()}
-            aria-label={app.translator.trans('core.admin.queue_widget.refresh')}
-          />
+          <div className="QueueWidget-headerActions">{this.headerActions().toArray()}</div>
         </div>
 
         {!this.stats ? <LoadingIndicator /> : <div className="QueueWidget-tiles">{this.tiles().toArray()}</div>}
       </div>
     );
+  }
+
+  /**
+   * Content appended after the widget title — e.g. status pills. Empty by
+   * default; a subclass adds items to surface at-a-glance state.
+   */
+  titleItems(): ItemList<Mithril.Children> {
+    return new ItemList<Mithril.Children>();
+  }
+
+  /**
+   * Action controls on the right of the header. Ships with the refresh button;
+   * a subclass can add its own (e.g. a link to a fuller dashboard).
+   */
+  headerActions(): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'refresh',
+      <Button
+        className="Button Button--icon Button--flat"
+        icon="fas fa-sync-alt"
+        loading={this.loading}
+        onclick={() => this.load()}
+        aria-label={app.translator.trans('core.admin.queue_widget.refresh')}
+      />,
+      100
+    );
+
+    return items;
   }
 
   tiles(): ItemList<Mithril.Children> {

--- a/framework/core/less/admin/QueueWidget.less
+++ b/framework/core/less/admin/QueueWidget.less
@@ -8,6 +8,16 @@
     padding: 16px 20px 12px;
   }
 
+  // Right-hand header controls. `space-between` on -header already pushes this
+  // to the right (it's the second flex child after -title); this lays its own
+  // items — the refresh button plus anything a subclass adds via
+  // headerActions() — out in a row with consistent spacing.
+  &-headerActions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
   &-title {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Why

Follow-up to #4849 (which made `QueueWidget`'s *tiles* extensible). An extension that subclasses `QueueWidget` to add its own tiles also wants to enrich the header — a status pill next to the title, a link to its own fuller dashboard next to the refresh button. Without a seam it would have to override `content()` wholesale and duplicate core's header markup (brittle when core's header changes).

## What

Two overridable `ItemList` methods for the header, mirroring the existing `tiles()` pattern:

- **`titleItems()`** — content appended after the widget title (e.g. status pills). Empty by default.
- **`headerActions()`** — the action controls on the right. Ships the refresh button as a default item (priority 100); a subclass adds its own.

The refresh button moves from inline JSX into `headerActions()`, so core's header renders identically. Purely additive — no behaviour change for core's own widget.

## Verification

`check-typings` clean, `yarn format` clean. Source only — the bot builds `dist`/`dist-typings` at merge.

First consumer is fof/horizon, which restores its status/health pills and full-dashboard link on the unified queue card via these seams.