### PR TITLE
[2.x] fix: Unwrap RoutingQueue when identifying the queue driver

### DIFF
--- a/framework/core/src/Foundation/ApplicationInfoProvider.php
+++ b/framework/core/src/Foundation/ApplicationInfoProvider.php
@@ -12,6 +12,7 @@ namespace Flarum\Foundation;
 use Carbon\Carbon;
 use Flarum\Database\DatabaseRequirements;
 use Flarum\Locale\Translator;
+use Flarum\Queue\RoutingQueue;
 use Flarum\User\SessionManager;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
@@ -57,8 +58,13 @@ class ApplicationInfoProvider
 
     public function identifyQueueDriver(): string
     {
+        // The connection is wrapped in a RoutingQueue so pushes can be routed by
+        // job class; the driver underneath is what identifies the queue backend.
+        $queue = $this->queue instanceof RoutingQueue
+            ? $this->queue->getDriver()
+            : $this->queue;
         // Get class name
-        $queue = $this->queue::class;
+        $queue = $queue::class;
         // Drop the namespace
         $queue = Str::afterLast($queue, '\\');
         // Lowercase the class name

--- a/framework/core/tests/unit/Foundation/ApplicationInfoProviderTest.php
+++ b/framework/core/tests/unit/Foundation/ApplicationInfoProviderTest.php
@@ -12,12 +12,15 @@ namespace Flarum\Tests\unit\Foundation;
 use Flarum\Foundation\ApplicationInfoProvider;
 use Flarum\Foundation\Config;
 use Flarum\Locale\Translator;
+use Flarum\Queue\RoutingQueue;
 use Flarum\Testing\unit\TestCase;
 use Flarum\User\SessionManager;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Queue\QueueRoutes;
+use Illuminate\Queue\SyncQueue;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
 use SessionHandlerInterface;
@@ -73,12 +76,34 @@ class ApplicationInfoProviderTest extends TestCase
         $this->assertNull($provider->identifyDatabaseDriverMismatch());
     }
 
+    #[Test]
+    public function queue_driver_is_derived_from_the_connection_class()
+    {
+        $provider = $this->provider('sqlite', null, new SyncQueue());
+
+        $this->assertSame('sync', $provider->identifyQueueDriver());
+    }
+
+    #[Test]
+    public function queue_driver_reports_the_real_driver_when_wrapped_in_a_routing_queue()
+    {
+        // flarum.queue.connection is wrapped in a RoutingQueue so pushes can be
+        // routed by job class. Reporting "routing" would hide the real backend
+        // from `flarum info` and the admin dashboard; unwrap to the driver.
+        $driver = new SyncQueue();
+        $wrapped = new RoutingQueue($driver, new QueueRoutes());
+
+        $provider = $this->provider('sqlite', null, $wrapped);
+
+        $this->assertSame('sync', $provider->identifyQueueDriver());
+    }
+
     /**
      * Build a provider with a configured driver and the version string the
      * server would report from `select version()`. Pass a null version for
      * drivers that should never trigger a version query (pgsql/sqlite).
      */
-    private function provider(string $configuredDriver, ?string $serverVersion): ApplicationInfoProvider
+    private function provider(string $configuredDriver, ?string $serverVersion, ?Queue $queue = null): ApplicationInfoProvider
     {
         $cache = m::mock(CacheRepository::class);
         // Execute the cached closure inline so the detection logic is exercised.
@@ -108,7 +133,7 @@ class ApplicationInfoProviderTest extends TestCase
             $config,
             m::mock(SessionManager::class),
             m::mock(SessionHandlerInterface::class),
-            m::mock(Queue::class),
+            $queue ?? m::mock(Queue::class),
         );
     }
 }


### PR DESCRIPTION
## Why

#4853 wraps the queue connection in a `RoutingQueue` so `push()` can be routed by job class. `ApplicationInfoProvider::identifyQueueDriver()` derives the driver name from the connection's class name, so with the wrapper in place it now reports **`routing`** instead of the real backend (`redis`/`database`/`sync`).

This is visible on every 2.x site:

```
$ php flarum info
...
Queue driver: routing      # should be: redis / database / sync
```

It also surfaces on the admin dashboard, and it breaks downstream code that keys off the reported driver — e.g. fof/horizon relabels `redis` → `Redis + Horizon` and gates its admin controls on that, so those controls silently disappear.

## What

Unwrap a `RoutingQueue` via its public `getDriver()` before reading the class name, so the reported driver reflects the actual backend again:

```php
$queue = $this->queue instanceof RoutingQueue
    ? $this->queue->getDriver()
    : $this->queue;
$queue = $queue::class;
// ...strip namespace, lowercase, drop 'queue'
```

## Tests

`ApplicationInfoProviderTest` gains:

- `queue_driver_is_derived_from_the_connection_class` — a bare `SyncQueue` reports `sync`.
- `queue_driver_reports_the_real_driver_when_wrapped_in_a_routing_queue` — a `SyncQueue` wrapped in a `RoutingQueue` still reports `sync`, not `routing`.

The `provider()` helper takes an optional queue instance so a specific connection can be injected.

Full `ApplicationInfoProviderTest` green (8 tests). Verified live: `php flarum info` reports `redis` again on a redis-backed stack.

## Regression from

#4853 (the `RoutingQueue` connection wrapper).
