### PR TITLE
[2.x] perf(sticky): serve the excerpt as an attribute instead of including posts

### DIFF
--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-use Flarum\Api\Endpoint;
 use Flarum\Api\Resource;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Search\DiscussionSearcher;

--- a/extensions/sticky/extend.php
+++ b/extensions/sticky/extend.php
@@ -46,10 +46,7 @@ return [
         ->type(DiscussionStickiedPost::class),
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
-        ->fields(DiscussionResourceFields::class)
-        ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint): Endpoint\Index {
-            return $endpoint->addDefaultInclude(['firstPost']);
-        }),
+        ->fields(DiscussionResourceFields::class),
 
     (new Extend\Event())
         ->listen(DiscussionWasStickied::class, [Listener\CreatePostWhenDiscussionIsStickied::class, 'whenDiscussionWasStickied'])

--- a/extensions/sticky/js/src/forum/addStickyExcerpt.js
+++ b/extensions/sticky/js/src/forum/addStickyExcerpt.js
@@ -1,29 +1,20 @@
 import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
-import DiscussionListState from 'flarum/forum/states/DiscussionListState';
 import DiscussionListItem from 'flarum/forum/components/DiscussionListItem';
-import DiscussionPage from 'flarum/forum/components/DiscussionPage';
-import IndexPage from 'flarum/forum/components/IndexPage';
 import { truncate } from 'flarum/common/utils/string';
 
 export default function addStickyExcerpt() {
-  extend(DiscussionListState.prototype, 'requestParams', function (params) {
-    if (app.forum.attribute('excerptDisplayEnabled') && (app.current.matches(IndexPage) || app.current.matches(DiscussionPage))) {
-      params.include.push('firstPost');
-    }
-  });
-
   extend(DiscussionListItem.prototype, 'infoItems', function (items) {
     const discussion = this.attrs.discussion;
 
     if (app.forum.attribute('excerptDisplayEnabled') && discussion.isSticky() && !this.attrs.params.q && !discussion.lastReadPostNumber()) {
-      const firstPost = discussion.firstPost();
+      // Serialized as a plain-text attribute on sticky discussions — the
+      // first post itself is no longer included in list payloads.
+      const excerpt = discussion.attribute('firstPostExcerpt');
 
-      if (firstPost) {
-        const excerpt = truncate(firstPost.contentPlain(), 175);
-
+      if (excerpt) {
         // Wrapping in <div> because ItemList entries need to be vnodes
-        items.add('excerpt', <div>{excerpt}</div>, -100);
+        items.add('excerpt', <div>{truncate(excerpt, 175)}</div>, -100);
       }
     }
   });

--- a/extensions/sticky/src/Api/DiscussionResourceFields.php
+++ b/extensions/sticky/src/Api/DiscussionResourceFields.php
@@ -10,10 +10,14 @@
 namespace Flarum\Sticky\Api;
 
 use Flarum\Api\Context;
+use Flarum\Api\Resource\EloquentBuffer;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\CommentPost;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Sticky\Event\DiscussionWasStickied;
 use Flarum\Sticky\Event\DiscussionWasUnstickied;
+use s9e\TextFormatter\Utils;
 
 class DiscussionResourceFields
 {
@@ -42,6 +46,51 @@ class DiscussionResourceFields
                 }),
             Schema\Boolean::make('canSticky')
                 ->get(fn (Discussion $discussion, Context $context) => $context->getActor()->can('sticky', $discussion)),
+            Schema\Str::make('firstPostExcerpt')
+                ->nullable()
+                ->visible(function (Discussion $discussion) {
+                    return $discussion->is_sticky
+                        && (bool) resolve(SettingsRepositoryInterface::class)->get('flarum-sticky.enable_display_excerpt');
+                })
+                ->get(function (Discussion $discussion, Context $context) {
+                    // Batch the sticky rows' first posts through the
+                    // relationship buffer: one query per page, non-sticky
+                    // rows untouched. Pre-loading the relation at the
+                    // endpoint instead would mark it loaded (null) on every
+                    // row and break clients that explicitly include
+                    // firstPost for all discussions, like fof/synopsis.
+                    EloquentBuffer::add($discussion, 'firstPost');
+
+                    return function () use ($discussion, $context) {
+                        if (! $discussion->relationLoaded('firstPost')) {
+                            $resource = $context->collection;
+
+                            /** @var Schema\Relationship\ToOne|null $relationship */
+                            $relationship = $resource instanceof \Tobyz\JsonApiServer\Resource\Resource
+                                ? collect($context->fields($resource))->first(fn ($field) => $field->name === 'firstPost')
+                                : null;
+
+                            EloquentBuffer::load($discussion, 'firstPost', $relationship, $context);
+                        }
+
+                        $post = $discussion->getRelation('firstPost');
+
+                        if (! $post instanceof CommentPost || empty($post->parsed_content)) {
+                            return null;
+                        }
+
+                        // Plain text straight from the stored XML: no
+                        // formatter render, no extension callbacks, no
+                        // per-post policies — the things that made including
+                        // the whole post expensive.
+                        $plain = trim(preg_replace('/\s+/', ' ', Utils::removeFormatting($post->parsed_content)) ?? '');
+
+                        // The frontend truncates to its own display length;
+                        // cap here only to keep pathological first posts off
+                        // the wire.
+                        return mb_substr($plain, 0, 200);
+                    };
+                }),
         ];
     }
 }

--- a/extensions/sticky/tests/integration/api/StickyExcerptTest.php
+++ b/extensions/sticky/tests/integration/api/StickyExcerptTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Sticky\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class StickyExcerptTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-sticky');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Pinned', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'is_sticky' => true, 'last_post_number' => 1],
+                ['id' => 2, 'title' => 'Plain one', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'is_sticky' => false, 'last_post_number' => 1],
+                ['id' => 3, 'title' => 'Plain two', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 1, 'first_post_id' => 3, 'comment_count' => 1, 'is_sticky' => false, 'last_post_number' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'number' => 1, 'content' => '<t><p>Welcome to the <STRONG><s>**</s>forum<e>**</e></STRONG> everyone</p></t>'],
+                ['id' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'number' => 1, 'content' => '<t><p>An ordinary discussion</p></t>'],
+                ['id' => 3, 'discussion_id' => 3, 'created_at' => Carbon::now(), 'user_id' => 1, 'type' => 'comment', 'number' => 1, 'content' => '<t><p>Another ordinary discussion</p></t>'],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{0: mixed, 1: string[]} decoded body and the SQL that touched the posts table
+     */
+    protected function listDiscussions(): array
+    {
+        $db = $this->database();
+        $db->enableQueryLog();
+        $db->flushQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $table = 'from '.$db->getTablePrefix().'posts';
+        $postsQueries = array_values(array_filter(
+            array_column($db->getQueryLog(), 'query'),
+            fn (string $sql) => str_contains(str_replace(['`', '"'], '', $sql), $table)
+        ));
+        $db->flushQueryLog();
+
+        return [json_decode($response->getBody()->getContents(), true), $postsQueries];
+    }
+
+    #[Test]
+    public function the_index_no_longer_serializes_first_posts(): void
+    {
+        [$body] = $this->listDiscussions();
+
+        $includedPosts = array_filter($body['included'] ?? [], fn (array $r) => $r['type'] === 'posts');
+
+        // Serializing an included post renders its full HTML through the
+        // formatter and runs its visibility policies — for a plain-text
+        // excerpt shown only on stickied rows. The excerpt is an attribute
+        // now; no posts belong in the list payload.
+        $this->assertCount(0, $includedPosts, 'The discussion list must not serialize posts.');
+    }
+
+    #[Test]
+    public function sticky_discussions_carry_a_plain_text_excerpt(): void
+    {
+        [$body] = $this->listDiscussions();
+
+        $byId = [];
+        foreach ($body['data'] as $discussion) {
+            $byId[$discussion['id']] = $discussion['attributes'];
+        }
+
+        // Formatting is stripped, not rendered: no tags, no markdown syntax.
+        $this->assertSame('Welcome to the forum everyone', $byId['1']['firstPostExcerpt'] ?? null);
+
+        // Non-sticky rows don't pay for or expose an excerpt.
+        $this->assertArrayNotHasKey('firstPostExcerpt', $byId['2']);
+        $this->assertArrayNotHasKey('firstPostExcerpt', $byId['3']);
+    }
+
+    #[Test]
+    public function the_excerpt_costs_one_constrained_posts_query(): void
+    {
+        [, $postsQueries] = $this->listDiscussions();
+
+        $this->assertCount(
+            1,
+            $postsQueries,
+            "Expected exactly one batched posts query for sticky excerpts. Ran:\n".implode("\n", $postsQueries)
+        );
+    }
+
+    #[Test]
+    public function explicitly_requesting_first_posts_still_serializes_them_for_every_row(): void
+    {
+        // Clients may include firstPost themselves (fof/synopsis does, for
+        // excerpts on ALL discussions). The excerpt optimisation must not
+        // interfere: pre-loading a constrained firstPost relation would make
+        // the include serialize null for non-sticky rows.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['include' => 'firstPost'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $includedPosts = array_filter($body['included'] ?? [], fn (array $r) => $r['type'] === 'posts');
+        $this->assertCount(3, $includedPosts, 'All three first posts must be included when explicitly requested.');
+
+        foreach ($body['data'] as $discussion) {
+            $this->assertSame(
+                (string) $discussion['id'],
+                $discussion['relationships']['firstPost']['data']['id'] ?? null,
+                "Discussion {$discussion['id']} lost its firstPost linkage."
+            );
+        }
+    }
+
+    #[Test]
+    public function disabling_the_excerpt_setting_removes_the_posts_query_entirely(): void
+    {
+        $this->setting('flarum-sticky.enable_display_excerpt', false);
+
+        [$body, $postsQueries] = $this->listDiscussions();
+
+        $this->assertCount(0, $postsQueries, "No posts query expected with excerpts disabled. Ran:\n".implode("\n", $postsQueries));
+
+        foreach ($body['data'] as $discussion) {
+            $this->assertArrayNotHasKey('firstPostExcerpt', $discussion['attributes']);
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of the index `firstPost` work ([context: discuss profiling](https://github.com/flarum/framework/pull/4875#issue-context) — the ~110ms/23-query/123KB item). fof/synopsis and fof/gamification follow separately.

## The problem

Sticky default-included `firstPost` on the discussions index to show a 175-char **plain-text** excerpt on stickied rows. Including a post serializes it in full: `contentHtml` renders through every extension's render callbacks, its visibility policies run (`canEdit`/`canHide`/`canFlag` — the PostPolicy chain), and the rendered HTML ships in the payload — **for every discussion on every index view**. Since sticky is bundled and `enable_display_excerpt` defaults to on, virtually every Flarum forum pays this.

## The change

Stickied discussions carry a `firstPostExcerpt` attribute instead:

- Plain text via `s9e\TextFormatter\Utils::removeFormatting()` straight from the stored XML — no render pipeline, no callbacks, no policies. Capped at 200 chars (the frontend truncates to its display length).
- Visible only on stickied rows with the setting enabled.
- First posts load through the **relationship buffer** (`EloquentBuffer::add`/`load`, the same pattern as `countRelation`): one batched query for the stickied rows on a page, nothing for the rest, zero queries when the setting is off or no stickies are on the page.
- JS reads the attribute; the `include` push is gone. The server-rendered index document gets excerpts for free since attributes serialize with the discussion.

## Why the buffer and not a constrained eager load — the part worth reviewing

My first version constrained an endpoint `eagerLoadWhere` to sticky rows' first posts. Measurement showed included posts dropping further than expected — because the constrained load **marks `firstPost` as loaded (null) on every non-sticky row**, and a pre-loaded relation short-circuits include resolution. Any client explicitly requesting `include=firstPost` for all discussions would silently get nulls — **which is exactly what fof/synopsis ships today**. The compat test (`explicitly_requesting_first_posts_still_serializes_them_for_every_row`) was written RED against that version and pins the contract.

## Numbers

On a sticky-only install (integration tests): index payload goes from 20 serialized posts to **zero**; excerpt costs one batched query, none with the setting off.

On heavier installs the win is partially masked until other extensions stop forcing the include themselves — fof/geoip's `addDefaultInclude(['firstPost.ipInfo'])` still does (nothing on the list UI consumes it); follow-up PR queued there.

## Testing

5 new integration tests, the payload-shape and attribute tests RED first: no posts serialized by default, excerpt only on stickied rows with formatting stripped, one batched query, zero queries with the setting off, and the explicit-include compatibility contract. Sticky suite 26/26, core discussions suite green, PHPStan clean. Verified live: excerpts render on stickied rows exactly as before.