### PR TITLE
[2.x] perf(mentions): eager load the discussion of mentioning posts

### DIFF
--- a/extensions/mentions/src/Api/PostResourceFields.php
+++ b/extensions/mentions/src/Api/PostResourceFields.php
@@ -29,7 +29,10 @@ class PostResourceFields
             Schema\Relationship\ToMany::make('mentionedBy')
                 ->type('posts')
                 ->includable()
-                ->scope(fn (BelongsToMany $query) => $query->oldest('id')->limit(static::$maxMentionedBy)),
+                // Serializing these posts checks whether the actor can see each
+                // one, and that check reads the post's discussion. Without the
+                // eager load every mentioning post fetches it separately.
+                ->scope(fn (BelongsToMany $query) => $query->with('discussion')->oldest('id')->limit(static::$maxMentionedBy)),
             Schema\Relationship\ToMany::make('mentionsPosts')
                 ->type('posts'),
             Schema\Relationship\ToMany::make('mentionsUsers')

--- a/extensions/mentions/tests/integration/api/MentionedByEagerLoadingTest.php
+++ b/extensions/mentions/tests/integration/api/MentionedByEagerLoadingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Database\ConnectionInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+class MentionedByEagerLoadingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-mentions');
+
+        $posts = [];
+        $mentions = [];
+
+        // Ten posts, each mentioned by a later one. Every "mentionedBy" post
+        // gets visibility-checked during serialization, which is where the
+        // discussion relation used to be lazily fetched one post at a time.
+        for ($i = 1; $i <= 10; $i++) {
+            $posts[] = [
+                'id' => $i, 'discussion_id' => 1, 'created_at' => Carbon::now(),
+                'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>',
+            ];
+        }
+
+        for ($i = 11; $i <= 20; $i++) {
+            $posts[] = [
+                'id' => $i, 'discussion_id' => 1, 'created_at' => Carbon::now(),
+                'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>text</p></t>',
+            ];
+            $mentions[] = ['post_id' => $i, 'mentions_post_id' => $i - 10];
+        }
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 20],
+            ],
+            Post::class => $posts,
+            'post_mentions_post' => $mentions,
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    #[Test]
+    public function listing_posts_does_not_lazy_load_a_discussion_per_mentioning_post(): void
+    {
+        $queries = $this->countQueriesFor(function () {
+            return $this->send(
+                $this->request('GET', '/api/posts', ['authenticatedAs' => 2])
+                    ->withQueryParams(['filter' => ['discussion' => 1], 'page' => ['limit' => 20]])
+            );
+        });
+
+        // Each mentioned post is fetched with its discussion in the same load,
+        // so the number of queries
+        // does not grow with the number of mentions. Before this was fixed the
+        // same discussion was fetched once per mentioning post.
+        $discussionQueries = $this->countMatching($queries, 'from "discussions" where "discussions"."id" = ');
+
+        $this->assertLessThanOrEqual(
+            1,
+            $discussionQueries,
+            'The discussion should not be fetched once per mentioning post. Queries: '.implode("\n", $queries)
+        );
+    }
+
+    #[Test]
+    public function listing_posts_still_returns_the_mentioning_posts(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['discussion' => 1], 'page' => ['limit' => 20]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $mentionedBy = [];
+        foreach ($body['data'] as $post) {
+            foreach ($post['relationships']['mentionedBy']['data'] ?? [] as $related) {
+                $mentionedBy[$post['id']][] = $related['id'];
+            }
+        }
+
+        // Post 1 is mentioned by post 11, post 2 by post 12, and so on.
+        $this->assertSame(['11'], $mentionedBy['1'] ?? null);
+        $this->assertSame(['20'], $mentionedBy['10'] ?? null);
+    }
+
+    /**
+     * @return string[] the SQL run while the callback executed
+     */
+    private function countQueriesFor(callable $callback): array
+    {
+        $queries = [];
+
+        $this->app()->getContainer()->make(ConnectionInterface::class)
+            ->listen(function ($query) use (&$queries) {
+                $queries[] = $query->sql;
+            });
+
+        $callback();
+
+        return $queries;
+    }
+
+    /**
+     * @param string[] $queries
+     */
+    private function countMatching(array $queries, string $needle): int
+    {
+        // Identifier quoting differs between drivers, so compare loosely.
+        $normalise = fn (string $sql) => str_replace(['`', '"', '[', ']'], '"', $sql);
+        $needle = $normalise($needle);
+
+        return count(array_filter($queries, fn (string $sql) => str_contains($normalise($sql), $needle)));
+    }
+}


### PR DESCRIPTION
## The problem

Serializing a post's `mentionedBy` relation runs a visibility check on every mentioning post, and [`PostPolicy::can()`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Post/Access/PostPolicy.php#L27) reads `$post->discussion` to do it. Those posts are materialised by the relation load *without* that relation, so each one fetched the same discussion over again. With tags enabled, [its discussion policy](https://github.com/flarum/framework/blob/2.x/extensions/tags/src/Access/DiscussionPolicy.php#L30) then read `$discussion->tags` per post as well.

On a 54-post discussion with 52 mentions, **34 of 77 queries** were these repeats — all with *identical* bindings, i.e. the same discussion fetched 17 times.

I confirmed the mechanism by object identity rather than inference: post 6353 existed as two PHP instances, one eager-loaded (`discussion` present) and one bare (`discussion` null). The bare copies are the ones the policy checks.

## The fix

Eager load `discussion` on the relationship's own scope.

**Why the scope and not the endpoint's `eagerLoad()`** — this is the part worth reviewing. The scope flows into `EloquentBuffer::loadLimitedBelongsToMany()`, which resolves a windowed set of keys first and only then fetches full rows, so the eager load applies to a bounded set. Putting it on the endpoint instead routes through `loadMissing()`, which is unbounded: I tried that first, and a thread with 1,402 mentions pointing at one post went from 46 to **5,618 queries** and 4.6s.

**Why `discussion` and not `discussion.tags`** — loading `discussion` is sufficient to remove the tags queries too, because the tags relation then batch-loads across the discussions already in memory. Loading `discussion.tags` directly would crash any install *without* the tags extension, where `Discussion` has no `tags` relation. That version passed against my dev forum (tags enabled) and only failed once the integration test ran it on a core-only install — see below.

## Results

A/B by reverting the change, on an install with 74 extensions and tags enabled:

| discussion | before | after |
|---|---|---|
| 54 posts, 52 mentions | 77 queries, 16.6 ms | **45 queries, 11.0 ms** |
| 73 posts, 69 mentions | 81 queries, 17.3 ms | **47 queries, 11.4 ms** |
| 112 posts, 100 mentions | 61 queries, 21.0 ms | **45 queries, 11.1 ms** |
| 1444 posts, 1402 mentions | 46 queries, 21.0 ms | **40 queries, 18.9 ms** |
| 69 posts, 1 mention (control) | 28 queries | 28 queries |

Both policy call sites disappear from the query attribution entirely. The high-fan-in case improves rather than regressing, which is the property the endpoint-level version failed.

## Testing

Two integration tests, written RED first. The failing run showed `10x (1 distinct bindings): select * from "discussions" where "discussions"."id" = ?` — the N+1 detector added in flarum/testing flagged it independently of my own assertion.

- 84 mentions integration tests pass; N+1 detector warnings across the suite drop from **12 to 10**, so no new patterns are introduced
- 130 core post/discussion integration tests pass
- PHPStan clean from the monorepo root
- Live JSON responses byte-identical before/after on all five discussions above

Note: `tags` has one pre-existing full-suite failure (`ListTest::admin_sees_all`) from test-ordering interference. I verified it fails identically on a clean tree — unrelated to this change.

## Context

Second of the findings from profiling the "discussion views feel slow" reports, after #4875 (model casts memoisation). This is a query-count and DB-load win; the wall-time gain is modest because these are sub-millisecond primary-key lookups, but it removes work that scales with mention density on exactly the long, mention-heavy threads that prompted the reports.