### PR TITLE
[2.x] perf: cache resolved model casts per class

### DIFF
--- a/framework/core/src/Database/AbstractModel.php
+++ b/framework/core/src/Database/AbstractModel.php
@@ -55,6 +55,18 @@ abstract class AbstractModel extends Eloquent
     public static array $defaults = [];
 
     /**
+     * Resolved casts, keyed by model class.
+     *
+     * Eloquent asks for the casts on every attribute access, so resolving the
+     * class hierarchy each time is measurable: an index request resolved them
+     * over 130,000 times. The result only changes when an extender registers
+     * new casts, which is what flushCastsCache() is for.
+     *
+     * @var array<class-string, array<string, string>>
+     */
+    protected static array $castsCache = [];
+
+    /**
      * An alias for the table name, used in queries.
      *
      * @internal
@@ -102,13 +114,27 @@ abstract class AbstractModel extends Eloquent
 
     public function getCasts(): array
     {
+        if (isset(static::$castsCache[static::class])) {
+            return static::$castsCache[static::class];
+        }
+
         $casts = parent::getCasts();
 
         foreach (array_merge(array_reverse(class_parents($this)), [static::class]) as $class) {
             $casts = array_merge($casts, Arr::get(static::$customCasts, $class, []));
         }
 
-        return $casts;
+        return static::$castsCache[static::class] = $casts;
+    }
+
+    /**
+     * Discard the resolved casts, so that newly registered ones are picked up.
+     *
+     * @internal
+     */
+    public static function flushCastsCache(): void
+    {
+        static::$castsCache = [];
     }
 
     /**

--- a/framework/core/src/Extend/Model.php
+++ b/framework/core/src/Extend/Model.php
@@ -181,5 +181,8 @@ class Model implements ExtenderInterface
                 $this->casts
             )
         );
+
+        // Models may already have resolved (and memoised) their casts by now.
+        AbstractModel::flushCastsCache();
     }
 }

--- a/framework/core/tests/unit/Database/AbstractModelCastsTest.php
+++ b/framework/core/tests/unit/Database/AbstractModelCastsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Database;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Testing\unit\TestCase;
+
+class AbstractModelCastsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        AbstractModel::$customCasts = [];
+        AbstractModel::flushCastsCache();
+    }
+
+    protected function tearDown(): void
+    {
+        AbstractModel::$customCasts = [];
+        AbstractModel::flushCastsCache();
+
+        parent::tearDown();
+    }
+
+    public function test_it_includes_casts_declared_on_the_model(): void
+    {
+        $model = new AbstractModelCastsTestModel;
+
+        $this->assertSame('bool', $model->getCasts()['is_native'] ?? null);
+    }
+
+    public function test_it_includes_custom_casts_registered_for_the_model(): void
+    {
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['extended' => 'datetime'];
+
+        $model = new AbstractModelCastsTestModel;
+
+        $this->assertSame('datetime', $model->getCasts()['extended'] ?? null);
+    }
+
+    public function test_it_inherits_custom_casts_registered_against_a_parent_class(): void
+    {
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['from_parent' => 'int'];
+
+        $model = new AbstractModelCastsTestChildModel;
+
+        $this->assertSame('int', $model->getCasts()['from_parent'] ?? null);
+    }
+
+    public function test_casts_registered_on_a_child_override_the_parent(): void
+    {
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['overridden' => 'int'];
+        AbstractModel::$customCasts[AbstractModelCastsTestChildModel::class] = ['overridden' => 'bool'];
+
+        $model = new AbstractModelCastsTestChildModel;
+
+        $this->assertSame('bool', $model->getCasts()['overridden'] ?? null);
+    }
+
+    public function test_two_instances_of_the_same_model_resolve_the_same_casts(): void
+    {
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['shared' => 'bool'];
+
+        $this->assertEquals(
+            (new AbstractModelCastsTestModel)->getCasts(),
+            (new AbstractModelCastsTestModel)->getCasts()
+        );
+    }
+
+    public function test_sibling_models_do_not_share_each_others_casts(): void
+    {
+        // A per-class cache keyed carelessly (or not keyed at all) would leak
+        // the first model's casts onto the second.
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['only_on_parent' => 'bool'];
+        AbstractModel::$customCasts[AbstractModelCastsTestSiblingModel::class] = ['only_on_sibling' => 'int'];
+
+        (new AbstractModelCastsTestModel)->getCasts();
+
+        $sibling = (new AbstractModelCastsTestSiblingModel)->getCasts();
+
+        $this->assertArrayNotHasKey('only_on_parent', $sibling);
+        $this->assertSame('int', $sibling['only_on_sibling'] ?? null);
+    }
+
+    public function test_casts_registered_after_a_first_resolution_are_picked_up(): void
+    {
+        // Extenders mutate $customCasts during boot, which can happen after a
+        // model has already resolved its casts once. A cache that never
+        // invalidates would silently ignore the newly registered cast.
+        $this->assertArrayNotHasKey('late', (new AbstractModelCastsTestModel)->getCasts());
+
+        AbstractModel::$customCasts[AbstractModelCastsTestModel::class] = ['late' => 'bool'];
+        AbstractModel::flushCastsCache();
+
+        $this->assertSame('bool', (new AbstractModelCastsTestModel)->getCasts()['late'] ?? null);
+    }
+}
+
+class AbstractModelCastsTestModel extends AbstractModel
+{
+    protected $casts = ['is_native' => 'bool'];
+}
+
+class AbstractModelCastsTestChildModel extends AbstractModelCastsTestModel
+{
+}
+
+class AbstractModelCastsTestSiblingModel extends AbstractModel
+{
+}


### PR DESCRIPTION
## The problem

Eloquent asks a model for its casts on **every attribute access**. In Laravel that's fine, because `getCasts()` is a property read:

```php
// Illuminate\Database\Eloquent\Concerns\HasAttributes
public function getCasts()
{
    if ($this->getIncrementing()) {
        return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
    }

    return $this->casts;
}
```

Laravel calls it unguarded in hot paths (`getCastType()`, `hasCast()`, `transformModelValue()`) precisely because it is O(1).

Flarum's override breaks that assumption:

```php
public function getCasts(): array
{
    $casts = parent::getCasts();

    foreach (array_merge(array_reverse(class_parents($this)), [static::class]) as $class) {
        $casts = array_merge($casts, Arr::get(static::$customCasts, $class, []));
    }

    return $casts;
}
```

The hierarchy walk is a real requirement — extensions register casts into a static `$customCasts` map keyed by class, and a model has to pick up casts registered against its ancestors, which Laravel has no equivalent of. But the result is immutable for a given class, so `class_parents()`, `array_reverse()` and a merge per ancestor were being repeated on every single attribute read.

Profiling the forum index (Xdebug cachegrind, debug off, assets warm) on an install with 74 extensions:

| | calls in one request |
|---|---|
| `AbstractModel->getCasts` | **131,619** |
| `array_merge` | 704,030 |
| `class_parents` | 138,295 |
| `Arr::get` | 431,815 |

`getCasts()` was the single hottest function in the profile at **14.3%** of total self cost, with `Arr::get()` adding another **13.6%** largely on its behalf.

## The fix

Memoise the resolved casts per class — which is what Laravel already does for everything else in this hot path. `HasAttributes` keeps five `protected static` per-class caches (`$mutatorCache`, `$attributeMutatorCache`, `$getAttributeMutatorCache`, `$setAttributeMutatorCache`, `$castTypeCache`) for exactly this reason. `getCastType()` is the closest precedent: it calls `getCasts()` and then guards the expensive part behind an `isset()` on a static cache, the same shape as this change.

The one hazard is invalidation: `Extend\Model` mutates `AbstractModel::$customCasts` during boot, which can happen *after* a model has already resolved its casts. A cache that never invalidates would silently ignore newly registered casts, so the extender flushes it. There's a test covering exactly that ordering.

## Results

Total profiled self cost **958.8M → 570.4M (−40%)**. `getCasts` and `Arr::get` both drop out of the top ten — `Arr::get` falls from 13.61% to 1.93%.

Wall time, A/B by stashing the patch and re-running the same in-process dispatch (median of 7):

| route | patched | baseline |
|---|---|---|
| `/` index | **216 ms** | 272 ms |
| `/d/709` (54 posts, mention-heavy) | **317 ms** | 345 ms |
| `/api/posts?filter[discussion]=709` | **135 ms** | 157 ms |

This helps any request that serializes models, so the benefit is broad rather than route-specific.

## Testing

7 new unit tests, written RED first — covering native casts, custom casts, inheritance from a parent class, child-overrides-parent precedence, that sibling models don't leak casts to each other, and that casts registered *after* a first resolution are still picked up (the invalidation case).

- 396 core unit tests pass
- 36 model integration tests pass (these exercise the `Extend\Model` cast path)
- PHPStan clean from the monorepo root
- Live JSON responses byte-identical patched vs baseline on `/api`, `/api/discussions/709`, and `/api/posts?filter[discussion]=709`

## Scope

Found while profiling a report that discussion views feel slow. It's a real, broad win, but it is **not** the whole story for that report — worth saying plainly. Booting Flarum turns out to be cheap (`/api` with all 74 extensions is 10ms / 7 queries); the cost is in serialization, which scales with how many models a response touches. Remaining threads I'm still chasing: HTML document rendering, and an N+1 where `mentionedBy` targets are materialised without their `discussion` relation so every visibility check lazy-loads it.