### PR TITLE
[2.x] fix: stop email values being parsed as markup

### DIFF
--- a/extensions/subscriptions/composer.json
+++ b/extensions/subscriptions/composer.json
@@ -90,6 +90,7 @@
     },
     "require-dev": {
         "flarum/testing": "^2.0",
-        "flarum/approval": "@dev"
+        "flarum/approval": "@dev",
+        "flarum/markdown": "@dev"
     }
 }

--- a/extensions/subscriptions/tests/fixtures/views/email-body.blade.php
+++ b/extensions/subscriptions/tests/fixtures/views/email-body.blade.php
@@ -1,0 +1,3 @@
+{{-- Mirrors what every notification email view does: translate a markup
+     template with user values, then render it through the formatter. --}}
+{!! $formatter->convert($translator->trans($template, $parameters)) !!}

--- a/extensions/subscriptions/tests/integration/NotificationEmailInjectionTest.php
+++ b/extensions/subscriptions/tests/integration/NotificationEmailInjectionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Subscriptions\Tests\integration;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\View\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The notification email body is this markdown template, with the discussion
+ * title as the link text:
+ *
+ *     {poster_display_name} just posted in a discussion you're following: [{title}]({url}).
+ *
+ * With the markdown extension enabled the string is parsed as markdown, so a
+ * title containing `](...)` closes the intended link and opens one of its own —
+ * pointing the notification wherever its author likes — and an image reference
+ * turns the email into a tracking beacon that fires when the mail is opened.
+ *
+ * Core's own tests pin that substituted values never reach the parser; this
+ * pins the same guarantee for the configuration where the exploit is worst,
+ * using the real template string and the real formatter.
+ */
+class NotificationEmailInjectionTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * The body template, copied from `locale/en.yml`
+     * (`flarum-subscriptions.email.new_post.html.body`).
+     *
+     * @todo Translate the key instead of copying the string, once the testing
+     *       suite registers `Extend\Locales` translations — see
+     *       https://github.com/flarum/framework/issues/4600, planned for 2.1.
+     *       Until then `trans()` returns the key itself here, leaving nothing
+     *       to attack and making the test meaningless.
+     */
+    private const TEMPLATE = "{poster_display_name} just posted in a discussion you're following: [{title}]({url}).";
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-subscriptions');
+        // Markdown is what parses the template's link syntax, and so what
+        // makes the injection reachable at all.
+        $this->extension('flarum-markdown');
+    }
+
+    /**
+     * Render the notification body the way the email view does.
+     */
+    private function renderBody(string $title, string $posterName = 'Poster'): string
+    {
+        $this->app();
+
+        /** @var Factory $views */
+        $views = $this->app()->getContainer()->make(Factory::class);
+
+        // Rendered as a view named like an email one, so it gets the same
+        // translator and formatter the real notification templates do.
+        $views->addNamespace('flarum-subscriptions-test', __DIR__.'/../fixtures/views');
+
+        return $views->make('flarum-subscriptions-test::email-body', [
+            'template' => self::TEMPLATE,
+            'parameters' => [
+                '{poster_display_name}' => $posterName,
+                '{title}' => $title,
+                '{url}' => 'https://forum.local/d/100-a-discussion',
+            ],
+        ])->render();
+    }
+
+    #[Test]
+    public function a_discussion_title_cannot_point_the_notification_at_another_site()
+    {
+        $body = $this->renderBody('Innocent](https://evil.example.com)[rest');
+
+        $this->assertStringNotContainsString('href="https://evil.example.com', $body);
+        $this->assertStringContainsString('forum.local/d/100', $body, 'The genuine discussion link must survive.');
+    }
+
+    #[Test]
+    public function a_discussion_title_cannot_embed_a_tracking_image()
+    {
+        $body = $this->renderBody('Hi ![](https://evil.example.com/beacon.png) there');
+
+        // The url may appear as visible text — that is the point, it is shown
+        // rather than acted on. What must not happen is it being loaded.
+        $this->assertStringNotContainsString('<img', $body);
+        $this->assertStringNotContainsString('src="https://evil.example.com', $body);
+    }
+
+    #[Test]
+    public function a_bare_url_in_a_title_is_not_autolinked()
+    {
+        $body = $this->renderBody('Look at https://evil.example.com now');
+
+        $this->assertStringNotContainsString('href="https://evil.example.com', $body);
+    }
+
+    #[Test]
+    public function a_display_name_cannot_point_the_notification_at_another_site()
+    {
+        $body = $this->renderBody('A normal title', '[Admin](https://evil.example.com)');
+
+        $this->assertStringNotContainsString('href="https://evil.example.com', $body);
+    }
+
+    #[Test]
+    public function an_ordinary_title_still_renders_as_the_link_text()
+    {
+        // The fix must not litter real titles: escaping markdown
+        // metacharacters would render this as `Version 2\.0 \- what\'s new\!`.
+        $body = $this->renderBody("Version 2.0 - what's new!");
+
+        // The apostrophe is html-escaped, as any value placed into markup is.
+        $this->assertStringContainsString('Version 2.0 - what&#039;s new!', $body);
+        $this->assertStringNotContainsString('\\', $body);
+    }
+
+    #[Test]
+    public function the_trusted_template_is_still_parsed_as_markdown()
+    {
+        // Only the values are inert; the template itself is trusted content
+        // and must keep rendering as a link.
+        $body = $this->renderBody('A normal title');
+
+        $this->assertStringContainsString('<a href="https://forum.local/d/100-a-discussion"', $body);
+        $this->assertStringContainsString('>A normal title</a>', $body);
+    }
+}

--- a/framework/core/src/Mail/MailFormatter.php
+++ b/framework/core/src/Mail/MailFormatter.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Formatter\Formatter;
+
+/**
+ * The formatter email views are given.
+ *
+ * Renders through the real formatter, then puts back the values
+ * {@see MailTranslator} held out of the way, escaped. Content that never went
+ * through the mail translator — a post's body via `formatContent()`, for
+ * instance — is unaffected, since it carries no markers.
+ *
+ * Not a subclass: email views only ever call `convert()`, and wrapping avoids
+ * inheriting the parser and renderer state the real formatter manages.
+ */
+class MailFormatter
+{
+    public function __construct(
+        protected Formatter $formatter
+    ) {
+    }
+
+    public function convert(?string $content): string
+    {
+        return SafeSubstitution::restore($this->formatter->convert($content));
+    }
+
+    /**
+     * Anything else an email view might reach for goes to the real formatter.
+     *
+     * @param array<mixed> $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->formatter->$method(...$arguments);
+    }
+}

--- a/framework/core/src/Mail/MailServiceProvider.php
+++ b/framework/core/src/Mail/MailServiceProvider.php
@@ -9,7 +9,9 @@
 
 namespace Flarum\Mail;
 
+use Flarum\Formatter\Formatter;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
 use Illuminate\Contracts\Container\Container;
@@ -20,6 +22,7 @@ use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Arr;
+use Illuminate\View\View;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
@@ -102,6 +105,7 @@ class MailServiceProvider extends AbstractServiceProvider
     }
 
     public function boot(
+        Container $container,
         Dispatcher $events,
         ViewFactory $views,
         FilesystemFactory $filesystemFactory,
@@ -114,5 +118,27 @@ class MailServiceProvider extends AbstractServiceProvider
         // ForumResource::getLogoUrl() uses for the frontend.
         $logoPath = $settings->get('logo_path');
         $views->share('logoUrl', $logoPath ? $filesystemFactory->disk('flarum-assets')->url($logoPath) : null);
+
+        // Email bodies are translation strings containing markup — a markdown
+        // link whose text is a discussion title, say — rendered by the
+        // formatter once their parameters have been substituted in. That order
+        // puts the values in front of the parser, so a title can close the link
+        // and choose its own destination, or add an image that loads when the
+        // mail is opened.
+        //
+        // Email views are therefore given a translator that holds parameter
+        // values back and a formatter that puts them in, escaped, after
+        // rendering. Doing it here means no template has to change — including
+        // the ones in extensions that will never be updated.
+        $views->composer('*', function (View $view) use ($container) {
+            if (! str_contains($view->name(), 'email')) {
+                return;
+            }
+
+            $view->with([
+                'translator' => new MailTranslator($container->make(TranslatorInterface::class)),
+                'formatter' => new MailFormatter($container->make(Formatter::class)),
+            ]);
+        });
     }
 }

--- a/framework/core/src/Mail/MailTranslator.php
+++ b/framework/core/src/Mail/MailTranslator.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+use Flarum\Locale\TranslatorInterface;
+
+/**
+ * The translator email views are given.
+ *
+ * Behaves like the ordinary translator except that parameter values are
+ * replaced by markers instead of being substituted directly, so that they are
+ * not present when {@see MailFormatter} renders the result. The markers are
+ * swapped back, escaped, once rendering is done.
+ *
+ * Email templates therefore need no changes — including those in extensions
+ * that will never be updated — while a discussion title or display name can no
+ * longer inject markup into a notification.
+ */
+class MailTranslator implements TranslatorInterface
+{
+    public function __construct(
+        protected TranslatorInterface $translator
+    ) {
+    }
+
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    {
+        return $this->translator->trans($id, SafeSubstitution::mark($parameters), $domain, $locale);
+    }
+
+    public function get($key, array $replace = [], $locale = null): string
+    {
+        return $this->translator->get($key, SafeSubstitution::mark($replace), $locale);
+    }
+
+    public function choice($key, $number, array $replace = [], $locale = null): string
+    {
+        return $this->translator->choice($key, $number, SafeSubstitution::mark($replace), $locale);
+    }
+
+    public function getLocale(): string
+    {
+        return $this->translator->getLocale();
+    }
+
+    public function setLocale($locale): void
+    {
+        $this->translator->setLocale($locale);
+    }
+}

--- a/framework/core/src/Mail/SafeSubstitution.php
+++ b/framework/core/src/Mail/SafeSubstitution.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mail;
+
+/**
+ * Carries values through a formatter without letting them be parsed.
+ *
+ * Email bodies are translation strings containing markup — a markdown link
+ * whose text is a discussion title, say — that get rendered by the formatter
+ * after their parameters are substituted in. Substituting first means the
+ * parser sees the values: a title can close the link and choose its own
+ * destination, or add an image that loads when the mail is opened.
+ *
+ * Values are therefore replaced with an opaque marker before rendering, and
+ * put back — HTML-escaped — afterwards. The marker is deliberately plain
+ * (letters and digits only) so that neither markdown parsing nor URL encoding
+ * alters it, and it encodes the value inline rather than in shared state, so
+ * that repeated or nested renders in one request cannot mix values up.
+ */
+abstract class SafeSubstitution
+{
+    private const PREFIX = 'flarumsafevalue';
+    private const SUFFIX = 'endflarumsafevalue';
+
+    /**
+     * Replace each parameter value with a marker that survives rendering.
+     *
+     * @param array<string, mixed> $parameters
+     * @return array<string, string>
+     */
+    public static function mark(array $parameters): array
+    {
+        return array_map(
+            fn (mixed $value) => self::PREFIX.self::encode((string) $value).self::SUFFIX,
+            $parameters
+        );
+    }
+
+    /**
+     * Put the marked values back into rendered output, escaped so that they
+     * are shown rather than interpreted.
+     */
+    public static function restore(string $rendered): string
+    {
+        return preg_replace_callback(
+            '/'.self::PREFIX.'([A-Za-z0-9]*)'.self::SUFFIX.'/',
+            fn (array $matches) => htmlspecialchars(self::decode($matches[1]), ENT_QUOTES, 'UTF-8'),
+            $rendered
+        ) ?? $rendered;
+    }
+
+    /**
+     * Whether rendered output still holds marked values.
+     */
+    public static function contains(string $rendered): bool
+    {
+        return str_contains($rendered, self::PREFIX);
+    }
+
+    /**
+     * Base16, so the encoded form is letters and digits only: base64 uses
+     * characters that markdown and URL encoding would alter.
+     */
+    private static function encode(string $value): string
+    {
+        return bin2hex($value);
+    }
+
+    private static function decode(string $encoded): string
+    {
+        // An odd length can only mean the marker was mangled after all; return
+        // nothing rather than a broken byte sequence.
+        if ($encoded === '' || strlen($encoded) % 2 !== 0) {
+            return '';
+        }
+
+        return hex2bin($encoded) ?: '';
+    }
+}

--- a/framework/core/tests/fixtures/views/email-body.blade.php
+++ b/framework/core/tests/fixtures/views/email-body.blade.php
@@ -1,0 +1,3 @@
+{{-- Mirrors what notification email views do: translate a markup template with
+     user-supplied values, then render the result through the formatter. --}}
+{!! $formatter->convert($translator->trans($template, $parameters)) !!}

--- a/framework/core/tests/integration/mail/NotificationMarkdownInjectionTest.php
+++ b/framework/core/tests/integration/mail/NotificationMarkdownInjectionTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\mail;
+
+use Flarum\Testing\integration\TestCase;
+use Illuminate\Contracts\View\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Notification email bodies are markdown templates with the discussion title
+ * and the poster's display name as link text, rendered through the full
+ * formatter. Interpolating those values before rendering lets them close the
+ * link early and choose their own destination, or embed an image that fires on
+ * open — so the values must never reach the markdown parser.
+ *
+ * Templates keep calling `$translator->trans()` then `$formatter->convert()`:
+ * the substitution has to be safe by default, because extension templates in
+ * the wild will not be updated.
+ *
+ * These tests use the core formatter only, which is enough to pin that the
+ * values never reach the parser — core's own autolinker will happily turn a
+ * url in a title into a link. The full markdown exploit (a title closing the
+ * link and choosing its destination, or embedding an image) needs the markdown
+ * extension, and is pinned in that extension's own suite.
+ */
+class NotificationMarkdownInjectionTest extends TestCase
+{
+    /**
+     * Render a template the way an email view does, with the translator and
+     * formatter those views are given.
+     *
+     * @param array<string, string> $parameters
+     */
+    private function render(string $template, array $parameters): string
+    {
+        $this->app();
+
+        /** @var Factory $views */
+        $views = $this->app()->getContainer()->make(Factory::class);
+        $views->addNamespace('flarum-core-test', __DIR__.'/../../fixtures/views');
+
+        return $views->make('flarum-core-test::email-body', compact('template', 'parameters'))->render();
+    }
+
+    /**
+     * Render a notification body the way every email template does.
+     */
+    private function renderBody(string $title, string $url = 'https://forum.local/d/1'): string
+    {
+        return $this->render(
+            'someone posted in a discussion you follow: [{title}]({url}).',
+            ['{title}' => $title, '{url}' => $url]
+        );
+    }
+
+    #[Test]
+    public function a_title_cannot_redirect_the_notification_link()
+    {
+        // Closes the intended link and opens its own.
+        $html = $this->renderBody('Innocent](https://evil.example.com)[rest');
+
+        $this->assertStringNotContainsString('evil.example.com"', $html, 'The title must not become a link destination.');
+        $this->assertStringNotContainsString('href="https://evil.example.com', $html);
+        $this->assertStringContainsString('https://forum.local/d/1', $html, 'The real discussion link must survive.');
+    }
+
+    #[Test]
+    public function a_title_cannot_embed_a_tracking_image()
+    {
+        // An image reference fires on open and discloses the recipient.
+        $html = $this->renderBody('Hi ![](https://evil.example.com/beacon.png) there');
+
+        $this->assertStringNotContainsString('<img', $html, 'The title must not be able to embed an image.');
+        $this->assertStringNotContainsString('evil.example.com/beacon.png"', $html);
+    }
+
+    #[Test]
+    public function a_bare_url_in_a_title_is_not_autolinked()
+    {
+        // The formatter autolinks bare URLs, so metacharacter escaping alone
+        // would not be enough.
+        $html = $this->renderBody('Look at https://evil.example.com now');
+
+        $this->assertStringNotContainsString('href="https://evil.example.com', $html);
+    }
+
+    #[Test]
+    public function a_title_cannot_inject_html()
+    {
+        $html = $this->renderBody('Bold <b>title</b> & "quoted"');
+
+        $this->assertStringNotContainsString('<b>title</b>', $html);
+        $this->assertStringContainsString('&lt;b&gt;', $html, 'Markup in a title must be shown as text.');
+    }
+
+    #[Test]
+    public function an_ordinary_title_renders_unchanged_inside_the_link()
+    {
+        // The fix must not litter legitimate titles with escape characters —
+        // escaping markdown metacharacters would turn this into
+        // `Version 2\.0 \- what\'s new\!`.
+        $html = $this->renderBody("Version 2.0 - what's new!");
+
+        // Html-escaped, as any value placed into markup is, but otherwise
+        // untouched — no backslashes.
+        $this->assertStringContainsString('Version 2.0 - what&#039;s new!', $html);
+        $this->assertStringNotContainsString('\\', $html, 'Titles must not gain escape characters.');
+        // Core alone doesn't parse link syntax; the url is still carried
+        // through for whichever formatter does.
+        $this->assertStringContainsString('https://forum.local/d/1', $html);
+    }
+
+    #[Test]
+    public function the_trusted_template_is_still_rendered()
+    {
+        // Only the substituted values are inert; the template itself is
+        // trusted content and keeps whatever the configured formatter does
+        // with it. Core alone doesn't parse link syntax — the markdown
+        // extension adds that — so this asserts the placeholder was replaced
+        // and the url survived, not the markup. Rendering of the template's
+        // own markdown is covered in the markdown extension's suite.
+        $html = $this->render('see [a link]({url})', ['{url}' => 'https://forum.local/x']);
+
+        $this->assertStringContainsString('https://forum.local/x', $html);
+        $this->assertStringNotContainsString('{url}', $html);
+    }
+
+    #[Test]
+    public function repeated_renders_in_one_request_do_not_leak_between_each_other()
+    {
+        // Core's notification template calls convert() three times, and
+        // extension templates render a preview alongside the body. Values from
+        // one render must not appear in another.
+        $first = $this->renderBody('First title');
+        $second = $this->renderBody('Second title');
+
+        $this->assertStringContainsString('First title', $first);
+        $this->assertStringNotContainsString('Second title', $first);
+        $this->assertStringContainsString('Second title', $second);
+        $this->assertStringNotContainsString('First title', $second);
+    }
+
+    #[Test]
+    public function a_display_name_is_treated_the_same_as_a_title()
+    {
+        // The report named titles; display names flow through the same
+        // templates (and are often self-service via nicknames).
+        $html = $this->render('{poster_display_name} posted: [{title}]({url}).', [
+            '{poster_display_name}' => '[Admin](https://evil.example.com)',
+            '{title}' => 'A title',
+            '{url}' => 'https://forum.local/d/1',
+        ]);
+
+        $this->assertStringNotContainsString('href="https://evil.example.com', $html);
+    }
+}


### PR DESCRIPTION
## The problem

Notification email bodies are translation strings containing markup, with user-supplied values as the link text:

```yaml
{poster_display_name} just posted in a discussion you're following: [{title}]({url}).
```

The parameters are substituted **before** the string is handed to the formatter, so the parser sees the values. With the markdown extension enabled — bundled, and on most forums — a discussion title of:

```
Innocent](https://evil.example.com)[rest
```

closes the intended link and opens its own, producing a notification, sent by the forum with its correct headers and styling, whose visible link goes wherever the discussion's author chose:

```html
<a href="https://evil.example.com">Innocent</a><a href="…/d/100">rest</a>
```

An image reference in a title (`![](https://evil.example.com/beacon.png)`) instead turns the email into a tracking beacon that fires on open, disclosing the recipient's address and client to a third party. 80 characters is ample for either.

The surface is wider than the title: the same templates interpolate **display names** (`{poster_display_name}`, `{mentioner_display_name}`, `{replier_display_name}`, `{user_display_name}`), which are often self-service, across `subscriptions`, `mentions` and `messages`. Even without the markdown extension, core's own autolinker turns a bare URL in a title into a clickable link in the email.

## The fix

Email views are given a translator that replaces parameter values with opaque markers, and a formatter that puts the values back — HTML-escaped — once rendering is done. The parser never sees user data.

- **No template changes.** Swapping the pair in a view composer (`MailServiceProvider`) rather than fixing nine call sites matters because most affected templates live in extensions, and many will never be updated. Third-party notification emails are fixed by upgrading core.
- **Stateless.** The value travels inside its own marker rather than in shared state, so templates that render repeatedly — core's notification view calls `convert()` three times, and extension views render a preview beside the body — cannot mix values between renders.
- **Markers are hex.** Base64's `+/=` are altered by markdown parsing and URL encoding; letters and digits survive both, so `{url}` in a link destination still round-trips.
- **Escaping was rejected as the fix.** Escaping markdown metacharacters in the value visibly corrupts ordinary titles (`Version 2\.0 \- what\'s new\!`) and, for one payload, destroys the notification link entirely — a user-visible regression on every forum, and hand-rolled CommonMark escaping is a future bug in its own right.

## Tests

- `framework/core` — 8 tests covering what core alone guarantees: a value can never be autolinked, embed an image, redirect a link or inject HTML, while the trusted template still renders and ordinary titles are not littered.
- `extensions/subscriptions` — 6 tests with **markdown enabled**, using the real body template, covering the full exploit. `flarum/markdown` added to `require-dev` for this.

Both suites were written first and observed failing on the real attack. Verified live on a forum with markdown enabled: both payloads render as inert text inside the correct link.

Regression: core mail/notification (20), forum/frontend (49), subscriptions (21), mentions (82), messages (12), suspend (19), PHPStan — all pass.

## Note on the test suite

The subscriptions test inlines the body template rather than translating its key, because integration tests do not register `Extend\Locales` translations (flarum/framework#4600) — `trans()` would return the key and leave nothing to attack. There is a `@todo` to switch back when that is fixed in 2.1.

## Credit

Reported by Arpit Jain (@arpitjain099), who verified it by reading the source and was explicit about not having run it. No advisory or CVE is issued, per the policy of not treating pre-stable releases as covered — 2.x is still RC.