### PR TITLE
[2.x] fix(realtime): honour user.viewLastSeenAt in the typing indicator

### DIFF
--- a/extensions/realtime/extend.php
+++ b/extensions/realtime/extend.php
@@ -64,6 +64,19 @@ return [
 
                     return $settings->get('flarum-realtime.typing-indicator')
                         && $context->getActor()->hasPermissionLike('flarum-realtime.view-who-types');
+                }),
+
+            // Whether to also subscribe to the channel that names users who are typing
+            // while hiding their online status. The channel is authorized server-side
+            // regardless (see AuthController::typingIdentified); this only saves the
+            // client a subscription it would be refused.
+            Schema\Boolean::make('canViewHiddenTypers')
+                ->visible(fn (User $user, Context $context) => $context->getActor()->id === $user->id)
+                ->get(function (User $model, Context $context) {
+                    $settings = resolve(SettingsRepositoryInterface::class);
+
+                    return $settings->get('flarum-realtime.typing-indicator')
+                        && $context->getActor()->hasPermission('user.viewLastSeenAt');
                 })
         ]),
 

--- a/extensions/realtime/js/src/@types/shims.d.ts
+++ b/extensions/realtime/js/src/@types/shims.d.ts
@@ -11,6 +11,12 @@ declare module 'flarum/common/Application' {
       user: Channel | null;
       /** Presence channel for the currently open discussion (typing indicator). */
       discussion?: Channel;
+      /**
+       * Companion to {@link discussion}, carrying the identities of users typing
+       * while hiding their online status. Only subscribable with core's
+       * `user.viewLastSeenAt` permission.
+       */
+      discussionIdentified?: Channel;
       /** Shared public channel feeding ambient typing dots on the discussion list. */
       indexTyping?: Channel;
       /** Per-restricted-tag channels feeding typing dots for restricted discussions. */

--- a/extensions/realtime/js/src/forum/extend/Discussion/TypingIndicator.tsx
+++ b/extensions/realtime/js/src/forum/extend/Discussion/TypingIndicator.tsx
@@ -31,11 +31,10 @@ export default function (): void {
     this.discussion.typingState = new TypingState();
 
     this.actorIsTyping = (): void => {
-      const discloseOnline = app.session.user?.preferences()?.discloseOnline;
-
+      // Nothing identifying is sent: the server resolves who we are from the
+      // connection's authenticated user channel, and decides which audience may
+      // learn it. `time` drives the receiving client's expiry countdown.
       app.websocket_channels.discussion?.trigger('client-typing', {
-        displayName: discloseOnline ? app.session.user?.displayName() : '[anonymous]',
-        discloseOnline,
         time: Date.now(),
       });
     };
@@ -60,12 +59,27 @@ export default function (): void {
     }
 
     if (this.discussion) {
-      app.websocket_channels.discussion = app.websocket.subscribe('private-typing=' + m.route.param('id').match(/[0-9]+/));
+      const discussionId = m.route.param('id').match(/[0-9]+/);
+
+      app.websocket_channels.discussion = app.websocket.subscribe('private-typing=' + discussionId);
 
       if (this.discussion.attribute('canViewWhoTypes')) {
         app.websocket_channels.discussion.bind('client-typing', (data: TypingData) => {
           this.discussion.typingState?.add(data);
         });
+
+        // Users who may see through a hidden online status (core's
+        // `user.viewLastSeenAt`) also listen on the channel that names hidden
+        // typists. Subscription is authorised server-side; the attribute just
+        // avoids asking for a channel we'd be refused. Anonymised events for
+        // those same typists are not sent here, so there's nothing to de-duplicate.
+        if (app.session.user?.attribute('canViewHiddenTypers')) {
+          app.websocket_channels.discussionIdentified = app.websocket.subscribe('private-typingIdentified=' + discussionId);
+
+          app.websocket_channels.discussionIdentified.bind('client-typing', (data: TypingData) => {
+            this.discussion.typingState?.add(data);
+          });
+        }
       }
     }
   });

--- a/extensions/realtime/js/src/forum/states/TypingState.ts
+++ b/extensions/realtime/js/src/forum/states/TypingState.ts
@@ -5,7 +5,11 @@ export interface TypingUserMap {
 }
 
 export interface TypingData {
-  displayName: string;
+  /**
+   * Null when the server withheld the identity: the user is hiding their online
+   * status and we are not permitted to see through it.
+   */
+  displayName: string | null;
   discloseOnline: boolean;
   time: number;
 }
@@ -29,15 +33,21 @@ export default class TypingState {
   protected truncationTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
-   * Record an incoming typing event. When the sender has not disclosed their
-   * online status, their name is replaced with the anonymous placeholder.
+   * Record an incoming typing event.
+   *
+   * Whether we are allowed to know who is typing is decided server-side — a name
+   * only reaches us if we are entitled to it — so this just renders what arrived.
+   * A hidden user we *are* permitted to see is labelled as such, so it's clear
+   * they are invisible to everyone else.
    */
   add(data: TypingData): void {
-    if (!data.discloseOnline) {
-      data.displayName = String(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
-    }
+    const name = data.displayName
+      ? data.discloseOnline
+        ? data.displayName
+        : String(app.translator.trans('flarum-realtime.forum.typing-indicator.hidden-user', { username: data.displayName }))
+      : String(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
 
-    this.usersTyping[data.displayName] = data.time;
+    this.usersTyping[name] = data.time;
     m.redraw();
   }
 

--- a/extensions/realtime/js/src/forum/states/TypingState.ts
+++ b/extensions/realtime/js/src/forum/states/TypingState.ts
@@ -1,4 +1,5 @@
 import app from 'flarum/forum/app';
+import extractText from 'flarum/common/utils/extractText';
 
 export interface TypingUserMap {
   [displayName: string]: number;
@@ -41,11 +42,13 @@ export default class TypingState {
    * they are invisible to everyone else.
    */
   add(data: TypingData): void {
+    // extractText, not String(): an interpolated translation comes back as an
+    // array of parts, which String() would join with commas.
     const name = data.displayName
       ? data.discloseOnline
         ? data.displayName
-        : String(app.translator.trans('flarum-realtime.forum.typing-indicator.hidden-user', { username: data.displayName }))
-      : String(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
+        : extractText(app.translator.trans('flarum-realtime.forum.typing-indicator.hidden-user', { username: data.displayName }))
+      : extractText(app.translator.trans('flarum-realtime.forum.typing-indicator.anonymous-user'));
 
     this.usersTyping[name] = data.time;
     m.redraw();

--- a/extensions/realtime/resources/locale/en.yml
+++ b/extensions/realtime/resources/locale/en.yml
@@ -4,7 +4,7 @@ flarum-realtime:
             discussion-list-new-activity: "{count, plural, one {Show # updated discussion} other {Show # updated discussions}}"
             discussion-list-new-activity-with-auto-release: "{count, plural, one {# discussion has} other {# discussions have}} updated activity and will be released in {releaseTimeout} seconds. Click to show now."
         typing-indicator:
-            anonymous-user: "[Anonymous]"
+            anonymous-user: "[Hidden]"
             hidden-user: "{username} (hidden)"
             people-are-typing: "{number, plural, one {# person is typing} other {# people are typing}}"
             users-are-typing: "{count, plural, one {{users} is typing} other {{users}{others, plural, =1 { & # other} =0 {} other { & # others}} are typing}}"

--- a/extensions/realtime/resources/locale/en.yml
+++ b/extensions/realtime/resources/locale/en.yml
@@ -5,6 +5,7 @@ flarum-realtime:
             discussion-list-new-activity-with-auto-release: "{count, plural, one {# discussion has} other {# discussions have}} updated activity and will be released in {releaseTimeout} seconds. Click to show now."
         typing-indicator:
             anonymous-user: "[Anonymous]"
+            hidden-user: "{username} (hidden)"
             people-are-typing: "{number, plural, one {# person is typing} other {# people are typing}}"
             users-are-typing: "{count, plural, one {{users} is typing} other {{users}{others, plural, =1 { & # other} =0 {} other { & # others}} are typing}}"
             no-activity: No one is typing

--- a/extensions/realtime/src/Websocket/Api/AuthController.php
+++ b/extensions/realtime/src/Websocket/Api/AuthController.php
@@ -12,6 +12,7 @@ namespace Flarum\Realtime\Websocket\Api;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\RequestUtil;
 use Flarum\Realtime\Push\Payload\Generator;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -28,7 +29,8 @@ class AuthController implements RequestHandlerInterface
     public function __construct(
         protected Pusher $pusher,
         protected Generator $generator,
-        protected PresenceChannelAuthorizer $presenceAuthorizer
+        protected PresenceChannelAuthorizer $presenceAuthorizer,
+        protected SettingsRepositoryInterface $settings
     ) {
     }
 
@@ -98,6 +100,29 @@ class AuthController implements RequestHandlerInterface
     protected function privateMessageTyping(int $id): bool
     {
         return \Flarum\Messages\Dialog::whereVisibleTo($this->actor)->where('id', $id)->exists();
+    }
+
+    /**
+     * Authorize the channel that discloses who is typing while hiding their online
+     * status. `user.viewLastSeenAt` is core's override for the `discloseOnline`
+     * preference, so it gates this too — plus the ordinary requirements for seeing
+     * the typing indicator at all, since this channel carries nothing else.
+     *
+     * Doing it here means the permission is evaluated once per subscription, against
+     * a real actor in a normal request, rather than per event inside the websocket
+     * server. See {@link \Flarum\Realtime\Websocket\Message\Message::relayTyping()}.
+     */
+    protected function typingIdentified(int $id): bool
+    {
+        if (! $this->settings->get('flarum-realtime.typing-indicator')
+            || ! $this->actor->hasPermission('user.viewLastSeenAt')) {
+            return false;
+        }
+
+        $discussion = Discussion::whereVisibleTo($this->actor)->find($id);
+
+        return $discussion !== null
+            && $this->actor->can('flarum-realtime.view-who-types', $discussion);
     }
 
     /**

--- a/extensions/realtime/src/Websocket/Channel/Channel.php
+++ b/extensions/realtime/src/Websocket/Channel/Channel.php
@@ -73,6 +73,18 @@ class Channel
         return $this->name;
     }
 
+    /**
+     * The socket IDs currently subscribed to this channel. Used to exclude one
+     * channel's audience from another channel's broadcast — see
+     * {@link \Flarum\Realtime\Websocket\Message\Message::relayTyping()}.
+     *
+     * @return string[]
+     */
+    public function socketIds(): array
+    {
+        return array_keys($this->connections);
+    }
+
     public function broadcast(stdClass $payload): bool
     {
         collect($this->connections)
@@ -81,14 +93,19 @@ class Channel
         return true;
     }
 
-    public function broadcastToEveryoneExcept(stdClass $payload, ?string $socketId): bool
+    /**
+     * @param string|string[]|null $socketIds One or more socket IDs to skip.
+     */
+    public function broadcastToEveryoneExcept(stdClass $payload, string|array|null $socketIds): bool
     {
-        if (! $socketId) {
+        $socketIds = array_filter((array) $socketIds);
+
+        if (empty($socketIds)) {
             return $this->broadcast($payload);
         }
 
         collect($this->connections)
-            ->except($socketId)
+            ->except($socketIds)
             ->each->send(json_encode($payload));
 
         return true;

--- a/extensions/realtime/src/Websocket/Channel/Manager.php
+++ b/extensions/realtime/src/Websocket/Channel/Manager.php
@@ -30,6 +30,21 @@ class Manager
     private array $users = [];
     private array $userSockets = [];
 
+    /**
+     * socketId => user id, for connections that have successfully subscribed to
+     * their own `private-user={id}` channel.
+     *
+     * That subscription is an authenticated identity claim: AuthController only
+     * signs it when the actor's own id matches, and the signature is verified
+     * against the socket ID before the subscription is accepted. So the channel
+     * name tells us, authoritatively, who is on the other end of a socket —
+     * something private channels otherwise can't (only presence channels carry
+     * member data, and using one for typing would leak every reader's identity).
+     *
+     * @var array<string, int>
+     */
+    private array $socketUsers = [];
+
     public function __construct(Settings $settings, Config $config)
     {
         $this->maxConnections = $settings->maxConnections;
@@ -74,31 +89,67 @@ class Manager
         return isset($this->channels[$channel]);
     }
 
-    public function subscribeToChannel(ConnectionInterface $connection, string $channel, stdClass $payload): PromiseInterface
+    public function subscribeToChannel(ConnectionInterface $connection, string $channelName, stdClass $payload): PromiseInterface
     {
-        $channel = $this->findOrCreate($channel);
+        $channel = $this->findOrCreate($channelName);
 
         /** @phpstan-ignore-next-line */
         $this->connections[$connection->socketId] = true;
 
         $this->connectionsAllowed = count($this->connections) < $this->maxConnections;
 
-        return $this->createFulfilledPromise(
-            $channel->subscribe($connection, $payload)
-        );
+        // Only recorded once the subscription is accepted — PrivateChannel::subscribe()
+        // throws on an invalid signature, so an unauthenticated claim never lands here.
+        $subscribed = $channel->subscribe($connection, $payload);
+
+        if ($subscribed) {
+            $this->rememberUserChannel($connection, $channelName);
+        }
+
+        return $this->createFulfilledPromise($subscribed);
     }
 
-    public function unsubscribeFromChannel(ConnectionInterface $connection, string $channel, stdClass $payload): PromiseInterface
+    public function unsubscribeFromChannel(ConnectionInterface $connection, string $channelName, stdClass $payload): PromiseInterface
     {
-        if (! $this->has($channel)) {
+        if (! $this->has($channelName)) {
             return $this->createFulfilledPromise(false);
         }
 
-        $channel = $this->find($channel);
+        $channel = $this->find($channelName);
+
+        if ($this->isUserChannel($channelName)) {
+            /** @phpstan-ignore-next-line */
+            unset($this->socketUsers[$connection->socketId]);
+        }
 
         return $this->createFulfilledPromise(
             $channel->unsubscribe($connection)
         );
+    }
+
+    /**
+     * The authenticated user behind a connection, or null when the connection has
+     * not subscribed to its own user channel (guests, or the brief window after a
+     * reconnect before channels are re-established). Callers must treat null as
+     * "unidentified" and fail closed. See {@link $socketUsers}.
+     */
+    public function userIdForConnection(ConnectionInterface $connection): ?int
+    {
+        /** @phpstan-ignore-next-line */
+        return $this->socketUsers[$connection->socketId] ?? null;
+    }
+
+    private function isUserChannel(string $channelName): bool
+    {
+        return (bool) preg_match('/^private-user=\d+$/', $channelName);
+    }
+
+    private function rememberUserChannel(ConnectionInterface $connection, string $channelName): void
+    {
+        if (preg_match('/^private-user=(\d+)$/', $channelName, $m)) {
+            /** @phpstan-ignore-next-line */
+            $this->socketUsers[$connection->socketId] = (int) $m[1];
+        }
     }
 
     public function unsubscribeFromAllChannels(ConnectionInterface $connection): PromiseInterface
@@ -116,7 +167,7 @@ class Manager
         });
 
         /** @phpstan-ignore-next-line */
-        unset($this->connections[$connection->socketId]);
+        unset($this->connections[$connection->socketId], $this->socketUsers[$connection->socketId]);
 
         $this->connectionsAllowed = count($this->connections) < $this->maxConnections;
 

--- a/extensions/realtime/src/Websocket/Message/Message.php
+++ b/extensions/realtime/src/Websocket/Message/Message.php
@@ -11,6 +11,7 @@ namespace Flarum\Realtime\Websocket\Message;
 
 use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\TypingIdentity;
 use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use stdClass;
@@ -27,16 +28,28 @@ class Message
             return;
         }
 
-        $channel = $this->manager->find($this->payload->channel);
+        if (! $this->relayTyping()) {
+            $channel = $this->manager->find($this->payload->channel);
 
-        $channel->broadcastToEveryoneExcept(
-            $this->payload,
-            /** @phpstan-ignore-next-line */
-            $this->connection->socketId
-        );
+            $channel->broadcastToEveryoneExcept(
+                $this->payload,
+                /** @phpstan-ignore-next-line */
+                $this->connection->socketId
+            );
+        }
 
         $this->relayIndexTyping();
         $this->relayComposeTyping();
+    }
+
+    /**
+     * The channel carrying the identities of users who are typing while hiding their
+     * online status. Subscription requires `user.viewLastSeenAt` — see
+     * {@link \Flarum\Realtime\Websocket\Api\AuthController::typingIdentified()}.
+     */
+    public static function identifiedTypingChannel(int $discussionId): string
+    {
+        return "private-typingIdentified=$discussionId";
     }
 
     /**
@@ -73,6 +86,98 @@ class Message
         $channel = $this->manager->find($channelName);
 
         return $channel !== null && $channel->hasConnection($this->connection);
+    }
+
+    /**
+     * Relay a discussion typing event, disclosing the typist's identity to exactly
+     * the audience entitled to it. Returns false for anything that isn't discussion
+     * typing, so the caller falls back to the plain relay.
+     *
+     * Core treats `user.viewLastSeenAt` as the override for a user's `discloseOnline`
+     * preference (see UserResource's `lastSeenAt` visibility). Typing is the one place
+     * that override wasn't honoured, because the name was scrubbed at the sender and
+     * so never reached anyone. It can't simply be scrubbed at the *receiver* either:
+     * `private-typing={id}` is subscribable by everyone who can see the discussion, so
+     * a name broadcast there is a name disclosed to all of them.
+     *
+     * Hence the split. When the typist is hiding:
+     *
+     *   - the full payload goes to the identified channel, which only holders of the
+     *     permission can subscribe to;
+     *   - an anonymised payload (no name at all) goes to the discussion channel,
+     *     skipping the identified channel's subscribers so a privileged viewer sees
+     *     one event rather than a name and an `[Anonymous]` for the same person.
+     *
+     * When the typist is disclosing, the single existing broadcast is unchanged. When
+     * nobody privileged is listening, the identified channel doesn't exist and the
+     * behaviour is exactly as before.
+     *
+     * Neither the name nor the preference is taken from the payload — both are looked
+     * up from the identity the connection authenticated with, so a modified client
+     * can't put words in another user's mouth (which it could, before this). An
+     * unidentifiable sender fails closed to anonymous.
+     */
+    protected function relayTyping(): bool
+    {
+        if ($this->payload->event !== 'client-typing'
+            || ! preg_match('/^private-typing=(\d+)$/', $this->payload->channel, $m)) {
+            return false;
+        }
+
+        $discussionId = (int) $m[1];
+        /** @phpstan-ignore-next-line */
+        $sender = $this->connection->socketId;
+
+        $userId = $this->manager->userIdForConnection($this->connection);
+        $identity = $userId !== null ? resolve(TypingIdentity::class)->for($userId) : null;
+
+        $channel = $this->manager->find($this->payload->channel);
+
+        if ($identity !== null && $identity['discloseOnline']) {
+            $channel->broadcastToEveryoneExcept(
+                $this->typingPayload($this->payload->channel, $identity['displayName'], true),
+                $sender
+            );
+
+            return true;
+        }
+
+        $identified = $this->manager->find(self::identifiedTypingChannel($discussionId));
+
+        if ($identified && $identity !== null) {
+            $identified->broadcastToEveryoneExcept(
+                $this->typingPayload($identified->getName(), $identity['displayName'], false),
+                $sender
+            );
+        }
+
+        $channel->broadcastToEveryoneExcept(
+            $this->typingPayload($this->payload->channel, null, false),
+            array_merge([$sender], $identified ? $identified->socketIds() : [])
+        );
+
+        return true;
+    }
+
+    /**
+     * Build a typing payload. The shape is unchanged, so existing `client-typing`
+     * listeners (including the copy in flarum/messages, whose own channel this
+     * doesn't touch) keep working; a null `displayName` is the anonymised form.
+     *
+     * `time` is passed through from the sender: it feeds the frontend's expiry
+     * countdown against the *receiving* browser's clock, exactly as before.
+     */
+    protected function typingPayload(string $channel, ?string $displayName, bool $discloseOnline): stdClass
+    {
+        return (object) [
+            'event' => 'client-typing',
+            'channel' => $channel,
+            'data' => [
+                'displayName' => $displayName,
+                'discloseOnline' => $discloseOnline,
+                'time' => $this->payload->data->time ?? null,
+            ],
+        ];
     }
 
     /**

--- a/extensions/realtime/src/Websocket/TypingIdentity.php
+++ b/extensions/realtime/src/Websocket/TypingIdentity.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Websocket;
+
+use Flarum\User\User;
+
+/**
+ * Resolves the display name and online-disclosure preference of a typing user.
+ *
+ * The typing payload used to carry both, asserted by the sender's own client. That
+ * was tolerable while the name was only ever echoed back to the same audience that
+ * could already see it — but once a name is disclosed to holders of
+ * `user.viewLastSeenAt` (and withheld from everyone else) the server is making an
+ * authority claim about who is typing, and a client-asserted string can't back it.
+ * So the relay ignores what the payload claims and looks both values up here,
+ * keyed on the identity the connection authenticated with (see
+ * {@link \Flarum\Realtime\Websocket\Channel\Manager::userIdForConnection()}).
+ *
+ * This runs in-process inside the long-lived websocket server, on every typing
+ * ping, so lookups are cached for a few seconds. The TTL is deliberately short:
+ * it bounds how long a user who has just hidden their online status keeps being
+ * announced by name.
+ */
+class TypingIdentity
+{
+    protected const TTL_MS = 5000;
+
+    /**
+     * Above this many cached users, prune expired entries before adding more, so a
+     * busy forum can't grow the map without bound over the server's lifetime.
+     */
+    protected const PRUNE_THRESHOLD = 500;
+
+    /**
+     * userId => [displayName, discloseOnline, cachedAt].
+     *
+     * @var array<int, array{0: string, 1: bool, 2: float}>
+     */
+    protected array $cache = [];
+
+    /**
+     * The authoritative identity of a typing user, or null if there is no such user.
+     *
+     * @return array{displayName: string, discloseOnline: bool}|null
+     */
+    public function for(int $userId): ?array
+    {
+        $now = $this->now();
+
+        if (isset($this->cache[$userId]) && ($now - $this->cache[$userId][2]) < self::TTL_MS) {
+            [$displayName, $discloseOnline] = $this->cache[$userId];
+
+            return compact('displayName', 'discloseOnline');
+        }
+
+        $user = User::query()->find($userId);
+
+        if (! $user) {
+            return null;
+        }
+
+        if (count($this->cache) >= self::PRUNE_THRESHOLD) {
+            $this->prune($now);
+        }
+
+        $displayName = (string) $user->display_name;
+        $discloseOnline = (bool) $user->getPreference('discloseOnline');
+
+        $this->cache[$userId] = [$displayName, $discloseOnline, $now];
+
+        return compact('displayName', 'discloseOnline');
+    }
+
+    protected function prune(float $now): void
+    {
+        foreach ($this->cache as $userId => [, , $cachedAt]) {
+            if (($now - $cachedAt) >= self::TTL_MS) {
+                unset($this->cache[$userId]);
+            }
+        }
+    }
+
+    protected function now(): float
+    {
+        return microtime(true) * 1000;
+    }
+}

--- a/extensions/realtime/src/WebsocketProvider.php
+++ b/extensions/realtime/src/WebsocketProvider.php
@@ -16,6 +16,7 @@ use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
 use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\IndexTypingPresence;
 use Flarum\Realtime\Websocket\Settings;
+use Flarum\Realtime\Websocket\TypingIdentity;
 use Illuminate\Contracts\Container\Container;
 use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
@@ -28,6 +29,7 @@ class WebsocketProvider extends AbstractServiceProvider
         $this->container->singleton(Manager::class);
         $this->container->singleton(IndexTypingPresence::class);
         $this->container->singleton(PresenceChannelAuthorizer::class);
+        $this->container->singleton(TypingIdentity::class);
 
         $this->container->singleton(Pusher::class, function (Container $container) {
             /** @var Settings $settings */

--- a/extensions/realtime/tests/integration/WebsocketBindingsTest.php
+++ b/extensions/realtime/tests/integration/WebsocketBindingsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration;
+
+use Flarum\Realtime\Push\RealtimeRegistry;
+use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\TypingIdentity;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The websocket server is a single long-lived process, and these services hold
+ * state for its lifetime — connected channels, the socket-to-user index, typing
+ * presence, cached identities. Every one of them is silently useless if it isn't
+ * bound as a singleton: the container hands out a fresh, empty instance per
+ * resolution, and the state (or cache) never accumulates.
+ *
+ * That failure is invisible in unit tests, which inject their own shared stub, so
+ * it is pinned here against the real container instead.
+ */
+class WebsocketBindingsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-realtime');
+    }
+
+    /**
+     * @return array<string, array{class-string}>
+     */
+    public static function statefulServices(): array
+    {
+        return [
+            'channel manager' => [Manager::class],
+            'index typing presence' => [IndexTypingPresence::class],
+            'presence channel authorizer' => [PresenceChannelAuthorizer::class],
+            'typing identity cache' => [TypingIdentity::class],
+            'realtime registry' => [RealtimeRegistry::class],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('statefulServices')]
+    public function stateful_websocket_services_are_shared(string $class): void
+    {
+        $container = $this->app()->getContainer();
+
+        $this->assertSame(
+            $container->make($class),
+            $container->make($class),
+            "$class must be bound as a singleton, or its state is discarded between resolutions."
+        );
+    }
+}

--- a/extensions/realtime/tests/integration/api/TypingIdentifiedAuthTest.php
+++ b/extensions/realtime/tests/integration/api/TypingIdentifiedAuthTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\integration\api;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The identities of users typing while hiding their online status are carried on
+ * `private-typingIdentified={id}`, separate from the discussion's own typing
+ * channel. Authorization for it is what keeps a hidden user's name away from
+ * anyone not entitled to it, so it must require all three of: core's
+ * `user.viewLastSeenAt` (the permission that overrides `discloseOnline`
+ * elsewhere), permission to see who is typing, and visibility of the discussion.
+ */
+class TypingIdentifiedAuthTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-realtime');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, Members
+                // id 3, additionally in the group that may see through a hidden
+                // online status.
+                ['id' => 3, 'username' => 'seer', 'email' => 'seer@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => 100, 'name_singular' => 'Seer', 'name_plural' => 'Seers'],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 100],
+            ],
+            'group_permission' => [
+                // Everyone may see who is typing; only group 100 may see through a
+                // hidden online status.
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'discussion.flarum-realtime.view-who-types'],
+                ['group_id' => 100, 'permission' => 'user.viewLastSeenAt'],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Visible', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>x</p></t>'],
+            ],
+        ]);
+    }
+
+    private function authorize(string $channel, ?int $actorId): int
+    {
+        $options = ['json' => ['channel_name' => $channel, 'socket_id' => '123.456']];
+
+        if ($actorId !== null) {
+            $options['authenticatedAs'] = $actorId;
+        }
+
+        return $this->send(
+            $this->request('POST', '/api/websocket/auth', $options)
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function user_with_view_last_seen_at_can_authorize_the_identified_channel(): void
+    {
+        $this->assertSame(200, $this->authorize('private-typingIdentified=1', 3));
+    }
+
+    #[Test]
+    public function user_without_view_last_seen_at_cannot_authorize_the_identified_channel(): void
+    {
+        // User 2 can see the discussion and who is typing in it, but has no business
+        // seeing through anyone's hidden online status.
+        $this->assertSame(403, $this->authorize('private-typingIdentified=1', 2));
+    }
+
+    #[Test]
+    public function guest_cannot_authorize_the_identified_channel(): void
+    {
+        $this->assertSame(403, $this->authorize('private-typingIdentified=1', null));
+    }
+
+    #[Test]
+    public function permission_does_not_grant_access_to_an_invisible_discussion(): void
+    {
+        // The permission is global; discussion visibility is still checked per channel.
+        $this->assertSame(403, $this->authorize('private-typingIdentified=404', 3));
+    }
+
+    #[Test]
+    public function the_ordinary_typing_channel_is_unaffected(): void
+    {
+        // Everyone who can see the discussion keeps joining it, as before — they
+        // simply receive anonymised events for users who are hiding.
+        $this->assertSame(200, $this->authorize('private-typing=1', 2));
+    }
+}

--- a/extensions/realtime/tests/unit/Websocket/TypingRelayTest.php
+++ b/extensions/realtime/tests/unit/Websocket/TypingRelayTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\unit\Websocket;
+
+use Flarum\Realtime\Websocket\Channel\Channel;
+use Flarum\Realtime\Websocket\Channel\Manager;
+use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\Message\Message;
+use Flarum\Realtime\Websocket\TypingIdentity;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use stdClass;
+
+/**
+ * Covers how a typing event is split between the discussion channel (everyone who
+ * can see the discussion) and the identified channel (only holders of
+ * `user.viewLastSeenAt`). See Message::relayTyping().
+ */
+class TypingRelayTest extends TestCase
+{
+    private const DISCUSSION = 42;
+    private const CHANNEL = 'private-typing=42';
+    private const IDENTIFIED = 'private-typingIdentified=42';
+
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container();
+        Container::setInstance($this->container);
+
+        // Typing also feeds the index dots; irrelevant here, but it resolves.
+        $this->container->instance(IndexTypingPresence::class, $this->createStub(IndexTypingPresence::class));
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        parent::tearDown();
+    }
+
+    private function connection(string $socketId): ConnectionInterface
+    {
+        $connection = new class implements ConnectionInterface {
+            public ?string $socketId = null;
+
+            public function send($data): void
+            {
+            }
+
+            public function close(): void
+            {
+            }
+        };
+
+        $connection->socketId = $socketId;
+
+        return $connection;
+    }
+
+    /**
+     * @param string[] $socketIds
+     */
+    private function channel(string $name, ConnectionInterface $sender, array $socketIds = []): Channel
+    {
+        $channel = $this->getMockBuilder(Channel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasConnection', 'broadcastToEveryoneExcept', 'socketIds', 'getName'])
+            ->getMock();
+
+        $channel->method('hasConnection')->willReturnCallback(fn (ConnectionInterface $c) => $c === $sender);
+        $channel->method('socketIds')->willReturn($socketIds);
+        $channel->method('getName')->willReturn($name);
+
+        return $channel;
+    }
+
+    /**
+     * @param array<string, Channel> $channels
+     */
+    private function manager(array $channels, ?int $userId): Manager
+    {
+        $manager = $this->createStub(Manager::class);
+        $manager->method('find')->willReturnCallback(fn (string $c) => $channels[$c] ?? null);
+        $manager->method('userIdForConnection')->willReturn($userId);
+
+        return $manager;
+    }
+
+    private function withIdentity(?string $displayName, bool $discloseOnline): void
+    {
+        $identity = $this->createStub(TypingIdentity::class);
+        $identity->method('for')->willReturn(
+            $displayName === null ? null : compact('displayName', 'discloseOnline')
+        );
+
+        $this->container->instance(TypingIdentity::class, $identity);
+    }
+
+    private function typingPayload(array $data = []): stdClass
+    {
+        return (object) [
+            'event' => 'client-typing',
+            'channel' => self::CHANNEL,
+            'data' => (object) array_merge(['time' => 1700000000000], $data),
+        ];
+    }
+
+    #[Test]
+    public function names_the_typist_to_the_whole_discussion_when_they_disclose_their_online_status(): void
+    {
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $this->withIdentity('Bob', true);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with(
+                $this->callback(fn (stdClass $p) => $p->data['displayName'] === 'Bob' && $p->data['discloseOnline'] === true),
+                '1.1'
+            );
+
+        (new Message($this->typingPayload(), $sender, $this->manager([self::CHANNEL => $channel], 7)))->respond();
+    }
+
+    #[Test]
+    public function withholds_the_name_from_the_discussion_channel_when_the_typist_is_hidden(): void
+    {
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $this->withIdentity('Bob', false);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->callback(fn (stdClass $p) => $p->data['displayName'] === null));
+
+        (new Message($this->typingPayload(), $sender, $this->manager([self::CHANNEL => $channel], 7)))->respond();
+    }
+
+    #[Test]
+    public function sends_the_name_to_the_identified_channel_when_the_typist_is_hidden(): void
+    {
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $identified = $this->channel(self::IDENTIFIED, $sender, ['5.5']);
+        $this->withIdentity('Bob', false);
+
+        $identified->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->callback(
+                fn (stdClass $p) => $p->data['displayName'] === 'Bob'
+                    && $p->data['discloseOnline'] === false
+                    // Addressed to the identified channel, or pusher-js would route
+                    // it to the wrong binding on the client.
+                    && $p->channel === self::IDENTIFIED
+            ));
+
+        // The discussion channel still gets its anonymised copy.
+        $channel->expects($this->once())->method('broadcastToEveryoneExcept');
+
+        $manager = $this->manager([self::CHANNEL => $channel, self::IDENTIFIED => $identified], 7);
+
+        (new Message($this->typingPayload(), $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function excludes_identified_subscribers_from_the_anonymised_broadcast(): void
+    {
+        // A privileged viewer is subscribed to both channels; without this exclusion
+        // they would see the same person as both "Bob" and "[Anonymous]".
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $identified = $this->channel(self::IDENTIFIED, $sender, ['5.5', '6.6']);
+        $this->withIdentity('Bob', false);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with(
+                $this->anything(),
+                $this->callback(fn (array $except) => $except === ['1.1', '5.5', '6.6'])
+            );
+
+        $identified->expects($this->once())->method('broadcastToEveryoneExcept');
+
+        $manager = $this->manager([self::CHANNEL => $channel, self::IDENTIFIED => $identified], 7);
+
+        (new Message($this->typingPayload(), $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function ignores_the_identity_claimed_in_the_payload(): void
+    {
+        // A modified client claiming to be a disclosing "Admin" must not be able to
+        // put that name in front of the discussion, nor escape being anonymised.
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $identified = $this->channel(self::IDENTIFIED, $sender, ['5.5']);
+        $this->withIdentity('Bob', false);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->callback(fn (stdClass $p) => $p->data['displayName'] === null));
+
+        $identified->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->callback(fn (stdClass $p) => $p->data['displayName'] === 'Bob'));
+
+        $manager = $this->manager([self::CHANNEL => $channel, self::IDENTIFIED => $identified], 7);
+        $payload = $this->typingPayload(['displayName' => 'Admin', 'discloseOnline' => true]);
+
+        (new Message($payload, $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function falls_back_to_anonymous_when_the_sender_cannot_be_identified(): void
+    {
+        // No authenticated user channel for this socket — a guest, or a reconnecting
+        // client whose channels aren't re-established yet. Fail closed.
+        $sender = $this->connection('1.1');
+        $channel = $this->channel(self::CHANNEL, $sender);
+        $identified = $this->channel(self::IDENTIFIED, $sender, ['5.5']);
+        $this->withIdentity('Bob', false);
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->callback(fn (stdClass $p) => $p->data['displayName'] === null));
+
+        $identified->expects($this->never())->method('broadcastToEveryoneExcept');
+
+        $manager = $this->manager([self::CHANNEL => $channel, self::IDENTIFIED => $identified], null);
+
+        (new Message($this->typingPayload(), $sender, $manager))->respond();
+    }
+
+    #[Test]
+    public function leaves_typing_on_other_channels_untouched(): void
+    {
+        // flarum/messages relays `client-typing` on its own dialog channel. That
+        // isn't discussion typing, so it must pass through verbatim.
+        $sender = $this->connection('1.1');
+        $dialog = 'private-privateMessageTyping=3';
+        $channel = $this->channel($dialog, $sender);
+        $this->withIdentity('Bob', false);
+
+        $payload = (object) [
+            'event' => 'client-typing',
+            'channel' => $dialog,
+            'data' => (object) ['displayName' => 'Bob', 'discloseOnline' => true, 'time' => 1],
+        ];
+
+        $channel->expects($this->once())
+            ->method('broadcastToEveryoneExcept')
+            ->with($this->identicalTo($payload), '1.1');
+
+        (new Message($payload, $sender, $this->manager([$dialog => $channel], 7)))->respond();
+    }
+}


### PR DESCRIPTION
Fixes #4879.

Core treats `user.viewLastSeenAt` as the override for a user's `discloseOnline` preference — someone who hides their online status still has `lastSeenAt` disclosed to actors holding it (`UserResource`). The typing indicator was the one place that override wasn't applied: the display name was scrubbed at the *sender*, so it never reached anyone, and a moderator saw `[Anonymous] is typing` for a user whose last-seen time they can read on the profile page.

Scrubbing at the receiver instead isn't an option: `private-typing={id}` is subscribable by everyone who can see the discussion, so a name broadcast there is a name disclosed to all of them. So the relay splits the event by audience instead.

### How it works

When the typist is hiding their online status:

- the full payload goes to `private-typingIdentified={id}`, which only holders of the permission can subscribe to;
- an anonymised payload — no name at all — goes to the discussion channel, **skipping the identified channel's subscribers**, so a privileged viewer sees one event rather than a name *and* an `[Anonymous]` for the same person.

When the typist is disclosing, the existing single broadcast is unchanged. When nobody privileged is listening, the identified channel doesn't exist and behaviour is exactly as before.

Authorisation happens in `AuthController::typingIdentified()`, so the permission is evaluated once per subscription against a real actor in an ordinary request — the websocket server does no permission work per event, only set arithmetic over socket IDs. This follows the pattern established by `private-index-typing-tag=` in #4756, and the relay split follows `relayIndexTyping()` / `relayComposeTyping()`.

### Identity is no longer taken from the payload

Gating a name behind a permission makes an authority claim about who is typing, and a client-asserted string can't back that. Both the display name and the disclosure preference are now resolved from the identity the connection authenticated with:

- `Manager` indexes socket → user id when a connection subscribes to `private-user={id}` — an authenticated identity claim, since that channel is only signed for the matching actor and the signature is verified against the socket ID. Same reasoning `relayComposeTyping()` already relies on;
- `TypingIdentity` resolves name + `discloseOnline` from that id, cached briefly (5s, deliberately short — it bounds how long someone who has just hidden their status keeps being announced by name);
- senders that can't be identified (guests, or the brief window after a reconnect before channels are re-established) fail closed to anonymous.

As a side effect this closes the existing ability for a modified client to broadcast an arbitrary `displayName` into a discussion.

The payload shape is unchanged, so existing `client-typing` listeners keep working — including flarum/messages, whose own dialog channel this doesn't touch (covered by a test).

### Notes

- **Defaults are unchanged for regular members.** `user.viewLastSeenAt` is seeded to Moderators only, so on a default install this discloses nothing to a group that can't already read the same users' last-seen time. Happy to add a setting (mirroring `index-typing-indicator-restricted`) if you'd prefer it opt-in.
- **The semantics are your call, not the mechanism** — whether `user.viewLastSeenAt` should imply "may see who is typing while hidden", or whether this deserves its own permission (`flarum-realtime.view-hidden-typers`). I assumed reuse: it's what admins already reach for when they want moderators to see through a hidden online status, and it needs no migration. Straightforward to switch.
- A disclosed hidden user is rendered `{username} (hidden)` rather than bare, so a moderator can tell that person is invisible to everyone else.
- Like the index typing dots, this lives in the relay and assumes the bundled websocket server.
- `flarum/messages` has its own copy of the typing indicator (it currently *drops* non-disclosing typists rather than showing `[Anonymous]`). Deliberately out of scope; it could follow the same shape separately.

### Tests

- `tests/unit/Websocket/TypingRelayTest.php` — 7 tests over the split: name reaches the whole discussion when disclosing; name withheld from the discussion channel when hidden; name reaches the identified channel (addressed to it, so pusher-js routes it correctly); identified subscribers excluded from the anonymised broadcast; payload-claimed identity ignored; unidentifiable sender falls back to anonymous; typing on other channels passes through verbatim.
- `tests/integration/api/TypingIdentifiedAuthTest.php` — 5 tests over channel auth: permitted user 200; user with view-who-types but without `user.viewLastSeenAt` 403; guest 403; permission doesn't bypass discussion visibility; the ordinary typing channel is unaffected.

Realtime's full unit (41) and integration (39) suites pass locally, PHPStan is clean, and `tsc` typechecks. No `js/dist` or `dist-typings` in the commit.
