### PR TITLE
[2.x] perf: single-discussion fast path for the posts ID linkage query

### DIFF
--- a/framework/core/src/Api/Resource/DiscussionResource.php
+++ b/framework/core/src/Api/Resource/DiscussionResource.php
@@ -223,9 +223,33 @@ class DiscussionResource extends AbstractDatabaseResource
                         || $context->creating(PostResource::class);
                 })
                 ->get(function (Discussion $discussion, Context $context) {
-                    // @todo: is it possible to refactor the frontend to not need all post IDs?
-                    //       some kind of percentage-based stream scrubber?
-                    return $discussion->posts()->whereVisibleTo($context->getActor())->select('id')->get()->all();
+                    // @todo: the ID query is now cheap, but the full ID list still bloats the
+                    //        payload on huge discussions. Refactoring the frontend to work from
+                    //        a post count + windowed fetches (percentage-based scrubber) would
+                    //        let us drop the linkage entirely.
+
+                    // This runs on every discussion view and scans every post
+                    // of the discussion, so it uses the single-discussion
+                    // visibility fast path (the actor's access to the
+                    // discussion itself was already established by this
+                    // endpoint) and skips Eloquent hydration: only ids leave
+                    // the database, and the serializer needs no more than
+                    // id-carrying Post instances for the linkage.
+                    $prototype = new Post();
+                    $prototype->exists = true;
+
+                    return $discussion->posts()
+                        ->whereVisibleToInDiscussion($context->getActor(), $discussion)
+                        ->orderBy('posts.number')
+                        ->toBase()
+                        ->pluck('posts.id')
+                        ->map(function ($id) use ($prototype) {
+                            $post = clone $prototype;
+                            $post->setRawAttributes(['id' => $id], true);
+
+                            return $post;
+                        })
+                        ->all();
                 }),
             Schema\Relationship\ToOne::make('mostRelevantPost')
                 ->visible(fn (Discussion $model, Context $context) => $context->listing())

--- a/framework/core/src/Post/Access/ScopePostVisibility.php
+++ b/framework/core/src/Post/Access/ScopePostVisibility.php
@@ -13,8 +13,38 @@ use Flarum\Discussion\Discussion;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder;
 
-class ScopePostVisibility
+class ScopePostVisibility implements ScopesPostVisibilityWithinDiscussion
 {
+    /**
+     * The fast path for posts of a single, already-authorized discussion: the
+     * per-row discussion subqueries below collapse to constants.
+     */
+    public function withinDiscussion(User $actor, Builder $query, Discussion $discussion): void
+    {
+        // The caller vouches for the discussion being visible, so the
+        // "discussion is visible" EXISTS is omitted entirely.
+
+        // Hide private posts by default. (Per-post: stays in SQL.)
+        $query->where(function ($query) use ($actor) {
+            $query->where('posts.is_private', false)
+                ->orWhere(function ($query) use ($actor) {
+                    $query->whereVisibleTo($actor, 'viewPrivate');
+                });
+        });
+
+        // Hide hidden posts unless the actor authored them or may moderate
+        // this discussion. The policy check is the same one that governs the
+        // actual hide/restore actions (core's global discussion.hidePosts
+        // permission, per-tag moderator grants via the tags policy, admins),
+        // evaluated once instead of per row.
+        if (! $actor->can('hidePosts', $discussion)) {
+            $query->where(function ($query) use ($actor) {
+                $query->whereNull('posts.hidden_at')
+                    ->orWhere('posts.user_id', $actor->id);
+            });
+        }
+    }
+
     public function __invoke(User $actor, Builder $query): void
     {
         // Make sure the post's discussion is visible as well.

--- a/framework/core/src/Post/Access/ScopesPostVisibilityWithinDiscussion.php
+++ b/framework/core/src/Post/Access/ScopesPostVisibilityWithinDiscussion.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Post\Access;
+
+use Flarum\Discussion\Discussion;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * A post visibility scoper that can take a fast path when every post in the
+ * query belongs to one discussion the actor is already allowed to see.
+ *
+ * The generic `view` scope must embed discussion-level access checks into the
+ * SQL as per-row subqueries, because the posts may span discussions. When the
+ * discussion is known and pre-authorized, those checks are constants: they can
+ * be evaluated once in PHP and the subqueries omitted, which matters on large
+ * discussions where the generic scope's cost grows with the post count.
+ *
+ * Implementations MUST apply the same post-level restrictions as their
+ * ordinary scoper; only discussion-level conditions may be lifted out.
+ * Scopers that don't implement this interface are simply applied as usual.
+ */
+interface ScopesPostVisibilityWithinDiscussion
+{
+    public function withinDiscussion(User $actor, Builder $query, Discussion $discussion): void;
+}

--- a/framework/core/src/Post/Post.php
+++ b/framework/core/src/Post/Post.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Arr;
 
 /**
  * @property int $id
@@ -118,6 +119,39 @@ class Post extends AbstractModel
     public function isVisibleTo(User $user): bool
     {
         return (bool) $this->newQuery()->whereVisibleTo($user)->find($this->id);
+    }
+
+    /**
+     * Scope a query over one discussion's posts to those visible to the user,
+     * where the caller has already established that the DISCUSSION is visible.
+     *
+     * Applies the same registered `view` scopers as whereVisibleTo(), but lets
+     * scopers implementing {@see Access\ScopesPostVisibilityWithinDiscussion}
+     * take their fast path: discussion-level access checks are evaluated once
+     * in PHP instead of as per-row subqueries, whose cost grows with the size
+     * of the discussion. Only meaningful when the query is restricted to the
+     * given discussion's posts.
+     */
+    public function scopeWhereVisibleToInDiscussion(Builder $query, User $actor, Discussion $discussion): Builder
+    {
+        foreach (array_reverse(array_merge([static::class], class_parents($this))) as $class) {
+            foreach (Arr::get(static::$visibilityScopers, "$class.*", []) as $scoper) {
+                if ($scoper instanceof Access\ScopesPostVisibilityWithinDiscussion) {
+                    $scoper->withinDiscussion($actor, $query, $discussion);
+                } else {
+                    $scoper($actor, $query, 'view');
+                }
+            }
+            foreach (Arr::get(static::$visibilityScopers, "$class.view", []) as $scoper) {
+                if ($scoper instanceof Access\ScopesPostVisibilityWithinDiscussion) {
+                    $scoper->withinDiscussion($actor, $query, $discussion);
+                } else {
+                    $scoper($actor, $query);
+                }
+            }
+        }
+
+        return $query;
     }
 
     public function discussion(): BelongsTo

--- a/framework/core/tests/integration/api/discussions/PostIdsVisibilityTest.php
+++ b/framework/core/tests/integration/api/discussions/PostIdsVisibilityTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The `posts` ID linkage on the show-discussion endpoint drives the post
+ * stream (scrubber positions, near-navigation, range loading), so its
+ * visibility semantics must exactly match what the actor may see. These pin
+ * the semantics so the ID query can be optimised without changing them.
+ */
+class PostIdsVisibilityTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 10, 'title' => 'Posts of all kinds', 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'first_post_id' => 100, 'comment_count' => 5, 'is_private' => 0],
+            ],
+            Post::class => [
+                ['id' => 100, 'discussion_id' => 10, 'number' => 1, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>normal one</p></t>'],
+                ['id' => 101, 'discussion_id' => 10, 'number' => 2, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>hidden, authored by user 2</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
+                ['id' => 102, 'discussion_id' => 10, 'number' => 3, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>hidden, authored by user 3</p></t>', 'hidden_at' => Carbon::now()->toDateTimeString()],
+                ['id' => 103, 'discussion_id' => 10, 'number' => 4, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>private</p></t>', 'is_private' => 1],
+                ['id' => 104, 'discussion_id' => 10, 'number' => 5, 'created_at' => Carbon::now()->toDateTimeString(), 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>normal two</p></t>'],
+            ],
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'acquaintance', 'email' => 'acquaintance@machine.local', 'is_email_confirmed' => 1],
+            ],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Visibility scopers live in static model state, so ones registered by
+        // this test's extenders would leak into every later test in the
+        // process. The next app boot re-registers core's scopers.
+        (function () {
+            self::$visibilityScopers = [];
+        })->bindTo(null, Post::class)();
+
+        parent::tearDown();
+    }
+
+    private function postIds(?int $actorId = null): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/10', $actorId ? ['authenticatedAs' => $actorId] : [])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return array_map('intval', array_column(Arr::get($json, 'data.relationships.posts.data', []), 'id'));
+    }
+
+    #[Test]
+    public function guest_sees_only_public_visible_post_ids()
+    {
+        $this->assertSame([100, 104], $this->postIds());
+    }
+
+    #[Test]
+    public function author_sees_own_hidden_post_id_but_not_others()
+    {
+        $this->assertSame([100, 101, 104], $this->postIds(2));
+    }
+
+    #[Test]
+    public function other_user_sees_own_hidden_post_id_but_not_others()
+    {
+        $this->assertSame([100, 102, 104], $this->postIds(3));
+    }
+
+    #[Test]
+    public function admin_sees_hidden_post_ids_but_not_private_without_a_grant()
+    {
+        // No viewPrivate scoper grants access in core, so the private post
+        // stays out even for admins; hidden posts are visible via the
+        // discussion.hidePosts permission.
+        $this->assertSame([100, 101, 102, 104], $this->postIds(1));
+    }
+
+    #[Test]
+    public function private_post_id_appears_when_a_view_private_scoper_grants_it()
+    {
+        $this->extend(
+            (new Extend\ModelVisibility(Post::class))
+                ->scope(AllowAllPrivatePosts::class, 'viewPrivate')
+        );
+
+        $this->assertSame([100, 103, 104], $this->postIds());
+    }
+
+    #[Test]
+    public function extension_view_scopers_still_restrict_post_ids()
+    {
+        // Approval-style: an extension scoping the `view` ability must keep
+        // applying to the ID query (approval hides unapproved posts this way).
+        $this->extend(
+            (new Extend\ModelVisibility(Post::class))
+                ->scope(HideSecondCommentScoper::class, 'view')
+        );
+
+        $this->assertSame([100], $this->postIds());
+    }
+}
+
+class AllowAllPrivatePosts
+{
+    public function __invoke(User $actor, Builder $query): void
+    {
+        $query->orWhereNotNull('posts.id');
+    }
+}
+
+class HideSecondCommentScoper
+{
+    public function __invoke(User $actor, Builder $query): void
+    {
+        $query->where('posts.id', '!=', 104);
+    }
+}


### PR DESCRIPTION
Follow-up to #4862 — the server-side half of the discussion-view performance work.

## Changes proposed in this pull request

Every discussion view builds the post stream's ID index by running the full post visibility scope over **every post of the discussion**, embedding discussion-level access checks as per-row subqueries, then hydrating a full Eloquent model per row just to read its id. Both costs scale linearly with discussion size — the biggest, most-visited discussions were disproportionately slow.

By the time this query runs, the endpoint has already authorized the actor's access to the discussion (it 404s otherwise), so the discussion-level conditions are per-query constants:

- New `ScopesPostVisibilityWithinDiscussion` interface: a post visibility scoper may declare a fast path for "all posts belong to one already-authorized discussion". **Post-level restrictions must be preserved; only discussion-level conditions may be lifted out.** Scopers that don't implement it — approval, all third-party — are applied verbatim, per row, via the new `Post::whereVisibleToInDiscussion()` scope, which iterates the exact same scoper registry as `whereVisibleTo()`.
- Core's `ScopePostVisibility` fast path keeps the `is_private`/`viewPrivate` and hidden-post blocks in SQL, drops only the discussion-visible `EXISTS`, and evaluates the `hidePosts` moderation grant once via `$actor->can('hidePosts', $discussion)` — the same policy that governs the actual hide/restore actions.
- The `DiscussionResource` linkage skips Eloquent hydration (base-builder `pluck` mapped onto id-carrying `Post` stubs — the serializer needs only `instanceof` + `getKey()`), and gains an explicit `ORDER BY posts.number`: the frontend's stream index math always assumed stream order, but the old query never guaranteed any.

### Numbers (dev install, per view)

| Posts | Before | After |
|---|---|---|
| 10 | 1.9ms | 0.6ms |
| 100 | 2.5ms | 0.6ms |
| 500 | 5.4ms | 1.0ms |
| 1,443 | 13.3ms | 2.0ms |
| 30,000 | 238ms | 32ms |

Whole show request on a 30k-post discussion: **434ms → 235ms** (guest), **409ms → 244ms** (admin). Identical result sets at every size and actor. This query sits on the critical path of both parallel requests from #4862, so the gain lands directly on perceived click latency.

### Semantic note for reviewers

For a per-tag moderator in a discussion with mixed tags, the SQL scoper and the policy disagree on `hidePosts` in one edge case (the scoper requires the permission in *all* tags; the policy allows when every *restricted* tag grants it). Hidden-post visibility now follows the policy — which already governs whether they can actually hide/restore there — fixing "moderator hides a post, then can't see it in the stream".

The `@todo` on the linkage is reworded rather than removed: the query is now cheap, but huge discussions still ship the full ID list in the payload; dropping the linkage for a count + windowed fetches remains future work.

## Reviewers should focus on

- The interface contract in `ScopesPostVisibilityWithinDiscussion` and the scoper iteration in `Post::scopeWhereVisibleToInDiscussion()` (`*`-ability scopers included).
- `PostIdsVisibilityTest`: 6 characterization tests pinned **before** the refactor and green on both implementations — hidden-post matrix (guest/author/other/admin), `viewPrivate` grants, and an approval-style extension `view` scoper still restricting the ID list. Its `tearDown` also documents a real footgun: visibility scopers live in static model state and leak across tests.

## Confirmed

- [x] Backend changes: tests are green (run `composer test`).