### PR TITLE
[2.x] perf: load limited BelongsToMany includes in two narrow phases

### DIFF
--- a/extensions/mentions/tests/integration/api/ListPostsTest.php
+++ b/extensions/mentions/tests/integration/api/ListPostsTest.php
@@ -240,6 +240,48 @@ class ListPostsTest extends TestCase
     }
 
     #[Test]
+    public function mentioned_by_limit_applies_per_post_not_per_page()
+    {
+        $this->prepareMentionedByData();
+
+        // Make a second post heavily mentioned too: each post on the page must
+        // get its own window of maxMentionedBy, not share one global limit.
+        $this->database()->table('post_mentions_post')->insert([
+            ['post_id' => 105, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(20)],
+            ['post_id' => 106, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(21)],
+            ['post_id' => 107, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(22)],
+            ['post_id' => 108, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(23)],
+            ['post_id' => 109, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(24)],
+            ['post_id' => 110, 'mentions_post_id' => 102, 'created_at' => Carbon::parse('2024-05-04')->addMinutes(25)],
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', [
+                'authenticatedAs' => 2,
+            ])->withQueryParams([
+                'filter' => ['discussion' => 100],
+                'include' => 'mentionedBy',
+                'sort' => 'createdAt',
+            ])
+        );
+
+        $data = json_decode($body = $response->getBody()->getContents(), true)['data'];
+
+        $this->assertEquals(200, $response->getStatusCode(), $body);
+
+        $byId = collect($data)->keyBy('id');
+
+        $this->assertEquals(
+            [102, 104, 105, 106],
+            Arr::pluck($byId['101']['relationships']['mentionedBy']['data'], 'id')
+        );
+        $this->assertEquals(
+            [105, 106, 107, 108],
+            Arr::pluck($byId['102']['relationships']['mentionedBy']['data'], 'id')
+        );
+    }
+
+    #[Test]
     public function mentioned_by_count_only_includes_visible_posts_to_actor()
     {
         $this->prepareMentionedByData();

--- a/framework/core/src/Api/Resource/EloquentBuffer.php
+++ b/framework/core/src/Api/Resource/EloquentBuffer.php
@@ -130,7 +130,9 @@ abstract class EloquentBuffer
         }
 
         if (! $aggregate && $relationship) {
-            $collection->load([$relationName => $loader]);
+            if (! self::loadLimitedBelongsToMany($collection, $relationName, $loader)) {
+                $collection->load([$relationName => $loader]);
+            }
 
             // Set the inverse relation on the loaded relations.
             $collection->each(function (Model $model) use ($relationName, $relationship) {
@@ -152,6 +154,91 @@ abstract class EloquentBuffer
         } else {
             self::loadAggregate($collection, $relationName, $aggregate, $loader);
         }
+    }
+
+    /**
+     * Load a LIMITED BelongsToMany include (e.g. mentions' "first 4 mentioning
+     * posts per post") without dragging every candidate row through the
+     * database's window sort.
+     *
+     * Laravel compiles a limited eager load into `row_number() OVER
+     * (PARTITION BY ...)` over the relation's full select — every column of
+     * every candidate row (for posts: content blobs included) is materialized
+     * into the window just to keep a handful per parent. Instead, run the
+     * window over the KEYS alone, then fetch only the surviving rows in full.
+     * The related-resource scoping (typically visibility) applies to the
+     * narrow phase, so the kept ids are exactly the ones the one-phase query
+     * would have kept, in the same order.
+     *
+     * Returns false when this isn't a limited BelongsToMany, so the caller
+     * falls back to the plain eager load.
+     */
+    protected static function loadLimitedBelongsToMany(Collection $collection, string $relationName, callable $loader): bool
+    {
+        /** @var Model $parent */
+        $parent = $collection->first();
+
+        $relation = Relation::noConstraints(fn () => $parent->newModelInstance()->{$relationName}());
+
+        if (! $relation instanceof BelongsToMany) {
+            return false;
+        }
+
+        $relation->addEagerConstraints($collection->all());
+
+        // Applies resource scoping and the relationship's scope callback —
+        // including any limit — to the relation.
+        $loader($relation);
+
+        $query = $relation->getQuery();
+
+        // In eager context, a relationship scope's ->limit() lands on the
+        // base builder as groupLimit — the per-parent window — not limit.
+        if (! $query->getQuery()->groupLimit && ! $query->getQuery()->limit) {
+            return false;
+        }
+
+        // The eager loads belong to the full rows, not the key window.
+        $eagerLoads = $query->getEagerLoads();
+        $query->setEagerLoads([]);
+
+        $related = $relation->getRelated();
+        $relatedKeyName = $related->getKeyName();
+
+        // Narrow phase: only the related key survives our select; the pivot
+        // keys are appended automatically. getEager() applies the same
+        // windowed limit the one-phase load would.
+        $query->select($related->qualifyColumn($relatedKeyName));
+
+        $pivotKeyName = $relation->getForeignPivotKeyName();
+        $idsByParent = [];
+
+        foreach ($relation->getEager() as $row) {
+            $idsByParent[$row->getRelation('pivot')->getAttribute($pivotKeyName)][] = $row->getKey();
+        }
+
+        // Full phase: fetch the surviving rows only. Visibility was already
+        // decided when the ids were selected, so no re-scoping is needed —
+        // but the endpoint's nested eager loads are.
+        $ids = array_unique(array_merge(...array_values($idsByParent) ?: [[]]));
+
+        $rows = $ids
+            ? $related->newQuery()->setEagerLoads($eagerLoads)->whereIn($related->getQualifiedKeyName(), $ids)->get()->keyBy($relatedKeyName)
+            : collect();
+
+        foreach ($collection as $model) {
+            $models = [];
+
+            foreach ($idsByParent[$model->getKey()] ?? [] as $id) {
+                if ($rows->has($id)) {
+                    $models[] = $rows[$id];
+                }
+            }
+
+            $model->setRelation($relationName, $related->newCollection($models));
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Discussion-view performance arc, part 5 (#4862, #4863, #4865, #4866) — the last heavy query on a discussion view: the limited `mentionedBy` include window.

## Changes proposed in this pull request

Laravel compiles a limited eager load into `row_number() OVER (PARTITION BY …)` over the relation's **full select** — every column of every candidate row, content blobs included, is materialized through the window sort just to keep a few per parent. Mentions keeps 4 mentioning posts per post; on a post mentioned 1,403 times, that's 1,403 full-width post rows into a temp table to keep 4. Likes' per-post user window has the identical shape.

`EloquentBuffer` now loads limited `BelongsToMany` includes in two phases:

1. **Narrow window** — the same `groupLimit` window Laravel would run, but selecting only the related key (pivot keys are appended automatically). Resource scoping (visibility) applies here, so the surviving ids are exactly the ones the one-phase query would keep, in the same order.
2. **Full fetch** — one `whereIn` for the surviving rows only, carrying the endpoint's nested eager loads (`mentionedBy.user`, …).

Anything that isn't a limited `BelongsToMany` falls through to the previous path untouched. Implementation note for reviewers: in eager context, a relationship scope's `->limit()` lands on the base query builder as `groupLimit`, not `limit` — checking the wrong property makes the fast path silently never engage (caught by inspecting the live SQL, which is also the honest way to verify this PR does what it says).

### Numbers (dev install, post with 1,403 mentions)

- Window-query cost: median **9.3ms → 6.1ms** (−35%); the remainder is visibility-scoping the candidate rows inside the window, which is bounded work per candidate rather than per column.
- Response payloads byte-identical (verified live: same 4 include ids, same order).
- Combined with #4866, the two mention queries on a discussion view went from **5.5 + 9.3ms** to **1.75 + 6.1ms** on the worst post in the database.

A UNION-per-parent (or LATERAL) shape could collapse the window cost further via per-parent early termination, but needs dialect branching (MySQL 5.7 has no LATERAL) — left as a documented escalation if real-world profiles ever demand it.

## Reviewers should focus on

- `EloquentBuffer::loadLimitedBelongsToMany()`: the probe relation + `$loader` application, the `groupLimit`/`limit` detection, id grouping via pivot key, and empty-collection `setRelation` (prevents lazy reload).
- The new mentions test pinning that the limit partitions **per post, not per page** — two heavily-mentioned posts on one page each get their own window; this was the coverage gap a global-limit regression would have slipped through.
- Existing pins that carried the semantics: exact include ids in oldest-first order with invisible posts excluded, across show/list/default-include endpoints (mentions 82 — also green under a `flarum_` table prefix — likes 22, messages 12).

## Confirmed

- [x] Backend changes: tests are green (run `composer test`).