### PR TITLE
[2.x] perf: point endpoint eager loads back at their parent models

### DIFF
--- a/extensions/likes/extend.php
+++ b/extensions/likes/extend.php
@@ -76,22 +76,6 @@ return [
             }
         ),
 
-    // When tags is enabled, also pre-load the back-reference to discussion and its tags,
-    // needed to avoid N+1s in DiscussionPolicy::can() which accesses $discussion->tags.
-    (new Extend\Conditional())
-        ->whenExtensionEnabled('flarum-tags', fn () => [
-            (new Extend\ApiResource(Resource\DiscussionResource::class))
-                ->endpoint(
-                    Endpoint\Index::class,
-                    function (Endpoint\Index $endpoint): Endpoint\Index {
-                        return $endpoint->eagerLoadWhenIncluded([
-                            'firstPost' => ['firstPost.discussion', 'firstPost.discussion.tags'],
-                            'lastPost' => ['lastPost.discussion', 'lastPost.discussion.tags'],
-                        ]);
-                    }
-                ),
-        ]),
-
     (new Extend\Event())
         ->listen(PostWasLiked::class, Listener\SendNotificationWhenPostIsLiked::class)
         ->listen(PostWasUnliked::class, Listener\SendNotificationWhenPostIsUnliked::class)

--- a/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
+++ b/framework/core/src/Api/Endpoint/Concerns/HasEagerLoading.php
@@ -11,7 +11,10 @@ namespace Flarum\Api\Endpoint\Concerns;
 
 use Closure;
 use Flarum\Api\Resource\AbstractDatabaseResource;
+use Flarum\Api\Schema\Relationship\ToMany;
+use Flarum\Api\Schema\Relationship\ToOne;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Tobyz\JsonApiServer\Context;
 
@@ -89,7 +92,9 @@ trait HasEagerLoading
      */
     protected function loadRelations(Collection $models, Context $context, array $included = []): void
     {
-        if (! $context->collection instanceof AbstractDatabaseResource) {
+        $resource = $context->collection;
+
+        if (! $resource instanceof AbstractDatabaseResource) {
             return;
         }
 
@@ -123,6 +128,74 @@ trait HasEagerLoading
 
         if (! empty($simpleRelations)) {
             $models->loadMissing($simpleRelations);
+        }
+
+        $this->setInverseRelations(
+            $models,
+            $context,
+            $resource,
+            array_merge(array_keys($whereRelations), $simpleRelations)
+        );
+    }
+
+    /**
+     * Point relations loaded above back at the models they were loaded for.
+     *
+     * The relationship buffer does this for the relations it loads (see
+     * EloquentBuffer::load()), but relations pre-loaded here arrive through
+     * loadMissing(), which wires nothing back — and the buffer then skips
+     * them because they are already loaded. Serializing such a related model
+     * re-fetched its parent one row at a time: every visibility check on an
+     * included firstPost read $post->discussion, which IS the discussion
+     * being listed.
+     *
+     * @param string[] $relations
+     */
+    private function setInverseRelations(Collection $models, Context $context, AbstractDatabaseResource $resource, array $relations): void
+    {
+        if ($models->isEmpty() || empty($relations)) {
+            return;
+        }
+
+        /** @var array<string, ToOne|ToMany> $fields */
+        $fields = array_filter(
+            $context->fields($resource),
+            fn ($field) => $field instanceof ToOne || $field instanceof ToMany
+        );
+
+        // Only the first segment of each loaded path is a relation of the
+        // models at hand; deeper segments belong to other parents.
+        $segments = array_unique(array_map(
+            fn (string $relation) => explode('.', $relation)[0],
+            $relations
+        ));
+
+        foreach ($segments as $segment) {
+            // A relationship field may expose the relation under a different
+            // name than the Eloquent relation used in eager load paths.
+            $field = collect($fields)->first(
+                fn (ToOne|ToMany $field) => ($field->property ?? $field->name) === $segment || $field->name === $segment
+            );
+
+            foreach ($models as $model) {
+                if (! $model->relationLoaded($segment)) {
+                    continue;
+                }
+
+                $related = $model->getRelation($segment);
+
+                if (! $related) {
+                    continue;
+                }
+
+                $inverse = $field->inverse ?? Str::camel(class_basename($model));
+
+                foreach ($related instanceof Collection ? $related : [$related] as $rel) {
+                    if ($rel instanceof Model && $rel->isRelation($inverse)) {
+                        $rel->setRelation($inverse, $model);
+                    }
+                }
+            }
         }
     }
 

--- a/framework/core/tests/integration/api/discussions/ListWithIncludedPostsQueryCountTest.php
+++ b/framework/core/tests/integration/api/discussions/ListWithIncludedPostsQueryCountTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\api\discussions;
+
+use Carbon\Carbon;
+use Flarum\Api\Endpoint;
+use Flarum\Api\Resource;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Database\ConnectionInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+class ListWithIncludedPostsQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const DISCUSSION_COUNT = 10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $discussions = [];
+        $posts = [];
+        $now = Carbon::now();
+
+        for ($i = 1; $i <= self::DISCUSSION_COUNT; $i++) {
+            $discussions[] = [
+                'id' => $i, 'title' => "Discussion $i", 'created_at' => $now,
+                'user_id' => 1, 'first_post_id' => $i, 'comment_count' => 1,
+            ];
+            $posts[] = [
+                'id' => $i, 'discussion_id' => $i, 'created_at' => $now,
+                'user_id' => 1, 'type' => 'comment', 'number' => 1,
+                'content' => '<t><p>first post</p></t>',
+            ];
+        }
+
+        $this->prepareDatabase([
+            Discussion::class => $discussions,
+            Post::class => $posts,
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    #[Test]
+    public function included_first_posts_reuse_the_discussion_being_listed(): void
+    {
+        $db = $this->database();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['include' => 'firstPost'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Serializing each included first post runs visibility checks
+        // (canEdit, canHide, ...) that read the post's discussion. The
+        // discussion is the very model being listed, so it must be reused,
+        // not fetched again one row at a time per post.
+        $singleFetches = array_filter($db->getQueryLog(), function (array $query) {
+            $sql = str_replace(['`', '"', '[', ']'], '"', $query['query']);
+
+            return str_contains($sql, 'from "discussions" where "discussions"."id" = ');
+        });
+
+        $this->assertCount(
+            0,
+            $singleFetches,
+            'Included posts should reuse the listed discussion instead of re-fetching it per post.'
+        );
+    }
+
+    #[Test]
+    public function posts_preloaded_by_endpoint_eager_loads_reuse_the_listed_discussion(): void
+    {
+        // Unlike the buffer-loaded case above, a relation PRE-loaded by an
+        // endpoint eager load arrives via loadMissing() — a path that
+        // historically set no inverse. The relationship buffer then sees the
+        // relation as loaded and skips it entirely, so nothing wired the post
+        // back to its discussion and every visibility check re-fetched it,
+        // one row per post. This extender reproduces what sticky+geoip,
+        // mentions and likes all do: eager load something UNDER an included
+        // post relation.
+        $this->extend(
+            (new Extend\ApiResource(Resource\DiscussionResource::class))
+                ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint): Endpoint\Index {
+                    return $endpoint->eagerLoadWhenIncluded(['firstPost' => ['firstPost.user']]);
+                })
+        );
+
+        $db = $this->database();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['include' => 'firstPost'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $singleFetches = array_filter($db->getQueryLog(), function (array $query) {
+            $sql = str_replace(['`', '"', '[', ']'], '"', $query['query']);
+
+            return str_contains($sql, 'from "discussions" where "discussions"."id" = ');
+        });
+
+        $this->assertCount(
+            0,
+            $singleFetches,
+            'Pre-loaded included posts should reuse the listed discussion instead of re-fetching it per post.'
+        );
+    }
+
+    #[Test]
+    public function included_first_posts_are_still_serialized(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['include' => 'firstPost'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $includedPosts = array_filter($body['included'] ?? [], fn (array $r) => $r['type'] === 'posts');
+
+        $this->assertCount(self::DISCUSSION_COUNT, $includedPosts);
+
+        // And each discussion still links to its own first post.
+        foreach ($body['data'] as $discussion) {
+            $this->assertSame(
+                $discussion['id'],
+                $discussion['relationships']['firstPost']['data']['id'],
+                'Fixture links discussion id N to post id N; the inverse wiring must not change linkage.'
+            );
+        }
+    }
+
+    protected function database(): ConnectionInterface
+    {
+        return parent::database();
+    }
+}


### PR DESCRIPTION
## The problem

Relations pre-loaded by an endpoint eager load (`eagerLoad()`, `eagerLoadWhenIncluded()`, `eagerLoadWhere()`) arrive through `loadMissing()`, which wires nothing back to the models they were loaded for. The relationship buffer *would* set the declared `->inverse()` — but it skips relations that are already loaded, so for pre-loaded relations nobody did.

Serializing an included post then re-fetched its discussion one row at a time for every visibility check (`canEdit`, `canHide`, `canFlag` → `PostPolicy::can()` → `$post->discussion`) — even though that discussion is **the very model being listed**, sitting in memory the whole time.

A pure-core reproduction (one `eagerLoadWhenIncluded(['firstPost' => ['firstPost.user']])` extender — the exact shape sticky+geoip, mentions and likes all use) on a 10-discussion page:

```
10x (10 distinct bindings): select * from "discussions" where "discussions"."id" = ? limit 1
```

The flarum/testing N+1 detector fails the request on its own before the test's assertion even runs.

## Why nobody noticed

**flarum/likes carries a hand-written workaround for exactly this bug** — a conditional block eager loading `firstPost.discussion` + `firstPost.discussion.tags` (and the lastPost pair), whose own comment says it exists "to avoid N+1s in DiscussionPolicy::can()". Any install running likes was masked; any leaner install paid one discussion fetch per included post. FoF/geoip's test suite surfaced it as a `30x (15 distinct)` repeated-query warning.

## The fix

After `loadRelations()` finishes its `loadMissing()` calls, `setInverseRelations()` points each loaded relation back at its parent — using the relationship's declared `->inverse()` and falling back to the same class-name derivation `EloquentBuffer::load()` already uses for buffered loads. The parent is already in memory, so the wiring costs **zero queries**. Only the first segment of each eager-load path is touched (deeper segments belong to other parents), and `isRelation()` guards against setting a relation the related model doesn't have.

**Likes' workaround is retired in the same change.** The parent discussions it re-fetched (with their tags) are exactly what the inverse now points at, and the tags extension already eager loads `tags` on those parents unconditionally, so `DiscussionPolicy::can()`'s `$discussion->tags` read stays batch-loaded.

## Measured (74-extension install, responses byte-identical on all compared endpoints)

| request | before | after |
|---|---|---|
| `/api/discussions?include=firstPost,lastPost` | 43 queries, 17.2ms SQL | **39 queries, 12.8ms** |
| `/` index document | 41 queries, 22.2ms SQL | **39 queries, 10.2ms** |

The removed queries are likes' now-redundant batched re-fetches. On installs *without* likes, the win is the N+1 itself: one query per included post, gone.

## Testing

- New `ListWithIncludedPostsQueryCountTest`, 3 tests: buffer-path regression guard (`include=firstPost`, was already correct), the loadMissing-path case written RED first, and a serialization-equivalence guard (linkage unchanged, all posts still included)
- 782 core integration + 396 unit tests pass; mentions (84), sticky (21), likes (22), subscriptions (21) suites pass; mentions detector warnings identical before/after (10 = 10)
- tags' single failure is the documented pre-existing utf8-slug flake on this host — verified identical on a clean tree
- PHPStan clean

Follow-up (separate): flarum/sticky still forces full rendered `firstPost` into every index document for a plain-text excerpt shown only on stickied discussions — that's the remaining ~110ms/index-view item from the discuss profiling.