### PR TITLE
[2.x] fix: keep icons whose style carries meaning out of the forced style

### DIFF
--- a/extensions/subscriptions/js/src/forum/addSubscriptionControls.js
+++ b/extensions/subscriptions/js/src/forum/addSubscriptionControls.js
@@ -1,6 +1,7 @@
 import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 import Button from 'flarum/common/components/Button';
+import Icon from 'flarum/common/components/Icon';
 import DiscussionPage from 'flarum/forum/components/DiscussionPage';
 import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 
@@ -10,8 +11,16 @@ export default function addSubscriptionControls() {
   extend(DiscussionControls, 'userControls', function (items, discussion, context) {
     if (app.session.user && !(context instanceof DiscussionPage)) {
       const states = {
-        none: { label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.follow_button'), icon: 'fas fa-star', save: 'follow' },
-        follow: { label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unfollow_button'), icon: 'far fa-star', save: null },
+        none: {
+          label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.follow_button'),
+          icon: <Icon name="fa-solid fa-star" className="Button-icon" noStyleOverride />,
+          save: 'follow',
+        },
+        follow: {
+          label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unfollow_button'),
+          icon: <Icon name="fa-regular fa-star" className="Button-icon" noStyleOverride />,
+          save: null,
+        },
         ignore: { label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unignore_button'), icon: 'fas fa-eye', save: null },
       };
 

--- a/extensions/subscriptions/js/src/forum/components/SubscriptionMenu.tsx
+++ b/extensions/subscriptions/js/src/forum/components/SubscriptionMenu.tsx
@@ -4,6 +4,7 @@ import Button from 'flarum/common/components/Button';
 import extractText from 'flarum/common/utils/extractText';
 import DetailedDropdownItem from 'flarum/common/components/DetailedDropdownItem';
 import SplitDropdown from 'flarum/common/components/SplitDropdown';
+import Icon from 'flarum/common/components/Icon';
 import type Discussion from 'flarum/common/models/Discussion';
 
 export interface ISubscriptionMenuAttrs extends IDropdownAttrs {
@@ -14,13 +15,13 @@ export default class SubscriptionMenu<CustomAttrs extends ISubscriptionMenuAttrs
   private options: any[] = [
     {
       subscription: null,
-      icon: 'far fa-star',
+      icon: <Icon name="fa-regular fa-star" className="Button-icon" noStyleOverride />,
       label: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_button'),
       description: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_text'),
     },
     {
       subscription: 'follow',
-      icon: 'fas fa-star',
+      icon: <Icon name="fa-solid fa-star" className="Button-icon" noStyleOverride />,
       label: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_button'),
       description: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_text'),
     },
@@ -34,11 +35,11 @@ export default class SubscriptionMenu<CustomAttrs extends ISubscriptionMenuAttrs
 
   private possibleButtonAttrs: any = {
     null: {
-      icon: 'far fa-star',
+      icon: <Icon name="fa-regular fa-star" className="Button-icon" noStyleOverride />,
       label: app.translator.trans('flarum-subscriptions.forum.sub_controls.follow_button'),
     },
     follow: {
-      icon: 'fas fa-star',
+      icon: <Icon name="fa-solid fa-star" className="Button-icon" noStyleOverride />,
       label: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_button'),
     },
     ignore: {

--- a/framework/core/js/src/common/components/DetailedDropdownItem.tsx
+++ b/framework/core/js/src/common/components/DetailedDropdownItem.tsx
@@ -1,11 +1,17 @@
+import type Mithril from 'mithril';
+
 import Component from '../Component';
 import type { ComponentAttrs } from '../Component';
 
 import Icon from './Icon';
 
 export interface IDetailedDropdownItemAttrs extends ComponentAttrs {
-  /** The name of an icon to show in the dropdown item. */
-  icon: string;
+  /**
+   * The name of an icon to show in the dropdown item, or a rendered icon —
+   * which lets the caller pass attributes of its own, e.g. `noStyleOverride`
+   * for an icon whose style carries meaning.
+   */
+  icon: string | Mithril.Children;
   /** The label of the dropdown item. */
   label: string;
   /** The description of the item. */
@@ -24,7 +30,7 @@ export default class DetailedDropdownItem<
       <button type="button" className="DetailedDropdownItem hasIcon" onclick={this.attrs.onclick}>
         <span className="DetailedDropdownItem-checkIcon">{this.attrs.active && <Icon name="fas fa-check" className="Button-icon" />}</span>
         <span className="DetailedDropdownItem-content">
-          <Icon name={this.attrs.icon} className="Button-icon" />
+          {typeof this.attrs.icon === 'string' ? <Icon name={this.attrs.icon} className="Button-icon" /> : this.attrs.icon}
           <span className="DetailedDropdownItem-label">
             <strong>{this.attrs.label}</strong>
             <span className="DetailedDropdownItem-description">{this.attrs.description}</span>

--- a/framework/core/js/src/common/helpers/userOnline.tsx
+++ b/framework/core/js/src/common/helpers/userOnline.tsx
@@ -9,7 +9,7 @@ export default function userOnline(user: User): Mithril.Vnode<{}, {}> | null {
   if (user.lastSeenAt() && user.isOnline()) {
     return (
       <span className="UserOnline">
-        <Icon name={'fas fa-circle'} />
+        <Icon name={'fa-solid fa-circle'} noStyleOverride />
       </span>
     );
   }

--- a/framework/core/js/src/forum/components/UserCard.js
+++ b/framework/core/js/src/forum/components/UserCard.js
@@ -102,7 +102,9 @@ export default class UserCard extends Component {
         'lastSeen',
         <span className={classList('UserCard-lastSeen', { online })}>
           {online
-            ? [<Icon name={'fas fa-circle'} />, ' ', app.translator.trans('core.forum.user.online_text')]
+            ? // A filled dot is the "online" signal; a forced light or duotone
+              // style would render it as a thin ring instead.
+              [<Icon name={'fa-solid fa-circle'} noStyleOverride />, ' ', app.translator.trans('core.forum.user.online_text')]
             : [<Icon name={'far fa-clock'} />, ' ', humanTime(lastSeenAt)]}
         </span>,
         100


### PR DESCRIPTION
Follow-up to #4868, which added the forced FontAwesome style setting along with a `noStyleOverride` escape hatch for icons that shouldn't be restyled. This applies that hatch where it's actually needed.

## Changes proposed in this pull request

An admin who forces a style is asking for uniform icons — but a few icons use their **weight** to convey state, and flattening those loses information rather than restyling it:

| Icon | What forcing a style does |
|---|---|
| Online indicator (`fa-solid fa-circle`) | A filled dot becomes a thin ring under `fa-light`/`fa-duotone`; "online" stops reading as online |
| Subscription star (`fa-regular` vs `fa-solid fa-star`) | **Following and not-following render identically** — the user can no longer tell which state they're in |

Fixed by opting those out:

- `common/helpers/userOnline` and `forum/components/UserCard` — the online dot (two separate copies of it).
- subscriptions' `SubscriptionMenu` (menu rows and the split-button) and `addSubscriptionControls` (the discussion controls item).

`DetailedDropdownItem` needed a small widening to make this possible: it typed `icon` as `string` and wrapped it in `<Icon>` itself, so there was no way to pass an attribute through. It now accepts `string | Mithril.Children` and renders a passed element as-is — the same contract `Button` already offers.

## What was deliberately left alone

I swept core and the bundled extensions for state-carrying icons. Pairs that use **distinct glyphs** rather than weights restyle perfectly safely and are untouched — tags' `ToggleButton` (`fa-check-circle` vs `fa-circle`), package-manager's `fa-check-circle`/`fa-circle-down`, likes' thumbs (decorative, single-state), and subscriptions' notification/filter icons (single-state labels).

## Verification

Live on a forum with `fa-duotone fa-light` forced: the stars keep their own weights in the DOM (`icon fa-regular fa-star` alongside `icon fa-solid fa-star`), so the follow state stays legible while every other icon takes the forced style. Core's JS suite (294 tests) passes, typings check clean in both packages, subscriptions builds.

Worth stating plainly: this is a limitation inherent to the feature, not a defect in it. Any icon whose weight is semantic needs the opt-out, so if reviewers know of others I've missed, they're one prop away from being fixed.

## Confirmed

- [x] Frontend changes: tests are green (`yarn jest`), typings check passes.