### PR TITLE
[2.x] fix: don't force asset writes on every debug-mode request

### DIFF
--- a/framework/core/src/Frontend/Compiler/JsCompiler.php
+++ b/framework/core/src/Frontend/Compiler/JsCompiler.php
@@ -59,12 +59,12 @@ class JsCompiler extends RevisionCompiler
             $line += substr_count($content, "\n") + 1;
         }
 
-        // Add a comment to the end of our file to point to the sourcemap
-        // we just constructed, then store the map. The JS file itself is
-        // written by the parent from the string we return.
+        // Add a comment to the end of our file to point to the sourcemap we
+        // just constructed, and queue the map so the parent writes it only if
+        // the JS itself is written — identical output rewrites neither file.
         $output[] = '//# sourceMappingURL='.$this->assetsDir->url($mapFile);
 
-        $this->assetsDir->put($mapFile, json_encode($map, JSON_UNESCAPED_SLASHES));
+        $this->pendingSidecars[$mapFile] = json_encode($map, JSON_UNESCAPED_SLASHES);
 
         return implode("\n", $output);
     }

--- a/framework/core/src/Frontend/Compiler/RevisionCompiler.php
+++ b/framework/core/src/Frontend/Compiler/RevisionCompiler.php
@@ -43,6 +43,17 @@ class RevisionCompiler implements CompilerInterface
         $this->filename = $filename;
     }
 
+    /**
+     * Recompile this asset and record its revision. Files are only written when
+     * the compiled output actually differs from what the revision manifest says
+     * is on disk (or the file has gone missing) — so routine rebuilds of
+     * unchanged assets are complete no-ops with zero writes.
+     *
+     * @param bool $force write unconditionally, even when the output is
+     *                    byte-identical — the trust-nothing repair path for when
+     *                    the on-disk state can't be relied on. Not a per-request
+     *                    tool: recompiling is what every commit() already does.
+     */
     public function commit(bool $force = false): void
     {
         $sources = $this->getSources();
@@ -55,18 +66,42 @@ class RevisionCompiler implements CompilerInterface
         // second) and not of the raw source content (which for LESS misses
         // @import contents and variable/import overrides, and for JS misses the
         // sourcemap and format rewrite the written file actually carries).
+        $this->pendingSidecars = [];
+
         $output = $this->renderOutput($sources);
 
         $newRevision = $output === null ? static::EMPTY_REVISION : $this->hashOutput($output);
 
         $oldRevision = $this->versioner->getRevision($this->filename);
 
-        if ($force || $oldRevision !== $newRevision || ! $this->assetsDir->exists($this->filename)) {
+        // The exists() arm repairs a deleted file whose revision is still
+        // recorded; it is guarded on $output so an empty bundle — which
+        // legitimately has no file — doesn't re-record EMPTY_REVISION (and
+        // rewrite the whole manifest) on every commit.
+        if ($force || $oldRevision !== $newRevision || ($output !== null && ! $this->assetsDir->exists($this->filename))) {
             if ($output !== null) {
                 $this->assetsDir->put($this->filename, $output);
+
+                $this->writePendingSidecars();
             }
 
             $this->versioner->putRevision($this->filename, $newRevision);
+        }
+    }
+
+    /**
+     * Sidecar files (e.g. JsCompiler's `.map`) queued by renderOutput() during
+     * the current commit, written only if the primary file is — so an unchanged
+     * bundle rewrites nothing at all.
+     *
+     * @var array<string, string> filename => content
+     */
+    protected array $pendingSidecars = [];
+
+    protected function writePendingSidecars(): void
+    {
+        foreach ($this->pendingSidecars as $file => $content) {
+            $this->assetsDir->put($file, $content);
         }
     }
 
@@ -80,8 +115,9 @@ class RevisionCompiler implements CompilerInterface
      * there is nothing to write (empty sources). This is what the revision is
      * hashed from, so it must be identical to what gets committed — subclasses
      * that transform or add to the output (e.g. JsCompiler's sourcemap handling)
-     * override this and may write sidecar files (like the `.map`) as a side
-     * effect, as long as the returned string is the primary file's content.
+     * override this and queue any sidecar files (like the `.map`) on
+     * {@see $pendingSidecars} rather than writing them, so sidecars are only
+     * written when the bundle itself is.
      *
      * @param SourceInterface[] $sources
      */

--- a/framework/core/src/Frontend/Content/Assets.php
+++ b/framework/core/src/Frontend/Content/Assets.php
@@ -62,7 +62,7 @@ class Assets
         $compilers = $this->assembleCompilers($locale);
 
         if ($this->config->inDebugMode()) {
-            $this->forceCommit(Arr::flatten($compilers));
+            $this->recompile(Arr::flatten($compilers));
         }
 
         $this->addAssetsToDocument($document, $compilers);
@@ -107,14 +107,17 @@ class Assets
     }
 
     /**
-     * Force compilation of assets when in debug mode.
+     * Recompile assets on every request when in debug mode, so changes show up
+     * immediately. A plain commit() recompiles from source but only writes when
+     * the output actually changed — forcing here would rewrite every bundle,
+     * sourcemap and the revision manifest on every page view.
      *
      * @param CompilerInterface[] $compilers
      */
-    protected function forceCommit(array $compilers): void
+    protected function recompile(array $compilers): void
     {
         foreach ($compilers as $compiler) {
-            $compiler->commit(true);
+            $compiler->commit();
         }
     }
 

--- a/framework/core/tests/unit/Frontend/Compiler/RevisionCompilerTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/RevisionCompilerTest.php
@@ -34,8 +34,19 @@ class RevisionCompilerTest extends TestCase
     /** @var array<string, string> in-memory stand-in for the assets dir */
     private array $written = [];
 
+    /** @var string[] every put() call, in order — for asserting write-churn */
+    private array $putLog = [];
+
     /** @var array<string, string|null> shared manifest, persists across compilers like production */
     private array $manifest = [];
+
+    /** @var int number of manifest (rev-manifest.json) writes */
+    private int $manifestWrites = 0;
+
+    private function putsFor(string $file): int
+    {
+        return count(array_keys($this->putLog, $file, true));
+    }
 
     protected function setUp(): void
     {
@@ -66,6 +77,7 @@ class RevisionCompilerTest extends TestCase
         $assetsDir = m::mock(Cloud::class);
         $assetsDir->shouldReceive('put')->andReturnUsing(function ($file, $content) {
             $this->written[$file] = $content;
+            $this->putLog[] = $file;
 
             return true;
         });
@@ -83,6 +95,7 @@ class RevisionCompilerTest extends TestCase
         $manifestFs->shouldReceive('put')->with(FileVersioner::REV_MANIFEST, m::type('string'))
             ->andReturnUsing(function ($_, $json) {
                 $this->manifest = json_decode($json, true);
+                $this->manifestWrites++;
 
                 return true;
             });
@@ -102,6 +115,89 @@ class RevisionCompilerTest extends TestCase
     private function makeJsCompiler(): JsCompiler
     {
         return new JsCompiler($this->assetsDir(), 'chunk.js', m::mock(SettingsRepositoryInterface::class), $this->versioner());
+    }
+
+    #[Test]
+    public function force_recompiles_and_writes_even_when_output_is_identical()
+    {
+        // force means FORCE: recompute and write unconditionally — the
+        // trust-nothing repair path for when the on-disk state can't be relied
+        // on. It is not a per-request tool; routine rebuilds use plain commit().
+        $path = $this->sourceFile('a.js', 'console.log(1);');
+
+        $compiler = $this->makeCompiler();
+        $compiler->addSources(fn ($sources) => $sources->addFile($path));
+        $compiler->commit();
+
+        $this->assertSame(1, $this->putsFor('target.js'));
+
+        $compiler->commit(true);
+
+        $this->assertSame(2, $this->putsFor('target.js'), 'force must rewrite even byte-identical output');
+    }
+
+    #[Test]
+    public function recommitting_identical_output_writes_nothing()
+    {
+        $path = $this->sourceFile('a.js', 'console.log(1);');
+
+        $compiler = $this->makeCompiler();
+        $compiler->addSources(fn ($sources) => $sources->addFile($path));
+        $compiler->commit();
+
+        $puts = count($this->putLog);
+        $manifestWrites = $this->manifestWrites;
+
+        $compiler->commit();
+
+        $this->assertSame($puts, count($this->putLog), 'unchanged output must not be rewritten');
+        $this->assertSame($manifestWrites, $this->manifestWrites, 'unchanged output must not rewrite the manifest');
+    }
+
+    #[Test]
+    public function empty_sources_do_not_rewrite_the_manifest_on_every_commit()
+    {
+        // An empty bundle (e.g. a locale CSS with no rules) has no file on disk,
+        // so a naive "write when the file is missing" check re-records its
+        // EMPTY_REVISION — rewriting the whole manifest — on every commit.
+        $compiler = $this->makeCompiler();
+        $compiler->commit();
+
+        $manifestWrites = $this->manifestWrites;
+
+        $compiler->commit();
+
+        $this->assertSame($manifestWrites, $this->manifestWrites, 'an unchanged empty bundle must not rewrite the manifest');
+    }
+
+    #[Test]
+    public function js_compiler_does_not_rewrite_the_sourcemap_when_output_is_unchanged()
+    {
+        $path = $this->sourceFile('chunk.js', 'export const x = 1;');
+
+        $compiler = $this->makeJsCompiler();
+        $compiler->addSources(fn ($sources) => $sources->addFile($path));
+        $compiler->commit();
+
+        $this->assertSame(1, $this->putsFor('chunk.js.map'));
+
+        $compiler->commit();
+
+        $this->assertSame(1, $this->putsFor('chunk.js.map'), 'the sidecar must only be written when the bundle is');
+
+        // A real change writes both again…
+        file_put_contents($path, 'export const x = 2;');
+        clearstatcache(true, $path);
+        $compiler->commit();
+
+        $this->assertSame(2, $this->putsFor('chunk.js.map'));
+        $this->assertSame(2, $this->putsFor('chunk.js'));
+
+        // …and force writes both regardless.
+        $compiler->commit(true);
+
+        $this->assertSame(3, $this->putsFor('chunk.js.map'));
+        $this->assertSame(3, $this->putsFor('chunk.js'));
     }
 
     #[Test]

--- a/framework/core/tests/unit/Frontend/Content/AssetsTest.php
+++ b/framework/core/tests/unit/Frontend/Content/AssetsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Content;
+
+use Flarum\Foundation\Config;
+use Flarum\Frontend\Assets as FrontendAssets;
+use Flarum\Frontend\Compiler\JsCompiler;
+use Flarum\Frontend\Compiler\JsDirectoryCompiler;
+use Flarum\Frontend\Compiler\LessCompiler;
+use Flarum\Frontend\Content\Assets;
+use Flarum\Frontend\Document;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Container\Container;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AssetsTest extends TestCase
+{
+    /**
+     * Debug mode recompiles the assets on every request so changes show up
+     * immediately — but it must do so with a plain commit(), which only writes
+     * when the output actually changed. Passing force would rewrite every
+     * bundle, sourcemap and the revision manifest on every single page view,
+     * even when byte-identical. force is the trust-nothing repair path, not a
+     * per-request tool.
+     */
+    #[Test]
+    public function debug_mode_recompiles_without_forcing_writes()
+    {
+        $commitArgs = [];
+
+        $makeCompiler = function (string $class) use (&$commitArgs) {
+            $compiler = m::mock($class);
+            $compiler->shouldReceive('commit')->andReturnUsing(function (...$args) use (&$commitArgs) {
+                $commitArgs[] = $args;
+            });
+            $compiler->shouldReceive('getUrl')->andReturn(null);
+
+            return $compiler;
+        };
+
+        $frontendAssets = m::mock(FrontendAssets::class);
+        $frontendAssets->shouldReceive('makeJs')->andReturn($makeCompiler(JsCompiler::class));
+        $frontendAssets->shouldReceive('makeLocaleJs')->andReturn($makeCompiler(JsCompiler::class));
+        $frontendAssets->shouldReceive('makeJsDirectory')->andReturn($makeCompiler(JsDirectoryCompiler::class));
+        $frontendAssets->shouldReceive('makeCss')->andReturn($makeCompiler(LessCompiler::class));
+        $frontendAssets->shouldReceive('makeLocaleCss')->andReturn($makeCompiler(LessCompiler::class));
+
+        $commonAssets = m::mock(FrontendAssets::class);
+        $commonAssets->shouldReceive('makeJsDirectory')->andReturn($makeCompiler(JsDirectoryCompiler::class));
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('flarum.assets.forum')->andReturn($frontendAssets);
+        $container->shouldReceive('make')->with('flarum.assets.common')->andReturn($commonAssets);
+
+        // Config is a readonly class and can't be mocked — use the real thing.
+        $config = new Config(['url' => 'http://localhost', 'debug' => true]);
+
+        /** @var Assets&m\MockInterface $content */
+        $content = m::mock(Assets::class.'[recompileIfDirty,addAssetsToDocument]', [$container, $config])
+            ->shouldAllowMockingProtectedMethods();
+        $content->shouldReceive('recompileIfDirty');
+        $content->shouldReceive('addAssetsToDocument');
+
+        $request = m::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getAttribute')->with('locale')->andReturn('en');
+
+        $content->forFrontend('forum');
+        $content(m::mock(Document::class), $request);
+
+        $this->assertNotEmpty($commitArgs, 'debug mode must recompile the assets');
+
+        foreach ($commitArgs as $args) {
+            $this->assertNotSame(true, $args[0] ?? false, 'debug recompiles must not force writes of unchanged output');
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #4857.

No originating issue; caught during the #4857 work.

## Changes proposed in this pull request

`commit(true)` means **force**: recompute and write unconditionally — the trust-nothing repair path for when the on-disk state can't be relied on. Debug mode was using it as a per-request tool, rewriting every bundle, every sourcemap and the revision manifest on every single page view, even when byte-identical.

- **`Content\Assets`**: the debug branch now calls plain `commit()` per compiler (renamed `forceCommit()` → `recompile()`). Debug still recompiles from source on every request so changes show up immediately — it just no longer *writes* unchanged output. `commit(bool $force)` itself is untouched and keeps its plain meaning.
- **Sidecar deferral**: `JsCompiler` used to write the `.map` directly inside `renderOutput()`, bypassing the write-only-on-change guard. Sidecars are now queued on `RevisionCompiler::$pendingSidecars` and written only when the bundle itself is — an unchanged bundle rewrites neither file.
- **Empty-bundle guard**: the "file missing → repair" arm of the write condition is now gated on there being output at all, so an empty bundle (e.g. a locale CSS with no rules) no longer re-records `EMPTY_REVISION` — rewriting the whole manifest — on every commit.

## Reviewers should focus on

- The write condition in `RevisionCompiler::commit()`: `$force || $oldRevision !== $newRevision || ($output !== null && ! exists)`.
- `AssetsTest` pins the contract that debug mode must never pass `force`; `RevisionCompilerTest` pins that `force` must still rewrite byte-identical output (it's the repair path, and the future `assets:compile --force` primitive).

All TDD (tests were red first). Verified live with `debug` enabled: repeated page loads leave `forum.js` / `forum.js.map` / `rev-manifest.json` untouched; a `custom_less` change writes through immediately and the revision moves.

## Confirmed

- [x] Backend changes: tests are green (run `composer test`).
