### PR TITLE
[2.x] perf: load the discussion and its post window in parallel

### DIFF
--- a/framework/core/js/src/common/Store.ts
+++ b/framework/core/js/src/common/Store.ts
@@ -155,6 +155,15 @@ export default class Store {
    */
   async find<M extends Model>(type: string, params?: ApiQueryParamsSingle): Promise<ApiResponseSingle<M>>;
   async find<Ms extends Model[]>(type: string, params?: ApiQueryParamsPlural): Promise<ApiResponsePlural<Ms[number]>>;
+  async find<Ms extends Model[]>(
+    type: string,
+    params: ApiQueryParamsPlural,
+    // When the second argument is a params object it doubles as the query;
+    // this argument is ignored at runtime and exists so request options can
+    // be passed positionally.
+    query?: undefined,
+    options?: ApiQueryRequestOptions<ApiPayloadPlural>
+  ): Promise<ApiResponsePlural<Ms[number]>>;
   async find<M extends Model>(
     type: string,
     id: string,

--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -45,6 +45,16 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
    */
   protected near: number = 0;
 
+  /**
+   * The window of posts obtained without the post stream having to request
+   * one — prefetched in parallel with the discussion, or embedded in the
+   * server-preloaded document — pending consumption by show(). Stashed on the
+   * instance rather than only threaded through show()'s arguments, so an
+   * extension override of show() that forwards just the discussion (a common
+   * mistake) cannot silently drop the window and force a redundant request.
+   */
+  protected pendingPostWindow: Post[] = [];
+
   protected useBrowserScrollRestoration = true;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
@@ -127,25 +137,80 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
    * Load the discussion from the API or use the preloaded one.
    */
   load(): void {
+    const preloadedDiscussion = app.preloadedApiDocument<Discussion>();
+
+    // Kick off the network requests immediately: they must not wait for the
+    // async component chunks below, and they must not wait for each other.
+    // The post window is derivable from the route alone, so requesting it
+    // serially after the discussion (what PostStreamState would do) wastes a
+    // full round-trip on every discussion visited.
+    let discussionPromise: Promise<ApiResponseSingle<Discussion>> | null = null;
+    let postsPromise: Promise<Post[]> | null = null;
+
+    if (!preloadedDiscussion) {
+      discussionPromise = app.store.find<Discussion>('discussions', m.route.param('id'), this.requestParams());
+      postsPromise = this.prefetchPosts();
+    }
+
     Promise.all([import('./PostStream'), import('./PostStreamScrubber')]).then(([PostStreamImport, PostStreamScrubberImport]) => {
       this.PostStream = PostStreamImport.default;
       this.PostStreamScrubber = PostStreamScrubberImport.default;
 
-      const preloadedDiscussion = app.preloadedApiDocument<Discussion>();
       if (preloadedDiscussion) {
         // We must wrap this in a setTimeout because if we are mounting this
         // component for the first time on page load, then any calls to m.redraw
         // will be ineffective and thus any configs (scroll code) will be run
         // before stuff is drawn to the page.
-        setTimeout(this.show.bind(this, preloadedDiscussion, this.preloadedNearPage(preloadedDiscussion)), 0);
+        setTimeout(() => {
+          this.pendingPostWindow = this.preloadedNearPage(preloadedDiscussion);
+          this.show(preloadedDiscussion, this.pendingPostWindow);
+        }, 0);
       } else {
-        const params = this.requestParams();
-
-        app.store.find<Discussion>('discussions', m.route.param('id'), params).then(this.show.bind(this));
+        Promise.all([discussionPromise!, postsPromise ?? []]).then(([discussion, posts]) => {
+          this.pendingPostWindow = posts;
+          this.show(discussion, posts);
+        });
       }
     });
 
     m.redraw();
+  }
+
+  /**
+   * Fetch the near-window of posts in parallel with the discussion request.
+   *
+   * This mirrors the request PostStreamState.loadNearNumber() would make
+   * serially after the discussion arrives; with the window already loaded,
+   * the stream finds its target post and makes no request of its own. Only
+   * possible when the discussion is already in the store (in-app navigation —
+   * exactly the case users notice), because the posts filter needs the ID and
+   * the route only carries a slug. Returns null to keep the serial flow when
+   * the discussion is unknown or the target is the reply placeholder. Failures
+   * are swallowed: the discussion request owns error handling, and the stream
+   * falls back to loading its own window.
+   */
+  protected prefetchPosts(): Promise<Post[]> | null {
+    const idParam = m.route.param('id');
+    const discussion = app.store.all<Discussion>('discussions').find((d) => d.slug() === idParam || d.id() === idParam);
+
+    if (!discussion) return null;
+
+    const nearParam = m.route.param('near');
+    if (nearParam === 'reply') return null;
+
+    const near = parseInt(nearParam);
+
+    return app.store
+      .find<Post[]>(
+        'posts',
+        {
+          filter: { discussion: discussion.id() as string },
+          page: { near: !isNaN(near) ? near : 1 },
+        },
+        undefined,
+        { errorHandler: () => {} }
+      )
+      .catch(() => []);
   }
 
   /**
@@ -164,6 +229,14 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
    */
   show(discussion: ApiResponseSingle<Discussion>, preloadedPosts: Post[] = []): void {
     this.loading = false;
+
+    // Recover the stashed window if an extension override of show() didn't
+    // forward the posts argument — without it the stream would immediately
+    // re-request posts we already have.
+    if (!preloadedPosts.length && this.pendingPostWindow.length) {
+      preloadedPosts = this.pendingPostWindow;
+    }
+    this.pendingPostWindow = [];
 
     app.history.push('discussion', discussion.title());
     app.setTitle(discussion.title());

--- a/framework/core/js/tests/integration/forum/components/DiscussionPage.test.ts
+++ b/framework/core/js/tests/integration/forum/components/DiscussionPage.test.ts
@@ -1,0 +1,215 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../../src/forum/app';
+import DiscussionPage from '../../../../src/forum/components/DiscussionPage';
+import Discussion from '../../../../src/common/models/Discussion';
+import Post from '../../../../src/common/models/Post';
+import mq from 'mithril-query';
+import m from 'mithril';
+
+/**
+ * Clicking into a discussion must not serialize its network round-trips.
+ * The near-window of posts is derivable from the route alone, so it is
+ * requested in PARALLEL with the discussion — not after it. These tests pin
+ * that contract; the serial flow is kept only when the discussion can't be
+ * identified client-side.
+ */
+
+const makePostData = (id: number, number: number, discussionId = '476') => ({
+  type: 'posts',
+  id: String(id),
+  attributes: {
+    number,
+    contentType: 'comment',
+    contentHtml: `<p>Post ${number}</p>`,
+    createdAt: '2024-01-01T00:00:00Z',
+    // The stream treats a post without canEdit as a partial record (e.g. from
+    // a search result) and reloads it — real post payloads always carry it.
+    canEdit: false,
+  },
+  relationships: {
+    discussion: { data: { type: 'discussions', id: discussionId } },
+    user: { data: { type: 'users', id: '1' } },
+  },
+});
+
+const discussionData = (postIds: number[], slug = '476-test-discussion') => ({
+  type: 'discussions',
+  id: '476',
+  attributes: {
+    title: 'Test discussion',
+    slug,
+    commentCount: postIds.length,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  relationships: {
+    posts: { data: postIds.map((id) => ({ type: 'posts', id: String(id) })) },
+  },
+});
+
+describe('DiscussionPage', () => {
+  const originalRouteParam = m.route.param;
+  const originalFind = app.store.find;
+
+  let routeParams: Record<string, string | undefined>;
+  let findCalls: any[][];
+  let pendingFinds: { args: any[]; resolve: (value: any) => void; reject: (error: any) => void }[];
+
+  beforeAll(() => {
+    bootstrapForum();
+    app.boot();
+  });
+
+  beforeEach(() => {
+    routeParams = {};
+    findCalls = [];
+    pendingFinds = [];
+
+    // @ts-ignore
+    m.route.param = (key?: string) => (key ? routeParams[key] : routeParams);
+
+    // Intercept store.find: record the call, return a promise we resolve by hand.
+    // @ts-ignore
+    app.store.find = (...args: any[]) => {
+      findCalls.push(args);
+      return new Promise((resolve, reject) => {
+        pendingFinds.push({ args, resolve, reject });
+      });
+    };
+  });
+
+  afterEach(() => {
+    m.route.param = originalRouteParam;
+    app.store.find = originalFind;
+  });
+
+  const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  const findsFor = (type: string) => findCalls.filter((args) => args[0] === type);
+
+  /** Simulate the discussion being known from the discussion list. */
+  const seedDiscussionFromList = () => {
+    app.store.pushPayload({
+      data: {
+        type: 'discussions',
+        id: '476',
+        attributes: { title: 'Test discussion', slug: '476-test-discussion', commentCount: 3 },
+      },
+    });
+  };
+
+  const mountPage = () => mq(DiscussionPage as any, { id: '476-test-discussion' });
+
+  /** Resolve the pending discussion request with a full show document. */
+  const resolveDiscussion = (postIds: number[]) => {
+    const pending = pendingFinds.find((p) => p.args[0] === 'discussions');
+    const document = { data: discussionData(postIds), included: postIds.map((id, i) => makePostData(id, i + 1)) };
+    const models = app.store.pushPayload<Discussion>(document as any);
+    pending!.resolve(models);
+  };
+
+  /** Resolve the pending posts request with the near-window. */
+  const resolvePosts = (postIds: number[]) => {
+    const pending = pendingFinds.find((p) => p.args[0] === 'posts');
+    const document = { data: postIds.map((id, i) => makePostData(id, i + 1)) };
+    const models = app.store.pushPayload<Post[]>(document as any);
+    pending!.resolve(models);
+  };
+
+  test('requests the discussion and the post window in parallel when the discussion is known', () => {
+    seedDiscussionFromList();
+    routeParams = { id: '476-test-discussion' };
+
+    mountPage();
+
+    // Both requests must be in flight immediately — before ANY response and
+    // before the async component chunks resolve.
+    expect(findsFor('discussions')).toHaveLength(1);
+    expect(findsFor('posts')).toHaveLength(1);
+
+    const [, postsParams] = findsFor('posts')[0];
+    expect(postsParams).toMatchObject({ filter: { discussion: '476' }, page: { near: 1 } });
+  });
+
+  test('the parallel post window honours the near route param', () => {
+    seedDiscussionFromList();
+    routeParams = { id: '476-test-discussion', near: '5' };
+
+    mountPage();
+
+    const [, postsParams] = findsFor('posts')[0];
+    expect(postsParams).toMatchObject({ filter: { discussion: '476' }, page: { near: 5 } });
+  });
+
+  test('a single posts request serves the whole page view', async () => {
+    seedDiscussionFromList();
+    routeParams = { id: '476-test-discussion' };
+
+    mountPage();
+
+    // Posts arrive BEFORE the discussion — the page must handle either order.
+    resolvePosts([101, 102, 103]);
+    resolveDiscussion([101, 102, 103]);
+
+    await flushAsync();
+
+    // The post stream was satisfied by the parallel window: no second request.
+    expect(findsFor('posts')).toHaveLength(1);
+    expect(findsFor('discussions')).toHaveLength(1);
+  });
+
+  test('falls back to the serial flow when the discussion is not in the store', async () => {
+    // The store persists across tests in this suite, so use a discussion no
+    // other test has seeded.
+    routeParams = { id: '999-unknown-discussion' };
+
+    mq(DiscussionPage as any, { id: '999-unknown-discussion' });
+
+    // Unknown discussion: only the discussion request goes out. The post
+    // window cannot be derived (the slug alone does not identify it), so the
+    // stream requests posts only after the discussion arrives.
+    expect(findsFor('discussions')).toHaveLength(1);
+    expect(findsFor('posts')).toHaveLength(0);
+
+    resolveDiscussion([101, 102, 103]);
+    await flushAsync();
+
+    expect(findsFor('posts')).toHaveLength(1);
+  });
+
+  test('survives an extension override of show() that drops the posts argument', async () => {
+    // fof/blog (and likely others) override show() as
+    // `override(DiscussionPage.prototype, 'show', (original, discussion) => original(discussion))`,
+    // silently dropping the second argument. The prefetched window must not
+    // depend on argument threading through show().
+    const originalShow = (DiscussionPage.prototype as any).show;
+    (DiscussionPage.prototype as any).show = function (discussion: any) {
+      return originalShow.call(this, discussion);
+    };
+
+    try {
+      seedDiscussionFromList();
+      routeParams = { id: '476-test-discussion' };
+
+      mountPage();
+
+      resolvePosts([101, 102, 103]);
+      resolveDiscussion([101, 102, 103]);
+
+      await flushAsync();
+
+      expect(findsFor('posts')).toHaveLength(1);
+    } finally {
+      (DiscussionPage.prototype as any).show = originalShow;
+    }
+  });
+
+  test('does not prefetch posts when navigating to the reply placeholder', () => {
+    seedDiscussionFromList();
+    routeParams = { id: '476-test-discussion', near: 'reply' };
+
+    mountPage();
+
+    expect(findsFor('discussions')).toHaveLength(1);
+    expect(findsFor('posts')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Changes proposed in this pull request

Clicking into a discussion currently performs three strictly serial steps: await the async `PostStream`/`PostStreamScrubber` chunk imports, fetch `/api/discussions/{id}`, and only then let the post stream fetch `/api/posts?filter[discussion]&page[near]` — a full extra network round-trip on every discussion visited, and the main reason the loading spinner lingers on the discussion page (a frequent community complaint, most recently in comparison to server-rendered platforms).

Since #4067 the show response intentionally carries no posts, but the posts request is **derivable from the route alone** whenever the discussion is already in the store — i.e. in-app navigation from any discussion list, exactly the case users notice. So:

- `DiscussionPage.load()` starts the discussion request immediately (no longer gated on the chunk imports) and fires the post-window request concurrently via a new `protected prefetchPosts()`. The stream then finds its target post already loaded and makes no request of its own.
- When the discussion can't be identified client-side (custom slug drivers with a cold store) or `near` is the `reply` placeholder, `prefetchPosts()` returns `null` and the existing serial flow is kept. Prefetch failures are swallowed — the discussion request owns error handling.
- The window is stashed on the component (`pendingPostWindow`) rather than only threaded through `show()`'s arguments. Live testing caught fof/blog overriding `show()` and dropping the second argument — which was already discarding the server-embedded window and forcing a redundant posts request on every cold discussion load on any forum running it. With the stash, argument-dropping overrides can't defeat either path. (Upstream fix to fof/blog to follow separately.)
- `Store.find` gains the missing TS overload for passing request options alongside a plural params object (the runtime already supported this).

Measured on a dev install (headless Chrome, in-app click): before — discussion request completes, *then* posts request starts (~2× API latency serialized). After — both requests start in the same millisecond, no duplicate, posts render after the slower of the two. Cold server-preloaded loads render with zero data API requests.

## Reviewers should focus on

- `prefetchPosts()`'s store lookup (`slug() === idParam || id() === idParam`) as the driver-agnostic guard for when parallel fetch is safe.
- The `pendingPostWindow` stash/consume in `show()` — kept back-compat: the argument still takes precedence when provided.

All TDD — 6 new jest tests (red first), including a regression test reproducing the fof/blog argument-dropping override, posts resolving before the discussion, and the serial fallback.

## Confirmed

- [x] Frontend changes: tests are green (`yarn jest`), typings check passes.