### PR TITLE
[2.x] feat(core): allow to run migrations in isolation

### DIFF
--- a/framework/core/src/Console/AbstractCommand.php
+++ b/framework/core/src/Console/AbstractCommand.php
@@ -9,8 +9,11 @@
 
 namespace Flarum\Console;
 
+use Illuminate\Console\CommandMutex;
+use Illuminate\Contracts\Console\Isolatable;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,12 +22,55 @@ abstract class AbstractCommand extends Command
     protected InputInterface $input;
     protected OutputInterface $output;
 
+    protected int $isolatedExitCode = Command::SUCCESS;
+
+    public function __construct(?string $name = null)
+    {
+        parent::__construct($name);
+
+        if ($this instanceof Isolatable) {
+            $this->configureIsolation();
+        }
+    }
+
+    protected function configureIsolation(): void
+    {
+        $this->getDefinition()->addOption(new InputOption(
+            'isolated',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Do not run the command if another instance of the command is already running',
+            false
+        ));
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;
 
-        return $this->fire() ?: 0;
+        $isolated = $this instanceof Isolatable && $input->getOption('isolated') !== false;
+
+        if ($isolated && ! $this->commandIsolationMutex()->create($this)) {
+            $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
+
+            return (int) (is_numeric($input->getOption('isolated'))
+                ? $input->getOption('isolated')
+                : $this->isolatedExitCode);
+        }
+
+        try {
+            return $this->fire() ?: 0;
+        } finally {
+            if ($isolated) {
+                $this->commandIsolationMutex()->forget($this);
+            }
+        }
+    }
+
+    protected function commandIsolationMutex(): CommandMutex
+    {
+        return resolve(CommandMutex::class);
     }
 
     abstract protected function fire(): int;
@@ -37,6 +83,11 @@ abstract class AbstractCommand extends Command
     protected function info(string $message): void
     {
         $this->output->writeln("<info>$message</info>");
+    }
+
+    protected function comment(string $message): void
+    {
+        $this->output->writeln("<comment>$message</comment>");
     }
 
     /**

--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -21,6 +21,8 @@ use Flarum\Foundation\Console\CacheClearCommand;
 use Flarum\Foundation\Console\InfoCommand;
 use Flarum\User\Console\BackfillAvatarVariantsCommand;
 use Flarum\User\Console\ConvertAvatarsToWebpCommand;
+use Illuminate\Console\CacheCommandMutex;
+use Illuminate\Console\CommandMutex;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\CacheSchedulingMutex;
@@ -54,6 +56,10 @@ class ConsoleServiceProvider extends AbstractServiceProvider
         });
         $this->container->bind(SchedulingMutex::class, function ($container) {
             return new CacheSchedulingMutex($container->make(Factory::class));
+        });
+
+        $this->container->bind(CommandMutex::class, function ($container) {
+            return new CacheCommandMutex($container->make(Factory::class));
         });
 
         $this->container->singleton(LaravelSchedule::class, function (Container $container) {

--- a/framework/core/src/Database/Console/MigrateCommand.php
+++ b/framework/core/src/Database/Console/MigrateCommand.php
@@ -15,12 +15,13 @@ use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
 use Flarum\Foundation\Paths;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Builder;
 use Symfony\Component\Console\Command\Command;
 
-class MigrateCommand extends AbstractCommand
+class MigrateCommand extends AbstractCommand implements Isolatable
 {
     public function __construct(
         protected Container $container,

--- a/framework/core/tests/integration/console/MigrateCommandIsolationTest.php
+++ b/framework/core/tests/integration/console/MigrateCommandIsolationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use Illuminate\Console\CommandMutex;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class MigrateCommandIsolationTest extends ConsoleTestCase
+{
+    #[Test]
+    public function migrate_runs_normally_with_isolated_option()
+    {
+        $result = $this->runCommandWithStatus([
+            'command' => 'migrate',
+            '--isolated' => null,
+        ]);
+
+        $this->assertStringContainsString('Migrating Flarum...', $result['output']);
+        $this->assertStringContainsString('DONE.', $result['output']);
+        $this->assertEquals(Command::SUCCESS, $result['status']);
+    }
+
+    #[Test]
+    public function isolated_run_is_skipped_while_mutex_is_held()
+    {
+        $command = $this->migrateCommand();
+
+        $this->assertTrue($this->mutex()->create($command));
+
+        try {
+            $result = $this->runCommandWithStatus([
+                'command' => 'migrate',
+                '--isolated' => null,
+            ]);
+
+            $this->assertStringContainsString('The [migrate] command is already running.', $result['output']);
+            $this->assertStringNotContainsString('DONE.', $result['output']);
+
+            $this->assertEquals(Command::SUCCESS, $result['status']);
+        } finally {
+            $this->mutex()->forget($command);
+        }
+    }
+
+    #[Test]
+    public function isolated_exit_code_can_be_customized()
+    {
+        $command = $this->migrateCommand();
+
+        $this->assertTrue($this->mutex()->create($command));
+
+        try {
+            $result = $this->runCommandWithStatus([
+                'command' => 'migrate',
+                '--isolated' => '13',
+            ]);
+
+            $this->assertStringContainsString('The [migrate] command is already running.', $result['output']);
+            $this->assertEquals(13, $result['status']);
+        } finally {
+            $this->mutex()->forget($command);
+        }
+    }
+
+    #[Test]
+    public function mutex_is_released_after_an_isolated_run()
+    {
+        $first = $this->runCommandWithStatus([
+            'command' => 'migrate',
+            '--isolated' => null,
+        ]);
+        $second = $this->runCommandWithStatus([
+            'command' => 'migrate',
+            '--isolated' => null,
+        ]);
+
+        $this->assertStringContainsString('DONE.', $first['output']);
+        $this->assertStringContainsString('DONE.', $second['output']);
+    }
+
+    #[Test]
+    public function non_isolated_run_ignores_the_mutex()
+    {
+        $command = $this->migrateCommand();
+
+        $this->assertTrue($this->mutex()->create($command));
+
+        try {
+            $result = $this->runCommandWithStatus([
+                'command' => 'migrate',
+            ]);
+
+            $this->assertStringContainsString('DONE.', $result['output']);
+            $this->assertEquals(Command::SUCCESS, $result['status']);
+        } finally {
+            $this->mutex()->forget($command);
+        }
+    }
+
+    protected function runCommandWithStatus(array $inputArray): array
+    {
+        $output = new BufferedOutput();
+        $status = $this->console()->run(new ArrayInput($inputArray), $output);
+
+        return ['output' => trim($output->fetch()), 'status' => $status];
+    }
+
+    protected function mutex(): CommandMutex
+    {
+        return $this->app()->getContainer()->make(CommandMutex::class);
+    }
+
+    protected function migrateCommand(): Command
+    {
+        return $this->console()->find('migrate');
+    }
+}

--- a/php-packages/phpstan/extension.neon
+++ b/php-packages/phpstan/extension.neon
@@ -19,6 +19,11 @@ parameters:
     # Flarum provides a stub implementation in Flarum\Log\Context\Repository.
     - stubs/Illuminate/Log/Context/Repository.stub
 
+    # The command mutex only duck-types the command (getName() + method_exists
+    # checks), but its docblock demands an Illuminate command. Flarum's commands
+    # are Symfony commands, so we widen the parameter to the actual requirement.
+    - stubs/Illuminate/Console/CommandMutex.stub
+
     # We know for a fact the JsonApi object used internally is always the Flarum one.
     - stubs/Tobyz/JsonApiServer/JsonApi.stub
     - stubs/Tobyz/JsonApiServer/Context.stub

--- a/php-packages/phpstan/stubs/Illuminate/Console/CommandMutex.stub
+++ b/php-packages/phpstan/stubs/Illuminate/Console/CommandMutex.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Console;
+
+interface CommandMutex
+{
+    /**
+     * Attempt to obtain a command mutex for the given command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command  $command
+     * @return bool
+     */
+    public function create($command);
+
+    /**
+     * Determine if a command mutex exists for the given command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command  $command
+     * @return bool
+     */
+    public function exists($command);
+
+    /**
+     * Release the mutex for the given command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command  $command
+     * @return bool
+     */
+    public function forget($command);
+}


### PR DESCRIPTION
_Docs PR at https://github.com/flarum/docs/pull/566_
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
When Flarum is running in a multi container environment, it's possible that during startup (like during a deployment) multiple containers try to run new migrations at the same time. What can happen is that two containers are provisioned at nearly the identical time, both containers invoke Flarums Migrator and detect that there are new outstanding `up` migrations, one container successfully `up` migrates, the other container tries to up migrate the same new migrations, however will exit because e.g. a column already exists.

This becomes an issue in hosting environments like AWS ECS where a non successful exit code of just one single container means that the whole deployment gets rollbacked even though one container ran the new migration successfully. 

**Changes proposed in this pull request:**
* Allows commands to implement Laravels `Isolatable` interface to allow running them in isolation. 
* Implement this interface for the `MigrateCommand`

**Reviewers should focus on:**
As Flarum doesn't use Laravels Migrator, this PR (re) implements it similarly to how Laravel implements it. See more information about how Laravel does it at https://laravel.com/docs/13.x/migrations#isolating-migration-execution and https://laravel.com/docs/13.x/artisan#isolatable-commands

The new input option isn't used by default. However we can consider if we wanna pass this input in the `UpdateController` which invokes the `MigrateCommand`. From what I can tell there should be no negative side effects but technically it could be considered a breaking change which at this point may be undesired.

My recommendation tends to not use the new input for the migration command by default. The issue which this PR addresses only occurs in multi container environments where a vendor might already have a heavily customized setup where the migration command is run differently and can be changed to use the `--isolated` input

About the PHPStan Stub:
Laravel's `CommandMutex` docblock demands an `Illuminate\Console\Command`, but its implementation only duck-types the command (`getName()` and `method_exists` checks), so Flarum's Symfony-based commands are fully compatible at runtime.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
