### PR TITLE
[2.x] feat: setting to force a FontAwesome icon style forum-wide

### DIFF
--- a/extensions/tags/js/src/common/helpers/tagIcon.js
+++ b/extensions/tags/js/src/common/helpers/tagIcon.js
@@ -1,10 +1,11 @@
 import classList from 'flarum/common/utils/classList';
+import Icon from 'flarum/common/components/Icon';
 
 export default function tagIcon(tag, attrs = {}, settings = {}) {
   const hasIcon = tag && tag.icon();
   const { useColor = true } = settings;
 
-  attrs.className = classList([attrs.className, 'icon text-colored', hasIcon ? tag.icon() : 'TagIcon']);
+  attrs.className = classList([attrs.className, 'text-colored', !hasIcon && 'icon TagIcon']);
 
   if (tag && useColor) {
     attrs.style = attrs.style || {};
@@ -13,5 +14,7 @@ export default function tagIcon(tag, attrs = {}, settings = {}) {
     attrs.className += ' untagged';
   }
 
-  return hasIcon ? <i {...attrs} /> : <span {...attrs} />;
+  // Render through the Icon component so global icon behavior (e.g. a forced
+  // FontAwesome style) applies to tag icons too. It adds the `icon` class.
+  return hasIcon ? <Icon name={tag.icon()} {...attrs} /> : <span {...attrs} />;
 }

--- a/framework/core/js/src/admin/components/AdvancedPage.tsx
+++ b/framework/core/js/src/admin/components/AdvancedPage.tsx
@@ -427,6 +427,16 @@ export default class AdvancedPage<CustomAttrs extends IPageAttrs = IPageAttrs> e
           </Form>
         )}
 
+        <Form>
+          {this.buildSettingComponent({
+            type: 'text',
+            setting: 'fontawesome_forced_style',
+            label: app.translator.trans('core.admin.advanced.fontawesome.forced_style_label'),
+            help: app.translator.trans('core.admin.advanced.fontawesome.forced_style_help'),
+            placeholder: 'fa-light',
+          })}
+        </Form>
+
         <Button className="Button" icon="fas fa-icons" onclick={() => app.modal.show(() => import('./FontAwesomePreviewModal'))}>
           {app.translator.trans('core.admin.advanced.fontawesome.preview.button')}
         </Button>

--- a/framework/core/js/src/common/components/Icon.tsx
+++ b/framework/core/js/src/common/components/Icon.tsx
@@ -1,19 +1,31 @@
 import Mithril from 'mithril';
+import app from '../app';
 import classList from '../utils/classList';
+import applyIconStyle from '../utils/applyIconStyle';
 import type { ComponentAttrs } from '../Component';
 import Component from '../Component';
 
 export interface IIconAttrs extends ComponentAttrs {
   /** The full icon class, prefix and the icon’s name. */
   name: string;
+  /**
+   * Escape hatch: keep the declared style even when the forum forces one.
+   * For icons whose meaning depends on their style — e.g. a solid vs regular
+   * star conveying "starred" state.
+   */
+  noStyleOverride?: boolean;
 }
 
 export default class Icon<CustomAttrs extends IIconAttrs = IIconAttrs> extends Component<CustomAttrs> {
   view(vnode: Mithril.Vnode<CustomAttrs, this>): Mithril.Children {
-    const { name, ...attrs } = vnode.attrs;
+    const { name, noStyleOverride, ...attrs } = vnode.attrs;
+
+    // Admins can force every icon to a particular FontAwesome style
+    // (e.g. `fa-duotone fa-light`); empty means icons render as declared.
+    const forcedStyle = noStyleOverride ? null : app?.forum?.attribute<string | null>('fontAwesomeForcedStyle');
 
     // @ts-ignore
-    attrs.className = classList('icon', name, attrs.className);
+    attrs.className = classList('icon', forcedStyle ? applyIconStyle(name, forcedStyle) : name, attrs.className);
 
     return <i aria-hidden="true" {...attrs} />;
   }

--- a/framework/core/js/src/common/utils/applyIconStyle.ts
+++ b/framework/core/js/src/common/utils/applyIconStyle.ts
@@ -1,0 +1,53 @@
+/**
+ * FontAwesome style classes, in both the short (`fas`) and long (`fa-solid`)
+ * syntax, plus the sharp modifier classes that pair with a style. This is a
+ * closed list on purpose: icon names (`fa-lightbulb`) and utility classes
+ * (`fa-fw`, `fa-spin`, `fa-2x`) also start with `fa-`, so anything
+ * pattern-based would mangle them.
+ */
+const STYLE_CLASSES = new Set([
+  'fa',
+  'fas',
+  'far',
+  'fal',
+  'fat',
+  'fad',
+  'fass',
+  'fasr',
+  'fasl',
+  'fast',
+  'fasds',
+  'fa-solid',
+  'fa-regular',
+  'fa-light',
+  'fa-thin',
+  'fa-duotone',
+  'fa-sharp',
+  'fa-sharp-duotone',
+]);
+
+const BRAND_CLASSES = new Set(['fab', 'fa-brands']);
+
+/**
+ * Rewrite the style classes of a FontAwesome icon class list to the given
+ * style, e.g. `fas fa-user` -> `fa-duotone fa-light fa-user`.
+ *
+ * Brand icons are never rewritten: their glyphs only exist in the brands
+ * family, so forcing a style would blank them. Everything that isn't a style
+ * class — the icon name and any utility classes — passes through untouched.
+ */
+export default function applyIconStyle(name: string | null | undefined, style: string): string | null | undefined {
+  // Some callers legitimately render an Icon without a name; never throw
+  // mid-render over it.
+  if (!style || typeof name !== 'string') return name;
+
+  const classes = name.split(/\s+/).filter(Boolean);
+
+  if (classes.some((cls) => BRAND_CLASSES.has(cls))) {
+    return name;
+  }
+
+  const kept = classes.filter((cls) => !STYLE_CLASSES.has(cls));
+
+  return `${style} ${kept.join(' ')}`.trim();
+}

--- a/framework/core/js/tests/integration/common/components/Icon.test.tsx
+++ b/framework/core/js/tests/integration/common/components/Icon.test.tsx
@@ -1,0 +1,49 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import app from '../../../../src/forum/app';
+import Icon from '../../../../src/common/components/Icon';
+import mq from 'mithril-query';
+
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+});
+
+describe('Icon', () => {
+  const render = (name: string) => mq(Icon as any, { name });
+
+  test('renders the given classes verbatim when no style is forced', () => {
+    // The default: setting absent/empty means zero behavior change.
+    expect(render('fas fa-user')).toHaveElement('i.icon.fas.fa-user');
+  });
+
+  test('rewrites the style when the forum forces one', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    try {
+      expect(render('fas fa-user')).toHaveElement('i.icon.fa-duotone.fa-light.fa-user');
+      expect(render('fa-solid fa-user')).toHaveElement('i.icon.fa-duotone.fa-light.fa-user');
+      // Brands stay untouched.
+      expect(render('fab fa-github')).toHaveElement('i.icon.fab.fa-github');
+    } finally {
+      app.forum.pushAttributes({ fontAwesomeForcedStyle: null });
+    }
+  });
+
+  test('noStyleOverride keeps the declared style despite a forced one', () => {
+    app.forum.pushAttributes({ fontAwesomeForcedStyle: 'fa-duotone fa-light' });
+
+    try {
+      const out = mq(Icon as any, { name: 'fas fa-user', noStyleOverride: true });
+
+      expect(out).toHaveElement('i.icon.fas.fa-user');
+      // The escape hatch is a component prop, not a DOM attribute.
+      expect(out).not.toHaveElement('i[nostyleoverride]');
+    } finally {
+      app.forum.pushAttributes({ fontAwesomeForcedStyle: null });
+    }
+  });
+
+  test('noStyleOverride is harmless when nothing is forced', () => {
+    expect(mq(Icon as any, { name: 'fas fa-user', noStyleOverride: true })).toHaveElement('i.icon.fas.fa-user');
+  });
+});

--- a/framework/core/js/tests/unit/common/utils/applyIconStyle.test.ts
+++ b/framework/core/js/tests/unit/common/utils/applyIconStyle.test.ts
@@ -1,0 +1,73 @@
+import applyIconStyle from '../../../../src/common/utils/applyIconStyle';
+
+/**
+ * applyIconStyle rewrites the STYLE classes of a FontAwesome icon class list
+ * to a forced variant, leaving the icon name, utility classes and brand
+ * icons untouched. It must recognize both the short (fas) and long
+ * (fa-solid) syntax for every family.
+ */
+describe('applyIconStyle', () => {
+  const style = 'fa-duotone fa-light';
+
+  test.each([
+    // Short syntax, all families
+    ['fas fa-user', 'fa-duotone fa-light fa-user'],
+    ['far fa-user', 'fa-duotone fa-light fa-user'],
+    ['fal fa-user', 'fa-duotone fa-light fa-user'],
+    ['fat fa-user', 'fa-duotone fa-light fa-user'],
+    ['fad fa-user', 'fa-duotone fa-light fa-user'],
+    // Long syntax, all families
+    ['fa-solid fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-regular fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-light fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-thin fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-duotone fa-user', 'fa-duotone fa-light fa-user'],
+    // FA4-style bare base class
+    ['fa fa-user', 'fa-duotone fa-light fa-user'],
+    // Sharp: short and compound long syntax replaced atomically
+    ['fass fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-sharp fa-solid fa-user', 'fa-duotone fa-light fa-user'],
+    ['fa-sharp-duotone fa-solid fa-user', 'fa-duotone fa-light fa-user'],
+    // Style position does not matter
+    ['fa-user fa-solid', 'fa-duotone fa-light fa-user'],
+  ])('rewrites the style: %s', (input, expected) => {
+    expect(applyIconStyle(input, style)).toBe(expected);
+  });
+
+  test.each([
+    // Brand icons never get restyled — the glyphs only exist in the brands family.
+    ['fab fa-github', 'fab fa-github'],
+    ['fa-brands fa-github', 'fa-brands fa-github'],
+  ])('leaves brands alone: %s', (input, expected) => {
+    expect(applyIconStyle(input, style)).toBe(expected);
+  });
+
+  test('icon names that resemble style classes are not touched', () => {
+    // fa-lightbulb contains "light"; fa-thin-line is a hypothetical name.
+    expect(applyIconStyle('fas fa-lightbulb', style)).toBe('fa-duotone fa-light fa-lightbulb');
+    expect(applyIconStyle('fa-solid fa-thumbs-up', style)).toBe('fa-duotone fa-light fa-thumbs-up');
+  });
+
+  test('utility classes pass through untouched', () => {
+    expect(applyIconStyle('fas fa-user fa-fw fa-spin fa-2x', style)).toBe('fa-duotone fa-light fa-user fa-fw fa-spin fa-2x');
+  });
+
+  test('a name with no style class gains the forced style', () => {
+    // Icons rendered with just a name rely on the css default; forcing makes
+    // the choice explicit.
+    expect(applyIconStyle('fa-user', style)).toBe('fa-duotone fa-light fa-user');
+  });
+
+  test('an empty style returns the name unchanged', () => {
+    expect(applyIconStyle('fas fa-user', '')).toBe('fas fa-user');
+  });
+
+  test('non-string names pass through instead of throwing mid-render', () => {
+    expect(applyIconStyle(undefined, style)).toBeUndefined();
+    expect(applyIconStyle(null, style)).toBeNull();
+  });
+
+  test('duplicate style classes collapse into one forced style', () => {
+    expect(applyIconStyle('fas fa-solid fa-user', style)).toBe('fa-duotone fa-light fa-user');
+  });
+});

--- a/framework/core/less/common/Input.less
+++ b/framework/core/less/common/Input.less
@@ -10,7 +10,12 @@
     width: 36px !important;
     font-size: 14px;
     text-align: center;
-    position: absolute;
+    // FA's duotone styles set position: relative on the icon element itself
+    // (for their two-layer rendering) and load after us at equal specificity,
+    // which would pop the icon out of the input into normal flow. Absolute
+    // positioning is fully compatible with the duotone layers — their ::after
+    // anchors to any non-static position.
+    position: absolute !important;
     pointer-events: none;
 
     // FontAwesome Kit overrides display which breaks vertical centering.

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -56,6 +56,8 @@ core:
         cdn_url_help: Full URL to the FontAwesome CSS file on a CDN
         kit_url_label: Kit URL
         kit_url_help: Your FontAwesome Kit script URL (from kit.fontawesome.com)
+        forced_style_label: Forced Icon Style
+        forced_style_help: "Force every icon to a particular FontAwesome style, e.g. \"fa-duotone fa-light\" or \"fa-regular\". Replaces the style declared by core and extensions (brand icons are never changed). The style must be available in your icon source — most styles require FontAwesome Pro. Leave empty to disable."
         config_override:
           label: Config Override
           help: FontAwesome settings are currently set in your config.php file and cannot be changed here.

--- a/framework/core/src/Api/Resource/ForumResource.php
+++ b/framework/core/src/Api/Resource/ForumResource.php
@@ -103,6 +103,10 @@ class ForumResource extends AbstractResource implements Findable
                 ->get(fn () => $this->settings->get('theme_secondary_color')),
             Schema\Str::make('colorScheme')
                 ->get(fn () => $this->settings->get('color_scheme')),
+            Schema\Str::make('fontAwesomeForcedStyle')
+                ->get(fn () => $this->settings->get('fontawesome_forced_style'))
+                // Only ship the attribute when the feature is actually on.
+                ->visible(fn () => (bool) $this->settings->get('fontawesome_forced_style')),
             Schema\Str::make('logoUrl')
                 ->get(fn () => $this->getLogoUrl()),
             Schema\Str::make('logoDarkModeUrl')

--- a/framework/core/src/Settings/SettingsServiceProvider.php
+++ b/framework/core/src/Settings/SettingsServiceProvider.php
@@ -26,6 +26,7 @@ class SettingsServiceProvider extends AbstractServiceProvider
                 'theme_secondary_color' => '#4D698E',
                 'mail_format' => 'multipart',
                 'fontawesome_source' => 'local',
+                'fontawesome_forced_style' => '',
                 'maintenance_mode' => 'none',
                 'show_language_selector' => true,
                 'slug_driver_Flarum\Discussion\Discussion' => 'default',


### PR DESCRIPTION
## Changes proposed in this pull request

Adds a **Forced Icon Style** setting (`fontawesome_forced_style`, default empty = zero behavior change) to the FontAwesome section of the admin Advanced page. When set — e.g. `fa-duotone fa-light`, or simply `fa-regular` — every icon rendered through the `Icon` component swaps its declared style classes for the configured one, giving forums with FontAwesome Pro a uniform icon style without forking extensions.

- **Recognition is a closed style-class list**, both syntaxes per family (`fas`/`fa-solid`, `far`/`fa-regular`, light/thin/duotone, the sharp variants, bare `fa`). Deliberately not pattern-based: icon names (`fa-lightbulb`) and utility classes (`fa-fw`, `fa-spin`, `fa-2x`) also start with `fa-` and pass through untouched.
- **Brand icons are never rewritten** — their glyphs only exist in the brands family; forcing a style would blank every GitHub/Discord icon.
- **`noStyleOverride` prop on `Icon`** is the per-icon escape hatch, for icons whose style *is* their meaning (the solid vs regular star conveying starred state). Stripped before the DOM spread, pinned by test.
- **The forum attribute only ships when the feature is on** (`visible()` guard), and non-string icon names pass through instead of throwing mid-render (an `Icon` without a name previously took down the whole mithril tree during live testing — now pinned).
- **tags' `tagIcon` helper renders through `Icon`** — previously it built `<i>` directly, so the tag sidebar (the most visible icon surface on most forums) bypassed the setting entirely.
- **`Input.less` fix found during live testing**: FA's duotone CSS sets `position: relative` on the icon element itself (for its two-glyph `::after` layering) and loads after our stylesheet at equal specificity — popping the search box's prefix icon out of the input into normal flow. Pinning `position: absolute !important` follows the exact pattern that block already documents for FA Kit's injected `width`/`display` styles, and duotone renders correctly on any non-static position.

The style must be available in the forum's configured icon source — most styles need FontAwesome Pro; the setting's help text says so.

## Reviewers should focus on

- The style-class list in `applyIconStyle.ts` (22 table-driven unit tests: every family in both syntaxes, sharp compounds replaced atomically, brands exemption, `fa-lightbulb`-style false positives, utility passthrough, duplicate-style collapse, non-string names).
- `Icon` component tests: set/unset behavior, brands, `noStyleOverride` (including that it doesn't leak as a DOM attribute).
- Verified live with `fa-duotone fa-light` and `fa-light`: 117/122 icons rewritten on the index page, brands intact, clean console, search box intact.

## Confirmed

- [x] Frontend changes: tests are green (`yarn jest`), typings check passes.
- [x] Backend changes: tests are green (run `composer test`).