### PR TITLE
[2.x] fix: keep the page shell rendered while a discussion loads

### DIFF
--- a/framework/core/js/src/forum/components/DiscussionPage.tsx
+++ b/framework/core/js/src/forum/components/DiscussionPage.tsx
@@ -5,7 +5,6 @@ import Page, { IPageAttrs } from '../../common/components/Page';
 import ItemList from '../../common/utils/ItemList';
 import DiscussionHero from './DiscussionHero';
 import DiscussionListPane from './DiscussionListPane';
-import LoadingIndicator from '../../common/components/LoadingIndicator';
 import SplitDropdown from '../../common/components/SplitDropdown';
 import listItems from '../../common/helpers/listItems';
 import DiscussionControls from '../utils/DiscussionControls';
@@ -94,19 +93,24 @@ export default class DiscussionPage<CustomAttrs extends IDiscussionPageAttrs = I
   }
 
   view() {
-    if (this.loading || !this.discussion) {
-      return <LoadingIndicator />;
-    }
+    // Keep the page shell rendered while the discussion loads. Bailing out to
+    // a bare loading indicator here blanks the whole layout on every
+    // discussion-to-discussion navigation — including the pinned discussion
+    // list pane, whose contents are already cached and need no network.
+    // PageStructure renders the spinner inside the main area and skips the
+    // hero/sidebar/content closures while `loading` is set, so none of them
+    // run without a discussion.
+    const loading = this.loading || !this.discussion;
 
     return (
       <PageStructure
         className="DiscussionPage"
-        loading={this.loading}
+        loading={loading}
         hero={this.hero.bind(this)}
         sidebar={this.sidebar.bind(this)}
         pane={() => <DiscussionListPane state={app.discussions} />}
       >
-        {this.loading || (
+        {loading || (
           <div className="DiscussionPage-stream">
             <this.PostStream discussion={this.discussion} stream={this.stream} onPositionChange={this.positionChanged.bind(this)} />
           </div>

--- a/framework/core/js/tests/integration/forum/components/DiscussionPage.test.ts
+++ b/framework/core/js/tests/integration/forum/components/DiscussionPage.test.ts
@@ -57,12 +57,18 @@ describe('DiscussionPage', () => {
   beforeAll(() => {
     bootstrapForum();
     app.boot();
+
   });
 
   beforeEach(() => {
     routeParams = {};
     findCalls = [];
     pendingFinds = [];
+
+    // The pane helper is created by ForumApplication when mounting the real
+    // app; the pane component's lifecycle hooks expect it to exist.
+    // @ts-ignore
+    app.pane = app.pane || { enable() {}, disable() {}, hide() {}, show() {}, onmouseleave() {}, togglePinned() {} };
 
     // @ts-ignore
     m.route.param = (key?: string) => (key ? routeParams[key] : routeParams);
@@ -114,6 +120,24 @@ describe('DiscussionPage', () => {
     const models = app.store.pushPayload<Post[]>(document as any);
     pending!.resolve(models);
   };
+
+  test('keeps the page structure while the discussion loads instead of blanking', () => {
+    // Navigating between discussions remounts the page. Rendering a bare
+    // loading indicator during the fetch blanks the whole layout — including
+    // the pinned discussion list pane, whose contents are already cached and
+    // need no network. The shell must stay; only the main area may spin.
+    seedDiscussionFromList();
+    routeParams = { id: '476-test-discussion' };
+
+    const page = mountPage();
+
+    // Nothing resolved yet: the page is loading. The pane slot must exist
+    // (its contents render whenever the list state has items), and the
+    // spinner must be inside the main area, not the whole page.
+    expect(page).toHaveElement('.DiscussionPage');
+    expect(page).toHaveElement('.Page-pane');
+    expect(page).toHaveElement('#page-main .LoadingIndicator');
+  });
 
   test('requests the discussion and the post window in parallel when the discussion is known', () => {
     seedDiscussionFromList();


### PR DESCRIPTION
## The problem

With the discussion list pane pinned, navigating from one discussion to another blanks the **entire page** — pane included — until the new discussion arrives, then everything redraws. The pane's contents are already cached in `app.discussions` and need no network, so tearing them down is pure perceived-slowness.

## Root cause

Two mechanisms combine:

1. `DiscussionPageResolver.makeKey()` includes the discussion id, so discussion→discussion navigation remounts `DiscussionPage`. That's by design — extensions rely on a fresh page lifecycle per discussion — and this PR does not touch it.
2. `DiscussionPage.view()` returned a **bare `<LoadingIndicator />`** while loading, bypassing `PageStructure` entirely. That's the blank: pane, hero and sidebar all vanish for the duration of the fetch.

The second part is the bug, because `PageStructure` was already built for exactly this: given `loading`, it renders the spinner *inside* `.Page-main`, keeps the pane, and skips the hero/sidebar/content closures — so none of them run without a discussion. The early return was defeating the shell designed to prevent the blank. `DiscussionListPane` also already restores its scroll position when arriving from another discussion page, so the rebuilt pane is visually stable.

## The change

`view()` now always renders `PageStructure`, passing `loading` while the discussion (or the async post stream chunks) are pending. During navigation the pane and header stay painted and only the main column shows the spinner. No lifecycle or remount semantics change — the smallest edit that removes the blank.

Deliberately out of scope: reusing the page instance across discussions (stable resolver key + in-place reload) would avoid rebuilding the pane DOM at all, but changes remount semantics that extensions depend on (`oninit` per discussion, `show()` overrides). Not a trade to make during RC for one frame of cached rendering.

## Testing

- New regression test in the DiscussionPage suite: while the discussion request is pending, the page keeps `.DiscussionPage` and `.Page-pane` with the loading indicator scoped to `#page-main` — RED against the old view, GREEN now.
- Full jest suite 229/229, typings clean.
- Manually verified on a live install: pinned pane, navigating between discussions — pane and header stay put, only the content area spins.