### PR TITLE
[2.x] feat: fail integration tests that run N+1 queries (and fix the first one it found)

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -287,11 +287,42 @@ jobs:
           fi
         working-directory: ${{ inputs.backend_directory }}
         env:
+          FLARUM_REPEATED_QUERY_LOG: ${{ runner.temp }}/repeated-queries.jsonl
           DB_HOST: 127.0.0.1
           DB_PORT: ${{ (matrix.driver == 'mysql' && job.services.mysql.ports['3306']) || (matrix.driver == 'mariadb' && job.services.mariadb.ports['3306']) || (matrix.driver == 'pgsql' && job.services.postgres.ports['5432']) }}
           DB_PREFIX: ${{ matrix.prefix }}
           DB_DRIVER: ${{ matrix.driver }}
           COMPOSER_PROCESS_TIMEOUT: 600
+
+      # Surface the query findings on the pull request itself. A developer who
+      # only ever looks at the checks page would otherwise never see the
+      # warnings PHPUnit prints mid-log. Runs even when the tests fail, since a
+      # failing N+1 is exactly what we want to point at.
+      - name: Report repeated queries
+        if: ${{ !cancelled() }}
+        run: |
+          log="${{ runner.temp }}/repeated-queries.jsonl"
+
+          [ -s "$log" ] || exit 0
+
+          # One annotation per distinct finding; identical findings recur across
+          # tests, so collapse them first.
+          sort -u "$log" | while read -r finding; do
+            level=$(echo "$finding" | jq -r 'if .scaling then "error" else "warning" end')
+            title=$(echo "$finding" | jq -r 'if .scaling then "N+1 query" else "Repeated query" end')
+            echo "$finding" | jq -r --arg level "$level" --arg title "$title" \
+              '"::\($level) title=\($title)::\(.where) — \(.count) executions, \(.distinctBindings) distinct: \(.sql)"'
+          done
+
+          {
+            echo "### Query findings"
+            echo
+            echo "| | Where | Executions | Distinct | Query |"
+            echo "|---|---|---|---|---|"
+            sort -u "$log" | jq -r '"| \(if .scaling then "🛑 N+1" else "⚠️ repeated" end) | `\(.where)` | \(.count) | \(.distinctBindings) | `\(.sql | .[0:120])` |"'
+            echo
+            echo "🛑 grows with your data — fix it. ⚠️ repeats a few values — consider memoising."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   phpstan:
     runs-on: ${{ inputs.runner_type }}

--- a/extensions/akismet/tests/phpunit.integration.xml
+++ b/extensions/akismet/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/approval/tests/phpunit.integration.xml
+++ b/extensions/approval/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/audit/tests/phpunit.integration.xml
+++ b/extensions/audit/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/flags/src/Api/Resource/FlagResource.php
+++ b/extensions/flags/src/Api/Resource/FlagResource.php
@@ -96,6 +96,16 @@ class FlagResource extends AbstractDatabaseResource
             Endpoint\Index::make()
                 ->authenticated()
                 ->defaultInclude(['user', 'post', 'post.user', 'post.discussion'])
+                // The included discussions and users are serialized like any
+                // others, so they need the relations their own resources
+                // eager load: the actor's discussion state, and group
+                // memberships for permission checks. Without this each
+                // flag's discussion reads `discussion_user` on its own.
+                ->eagerLoad([
+                    'post.discussion.state',
+                    'post.user.groups',
+                    'user.groups',
+                ])
                 ->defaultSort('-createdAt')
                 ->paginate()
                 ->after(function (FlarumContext $context, $data) {

--- a/extensions/flags/tests/phpunit.integration.xml
+++ b/extensions/flags/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/gdpr/tests/phpunit.integration.xml
+++ b/extensions/gdpr/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/likes/tests/phpunit.integration.xml
+++ b/extensions/likes/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/lock/tests/phpunit.integration.xml
+++ b/extensions/lock/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/mentions/tests/phpunit.integration.xml
+++ b/extensions/mentions/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/messages/tests/phpunit.integration.xml
+++ b/extensions/messages/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/nicknames/tests/phpunit.integration.xml
+++ b/extensions/nicknames/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/package-manager/tests/phpunit.integration.xml
+++ b/extensions/package-manager/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/realtime/tests/phpunit.integration.xml
+++ b/extensions/realtime/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/statistics/tests/phpunit.integration.xml
+++ b/extensions/statistics/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/sticky/tests/phpunit.integration.xml
+++ b/extensions/sticky/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/subscriptions/tests/phpunit.integration.xml
+++ b/extensions/subscriptions/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/suspend/tests/phpunit.integration.xml
+++ b/extensions/suspend/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/extensions/tags/tests/phpunit.integration.xml
+++ b/extensions/tags/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/php-packages/testing/src/integration/RepeatedQueryDetector.php
+++ b/php-packages/testing/src/integration/RepeatedQueryDetector.php
@@ -118,6 +118,35 @@ class RepeatedQueryDetector
     }
 
     /**
+     * Record a finding for tooling to pick up after the run.
+     *
+     * PHPUnit's own warnings are per-test and easy to miss in a long log, so
+     * findings are also appended to a file when FLARUM_REPEATED_QUERY_LOG
+     * points at one. CI turns that into annotations and a run summary, which
+     * is what reaches a developer who only ever looks at the pull request.
+     *
+     * @param array<array{sql: string, count: int, distinctBindings: int}> $repeats
+     */
+    public static function log(string $where, array $repeats, bool $scaling): void
+    {
+        $path = getenv('FLARUM_REPEATED_QUERY_LOG');
+
+        if (! $path) {
+            return;
+        }
+
+        foreach ($repeats as $repeat) {
+            file_put_contents($path, json_encode([
+                'where' => $where,
+                'scaling' => $scaling,
+                'count' => $repeat['count'],
+                'distinctBindings' => $repeat['distinctBindings'],
+                'sql' => $repeat['sql'],
+            ])."\n", FILE_APPEND | LOCK_EX);
+        }
+    }
+
+    /**
      * @param array<array{sql: string, count: int, distinctBindings: int}> $repeats
      */
     public static function describe(array $repeats): string

--- a/php-packages/testing/src/integration/RepeatedQueryDetector.php
+++ b/php-packages/testing/src/integration/RepeatedQueryDetector.php
@@ -28,6 +28,24 @@ namespace Flarum\Testing\integration;
 class RepeatedQueryDetector
 {
     /**
+     * Does this repeated shape represent work that grows with the data?
+     *
+     * One query per record — the same SQL run once for each of many different
+     * values — is an N+1: add rows and you add queries. Repetitions of the
+     * same few values are merely wasteful: they don't multiply as a forum
+     * grows. Both are worth knowing about, but only the first is a defect that
+     * gets worse over time.
+     *
+     * @param array{count: int, distinctBindings: int} $repeat
+     */
+    public static function scalesWithData(array $repeat): bool
+    {
+        // Allow one duplicate: batch loaders and permission checks often fetch
+        // one value twice while still being per-record work.
+        return $repeat['distinctBindings'] >= $repeat['count'] - 1;
+    }
+
+    /**
      * @param array<array{query: string, bindings: array}> $queries
      * @param int $threshold Repetitions of one shape before it is reported.
      * @return array<array{sql: string, count: int, distinctBindings: int}>

--- a/php-packages/testing/src/integration/RepeatedQueryDetector.php
+++ b/php-packages/testing/src/integration/RepeatedQueryDetector.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Testing\integration;
+
+/**
+ * Spots N+1 query patterns in the queries a request ran.
+ *
+ * An N+1 is one query shape executed many times with different values — a
+ * relationship loaded per model, a permission check per row, a serializer
+ * callback hitting the database for each item. Grouping the query log by
+ * normalised SQL surfaces them: legitimate work uses a handful of distinct
+ * shapes, while an N+1 repeats one shape as many times as there are records.
+ *
+ * Bindings are counted, not folded into the shape. Two executions of the same
+ * SQL with the *same* bindings are usually memoisation the caller could have
+ * done, but they don't grow with the data; a shape repeated with *different*
+ * bindings is the real N+1 signal. Reporting them separately is what stops
+ * "the same SQL text appeared 4 times" from being mistaken for an N+1 when the
+ * queries were for four different users.
+ */
+class RepeatedQueryDetector
+{
+    /**
+     * @param array<array{query: string, bindings: array}> $queries
+     * @param int $threshold Repetitions of one shape before it is reported.
+     * @return array<array{sql: string, count: int, distinctBindings: int}>
+     */
+    public static function findRepeats(array $queries, int $threshold): array
+    {
+        $shapes = [];
+
+        foreach ($queries as $query) {
+            $sql = $query['query'] ?? '';
+
+            if ($sql === '' || ! self::isWorthCounting($sql)) {
+                continue;
+            }
+
+            $shape = self::normalise($sql);
+
+            if (! isset($shapes[$shape])) {
+                $shapes[$shape] = ['sql' => $sql, 'count' => 0, 'bindings' => []];
+            }
+
+            $shapes[$shape]['count']++;
+            $shapes[$shape]['bindings'][json_encode($query['bindings'] ?? [])] = true;
+        }
+
+        $repeats = [];
+
+        foreach ($shapes as $shape) {
+            if ($shape['count'] < $threshold) {
+                continue;
+            }
+
+            $repeats[] = [
+                'sql' => $shape['sql'],
+                'count' => $shape['count'],
+                'distinctBindings' => count($shape['bindings']),
+            ];
+        }
+
+        usort($repeats, fn ($a, $b) => $b['count'] <=> $a['count']);
+
+        return $repeats;
+    }
+
+    /**
+     * Reduce a query to its shape: values that vary between executions of the
+     * same code path are replaced, so `id in (1, 2, 3)` and `id in (4, 5)`
+     * count as one shape.
+     */
+    public static function normalise(string $sql): string
+    {
+        // Collapse IN lists (both placeholders and inlined values) first, so
+        // batched loads of different sizes are recognised as the same shape.
+        $sql = preg_replace('/\bin\s*\([^()]*\)/i', 'in (?)', $sql);
+
+        // Inlined numbers and quoted strings.
+        $sql = preg_replace('/\b\d+\b/', '?', $sql);
+        $sql = preg_replace("/'[^']*'/", '?', $sql);
+
+        return preg_replace('/\s+/', ' ', trim($sql));
+    }
+
+    /**
+     * Transactions, savepoints and the like are issued per test by the harness
+     * itself and say nothing about the code under test.
+     */
+    private static function isWorthCounting(string $sql): bool
+    {
+        return (bool) preg_match('/^\s*(select|insert|update|delete)\b/i', $sql);
+    }
+
+    /**
+     * @param array<array{sql: string, count: int, distinctBindings: int}> $repeats
+     */
+    public static function describe(array $repeats): string
+    {
+        $lines = [];
+
+        foreach ($repeats as $repeat) {
+            $lines[] = sprintf(
+                '  %dx (%d distinct bindings): %s',
+                $repeat['count'],
+                $repeat['distinctBindings'],
+                strlen($repeat['sql']) > 160 ? substr($repeat['sql'], 0, 160).'…' : $repeat['sql']
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/php-packages/testing/src/integration/RepeatedQueryDetector.php
+++ b/php-packages/testing/src/integration/RepeatedQueryDetector.php
@@ -118,6 +118,49 @@ class RepeatedQueryDetector
     }
 
     /**
+     * A pointer, appended to the first warning of a run, explaining how to see
+     * the detail.
+     *
+     * PHPUnit only prints warning messages when the phpunit config sets
+     * `displayDetailsOnTestsThatTriggerWarnings`; without it the run reports a
+     * bare count. Since that is the default in most extensions, the first
+     * warning has to carry its own instructions — and only the first, or it
+     * repeats on every finding.
+     *
+     * Tests usually run with `processIsolation`, so "first" cannot be tracked
+     * in memory: each test is a fresh process. A marker file next to the
+     * findings log gives one hint per run instead of one per process.
+     */
+    public static function hintOnce(): string
+    {
+        $hint = "\n\nRun with --display-warnings, or set"
+            ."\ndisplayDetailsOnTestsThatTriggerWarnings=\"true\" in your phpunit config, to see"
+            ."\nwhich queries these were.";
+
+        // Keyed to the project and to the hour, so every isolated test process
+        // in a run agrees on what "first" means without needing cleanup that a
+        // per-test process can't reliably perform. A later run gets a fresh
+        // hint; a run straddling the hour boundary may hint twice, which is a
+        // fair trade for not carrying state between processes.
+        $marker = sprintf(
+            '%s/flarum-repeated-queries-hinted-%s',
+            sys_get_temp_dir(),
+            md5((string) realpath('.').gmdate('YmdH'))
+        );
+
+        // `x` mode succeeds only for whoever gets there first.
+        $handle = @fopen($marker, 'x');
+
+        if ($handle === false) {
+            return '';
+        }
+
+        fclose($handle);
+
+        return $hint;
+    }
+
+    /**
      * Record a finding for tooling to pick up after the run.
      *
      * PHPUnit's own warnings are per-test and easy to miss in a long log, so

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -401,11 +401,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             fn (array $repeat) => ! RepeatedQueryDetector::scalesWithData($repeat)
         ));
 
+        RepeatedQueryDetector::log($where, $scaling, true);
+        RepeatedQueryDetector::log($where, $wasteful, false);
+
         if ($wasteful) {
             // Raised as a PHP warning: PHPUnit surfaces these against the test
             // that triggered them (with `displayDetailsOnTestsThatTriggerWarnings`
             // it prints the detail) without failing the run.
-            @trigger_error(sprintf(
+            trigger_error(sprintf(
                 "%s repeated queries for the same few values — consider memoising.\n%s",
                 $where,
                 RepeatedQueryDetector::describe($wasteful)

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -295,7 +295,110 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function send(ServerRequestInterface $request): ResponseInterface
     {
-        return $this->server()->handle($request);
+        if (! $this->detectsRepeatedQueries()) {
+            return $this->server()->handle($request);
+        }
+
+        $database = $this->database();
+        $wasLogging = $database->logging();
+
+        $database->flushQueryLog();
+        $database->enableQueryLog();
+
+        try {
+            $response = $this->server()->handle($request);
+        } finally {
+            $queries = $database->getQueryLog();
+
+            if (! $wasLogging) {
+                $database->disableQueryLog();
+            }
+        }
+
+        $this->reportRepeatedQueries($request, $queries);
+
+        return $response;
+    }
+
+    /**
+     * Whether requests sent through this test case are inspected for N+1 query
+     * patterns, failing the test when one is found.
+     *
+     * On by default: an N+1 is a defect, and finding it while writing the
+     * feature is far cheaper than finding it in production. Override in a test
+     * case that legitimately needs it off:
+     *
+     *     protected function detectsRepeatedQueries(): bool
+     *     {
+     *         return false; // and say why
+     *     }
+     *
+     * Prefer {@see allowedRepeatedQueries()} to exempt one known query shape
+     * rather than disabling the check for the whole test case. Setting
+     * FLARUM_DETECT_REPEATED_QUERIES=0 turns it off for a whole run, which is
+     * useful when bisecting an unrelated failure.
+     */
+    protected function detectsRepeatedQueries(): bool
+    {
+        $env = getenv('FLARUM_DETECT_REPEATED_QUERIES');
+
+        return $env === false || $env === '' ? true : (bool) filter_var($env, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Repetitions of one query shape tolerated before a request is reported.
+     * Small fixed-size loops (the actor, a couple of authors) are normal; an
+     * N+1 grows with the fixture, so it clears any sensible threshold.
+     */
+    protected function repeatedQueryThreshold(): int
+    {
+        return (int) (getenv('FLARUM_REPEATED_QUERY_THRESHOLD') ?: 5);
+    }
+
+    /**
+     * Query shapes this test case knowingly repeats, as substrings of the
+     * normalised SQL — e.g. `'from `sessions`'`. A shape matching any of these
+     * does not fail the test.
+     *
+     * Preferable to turning the check off wholesale: the rest of the request
+     * stays covered. Say why each entry is legitimate.
+     *
+     * @return string[]
+     */
+    protected function allowedRepeatedQueries(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<array{query: string, bindings: array}> $queries
+     */
+    private function reportRepeatedQueries(ServerRequestInterface $request, array $queries): void
+    {
+        $repeats = RepeatedQueryDetector::findRepeats($queries, $this->repeatedQueryThreshold());
+
+        foreach ($this->allowedRepeatedQueries() as $allowed) {
+            $repeats = array_values(array_filter(
+                $repeats,
+                fn (array $repeat) => ! str_contains(RepeatedQueryDetector::normalise($repeat['sql']), $allowed)
+            ));
+        }
+
+        if (! $repeats) {
+            return;
+        }
+
+        self::fail(sprintf(
+            "%s %s ran repeated queries — likely an N+1.\n\n%s\n\n"
+            ."A query shape repeated with different bindings is usually a relationship, permission check or\n"
+            ."serialized field resolved per model; load it for the whole page instead (eager loading, a\n"
+            ."batched relation, or a single grouped query). If the repetition is legitimate, list the shape\n"
+            ."in %s::allowedRepeatedQueries() with a comment saying why.",
+            $request->getMethod(),
+            (string) $request->getUri()->getPath(),
+            RepeatedQueryDetector::describe($repeats),
+            static::class
+        ));
     }
 
     /**

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -388,17 +388,42 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             return;
         }
 
-        self::fail(sprintf(
-            "%s %s ran repeated queries — likely an N+1.\n\n%s\n\n"
-            ."A query shape repeated with different bindings is usually a relationship, permission check or\n"
-            ."serialized field resolved per model; load it for the whole page instead (eager loading, a\n"
-            ."batched relation, or a single grouped query). If the repetition is legitimate, list the shape\n"
-            .'in %s::allowedRepeatedQueries() with a comment saying why.',
-            $request->getMethod(),
-            (string) $request->getUri()->getPath(),
-            RepeatedQueryDetector::describe($repeats),
-            static::class
+        $where = $request->getMethod().' '.$request->getUri()->getPath();
+
+        // Work that grows with the data is a defect: one query per record
+        // means a forum with a thousand records runs a thousand queries.
+        $scaling = array_values(array_filter($repeats, RepeatedQueryDetector::scalesWithData(...)));
+
+        // The rest repeat a handful of values: wasteful, but it does not
+        // multiply as a forum grows. Worth knowing, not worth failing over.
+        $wasteful = array_values(array_filter(
+            $repeats,
+            fn (array $repeat) => ! RepeatedQueryDetector::scalesWithData($repeat)
         ));
+
+        if ($wasteful) {
+            // Raised as a PHP warning: PHPUnit surfaces these against the test
+            // that triggered them (with `displayDetailsOnTestsThatTriggerWarnings`
+            // it prints the detail) without failing the run.
+            @trigger_error(sprintf(
+                "%s repeated queries for the same few values — consider memoising.\n%s",
+                $where,
+                RepeatedQueryDetector::describe($wasteful)
+            ), E_USER_WARNING);
+        }
+
+        if ($scaling) {
+            self::fail(sprintf(
+                "%s ran one query per record — an N+1.\n\n%s\n\n"
+                ."This is usually a relationship, permission check or serialized field resolved per model.\n"
+                ."Load it for the whole page instead: eager loading, a batched relation, or one grouped\n"
+                ."query. If the repetition is unavoidable, list the shape in\n"
+                .'%s::allowedRepeatedQueries() with a comment saying why.',
+                $where,
+                RepeatedQueryDetector::describe($scaling),
+                static::class
+            ));
+        }
     }
 
     /**

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -393,7 +393,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             ."A query shape repeated with different bindings is usually a relationship, permission check or\n"
             ."serialized field resolved per model; load it for the whole page instead (eager loading, a\n"
             ."batched relation, or a single grouped query). If the repetition is legitimate, list the shape\n"
-            ."in %s::allowedRepeatedQueries() with a comment saying why.",
+            .'in %s::allowedRepeatedQueries() with a comment saying why.',
             $request->getMethod(),
             (string) $request->getUri()->getPath(),
             RepeatedQueryDetector::describe($repeats),

--- a/php-packages/testing/src/integration/TestCase.php
+++ b/php-packages/testing/src/integration/TestCase.php
@@ -408,10 +408,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             // Raised as a PHP warning: PHPUnit surfaces these against the test
             // that triggered them (with `displayDetailsOnTestsThatTriggerWarnings`
             // it prints the detail) without failing the run.
+            //
+            // Without that setting PHPUnit reports only a count — "Warnings: 11"
+            // — so the first warning of the run says how to see the rest.
+            // Otherwise the default experience is a number with no next step.
             trigger_error(sprintf(
-                "%s repeated queries for the same few values — consider memoising.\n%s",
+                "%s repeated queries for the same few values — consider memoising.\n%s%s",
                 $where,
-                RepeatedQueryDetector::describe($wasteful)
+                RepeatedQueryDetector::describe($wasteful),
+                RepeatedQueryDetector::hintOnce()
             ), E_USER_WARNING);
         }
 

--- a/php-packages/testing/tests/tests/phpunit.integration.xml
+++ b/php-packages/testing/tests/tests/phpunit.integration.xml
@@ -5,6 +5,7 @@
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"

--- a/php-packages/testing/tests/tests/unit/RepeatedQueryDetectorTest.php
+++ b/php-packages/testing/tests/tests/unit/RepeatedQueryDetectorTest.php
@@ -141,6 +141,28 @@ class RepeatedQueryDetectorTest extends TestCase
     }
 
     #[Test]
+    public function one_query_per_record_scales_with_the_data()
+    {
+        // The N+1 signature: as many distinct values as executions. Add rows,
+        // add queries — this is the defect that gets worse as a forum grows.
+        $this->assertTrue(RepeatedQueryDetector::scalesWithData(['count' => 10, 'distinctBindings' => 10]));
+
+        // One duplicate is tolerated: batch loaders and permission checks
+        // often re-read a single value while still being per-record work.
+        $this->assertTrue(RepeatedQueryDetector::scalesWithData(['count' => 10, 'distinctBindings' => 9]));
+    }
+
+    #[Test]
+    public function repeating_a_handful_of_values_does_not_scale_with_the_data()
+    {
+        // Wasteful, but bounded: five queries for two users stays five queries
+        // whether the forum has two users or two million.
+        $this->assertFalse(RepeatedQueryDetector::scalesWithData(['count' => 5, 'distinctBindings' => 2]));
+        $this->assertFalse(RepeatedQueryDetector::scalesWithData(['count' => 8, 'distinctBindings' => 4]));
+        $this->assertFalse(RepeatedQueryDetector::scalesWithData(['count' => 6, 'distinctBindings' => 1]));
+    }
+
+    #[Test]
     public function the_description_names_counts_and_binding_diversity()
     {
         $description = RepeatedQueryDetector::describe([

--- a/php-packages/testing/tests/tests/unit/RepeatedQueryDetectorTest.php
+++ b/php-packages/testing/tests/tests/unit/RepeatedQueryDetectorTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Testing\Tests\unit;
+
+use Flarum\Testing\integration\RepeatedQueryDetector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class RepeatedQueryDetectorTest extends TestCase
+{
+    /**
+     * @param array<array{0: string, 1: array}> $queries
+     */
+    private function log(array $queries): array
+    {
+        return array_map(fn ($q) => ['query' => $q[0], 'bindings' => $q[1]], $queries);
+    }
+
+    #[Test]
+    public function a_relationship_loaded_per_model_is_reported()
+    {
+        // The shape of a real N+1: one query per record, different binding
+        // each time. (Taken from a post listing loading each post's warnings.)
+        $queries = [];
+
+        for ($id = 100; $id < 110; $id++) {
+            $queries[] = ['select * from `warnings` where `warnings`.`post_id` = ?', [$id]];
+        }
+
+        $repeats = RepeatedQueryDetector::findRepeats($this->log($queries), 5);
+
+        $this->assertCount(1, $repeats);
+        $this->assertSame(10, $repeats[0]['count']);
+        $this->assertSame(10, $repeats[0]['distinctBindings']);
+    }
+
+    #[Test]
+    public function batched_loads_of_differing_sizes_are_one_shape_not_an_n_plus_one()
+    {
+        // Eager loading emits `in (...)` lists of whatever length; those are
+        // the fix for an N+1, not an instance of one.
+        $repeats = RepeatedQueryDetector::findRepeats($this->log([
+            ['select * from `users` where `users`.`id` in (1, 2, 3)', []],
+            ['select * from `users` where `users`.`id` in (4, 5)', []],
+        ]), 5);
+
+        $this->assertSame([], $repeats);
+    }
+
+    #[Test]
+    public function a_handful_of_distinct_queries_is_not_reported()
+    {
+        $repeats = RepeatedQueryDetector::findRepeats($this->log([
+            ['select * from `discussions` where `id` = ?', [1]],
+            ['select * from `posts` where `discussion_id` = ?', [1]],
+            ['select * from `users` where `id` in (?, ?)', [1, 2]],
+        ]), 5);
+
+        $this->assertSame([], $repeats);
+    }
+
+    #[Test]
+    public function repeats_below_the_threshold_are_left_alone()
+    {
+        // Small fixed-size loops are everywhere in a request (the actor, a
+        // couple of authors) and must not be flagged.
+        $queries = [];
+
+        for ($id = 1; $id <= 4; $id++) {
+            $queries[] = ['select * from `groups` where `user_id` = ?', [$id]];
+        }
+
+        $this->assertSame([], RepeatedQueryDetector::findRepeats($this->log($queries), 5));
+    }
+
+    #[Test]
+    public function the_same_query_with_the_same_bindings_is_distinguished_from_an_n_plus_one()
+    {
+        // A missed memoisation: the same rows fetched repeatedly. Worth
+        // reporting, but the binding count tells the reader it does NOT grow
+        // with the data — the distinction that stops false N+1 diagnoses.
+        $queries = array_fill(0, 6, ['select * from `settings` where `key` = ?', ['foo']]);
+
+        $repeats = RepeatedQueryDetector::findRepeats($this->log($queries), 5);
+
+        $this->assertCount(1, $repeats);
+        $this->assertSame(6, $repeats[0]['count']);
+        $this->assertSame(1, $repeats[0]['distinctBindings']);
+    }
+
+    #[Test]
+    public function harness_transactions_are_ignored()
+    {
+        $queries = array_fill(0, 10, ['SAVEPOINT trans1', []]);
+        $queries[] = ['BEGIN', []];
+
+        $this->assertSame([], RepeatedQueryDetector::findRepeats($this->log($queries), 5));
+    }
+
+    #[Test]
+    public function inlined_values_normalise_to_the_same_shape_as_placeholders()
+    {
+        // Some code paths inline values instead of binding them; they are the
+        // same shape and must count together.
+        $repeats = RepeatedQueryDetector::findRepeats($this->log([
+            ['select * from `posts` where `id` = 1', []],
+            ['select * from `posts` where `id` = 2', []],
+            ['select * from `posts` where `id` = ?', [3]],
+            ['select * from `posts` where `id` = ?', [4]],
+            ['select * from `posts` where `id` = ?', [5]],
+        ]), 5);
+
+        $this->assertCount(1, $repeats);
+        $this->assertSame(5, $repeats[0]['count']);
+    }
+
+    #[Test]
+    public function the_worst_offender_is_reported_first()
+    {
+        $queries = [];
+
+        for ($i = 0; $i < 6; $i++) {
+            $queries[] = ['select * from `flags` where `post_id` = ?', [$i]];
+        }
+        for ($i = 0; $i < 12; $i++) {
+            $queries[] = ['select * from `warnings` where `post_id` = ?', [$i]];
+        }
+
+        $repeats = RepeatedQueryDetector::findRepeats($this->log($queries), 5);
+
+        $this->assertCount(2, $repeats);
+        $this->assertStringContainsString('warnings', $repeats[0]['sql']);
+        $this->assertSame(12, $repeats[0]['count']);
+    }
+
+    #[Test]
+    public function the_description_names_counts_and_binding_diversity()
+    {
+        $description = RepeatedQueryDetector::describe([
+            ['sql' => 'select * from `warnings` where `post_id` = ?', 'count' => 10, 'distinctBindings' => 10],
+        ]);
+
+        $this->assertStringContainsString('10x', $description);
+        $this->assertStringContainsString('10 distinct bindings', $description);
+        $this->assertStringContainsString('warnings', $description);
+    }
+}


### PR DESCRIPTION
## Changes proposed in this pull request

Every request sent through `Flarum\Testing\integration\TestCase::send()` is now inspected for N+1 query patterns, and **the test fails when one is found**.

The motivation is concrete: while profiling discussion-view performance this week, one extension turned out to be issuing a query *per post* on every page of every discussion, and another declared default includes that were never eager-loaded. Both were found by hand-profiling a live forum — no test noticed, because no test could. Extension authors should get that feedback while writing the feature.

**And it immediately proved the point.** On this PR's first CI run the detector failed two tests in `flarum/flags` — a bundled extension nobody had profiled, whose suite was green. `GET /api/flags` declares `post.discussion` and `post.user` as default includes but never eager-loaded what those nested resources need: core's `DiscussionResource` eager-loads the actor's discussion state on *its own* endpoints, and that doesn't carry over when a discussion is included by another resource. So every flag on the moderation page read `discussion_user` on its own, and the flag authors' groups were re-fetched per flag. That fix is included here (`FlagResource`), because a detector that lands with a known finding allow-listed on day one teaches the wrong lesson.

**How it detects.** An N+1 is one query shape executed once per record. `RepeatedQueryDetector` groups a request's query log by normalised SQL (IN lists collapsed so batched loads of differing sizes count as one shape, numeric and quoted literals replaced, transaction/savepoint noise skipped) and fails when a shape repeats past a threshold (default 5).

**Two tiers, decided by whether the work grows with the data.** Bindings are counted rather than folded into the shape, and that count is what separates a defect from mere waste:

| Signature | Meaning | Result |
|---|---|---|
| distinct bindings ≈ executions (`10x`, 10 distinct) | one query per record — add rows, add queries | **fails** |
| a few values repeated (`8x`, 1 distinct) | wasteful but bounded; five queries for two users stays five at two million | **warns** |

The warning is a `E_USER_WARNING`, which PHPUnit attributes to the triggering test — the author sees it without the build going red.

**Making the warnings actually visible.** As first written the warning tier was invisible three times over: the `trigger_error` call was `@`-silenced so PHPUnit never saw it, only one of eighteen phpunit configs in this repo enabled `displayDetailsOnTestsThatTriggerWarnings`, and a developer who relies on CI would have had to read the middle of a job log regardless. Fixed here: the `@` is gone, every integration config displays warning details, and the detector appends findings to `FLARUM_REPEATED_QUERY_LOG` when set. The reusable backend workflow points that at a temp file and turns it into **GitHub annotations** (errors for N+1s, warnings for non-scaling repetition) plus a **table in the run summary** — so findings land on the pull request itself, where the CI-only audience is looking.

This calibration came from running the detector across every bundled extension: beyond the flags N+1 it produced 22 further findings, and all of them were the second kind (5–10 executions, 1–4 distinct values), mostly on post-save paths where a formatter resolves each mention. Failing on those would have meant rewriting formatter and write-path code for no scaling benefit — the threshold was what was wrong, not the extensions. `mentions` (19 findings) and `subscriptions` (1) now pass with warnings; the flags N+1 still fails.

**On by default**, with graduated escapes:

| Escape | Scope | When |
|---|---|---|
| `allowedRepeatedQueries()` | one query shape | Preferred — rest of the request stays covered |
| `detectsRepeatedQueries()` | one test case | A test that legitimately can't satisfy it |
| `FLARUM_DETECT_REPEATED_QUERIES=0` | whole run | Bisecting an unrelated failure |

## Verification

- **11 unit tests** on the detector: the real N+1 shape, batched `in (…)` loads of differing sizes (must not flag), sub-threshold loops, same-bindings repetition, transaction noise, inlined vs bound literals, ordering, and the message format.
- **Against a real N+1**: reintroducing the per-post loading in fof/moderator-warnings fails with `10x (10 distinct bindings): select * from `warnings` where `warnings`.`post_id` = ?`. With the fix restored, that extension's whole suite passes with detection on.
- **Against core**: `tests/integration/api` gives **identical results with detection on and off** — 353 tests, the same pre-existing failures, zero findings.
- **flags**: 16 tests green with detection on, after the `FlagResource` fix (was 2 failures).
- **Bundled extensions**: flags, mentions, subscriptions and approval all pass with detection on. `tags` (5) and `likes` (1) have pre-existing failures unrelated to queries — identical with `FLARUM_DETECT_REPEATED_QUERIES=0`.

## Reviewers should focus on

- The threshold (5) and whether the normalisation is too aggressive or not aggressive enough for query shapes I haven't seen.
- The `distinctBindings >= count - 1` rule that decides fail vs warn (one duplicate is tolerated, since batch loaders often re-read a single value while still doing per-record work), and whether that boundary holds for shapes I haven't seen.
- Implementation note worth knowing: `processIsolation="true"` makes PHPUnit parse a subprocess's entire output as its result protocol, so printing findings — STDOUT, STDERR, `/dev/tty`, shutdown functions — all surface as test *errors*. Failing the assertion is the only channel PHPUnit sanctions here.

Developer documentation: flarum/docs#568.

## Confirmed

- [x] Backend changes: tests are green (run `composer test`).
