### PR TITLE
[2.x] chore(ts): fix ext:flarum/flags typings path in realtime tsconfig

### DIFF
--- a/extensions/realtime/js/tsconfig.json
+++ b/extensions/realtime/js/tsconfig.json
@@ -10,7 +10,7 @@
     "declarationDir": "./dist-typings",
     "paths": {
       "flarum/*": ["../../../framework/core/js/dist-typings/*"],
-      "ext:flarum/flags/*": ["../../../framework/extensions/flags/js/dist-typings/*"]
+      "ext:flarum/flags/*": ["../../flags/js/dist-typings/*"]
     }
   }
 }


### PR DESCRIPTION
The `ext:flarum/flags/*` mapping in realtime's tsconfig pointed at a nonexistent directory (`../../../framework/extensions/flags/js/dist-typings`), so any future `ext:flarum/flags` import in realtime would fail `check-typings` with TS2307. Points it at the flags extension's actual `dist-typings`, matching how sticky/tags map `ext:flarum/realtime/*`.

Currently dead config (realtime has no such imports), verified both ways: a real flags typing resolves through the corrected path, and a bogus module still fails with TS2307 — confirming resolution is genuinely exercised.