### PR TITLE
[1.x] fix(core): render only the requested posts on the no-JS discussion page

### DIFF
--- a/extensions/mentions/tests/integration/frontend/DiscussionPageMentionsTest.php
+++ b/extensions/mentions/tests/integration/frontend/DiscussionPageMentionsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\frontend;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Support\Str;
+
+class DiscussionPageMentionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        $posts = [];
+
+        for ($i = 1; $i <= 25; $i++) {
+            $posts[] = [
+                'id' => $i,
+                'number' => $i,
+                'discussion_id' => 1,
+                'created_at' => Carbon::parse('2024-01-01 00:00:00')->addMinutes($i),
+                'user_id' => 2,
+                'type' => 'comment',
+                'content' => '<t><p>POST-MARKER-'.str_pad((string) $i, 2, '0', STR_PAD_LEFT).'</p></t>',
+            ];
+        }
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 2, 'first_post_id' => 1, 'last_post_id' => 25, 'comment_count' => 25, 'is_private' => 0],
+            ],
+            'posts' => $posts,
+            // Post 21 sits on page 2 and quotes post 2, which sits on page 1.
+            'post_mentions_post' => [
+                ['post_id' => 21, 'mentions_post_id' => 2],
+            ],
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    private function html(string $path): string
+    {
+        $body = $this->send($this->request('GET', $path))->getBody()->getContents();
+
+        return Str::before($body, '<script id="flarum-json-payload"');
+    }
+
+    private function marker(int $number): string
+    {
+        return 'POST-MARKER-'.str_pad((string) $number, 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * This extension asks the discussion endpoint to include, for every post on
+     * the page, the posts that quoted it. Those arrive as full posts, with a
+     * discussion relationship and rendered content, so a page must not decide
+     * what to render by looking for post-shaped resources in the response.
+     *
+     * @test
+     */
+    public function page_does_not_render_a_later_post_that_quotes_one_of_its_posts()
+    {
+        $body = $this->html('/d/1');
+
+        // Page 1 is posts 1 to 20.
+        $this->assertStringContainsString($this->marker(2), $body);
+        $this->assertStringContainsString($this->marker(20), $body);
+
+        // Post 21 belongs to page 2. It quotes post 2, and that must not drag
+        // it onto page 1.
+        $this->assertStringNotContainsString($this->marker(21), $body);
+    }
+}

--- a/framework/core/src/Forum/Content/Discussion.php
+++ b/framework/core/src/Forum/Content/Discussion.php
@@ -85,9 +85,27 @@ class Discussion
                 ($queryString ? '?'.$queryString : '');
         };
 
+        // Ask for the posts this page is supposed to show, instead of sifting the
+        // included resources for anything post-shaped. Extensions register their
+        // own post relationships on this endpoint: flarum/mentions includes
+        // posts.mentionedBy along with posts.mentionedBy.discussion, so every post
+        // that quoted a post on this page arrives as a full post, with a discussion
+        // relationship and rendered content, and is indistinguishable from the
+        // page's own posts once it is in `included`. That is how quoted posts ended
+        // up printed on pages they do not belong to, and printed again on the page
+        // they do.
+        $postsApiDocument = $this->getPostsApiDocument($request, [
+            'filter' => ['discussion' => $apiDocument->data->id],
+            'sort' => 'number',
+            'page' => [
+                'offset' => ($page - 1) * 20,
+                'limit' => 20,
+            ],
+        ]);
+
         $posts = [];
 
-        foreach ($apiDocument->included as $resource) {
+        foreach ($postsApiDocument->data as $resource) {
             if ($resource->type === 'posts' && isset($resource->relationships->discussion) && isset($resource->attributes->contentHtml)) {
                 $posts[] = $resource;
             }
@@ -129,6 +147,23 @@ class Discussion
         if ($statusCode === 404) {
             throw new RouteNotFoundException;
         }
+
+        return json_decode($response->getBody());
+    }
+
+    /**
+     * Get the result of an API request to list one page of a discussion's posts.
+     *
+     * The primary data of this response is exactly the posts being asked for, so
+     * unlike the discussion endpoint's `included`, extensions cannot add posts of
+     * their own to it.
+     */
+    protected function getPostsApiDocument(Request $request, array $params)
+    {
+        $response = $this->api
+            ->withParentRequest($request)
+            ->withQueryParams($params)
+            ->get('/posts');
 
         return json_decode($response->getBody());
     }

--- a/framework/core/tests/integration/frontend/DiscussionPageContentTest.php
+++ b/framework/core/tests/integration/frontend/DiscussionPageContentTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\frontend;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Support\Str;
+
+class DiscussionPageContentTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $posts = [];
+
+        // Markers are zero padded so that no marker is a prefix of another one,
+        // which keeps assertStringNotContainsString honest.
+        for ($i = 1; $i <= 30; $i++) {
+            $posts[] = [
+                'id' => $i,
+                'number' => $i,
+                'discussion_id' => 1,
+                'created_at' => Carbon::parse('2024-01-01 00:00:00')->addMinutes($i)->toDateTimeString(),
+                'user_id' => 2,
+                'type' => 'comment',
+                'content' => '<t><p>POST-MARKER-'.str_pad((string) $i, 2, '0', STR_PAD_LEFT).'</p></t>',
+            ];
+        }
+
+        $this->prepareDatabase([
+            'discussions' => [
+                ['id' => 1, 'title' => 'Paginated discussion', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 1, 'last_post_id' => 30, 'comment_count' => 30, 'is_private' => 0],
+            ],
+            'posts' => $posts,
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * The rendered markup, without the JSON payload that follows it.
+     *
+     * The markup is what a client with no JavaScript, and a crawler, reads as
+     * the page. The payload after it is the data the JS app boots from, which
+     * still carries the posts surrounding the one being linked to so that the
+     * app can scroll to it, and is not page text.
+     */
+    private function html(string $path, array $query = []): string
+    {
+        $request = $this->request('GET', $path);
+
+        if ($query) {
+            $request = $request->withQueryParams($query);
+        }
+
+        $body = $this->send($request)->getBody()->getContents();
+
+        return Str::before($body, '<script id="flarum-json-payload"');
+    }
+
+    private function marker(int $number): string
+    {
+        return 'POST-MARKER-'.str_pad((string) $number, 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @test
+     */
+    public function first_page_renders_only_the_first_twenty_posts()
+    {
+        $body = $this->html('/d/1');
+
+        $this->assertStringContainsString($this->marker(1), $body);
+        $this->assertStringContainsString($this->marker(20), $body);
+        $this->assertStringNotContainsString($this->marker(21), $body);
+        $this->assertStringNotContainsString($this->marker(30), $body);
+    }
+
+    /**
+     * @test
+     */
+    public function second_page_renders_only_the_second_page_of_posts()
+    {
+        $body = $this->html('/d/1', ['page' => 2]);
+
+        $this->assertStringNotContainsString($this->marker(1), $body);
+        $this->assertStringNotContainsString($this->marker(20), $body);
+        $this->assertStringContainsString($this->marker(21), $body);
+        $this->assertStringContainsString($this->marker(30), $body);
+    }
+
+    /**
+     * A discussion page must not serve content that belongs to another page.
+     * A numbered URL declares a canonical page, so the page it renders has to
+     * be that one, otherwise a crawler indexes one page's posts under another
+     * page's URL.
+     *
+     * @test
+     */
+    public function numbered_url_renders_the_page_it_declares_as_canonical()
+    {
+        $body = $this->html('/d/1/25');
+
+        $this->assertStringContainsString('?page=2', $body, 'Expected the numbered URL to declare page 2 as its canonical URL.');
+
+        // Post 25 sits on page 2, so page 2 is what should be rendered.
+        $this->assertStringContainsString($this->marker(21), $body);
+        $this->assertStringContainsString($this->marker(30), $body);
+
+        // Posts 15 to 20 belong to page 1, and must not appear on a page whose
+        // canonical URL says it is page 2.
+        $this->assertStringNotContainsString($this->marker(15), $body);
+        $this->assertStringNotContainsString($this->marker(20), $body);
+    }
+}


### PR DESCRIPTION
## Why

The server-rendered discussion page decides what to print by scanning the whole API response for anything post-shaped:

```php
foreach ($apiDocument->included as $resource) {
    if ($resource->type === 'posts'
        && isset($resource->relationships->discussion)
        && isset($resource->attributes->contentHtml)) {
```

Extensions register their own post relationships on that endpoint. `flarum/mentions` adds `posts.mentionedBy` together with `posts.mentionedBy.discussion`, so every post that quoted a post on the page arrives in `included` as a full post, carrying both a discussion relationship and rendered content. That makes it indistinguishable from the page's own posts, so the quoting post is printed on a page it does not belong to, and printed again on the page it does.

On a live forum with mentions enabled this is easy to see. Fetching the first eight pages of a busy discussion returned **29, 20, 23, 24, 21, 23, 20 and 24** posts rather than 20 each, with **21 posts appearing on two different pages**. Checking page 1 against the API, 10 of the 29 rendered posts were `mentionedBy` targets of posts on that page.

The page also disagrees with itself about which page it is. A numbered URL computes `$page` as `1 + intdiv($near, 20)` and uses it for the previous/next links and the canonical URL, while the window it renders is centred on the linked post. So `/d/1/25` declares page 2 as canonical and then prints posts 15 to 30, putting six of page 1's posts on a page that claims to be page 2.

Both are the same class of problem as #3370, where the reporter found Google indexing a discussion page using content from other pages. That issue is discussed in terms of frontend auto-loading, and this is a separate, server-side mechanism producing the same symptom, so I would not call it a fix for #3370, but it removes one concrete way the rendered HTML ends up holding another page's posts. I have added the details there.

## What

Ask the posts endpoint for the page and render its primary data. Extensions cannot add posts to another endpoint's primary data, so the render is correct by construction rather than by filtering more cleverly, and the rendered window always matches the canonical URL.

The discussion document, and therefore the payload the JS app boots from, is deliberately left untouched. It still carries the posts surrounding the one being linked to, which is what lets the app scroll to it. This is narrower than the equivalent code on `2.x`, which also rewrites `included`.

The one behaviour change is that a numbered URL now renders the page it declares as canonical, rather than a window centred on the post. For the no-JS render I think that is the point: it is what the pagination links and the canonical URL already claim.

## Tests

`framework/core/tests/integration/frontend/DiscussionPageContentTest.php`, 3 tests, covering the first page, the second page, and a numbered URL rendering the page it declares as canonical. The last one fails on current `1.x`.

`extensions/mentions/tests/integration/frontend/DiscussionPageMentionsTest.php`, 1 test, pinning the reported case: a post that merely quotes a post on page 1 must not be rendered on page 1. This fails on current `1.x`.

## Verification

- core integration suite: 561 tests, 0 failures
- mentions integration suite: 75 tests, 0 failures
- both new tests confirmed to fail with the change reverted and pass with it applied
- checked by hand on a 1.8 forum with mentions enabled: a 30 post discussion renders 20 and 10 with no post on two pages, against 23 and 10 before
