### PR TITLE
[2.x] fix: complete the wide-screen breakpoints for the main layout

### DIFF
--- a/framework/core/less/common/root.less
+++ b/framework/core/less/common/root.less
@@ -175,6 +175,16 @@
 
 :root {
 
+  // Main container width per breakpoint band. Themes can retune each band
+  // (or pin them all to one value) without re-declaring media queries.
+  --container-hd:                  1200px;
+  --container-xl:                  1300px;
+  --container-xxl:                 1600px;
+
+  // Readability cap for the discussion post stream on wide screens: the
+  // container keeps growing, prose does not. See DiscussionPage.less.
+  --discussion-content-max-width:  1000px;
+
   --primary-color:                 @primary-color;
   --secondary-color:               @secondary-color;
 

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -63,8 +63,19 @@ p {
   @media @desktop {
     width: @screen-desktop;
   }
+  // The xl/xxl breakpoints exist since the extension list UI introduced them,
+  // but the container never used them: every screen wider than 1100px got the
+  // same fixed width, wasting half the viewport on modern displays. The widths
+  // are CSS custom properties (see root.less) so themes can retune each band
+  // without re-declaring the media queries.
   @media @desktop-hd {
-    width: @screen-desktop-hd;
+    width: var(--container-hd);
+  }
+  @media @desktop-xl {
+    width: var(--container-xl);
+  }
+  @media @desktop-xxl {
+    width: var(--container-xxl);
   }
 }
 

--- a/framework/core/less/forum/DiscussionPage.less
+++ b/framework/core/less/forum/DiscussionPage.less
@@ -69,3 +69,14 @@
     }
   }
 }
+
+// On the widest bands the container keeps growing but prose should not: long
+// text lines get hard to read. Cap the post stream and let the slack sit
+// between it and the scrubber sidebar (the container is row-reversed, so the
+// auto margin on the content's main-start side absorbs the slack).
+@media @desktop-xl {
+  .DiscussionPage .Page-content {
+    max-width: var(--discussion-content-max-width);
+    margin-right: auto;
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request

The `@desktop-xl` (≥1600px), `@desktop-xxl` (≥2000px) and `@desktop-xxxl` (≥3000px) breakpoints were introduced in #4066 — but only the extension-discover grid ever used them. The main `.container` still stops stepping at `@desktop-hd`: every screen wider than 1100px renders the same fixed 1100px column, leaving 40–55% of the viewport as dead margin on ordinary 1440–2560px displays.

This completes what #4066 started:

- **`.container` steps through the existing bands**: 1200px (hd), 1300px (xl), 1600px (xxl). Below 1100px nothing changes.
- **The desktop band widths are CSS custom properties** (`--container-hd` / `--container-xl` / `--container-xxl` in `root.less`), so themes retune any band from `:root` without re-declaring media queries — media queries can't read custom properties, but their width *values* can.
- **Wider container ≠ longer text lines**: from `@desktop-xl` up the discussion post stream is capped at `--discussion-content-max-width` (1000px), with the slack sitting between the prose and the scrubber sidebar. Without this, post text at a 1600px container reaches ~155 characters per line.

Measured (viewport → container / post text width): 1440 → 1200/830px · 1920 → 1300/895px · 2560 → 1600/895px (capped; previously 1100/730px fixed at every size).

## Reviewers should focus on

- The slack-absorption mechanics in `DiscussionPage.less`: the page container is row-reversed, so `margin-right: auto` on the content is the main-start auto margin that pushes prose flush-left with the whitespace before the scrubber.
- Visual pass at wide viewports: index, discussion, tags grid verified at 1280/1440/1920/2560; the fixed-position composer aligns to the container and deserves a check with a wide window.
- This is a visual change for every forum on screens ≥1100px, and custom LESS written against the fixed 1100px container exists in the wild — release-note-worthy either way.

Themer documentation: flarum/docs#567.

## Confirmed

- [x] Frontend changes: LESS only — verified live at four viewport widths with before/after measurements.

