### PR TITLE
[2.x] fix(sticky): look up the excerpt relationship on the discussions resource

### DIFF
--- a/extensions/sticky/src/Api/DiscussionResourceFields.php
+++ b/extensions/sticky/src/Api/DiscussionResourceFields.php
@@ -63,12 +63,17 @@ class DiscussionResourceFields
 
                     return function () use ($discussion, $context) {
                         if (! $discussion->relationLoaded('firstPost')) {
-                            $resource = $context->collection;
+                            // Look the relationship up on the discussions
+                            // resource itself — $context->collection is the
+                            // REQUEST's primary resource, which is a different
+                            // one whenever a sticky discussion is serialized
+                            // as an included resource (e.g. of a posts
+                            // request), and a null relationship sends the
+                            // buffer down its aggregate path.
+                            $resource = $context->api->getResource('discussions');
 
                             /** @var Schema\Relationship\ToOne|null $relationship */
-                            $relationship = $resource instanceof \Tobyz\JsonApiServer\Resource\Resource
-                                ? collect($context->fields($resource))->first(fn ($field) => $field->name === 'firstPost')
-                                : null;
+                            $relationship = collect($context->fields($resource))->first(fn ($field) => $field->name === 'firstPost');
 
                             EloquentBuffer::load($discussion, 'firstPost', $relationship, $context);
                         }

--- a/extensions/sticky/tests/integration/api/StickyExcerptTest.php
+++ b/extensions/sticky/tests/integration/api/StickyExcerptTest.php
@@ -141,6 +141,28 @@ class StickyExcerptTest extends TestCase
     }
 
     #[Test]
+    public function a_sticky_discussion_included_in_a_posts_payload_serializes_safely(): void
+    {
+        // The posts index default-includes each post's discussion. When that
+        // discussion is sticky, the excerpt field runs while the REQUEST's
+        // primary resource is posts — the relationship lookup must target the
+        // discussions resource explicitly, or the buffer is handed a null
+        // relationship and crashes down its aggregate path.
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['discussion' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $discussions = array_values(array_filter($body['included'] ?? [], fn (array $r) => $r['type'] === 'discussions'));
+
+        $this->assertNotEmpty($discussions);
+        $this->assertSame('Welcome to the forum everyone', $discussions[0]['attributes']['firstPostExcerpt'] ?? null);
+    }
+
+    #[Test]
     public function disabling_the_excerpt_setting_removes_the_posts_query_entirely(): void
     {
         $this->setting('flarum-sticky.enable_display_excerpt', false);


### PR DESCRIPTION
Regression fix for #4882, found by clicking around a live install within hours of merge — a posts request for any **sticky** discussion 500s:

```
EloquentBuffer::loadAggregate(): Argument #3 ($aggregate) must be of type array, null given
```

## Root cause

The excerpt field resolved the `firstPost` relationship from `$context->collection` — the **request's primary resource**. On the discussions index that's `DiscussionResource` and everything works (which is why #4882's tests all passed). But the posts index default-includes each post's `discussion`, and when a sticky discussion is serialized as an **included** resource, the primary resource is `PostResource`: the field lookup misses, `EloquentBuffer::load()` receives a null relationship, and its `!$aggregate && $relationship` branch condition sends it into `loadAggregate(null)` → TypeError.

The testing gap in #4882: every payload test hit `/api/discussions`; none exercised a discussion serialized as an included resource of another endpoint.

## Fix

Look the relationship up on the discussions resource explicitly:

```php
$resource = $context->api->getResource('discussions');
```

## Testing

New regression test: `GET /api/posts?filter[discussion]=<sticky>` returns 200 with `firstPostExcerpt` on the included discussion — verified **failing (500) against current 2.x HEAD** and green with the fix. Sticky suite 27/27, PHPStan clean, and the reporting URL's document + posts API both return 200 on a live install.

Worth a thought for later (not this PR): `EloquentBuffer::load()` treating "no aggregate + no relationship" as an aggregate call is a footgun — a loud guard there would have turned this into an obvious error instead of a TypeError two frames deep.