### PR TITLE
[2.x] fix(tags): validate the currentTag cache against the current route's slug

### DIFF
--- a/extensions/tags/js/jest.config.cjs
+++ b/extensions/tags/js/jest.config.cjs
@@ -1,0 +1,8 @@
+module.exports = require('@flarum/jest-config')({
+  moduleNameMapper: {
+    '^flarum/(.*)$': '<rootDir>/../../../framework/core/js/src/$1',
+    // TagHero drags in legacy `.js` helpers the ESM transform can't load, and
+    // nothing under test renders it.
+    'components/TagHero$': '<rootDir>/tests/stubs/TagHero.ts',
+  },
+});

--- a/extensions/tags/js/package.json
+++ b/extensions/tags/js/package.json
@@ -16,9 +16,11 @@
         "build-typings": "yarn run clean-typings && ([ -e src/@types ] && cp -r src/@types dist-typings/@types || true) && tsc && yarn run post-build-typings",
         "post-build-typings": "find dist-typings -type f -name '*.d.ts' -print0 | xargs -0 sed -i 's,../src/@types,@types,g'",
         "check-typings": "tsc --noEmit --emitDeclarationOnly false",
-        "check-typings-coverage": "typescript-coverage-report"
+        "check-typings-coverage": "typescript-coverage-report",
+        "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
     },
     "devDependencies": {
+        "@flarum/jest-config": "^2.0.0",
         "flarum-tsconfig": "^2.0.0",
         "flarum-webpack-config": "^3.0.0",
         "prettier": "^2.7.1",

--- a/extensions/tags/js/src/forum/addTagFilter.tsx
+++ b/extensions/tags/js/src/forum/addTagFilter.tsx
@@ -16,11 +16,21 @@ const findTag = (slug: string) => app.store.all<Tag>('tags').find((tag) => tag.s
 
 export default function addTagFilter() {
   app.currentTag = function (reload?: boolean) {
+    const slug = this.search.state.params().tags;
+
+    // The cache is only valid for the tag the current route actually points
+    // at. Without this check, the cached tag from a previously visited tag
+    // page leaks into any route that doesn't call currentTag(true) — e.g. a
+    // custom homepage — preselecting composer tags and mis-styling the
+    // "Start a Discussion" button there.
     if (this.currentActiveTag && !reload) {
-      return this.currentActiveTag;
+      if (!slug) {
+        this.currentActiveTag = undefined;
+      } else if (this.currentActiveTag.slug().localeCompare(slug, undefined, { sensitivity: 'base' }) === 0) {
+        return this.currentActiveTag;
+      }
     }
 
-    const slug = this.search.state.params().tags;
     let tag = null;
 
     if (slug) {

--- a/extensions/tags/js/tests/stubs/TagHero.ts
+++ b/extensions/tags/js/tests/stubs/TagHero.ts
@@ -1,0 +1,5 @@
+/**
+ * Test stub. The real TagHero pulls in legacy `.js` helpers (tagIcon) that the
+ * jest ESM transform can't load; none of the logic under test renders it.
+ */
+export default class TagHero {}

--- a/extensions/tags/js/tests/unit/forum/addTagFilter.test.ts
+++ b/extensions/tags/js/tests/unit/forum/addTagFilter.test.ts
@@ -1,0 +1,117 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from 'flarum/forum/app';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+import addTagFilter from '../../../src/forum/addTagFilter';
+import Tag from '../../../src/common/models/Tag';
+
+const coreJsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../../framework/core/js');
+
+/**
+ * The slug the current route would expose via m.route.param('tags'), as
+ * surfaced through app.search.state.params(). Tests drive navigation by
+ * changing this value — app.currentTag() must stay consistent with it.
+ */
+let routeTagsParam: string | undefined;
+
+beforeAll(() => {
+  const cwd = process.cwd();
+
+  try {
+    process.chdir(coreJsDir);
+    bootstrapForum();
+  } finally {
+    process.chdir(cwd);
+  }
+
+  app.boot();
+
+  (app.store.models as any).tags = Tag;
+
+  app.store.pushPayload({
+    data: [
+      {
+        id: '1',
+        type: 'tags',
+        attributes: { slug: 'general', name: 'General' },
+        relationships: { children: { data: [] } },
+      },
+      {
+        id: '2',
+        type: 'tags',
+        attributes: { slug: 'bugs', name: 'Bugs' },
+        relationships: { children: { data: [] } },
+      },
+    ],
+  });
+
+  addTagFilter();
+
+  (app as any).search = { state: { params: () => ({ tags: routeTagsParam }) } };
+});
+
+beforeEach(() => {
+  routeTagsParam = undefined;
+  (app as any).currentActiveTag = undefined;
+  (app as any).currentTagLoading = false;
+});
+
+describe('app.currentTag()', () => {
+  it('resolves the tag for the current route and caches it', () => {
+    routeTagsParam = 'general';
+
+    const tag = app.currentTag();
+
+    expect(tag).toBeDefined();
+    expect(tag!.slug()).toBe('general');
+    expect((app as any).currentActiveTag).toBe(tag);
+  });
+
+  it('returns the cached tag for the same slug without refetching', () => {
+    routeTagsParam = 'general';
+
+    const first = app.currentTag();
+
+    const find = jest.spyOn(app.store, 'find');
+    const second = app.currentTag();
+    find.mockRestore();
+
+    expect(second).toBe(first);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('matches the cached tag against the slug case-insensitively', () => {
+    routeTagsParam = 'general';
+    const first = app.currentTag();
+
+    routeTagsParam = 'General';
+
+    expect(app.currentTag()).toBe(first);
+  });
+
+  it('returns undefined on a route with no tags param, even when a tag was cached', () => {
+    // Visit a tag page…
+    routeTagsParam = 'general';
+    expect(app.currentTag()).toBeDefined();
+
+    // …then navigate to a route with no tags param (e.g. a custom homepage).
+    // The cached tag no longer matches the route and must not leak into it:
+    // consumers such as the composer's tag preselection and the sidebar's
+    // "Start a Discussion" gating read this on every route.
+    routeTagsParam = undefined;
+
+    expect(app.currentTag()).toBeUndefined();
+    expect((app as any).currentActiveTag).toBeUndefined();
+  });
+
+  it('re-resolves when the route points at a different tag than the cached one', () => {
+    routeTagsParam = 'general';
+    expect(app.currentTag()!.slug()).toBe('general');
+
+    routeTagsParam = 'bugs';
+
+    expect(app.currentTag()!.slug()).toBe('bugs');
+  });
+});


### PR DESCRIPTION
Fixes #4859

`app.currentTag()` returned its cached tag before ever reading the route's `tags` param, and the only cache-buster was the `currentTag(true)` call extended onto `IndexPage.prototype.view` — so any route whose page doesn't extend `IndexPage` (e.g. FoF Categories as homepage) kept getting the previously visited tag. The composer preselected it, and the sidebar's Start a Discussion button was styled and gated by it.

The cache now invalidates when the route has no `tags` param and is returned only when its slug matches the route's (case-insensitively, matching `findTag`'s semantics); anything else falls through to re-resolve from the store or fetch. On a mismatch to a not-yet-loaded tag, the cache is cleared before the fetch resolves, so a stale tag is never returned mid-load. The `IndexPage.prototype.view` refresh is now redundant but left in place for a separate cleanup, per the issue.

Also adds jest to the tags extension (mirroring mentions/embed — `@flarum/jest-config` was already in the root lockfile) with five tests: the two stale cases (tagless route, different tag) fail without the fix; the three cache-preservation cases (hit, no refetch, case-insensitive match) pin the existing behaviour. A `TagHero` test stub is included because it pulls in legacy `.js` helpers the ESM transform can't load, and nothing under test renders it.

Source only — no `js/dist` changes.