### PR TITLE
[2.x] fix: keep the unread comment icon's weight out of the forced style

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionListItem.tsx
+++ b/framework/core/js/src/forum/components/DiscussionListItem.tsx
@@ -319,7 +319,15 @@ export default class DiscussionListItem<CustomAttrs extends IDiscussionListItemA
     return (
       <DiscussionListItemStatsItem
         className="DiscussionListItem-count"
-        icon={showUnread ? [<Icon name={'fas fa-check _checkmark'} />, <Icon name={'fas fa-comment _comment'} />] : <Icon name={'far fa-comment'} />}
+        icon={
+          showUnread ? (
+            // The solid comment against the read state's regular one is what
+            // signals unread, so it must keep its weight under a forced style.
+            [<Icon name={'fas fa-check _checkmark'} />, <Icon name={'fa-solid fa-comment _comment'} noStyleOverride />]
+          ) : (
+            <Icon name={'far fa-comment'} />
+          )
+        }
         label={showUnread ? abbreviateNumber(discussion.unreadCount()) : abbreviateNumber(discussion.replyCount())}
         ariaLabel={app.translator.trans(a11yKey, { count: discussion.unreadCount() })}
         onclick={showUnread ? this.markAsRead.bind(this) : undefined}


### PR DESCRIPTION
Follow-up to #4873, same class of bug: the discussion list signals unread replies **by icon weight alone** — `fas fa-comment` (solid) for unread against `far fa-comment` (regular) for read. With a forced FontAwesome style configured, both restyled to the same weight and the two states became indistinguishable.

The unread icon now opts out with `noStyleOverride`, exactly like the online indicator and subscription stars.

Deliberately left following the forced style:

- **the read-state `far fa-comment`** — that's the uniform-styling case the admin asked for, and restyling only the read side *preserves* the solid-vs-styled contrast;
- **the hover `fa-check` (mark-as-read affordance)** — an action glyph, not a weight signal, so it falls on the same side of #4873's line as the tags toggle.

Verified: typecheck and Prettier clean. The visual (authenticated session, unread badge, override active) uses the identical mechanism manually verified in #4873.