### PR TITLE
[2.x] fix: Handle network connection loss in the frontend 

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -75,7 +75,7 @@ export type AsyncNewComponent<Comp> = () => Promise<any & { default: NewComponen
 export type RouteItem<
   Attrs extends ComponentAttrs,
   Comp extends Component<Attrs & { routeName: string }>,
-  RouteArgs extends Record<string, unknown> = {}
+  RouteArgs extends Record<string, unknown> = {},
 > = {
   /**
    * The path for your route.
@@ -111,7 +111,7 @@ export type RouteItem<
 export interface RouteResolver<
   Attrs extends ComponentAttrs,
   Comp extends Component<Attrs & { routeName: string }>,
-  RouteArgs extends Record<string, unknown> = {}
+  RouteArgs extends Record<string, unknown> = {},
 > {
   /**
    * A method which selects which component to render based on
@@ -304,6 +304,33 @@ export default class Application {
    */
   private requestErrorAlert: number | null = null;
 
+  /**
+   * The key for the Alert that was shown as a result of an AJAX request
+   * failing at the network level (status 0). Unlike other request error
+   * alerts, only one of these is shown at a time.
+   */
+  protected networkErrorAlert: number | null = null;
+
+  /**
+   * The key for the Alert that is shown while the browser reports being
+   * offline.
+   */
+  protected offlineAlert: number | null = null;
+
+  /**
+   * GET requests that failed because the browser was offline, keyed by
+   * method, URL and params. They are retried, and their original promises
+   * settled, once connectivity is restored. Identical requests (e.g. from a
+   * polling extension) share one entry and are retried only once.
+   */
+  protected deferredRequests: Map<
+    string,
+    {
+      options: FlarumRequestOptions<any>;
+      settlers: { resolve: (value: any) => void; reject: (error: unknown) => void }[];
+    }
+  > = new Map();
+
   initialRoute!: string;
 
   /**
@@ -357,6 +384,8 @@ export default class Application {
     this.runBeforeMount();
 
     this.mount();
+
+    this.registerConnectivityListeners();
 
     this.initialRoute = window.location.href;
 
@@ -667,7 +696,61 @@ export default class Application {
 
     if (this.requestErrorAlert) this.alerts.dismiss(this.requestErrorAlert);
 
-    return m.request(options).catch((e) => this.requestErrorCatch(e, originalOptions.errorHandler));
+    if (this.networkErrorAlert) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
+    return m.request(options).catch((e) => {
+      if (this.shouldDeferRequest(e, originalOptions)) {
+        return this.deferRequest(originalOptions);
+      }
+
+      return this.requestErrorCatch(e, originalOptions.errorHandler);
+    });
+  }
+
+  /**
+   * Whether a failed request should be held back and retried once
+   * connectivity is restored, instead of being rejected.
+   *
+   * Only GET requests that failed at the network level while the browser
+   * reported being offline qualify: they are safe to repeat, and the
+   * `online` event provides a reliable signal to retry them.
+   */
+  protected shouldDeferRequest(error: unknown, originalOptions: FlarumRequestOptions<any>): boolean {
+    return (
+      error instanceof RequestError && error.status === 0 && navigator.onLine === false && (originalOptions.method ?? 'GET').toUpperCase() === 'GET'
+    );
+  }
+
+  /**
+   * Hold a request that failed while offline. The returned promise settles
+   * with the result of retrying the request once connectivity is restored.
+   */
+  protected deferRequest<ResponseType>(originalOptions: FlarumRequestOptions<ResponseType>): Promise<ResponseType> {
+    // Make sure the offline alert is showing, in case the page was loaded
+    // while already offline and no `offline` event was ever fired.
+    this.connectionLost();
+
+    return new Promise((resolve, reject) => {
+      const key = this.deferredRequestKey(originalOptions);
+      const deferred = this.deferredRequests.get(key);
+
+      if (deferred) {
+        deferred.settlers.push({ resolve, reject });
+      } else {
+        this.deferredRequests.set(key, { options: originalOptions, settlers: [{ resolve, reject }] });
+      }
+    });
+  }
+
+  /**
+   * The identity of a request for deferral purposes: requests with the same
+   * key are considered identical and are retried only once.
+   */
+  protected deferredRequestKey(options: FlarumRequestOptions<any>): string {
+    return [options.method ?? 'GET', options.url, JSON.stringify(options.params ?? null)].join(' ');
   }
 
   /**
@@ -682,6 +765,20 @@ export default class Application {
 
     let content;
     switch (error.status) {
+      // Status 0 means the request failed at the network level: the client is
+      // offline, DNS resolution failed, the origin was unreachable, or the
+      // response was blocked by CORS. Aborted requests never get here, as
+      // Mithril leaves their promises unsettled.
+      case 0:
+        if (navigator.onLine === false) {
+          content = app.translator.trans('core.lib.error.offline_message');
+        } else if (this.requestWasCrossOrigin(error)) {
+          content = app.translator.trans('core.lib.error.generic_cross_origin_message');
+        } else {
+          content = app.translator.trans('core.lib.error.network_message');
+        }
+        break;
+
       case 422:
         content = formattedErrors
           .map((detail) => [detail, <br />])
@@ -780,11 +877,87 @@ export default class Application {
       if (e.status === 500 && isDebug) {
         app.modal.show(RequestErrorModal, { error: e, formattedError: formattedErrors });
       } else if (e.alert) {
-        this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
+        if (e.status === 0) {
+          // A connection problem produces a single alert, even if several
+          // parallel requests fail at once.
+          if (!this.connectionAlertActive()) {
+            this.networkErrorAlert = this.alerts.show(e.alert, e.alert.content);
+          }
+        } else {
+          this.requestErrorAlert = this.alerts.show(e.alert, e.alert.content);
+        }
       }
     } else {
       throw e;
     }
+  }
+
+  /**
+   * Whether an alert about a connection problem (a network-level request
+   * failure or the browser being offline) is currently being shown.
+   */
+  protected connectionAlertActive(): boolean {
+    const activeAlerts = this.alerts.getActiveAlerts();
+
+    return (
+      (this.networkErrorAlert !== null && this.networkErrorAlert in activeAlerts) || (this.offlineAlert !== null && this.offlineAlert in activeAlerts)
+    );
+  }
+
+  /**
+   * Register listeners to proactively notify the user when the browser goes
+   * offline and when connectivity is restored.
+   */
+  protected registerConnectivityListeners(): void {
+    window.addEventListener('offline', () => this.connectionLost());
+    window.addEventListener('online', () => this.connectionRestored());
+  }
+
+  /**
+   * Show a persistent (but dismissible) alert while the browser reports being
+   * offline.
+   */
+  protected connectionLost(): void {
+    if (this.offlineAlert !== null && this.offlineAlert in this.alerts.getActiveAlerts()) return;
+
+    // The offline alert supersedes any alert shown for a failed request.
+    if (this.networkErrorAlert !== null) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
+    this.offlineAlert = this.alerts.show({ type: 'error', dismissible: true }, app.translator.trans('core.lib.error.offline_message'));
+  }
+
+  /**
+   * Dismiss any connection problem alerts, retry requests that were deferred
+   * while offline, and briefly confirm to the user that connectivity has
+   * been restored.
+   */
+  protected connectionRestored(): void {
+    if (this.networkErrorAlert !== null) {
+      this.alerts.dismiss(this.networkErrorAlert);
+      this.networkErrorAlert = null;
+    }
+
+    const deferred = Array.from(this.deferredRequests.values());
+    this.deferredRequests = new Map();
+
+    deferred.forEach(({ options, settlers }) => {
+      this.request(options).then(
+        (response) => settlers.forEach(({ resolve }) => resolve(response)),
+        (error) => settlers.forEach(({ reject }) => reject(error))
+      );
+    });
+
+    if (this.offlineAlert === null) return;
+
+    this.alerts.dismiss(this.offlineAlert);
+    this.offlineAlert = null;
+
+    const confirmationAlert = this.alerts.show({ type: 'success' }, app.translator.trans('core.lib.connection_restored_message'));
+
+    setTimeout(() => this.alerts.dismiss(confirmationAlert), 10000);
   }
 
   private showDebug(error: RequestError, formattedError: string[]) {

--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -75,7 +75,7 @@ export type AsyncNewComponent<Comp> = () => Promise<any & { default: NewComponen
 export type RouteItem<
   Attrs extends ComponentAttrs,
   Comp extends Component<Attrs & { routeName: string }>,
-  RouteArgs extends Record<string, unknown> = {},
+  RouteArgs extends Record<string, unknown> = {}
 > = {
   /**
    * The path for your route.
@@ -111,7 +111,7 @@ export type RouteItem<
 export interface RouteResolver<
   Attrs extends ComponentAttrs,
   Comp extends Component<Attrs & { routeName: string }>,
-  RouteArgs extends Record<string, unknown> = {},
+  RouteArgs extends Record<string, unknown> = {}
 > {
   /**
    * A method which selects which component to render based on

--- a/framework/core/js/src/common/ExportRegistry.ts
+++ b/framework/core/js/src/common/ExportRegistry.ts
@@ -172,17 +172,40 @@ export default class ExportRegistry implements IExportRegistry, IChunkRegistry {
     // @ts-ignore
     app.alerts.showLoading();
 
-    return await original(
-      this.chunkUrl(chunkId) || url,
-      (...args: any) => {
-        // @ts-ignore
-        app.alerts.clearLoading();
+    const chunkUrl = this.chunkUrl(chunkId) || url;
 
-        return done(...args);
-      },
-      key,
-      chunkId
-    );
+    const load = (): Promise<void> =>
+      original(
+        chunkUrl,
+        (...args: any) => {
+          const event: Event | undefined = args[0];
+
+          // A chunk that failed to load because the browser is offline is
+          // retried once connectivity is restored. Its import() promise stays
+          // pending in the meantime, so every caller awaiting the chunk
+          // recovers on its own — mirroring how `Application#request` defers
+          // GET requests that fail while offline.
+          if (event?.type === 'error' && navigator.onLine === false) {
+            const retry = () => {
+              window.removeEventListener('online', retry);
+              load();
+            };
+
+            window.addEventListener('online', retry);
+
+            return;
+          }
+
+          // @ts-ignore
+          app.alerts.clearLoading();
+
+          return done(...args);
+        },
+        key,
+        chunkId
+      );
+
+    return await load();
   }
 
   chunkUrl(chunkId: number | string): string | null {

--- a/framework/core/js/tests/unit/common/Application.test.ts
+++ b/framework/core/js/tests/unit/common/Application.test.ts
@@ -1,0 +1,344 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../src/forum/app';
+import RequestError from '../../../src/common/utils/RequestError';
+import extractText from '../../../src/common/utils/extractText';
+import { jest } from '@jest/globals';
+import m from 'mithril';
+import type Mithril from 'mithril';
+
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+const trans = (key: string) => extractText(app.translator.trans(key));
+
+function makeError(status: number, responseText: string | null = null, url: string = '/api/test'): RequestError {
+  return new RequestError(status, responseText, { url, method: 'GET' } as any, { status } as XMLHttpRequest);
+}
+
+function catchError(error: RequestError, customErrorHandler?: (e: RequestError) => void): Promise<void> {
+  return (app as any).requestErrorCatch(error, customErrorHandler).catch(() => {});
+}
+
+function activeAlerts(): { text: string; attrs: Record<string, unknown> }[] {
+  return Object.values(app.alerts.getActiveAlerts()).map((state) => ({
+    text: extractText(state.children as Mithril.Children),
+    attrs: state.attrs as Record<string, unknown>,
+  }));
+}
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true });
+}
+
+function flushPromises(): Promise<void> {
+  // A macrotask runs after all pending promise chains, however deep.
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  app.alerts.clear();
+  (app as any).requestErrorAlert = null;
+  (app as any).networkErrorAlert = null;
+  (app as any).offlineAlert = null;
+  (app as any).deferredRequests = new Map();
+  setOnline(true);
+});
+
+describe('Application#requestErrorCatch handles network-level failures', () => {
+  it('shows a dedicated connection alert for a network-level failure (status 0)', async () => {
+    await catchError(makeError(0));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.network_message'));
+  });
+
+  it('shows an offline message when the browser reports being offline', async () => {
+    setOnline(false);
+
+    await catchError(makeError(0));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('still shows the cross-origin message for a failed cross-origin request', async () => {
+    await catchError(makeError(0, null, 'https://other-origin.example.com/api/test'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.generic_cross_origin_message'));
+  });
+
+  it('prefers the offline message over the cross-origin one while offline', async () => {
+    setOnline(false);
+
+    await catchError(makeError(0, null, 'https://other-origin.example.com/api/test'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('shows only one alert for multiple network-level failures', async () => {
+    await catchError(makeError(0));
+    await catchError(makeError(0));
+    await catchError(makeError(0));
+
+    expect(activeAlerts()).toHaveLength(1);
+  });
+
+  it('rejects with the original RequestError', async () => {
+    const error = makeError(0);
+
+    await expect((app as any).requestErrorCatch(error, undefined)).rejects.toBe(error);
+  });
+
+  it('respects a custom error handler instead of showing an alert', async () => {
+    const customErrorHandler = jest.fn();
+    const error = makeError(0);
+
+    await catchError(error, customErrorHandler);
+
+    expect(customErrorHandler).toHaveBeenCalledWith(error);
+    expect(activeAlerts()).toHaveLength(0);
+    expect(error.alert).not.toBeNull();
+  });
+});
+
+describe('Application#requestErrorCatch keeps existing behavior for server responses', () => {
+  it('shows the generic message for a 500 response', async () => {
+    await catchError(makeError(500, 'Internal Server Error'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.generic_message'));
+  });
+
+  it('shows validation error details for a 422 response', async () => {
+    const responseText = JSON.stringify({ errors: [{ detail: 'The title is required.' }] });
+
+    await catchError(makeError(422, responseText));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe('The title is required.');
+  });
+
+  it('shows one alert per error for consecutive server errors', async () => {
+    await catchError(makeError(500, 'Internal Server Error'));
+    await catchError(makeError(500, 'Internal Server Error'));
+
+    expect(activeAlerts()).toHaveLength(2);
+  });
+});
+
+describe('Application reacts to browser connectivity events', () => {
+  it('shows a dismissible offline alert when the browser goes offline', () => {
+    window.dispatchEvent(new Event('offline'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+    expect(alerts[0].attrs.type).toBe('error');
+    expect(alerts[0].attrs.dismissible).toBe(true);
+  });
+
+  it('shows only one alert for repeated offline events', () => {
+    window.dispatchEvent(new Event('offline'));
+    window.dispatchEvent(new Event('offline'));
+
+    expect(activeAlerts()).toHaveLength(1);
+  });
+
+  it('replaces a request failure alert with the offline alert when the browser goes offline', async () => {
+    await catchError(makeError(0));
+    window.dispatchEvent(new Event('offline'));
+
+    const alerts = activeAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].text).toBe(trans('core.lib.error.offline_message'));
+  });
+
+  it('dismisses the offline alert and confirms once the connection is restored', () => {
+    jest.useFakeTimers();
+
+    try {
+      window.dispatchEvent(new Event('offline'));
+      window.dispatchEvent(new Event('online'));
+
+      const alerts = activeAlerts();
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].text).toBe(trans('core.lib.connection_restored_message'));
+
+      jest.runAllTimers();
+
+      expect(activeAlerts()).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('dismisses a request failure alert once the connection is restored', async () => {
+    await catchError(makeError(0));
+
+    jest.useFakeTimers();
+
+    try {
+      window.dispatchEvent(new Event('online'));
+
+      jest.runAllTimers();
+
+      expect(activeAlerts()).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not show a confirmation when the connection was never lost', () => {
+    window.dispatchEvent(new Event('online'));
+
+    expect(activeAlerts()).toHaveLength(0);
+  });
+});
+
+describe('Application defers GET requests that fail while offline', () => {
+  let requestSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    requestSpy = jest.spyOn(m, 'request');
+  });
+
+  afterEach(() => {
+    requestSpy.mockRestore();
+  });
+
+  it('holds a failed GET request and resolves it once the connection is restored', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolved = jest.fn();
+    const rejected = jest.fn();
+    app.request({ url: '/api/test' }).then(resolved, rejected);
+
+    await flushPromises();
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+    expect(activeAlerts().some((alert) => alert.text === trans('core.lib.error.offline_message'))).toBe(true);
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).toHaveBeenCalledWith(response);
+    expect(rejected).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-GET request that fails while offline', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    await expect(app.request({ url: '/api/test', method: 'POST' })).rejects.toBeInstanceOf(RequestError);
+  });
+
+  it('rejects a GET request that fails at the network level while the browser reports being online', async () => {
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    await expect(app.request({ url: '/api/test' })).rejects.toBeInstanceOf(RequestError);
+    expect(activeAlerts().some((alert) => alert.text === trans('core.lib.error.network_message'))).toBe(true);
+  });
+
+  it('re-defers a retried GET request that fails while still offline', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolved = jest.fn();
+    const rejected = jest.fn();
+    app.request({ url: '/api/test' }).then(resolved, rejected);
+
+    await flushPromises();
+
+    // The browser briefly reports being online, but the retry fails while
+    // offline again: the request must stay deferred, not reject.
+    requestSpy.mockImplementationOnce(() => {
+      setOnline(false);
+      return Promise.reject(makeError(0));
+    });
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(resolved).toHaveBeenCalledWith(response);
+    expect(rejected).not.toHaveBeenCalled();
+  });
+
+  it('retries identical deferred requests only once, settling every caller', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    // A polling extension fires the same request on every tick while offline.
+    const resolved = [jest.fn(), jest.fn(), jest.fn()];
+    resolved.forEach((callback) => void app.request({ url: '/api/stats', params: { period: 'day' } }).then(callback));
+
+    await flushPromises();
+
+    expect(requestSpy).toHaveBeenCalledTimes(3);
+
+    const response = { data: [] };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(response));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    // One retry for the three identical requests, resolving all callers.
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    resolved.forEach((callback) => expect(callback).toHaveBeenCalledWith(response));
+  });
+
+  it('retries distinct deferred requests separately', async () => {
+    setOnline(false);
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+    requestSpy.mockImplementationOnce(() => Promise.reject(makeError(0)));
+
+    const resolvedA = jest.fn();
+    const resolvedB = jest.fn();
+    app.request({ url: '/api/discussions' }).then(resolvedA);
+    app.request({ url: '/api/posts' }).then(resolvedB);
+
+    await flushPromises();
+
+    const responseA = { data: 'discussions' };
+    const responseB = { data: 'posts' };
+    requestSpy.mockImplementationOnce(() => Promise.resolve(responseA));
+    requestSpy.mockImplementationOnce(() => Promise.resolve(responseB));
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    await flushPromises();
+
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    expect(resolvedA).toHaveBeenCalledWith(responseA);
+    expect(resolvedB).toHaveBeenCalledWith(responseB);
+  });
+});

--- a/framework/core/js/tests/unit/common/ExportRegistry.test.ts
+++ b/framework/core/js/tests/unit/common/ExportRegistry.test.ts
@@ -1,0 +1,110 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import ExportRegistry from '../../../src/common/ExportRegistry';
+import { jest } from '@jest/globals';
+
+beforeAll(() => bootstrapForum());
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true });
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * A stand-in for webpack's script loader (`__webpack_require__.l`): invokes
+ * the callback with the event produced by the next queued outcome.
+ */
+function makeScriptLoader(outcomes: ('load' | 'error')[]) {
+  const loader = jest.fn((url: string, callback: (event: Event) => void) => {
+    const outcome = outcomes.shift() ?? 'load';
+    callback(new Event(outcome));
+  });
+
+  return loader;
+}
+
+beforeEach(() => {
+  setOnline(true);
+});
+
+describe('ExportRegistry#loadChunk', () => {
+  it('completes a successful chunk load', async () => {
+    const registry = new ExportRegistry();
+    const original = makeScriptLoader(['load']);
+    const done = jest.fn();
+
+    await registry.loadChunk(original as any, '/chunk.js', done as any, 0, 'test-chunk');
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(done).toHaveBeenCalledTimes(1);
+    expect((done.mock.calls[0][0] as Event).type).toBe('load');
+  });
+
+  it('reports a chunk load failure while the browser is online', async () => {
+    const registry = new ExportRegistry();
+    const original = makeScriptLoader(['error']);
+    const done = jest.fn();
+
+    await registry.loadChunk(original as any, '/chunk.js', done as any, 0, 'test-chunk');
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(done).toHaveBeenCalledTimes(1);
+    expect((done.mock.calls[0][0] as Event).type).toBe('error');
+  });
+
+  it('retries a chunk load that failed while offline once the connection is restored', async () => {
+    const registry = new ExportRegistry();
+    const original = makeScriptLoader(['error', 'load']);
+    const done = jest.fn();
+
+    setOnline(false);
+    await registry.loadChunk(original as any, '/chunk.js', done as any, 0, 'test-chunk');
+
+    // The failure is held back, not reported.
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(done).not.toHaveBeenCalled();
+
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+    await flushPromises();
+
+    expect(original).toHaveBeenCalledTimes(2);
+    expect(done).toHaveBeenCalledTimes(1);
+    expect((done.mock.calls[0][0] as Event).type).toBe('load');
+  });
+
+  it('keeps retrying while the browser remains offline', async () => {
+    const registry = new ExportRegistry();
+    const done = jest.fn();
+
+    // The retry fails again while offline; only the third attempt succeeds.
+    const original = jest.fn((url: string, callback: (event: Event) => void) => {
+      if (original.mock.calls.length < 3) {
+        setOnline(false);
+        callback(new Event('error'));
+      } else {
+        callback(new Event('load'));
+      }
+    });
+
+    setOnline(false);
+    await registry.loadChunk(original as any, '/chunk.js', done as any, 0, 'test-chunk');
+
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+    await flushPromises();
+
+    expect(original).toHaveBeenCalledTimes(2);
+    expect(done).not.toHaveBeenCalled();
+
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+    await flushPromises();
+
+    expect(original).toHaveBeenCalledTimes(3);
+    expect(done).toHaveBeenCalledTimes(1);
+    expect((done.mock.calls[0][0] as Event).type).toBe('load');
+  });
+});

--- a/framework/core/js/tests/unit/common/ExportRegistry.test.ts
+++ b/framework/core/js/tests/unit/common/ExportRegistry.test.ts
@@ -25,8 +25,18 @@ function makeScriptLoader(outcomes: ('load' | 'error')[]) {
   return loader;
 }
 
+let warnSpy: ReturnType<typeof jest.spyOn>;
+
 beforeEach(() => {
   setOnline(true);
+
+  // The tests don't register any chunks, so the registry legitimately warns
+  // that it has no URL for the chunk and falls back to the one we pass in.
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
 });
 
 describe('ExportRegistry#loadChunk', () => {

--- a/framework/core/js/tests/unit/common/ExportRegistry.test.ts
+++ b/framework/core/js/tests/unit/common/ExportRegistry.test.ts
@@ -50,6 +50,10 @@ describe('ExportRegistry#loadChunk', () => {
     expect(original).toHaveBeenCalledTimes(1);
     expect(done).toHaveBeenCalledTimes(1);
     expect((done.mock.calls[0][0] as Event).type).toBe('load');
+
+    // An unregistered chunk warns and falls back to the URL passed in.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No chunk by the ID'));
+    expect(original).toHaveBeenCalledWith('/chunk.js', expect.any(Function), 0, 'test-chunk');
   });
 
   it('reports a chunk load failure while the browser is online', async () => {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -841,6 +841,7 @@ core:
 
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
+    connection_restored_message: Your connection has been restored.
     debug_button: Debug
 
     # These translations are used in the Alert component.
@@ -889,7 +890,9 @@ core:
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       generic_cross_origin_message: "Oops! Something went wrong during a cross-origin request. Please reload the page and try again."
       missing_dependencies_message: "Cannot enable {extension} until the following dependencies are enabled: {extensions}"
+      network_message: Something seems to be wrong with your connection. Please check your network and try again.
       not_found_message: The requested resource was not found.
+      offline_message: You appear to be offline. Please check your connection and try again.
       payload_too_large_message: The request payload was too large.
       permission_denied_message: You do not have permission to do that.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.


### PR DESCRIPTION
## Problem

All frontend XHR goes through `Application#request()`. When a request fails at the network level — the user is offline, DNS fails, the origin is unreachable — the rejection carries `status === 0`, which `requestErrorCatch()` has no branch for. Users get the generic *"Oops! Something went wrong. Please reload the page and try again."* alert, which wrongly suggests a server-side bug and prompts bug reports for what is a client connectivity issue.

Core also makes no use of the browser's `online`/`offline` events, so users get no proactive indication that they've gone offline, and content that failed to load while offline stays missing until a full page reload.

On 2.x specifically, there is a second network dependency 1.x didn't have: **code-split chunks**. A lazy chunk that fails to load while offline currently breaks its caller with no recovery — opening a discussion leaves the page stuck on its loading skeleton (the `PostStream` import in `DiscussionPage#load` has no rejection handling and never retries), and the reply/discussion composer, log-in/sign-up modals, search modal, and lazy routes (`/settings`, `/notifications`, …) silently do nothing. Reconnecting does not recover any of these.

This is the 2.x counterpart of #4843 (1.x), discussed with @imorland. Two self-contained commits.

## What this PR does

**Commit 1 — network-loss handling in the request layer** (port of #4843):

1. **Classify network-level failures (`status === 0`)** in `requestErrorCatch`: an offline-specific message when `navigator.onLine === false`, otherwise a generic connection-problem message. The existing cross-origin special case is preserved. Parallel failures produce a single alert. Aborted requests cannot trigger this — Mithril leaves their promises unsettled.
2. **`online`/`offline` events**: going offline shows a persistent, dismissible alert; reconnecting clears connection alerts and shows a brief confirmation.
3. **Defer GETs that fail while offline**: instead of rejecting, their promises are held open and settled with the result of a retry once the `online` event fires — so content that failed to load appears automatically on reconnection, with no changes to calling code. Only GETs qualify; writes keep failing fast so nothing can be submitted twice. Deferred requests are keyed by method + URL + params, and identical ones (e.g. a widget polling every few seconds) are retried with a single request that settles every caller.

**Commit 2 — the same self-healing for lazy chunks** (2.x-only): every chunk load funnels through `ExportRegistry#loadChunk` (webpack's script loader is overridden with it), so a chunk failure that occurs while the browser is offline is now held back and retried on the `online` event. The `import()` promise stays pending in the meantime, and every call site — composer bodies, lazy routes, modals, the post stream, and extension chunks — recovers on its own. Chunk failures while the browser is online are reported unchanged.

New locale keys: `core.lib.error.network_message`, `core.lib.error.offline_message`, `core.lib.connection_restored_message` (English only).

## Behavior notes

- `errorHandler` and rejection propagation are unchanged for every status except the offline-GET deferral case; regression tests cover 422/500/cross-origin.
- A survey of core, bundled extensions, and popular FoF extensions found no GET call sites whose `errorHandler`/`.catch` logic would be adversely affected by deferral — GET failure handling in the wild is loading-flag resets, which now correctly keep spinners visible until the content self-heals.
- No `js/dist` changes included; bundles are left to CI.

## Testing

- 26 new Jest unit tests: `tests/unit/common/Application.test.ts` (classification online/offline/cross-origin, alert dedup, custom-error-handler contract, 422/500 regression guards, connectivity events, deferral + resolution on reconnect, re-deferral while still offline, retry dedup) and `tests/unit/common/ExportRegistry.test.ts` (chunk load success, online-failure passthrough, offline-failure retry on reconnect, repeated offline failures). Full suite: 259 passing.
- Manual smoke test on a local 2.x instance: offline request failure → single dedicated alert; opening a discussion / the composer while offline → waits instead of breaking; reply while offline → alert + composer content preserved; reconnect → offline alert cleared, confirmation shown, deferred content and chunks load without reload; 422/500 render as on `2.x`.

**Screenshot**
<img width="499" height="70" alt="image" src="https://github.com/user-attachments/assets/2c00481c-2606-4aad-ba5e-21453ef02f1f" />
<img width="301" height="69" alt="image" src="https://github.com/user-attachments/assets/f636229d-05c8-4c0c-8a05-c7b3527347e4" />

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
