### PR TITLE
[2.x] fix(akismet): modernize the API client, fail open, verify keys, recheck edits

### DIFF
--- a/extensions/akismet/extend.php
+++ b/extensions/akismet/extend.php
@@ -14,6 +14,7 @@ use Flarum\Extend;
 use Flarum\Post\Event\Hidden;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\Post;
+use Flarum\Settings\Event\Saving as SettingsSaving;
 
 return [
     (new Extend\Frontend('forum'))
@@ -27,7 +28,8 @@ return [
     (new Extend\Event())
         ->listen(Hidden::class, Listener\SubmitSpam::class)
         ->listen(PostWasApproved::class, Listener\SubmitHam::class)
-        ->listen(Saving::class, Listener\ValidatePost::class),
+        ->listen(Saving::class, Listener\ValidatePost::class)
+        ->listen(SettingsSaving::class, Listener\ValidateApiKey::class),
 
     (new Extend\ServiceProvider())
         ->register(AkismetProvider::class),

--- a/extensions/akismet/locale/en.yml
+++ b/extensions/akismet/locale/en.yml
@@ -10,6 +10,7 @@ flarum-akismet:
     # These translations are used in the Akismet Settings.
     akismet_settings:
       api_key_label: API Key
+      invalid_api_key_message: Akismet rejected this API key. Check it against your Akismet account and try again.
       title: Akismet Settings
       delete_blatant_spam_label: Automatically delete blatant spam
       delete_blatant_spam_help: If Akismet has determined that the comment is blatant spam, instead of flagging, automatically delete post

--- a/extensions/akismet/src/Akismet.php
+++ b/extensions/akismet/src/Akismet.php
@@ -10,22 +10,40 @@
 namespace Flarum\Akismet;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 
 class Akismet
 {
-    private string $apiUrl;
+    /**
+     * Akismet's current API form: one fixed host, with the key sent as a POST
+     * parameter. The legacy {key}.rest.akismet.com subdomain form leaked the
+     * secret key into DNS lookups and TLS SNI on every request.
+     */
+    private const API_URL = 'https://rest.akismet.com/1.1';
+
+    /**
+     * Spam checking runs inside the user's own request, so a hanging Akismet
+     * must never hang the forum: keep the timeout short and let callers fail
+     * open when it trips.
+     */
+    private const TIMEOUT_SECONDS = 3;
+
     private array $params = [];
+
+    private ?ClientInterface $client;
 
     public function __construct(
         private readonly string $apiKey,
         string $homeUrl,
         private readonly string $flarumVersion,
         private readonly string $extensionVersion,
-        bool $inDebugMode = false
+        bool $inDebugMode = false,
+        ?ClientInterface $client = null
     ) {
-        $this->apiUrl = "https://$apiKey.rest.akismet.com/1.1";
+        $this->client = $client;
+        $this->params['api_key'] = $apiKey;
         $this->params['blog'] = $homeUrl;
 
         if ($inDebugMode) {
@@ -39,32 +57,58 @@ class Akismet
     }
 
     /**
-     * @param  string  $type  e.g. comment-check, submit-spam or submit-ham;
+     * @param  string  $type  e.g. comment-check, verify-key, submit-spam or submit-ham
+     * @param  array  $overrides  parameters overriding the accumulated ones for this request only
      * @throws GuzzleException
      */
-    protected function sendRequest(string $type): ResponseInterface
+    protected function sendRequest(string $type, array $overrides = []): ResponseInterface
     {
-        $client = new Client();
+        $client = $this->client ??= new Client();
 
-        return $client->request('POST', "$this->apiUrl/$type", [
+        return $client->request('POST', self::API_URL."/$type", [
             'headers' => [
                 'User-Agent' => "Flarum/$this->flarumVersion | Akismet/$this->extensionVersion",
             ],
-            'form_params' => $this->params,
+            'form_params' => array_merge($this->params, $overrides),
+            'timeout' => self::TIMEOUT_SECONDS,
+            'connect_timeout' => self::TIMEOUT_SECONDS,
         ]);
     }
 
     /**
-     * @throws GuzzleException
+     * @return array{isSpam: bool, proTip: string}
+     *
+     * @throws GuzzleException on network failure
+     * @throws AkismetUnexpectedResponseException when Akismet rejects the request
+     *         (e.g. a misconfigured key) — never silently treated as ham.
      */
     public function checkSpam(): array
     {
         $response = $this->sendRequest('comment-check');
 
+        $body = $response->getBody()->getContents();
+
+        if ($body !== 'true' && $body !== 'false') {
+            throw new AkismetUnexpectedResponseException($body, $response->getHeaderLine('X-akismet-debug-help'));
+        }
+
         return [
-            'isSpam' => $response->getBody()->getContents() === 'true',
+            'isSpam' => $body === 'true',
             'proTip' => $response->getHeaderLine('X-akismet-pro-tip'),
         ];
+    }
+
+    /**
+     * Check a key against Akismet's verify-key endpoint. Pass a candidate key
+     * to validate it before it is saved; defaults to the configured key.
+     *
+     * @throws GuzzleException
+     */
+    public function verifyKey(?string $candidateKey = null): bool
+    {
+        $response = $this->sendRequest('verify-key', $candidateKey !== null ? ['api_key' => $candidateKey] : []);
+
+        return $response->getBody()->getContents() === 'valid';
     }
 
     /**
@@ -206,6 +250,14 @@ class Akismet
     public function withLanguage(string $language): Akismet
     {
         return $this->withParam('blog_lang', $language);
+    }
+
+    /**
+     * The character encoding for the form values included in comment_* parameters, such as UTF-8 or ISO-8859-1.
+     */
+    public function withCharset(string $charset): Akismet
+    {
+        return $this->withParam('blog_charset', $charset);
     }
 
     /**

--- a/extensions/akismet/src/AkismetUnexpectedResponseException.php
+++ b/extensions/akismet/src/AkismetUnexpectedResponseException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet;
+
+use RuntimeException;
+
+/**
+ * Thrown when Akismet answers something other than a spam verdict — most
+ * commonly the literal body "invalid" for a misconfigured key, accompanied by
+ * an X-akismet-debug-help header explaining why. Callers treat this like any
+ * other Akismet failure: log it and fail open.
+ */
+class AkismetUnexpectedResponseException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $body,
+        string $debugHelp = ''
+    ) {
+        parent::__construct(
+            $debugHelp !== ''
+                ? $debugHelp
+                : "Unexpected Akismet response: $body"
+        );
+    }
+}

--- a/extensions/akismet/src/Listener/SubmitHam.php
+++ b/extensions/akismet/src/Listener/SubmitHam.php
@@ -11,11 +11,14 @@ namespace Flarum\Akismet\Listener;
 
 use Flarum\Akismet\Akismet;
 use Flarum\Approval\Event\PostWasApproved;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
 
 class SubmitHam
 {
     public function __construct(
-        protected Akismet $akismet
+        protected Akismet $akismet,
+        protected LoggerInterface $log
     ) {
     }
 
@@ -28,13 +31,19 @@ class SubmitHam
         $post = $event->post;
 
         if ($post->is_spam) {
-            $this->akismet
-                ->withContent($post->content)
-                ->withIp($post->ip_address)
-                ->withAuthorName($post->user->username)
-                ->withAuthorEmail($post->user->email)
-                ->withType($post->number === 1 ? 'forum-post' : 'reply')
-                ->submitHam();
+            try {
+                $this->akismet
+                    ->withContent($post->content)
+                    ->withIp($post->ip_address ?? '')
+                    ->withAuthorName($post->user->username)
+                    ->withAuthorEmail($post->user->email)
+                    ->withType($post->number === 1 ? 'forum-post' : 'reply')
+                    ->submitHam();
+            } catch (GuzzleException $e) {
+                // The feedback loop is best-effort — never let an Akismet
+                // outage break the moderation action itself.
+                $this->log->warning("[flarum/akismet] Failed to submit ham feedback: {$e->getMessage()}");
+            }
         }
     }
 }

--- a/extensions/akismet/src/Listener/SubmitSpam.php
+++ b/extensions/akismet/src/Listener/SubmitSpam.php
@@ -11,11 +11,14 @@ namespace Flarum\Akismet\Listener;
 
 use Flarum\Akismet\Akismet;
 use Flarum\Post\Event\Hidden;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
 
 class SubmitSpam
 {
     public function __construct(
-        protected Akismet $akismet
+        protected Akismet $akismet,
+        protected LoggerInterface $log
     ) {
     }
 
@@ -28,13 +31,19 @@ class SubmitSpam
         $post = $event->post;
 
         if ($post->is_spam) {
-            $this->akismet
-                ->withContent($post->content)
-                ->withIp($post->ip_address)
-                ->withAuthorName($post->user->username)
-                ->withAuthorEmail($post->user->email)
-                ->withType($post->number === 1 ? 'forum-post' : 'reply')
-                ->submitSpam();
+            try {
+                $this->akismet
+                    ->withContent($post->content)
+                    ->withIp($post->ip_address ?? '')
+                    ->withAuthorName($post->user->username)
+                    ->withAuthorEmail($post->user->email)
+                    ->withType($post->number === 1 ? 'forum-post' : 'reply')
+                    ->submitSpam();
+            } catch (GuzzleException $e) {
+                // The feedback loop is best-effort — never let an Akismet
+                // outage break the moderation action itself.
+                $this->log->warning("[flarum/akismet] Failed to submit spam feedback: {$e->getMessage()}");
+            }
         }
     }
 }

--- a/extensions/akismet/src/Listener/ValidateApiKey.php
+++ b/extensions/akismet/src/Listener/ValidateApiKey.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Listener;
+
+use Flarum\Akismet\Akismet;
+use Flarum\Foundation\ValidationException;
+use Flarum\Locale\TranslatorInterface;
+use Flarum\Settings\Event\Saving;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Checks a submitted API key against Akismet's verify-key endpoint before it
+ * is saved. Without this, a typo'd key was accepted silently and the forum
+ * ran unprotected with nothing to show for it.
+ */
+class ValidateApiKey
+{
+    public function __construct(
+        protected Akismet $akismet,
+        protected TranslatorInterface $translator,
+        protected LoggerInterface $log
+    ) {
+    }
+
+    public function handle(Saving $event): void
+    {
+        $key = Arr::get($event->settings, 'flarum-akismet.api_key');
+
+        // Not part of this save, or deliberately being cleared.
+        if ($key === null || $key === '') {
+            return;
+        }
+
+        try {
+            $valid = $this->akismet->verifyKey($key);
+        } catch (GuzzleException $e) {
+            // Can't reach Akismet right now — don't block the admin from
+            // saving; a wrong key will still surface in the log on use.
+            $this->log->warning("[flarum/akismet] Could not verify the API key, saving unverified: {$e->getMessage()}");
+
+            return;
+        }
+
+        if (! $valid) {
+            throw new ValidationException([
+                'flarum-akismet.api_key' => $this->translator->trans('flarum-akismet.admin.akismet_settings.invalid_api_key_message'),
+            ]);
+        }
+    }
+}

--- a/extensions/akismet/src/Listener/ValidatePost.php
+++ b/extensions/akismet/src/Listener/ValidatePost.php
@@ -11,16 +11,22 @@ namespace Flarum\Akismet\Listener;
 
 use Carbon\Carbon;
 use Flarum\Akismet\Akismet;
+use Flarum\Akismet\AkismetUnexpectedResponseException;
 use Flarum\Flags\Flag;
+use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
 use Flarum\Post\Event\Saving;
 use Flarum\Settings\SettingsRepositoryInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
 
 class ValidatePost
 {
     public function __construct(
         protected Akismet $akismet,
-        protected SettingsRepositoryInterface $settings
+        protected SettingsRepositoryInterface $settings,
+        protected UrlGenerator $url,
+        protected LoggerInterface $log
     ) {
     }
 
@@ -32,49 +38,119 @@ class ValidatePost
 
         $post = $event->post;
 
-        //TODO Sometimes someone posts spam when editing a post. In this case 'recheck_reason=edit' can be used when sending a request to Akismet
-        if ($post->exists || ! ($post instanceof CommentPost) || $post->user->hasPermission('bypassAkismet')) {
+        if (! ($post instanceof CommentPost) || $post->user?->hasPermission('bypassAkismet')) {
             return;
         }
 
-        $result = $this->akismet
-            ->withContent($post->content)
+        // Spam is also introduced by editing an innocuous post after the
+        // initial check passed, so edited content is rechecked.
+        $isEdit = $post->exists;
+
+        if ($isEdit && ! $post->isDirty('content')) {
+            return;
+        }
+
+        try {
+            $result = $this->buildRequest($post, $isEdit)->checkSpam();
+        } catch (GuzzleException|AkismetUnexpectedResponseException $e) {
+            // Fail open: an unreachable or misconfigured Akismet must never
+            // block posting. The log line is the only place a bad key
+            // surfaces, so make it identifiable.
+            $this->log->warning("[flarum/akismet] Spam check failed, allowing the post through: {$e->getMessage()}");
+
+            return;
+        }
+
+        if (! $result['isSpam']) {
+            return;
+        }
+
+        $post->is_spam = true;
+
+        if ($result['proTip'] === 'discard' && $this->settings->get('flarum-akismet.delete_blatant_spam')) {
+            $post->hide();
+
+            $post->afterSave(function ($post) {
+                if ($post->number == 1) {
+                    $post->discussion->hide();
+                }
+            });
+        } else {
+            $post->is_approved = false;
+
+            $post->afterSave(function ($post) {
+                if ($post->number == 1) {
+                    $post->discussion->is_approved = false;
+                    $post->discussion->save();
+                }
+
+                $flag = new Flag;
+
+                $flag->post_id = $post->id;
+                $flag->type = 'akismet';
+                $flag->created_at = Carbon::now();
+
+                $flag->save();
+            });
+        }
+    }
+
+    /**
+     * Assemble the comment-check request. Akismet's docs are explicit that
+     * detection accuracy "can drop dramatically" when data points are
+     * omitted, so send everything we can know at this point.
+     */
+    protected function buildRequest(CommentPost $post, bool $isEdit): Akismet
+    {
+        $discussion = $post->discussion;
+
+        // For new posts the number isn't assigned yet: the post starting a
+        // discussion is the one whose discussion has no first post on record.
+        $isFirstPost = $isEdit
+            ? $post->number == 1
+            : $discussion === null || ! $discussion->exists || $discussion->first_post_id === null;
+
+        // Spam often lives in the discussion title; Akismet has no separate
+        // title field, so fold it into the content for first posts.
+        $content = $isFirstPost && $discussion !== null && $discussion->title
+            ? $discussion->title."\n\n".$post->content
+            : $post->content;
+
+        $akismet = $this->akismet
+            ->withContent($content)
             ->withAuthorName($post->user->username)
             ->withAuthorEmail($post->user->email)
-            ->withType($post->number === 1 ? 'forum-post' : 'reply')
-            ->withIp($post->ip_address)
-            ->withUserAgent($_SERVER['HTTP_USER_AGENT'])
-            ->checkSpam();
+            ->withType($isFirstPost ? 'forum-post' : 'reply')
+            ->withCharset('UTF-8');
 
-        if ($result['isSpam']) {
-            $post->is_spam = true;
-
-            if ($result['proTip'] === 'discard' && $this->settings->get('flarum-akismet.delete_blatant_spam')) {
-                $post->hide();
-
-                $post->afterSave(function ($post) {
-                    if ($post->number == 1) {
-                        $post->discussion->hide();
-                    }
-                });
-            } else {
-                $post->is_approved = false;
-
-                $post->afterSave(function ($post) {
-                    if ($post->number == 1) {
-                        $post->discussion->is_approved = false;
-                        $post->discussion->save();
-                    }
-
-                    $flag = new Flag;
-
-                    $flag->post_id = $post->id;
-                    $flag->type = 'akismet';
-                    $flag->created_at = Carbon::now();
-
-                    $flag->save();
-                });
-            }
+        if ($post->ip_address) {
+            $akismet = $akismet->withIp($post->ip_address);
         }
+
+        // Posts can also be created outside a browser request (console,
+        // queue, integrations) — only pass request headers that exist.
+        if ($userAgent = $_SERVER['HTTP_USER_AGENT'] ?? null) {
+            $akismet = $akismet->withUserAgent($userAgent);
+        }
+
+        if ($referrer = $_SERVER['HTTP_REFERER'] ?? null) {
+            $akismet = $akismet->withReferrer($referrer);
+        }
+
+        if ($discussion !== null && $discussion->exists) {
+            $akismet = $akismet->withPermalink(
+                $this->url->to('forum')->route('discussion', ['id' => $discussion->id])
+            );
+        }
+
+        if ($locale = $this->settings->get('default_locale')) {
+            $akismet = $akismet->withLanguage($locale);
+        }
+
+        if ($isEdit) {
+            $akismet = $akismet->withRecheckReason('edit');
+        }
+
+        return $akismet;
     }
 }

--- a/extensions/akismet/tests/fixtures/FakeAkismetProvider.php
+++ b/extensions/akismet/tests/fixtures/FakeAkismetProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Tests\fixtures;
+
+use Flarum\Akismet\Akismet;
+use Flarum\Foundation\AbstractServiceProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+
+/**
+ * Rebinds the Akismet client onto a Guzzle mock handler so integration tests
+ * can script Akismet's answers and inspect what was sent, without any real
+ * HTTP. Registered from a test's extenders, it wins over the extension's own
+ * binding because it registers later.
+ *
+ * Tests interact through the static state: queue responses (or exceptions)
+ * before acting, read {@link $history} afterwards.
+ */
+class FakeAkismetProvider extends AbstractServiceProvider
+{
+    /** @var array<int, mixed> responses (Psr Response or Throwable) to serve, in order */
+    public static array $queue = [];
+
+    /** @var array<int, array{request: \Psr\Http\Message\RequestInterface, options: array}> */
+    public static array $history = [];
+
+    public static function reset(array $queue = []): void
+    {
+        static::$queue = $queue;
+        static::$history = [];
+    }
+
+    public function register(): void
+    {
+        $this->container->bind(Akismet::class, function () {
+            $mock = new MockHandler(static::$queue);
+            $stack = HandlerStack::create($mock);
+            $stack->push(Middleware::history(static::$history));
+
+            return new Akismet(
+                'fake-key',
+                'https://forum.example.com',
+                '2.0.0',
+                'test',
+                false,
+                new Client(['handler' => $stack])
+            );
+        });
+    }
+}

--- a/extensions/akismet/tests/integration/ValidatePostTest.php
+++ b/extensions/akismet/tests/integration/ValidatePostTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Akismet\Tests\fixtures\FakeAkismetProvider;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+
+class ValidatePostTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-flags', 'flarum-approval', 'flarum-akismet');
+
+        $this->extend(
+            (new Extend\ServiceProvider())->register(FakeAkismetProvider::class)
+        );
+
+        FakeAkismetProvider::reset();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Existing discussion', 'created_at' => Carbon::parse('2024-01-01'), 'last_posted_at' => Carbon::parse('2024-01-01'), 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'created_at' => Carbon::parse('2024-01-01'), 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>first post</p></t>'],
+            ],
+        ]);
+    }
+
+    private function reply(string $content = 'A perfectly normal reply message.'): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'attributes' => ['content' => $content],
+                        'relationships' => ['discussion' => ['data' => ['type' => 'discussions', 'id' => 1]]],
+                    ],
+                ],
+            ])
+        );
+    }
+
+    private function lastCheckParams(): array
+    {
+        $requests = FakeAkismetProvider::$history;
+        $this->assertNotEmpty($requests, 'Expected a comment-check request to have been sent.');
+
+        parse_str((string) $requests[count($requests) - 1]['request']->getBody(), $params);
+
+        return $params;
+    }
+
+    #[Test]
+    public function a_spam_reply_is_unapproved_and_flagged()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'true')]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::query()->orderByDesc('id')->first();
+
+        $this->assertTrue((bool) $post->is_spam);
+        $this->assertFalse((bool) $post->is_approved);
+        $this->assertSame(1, $post->flags()->where('type', 'akismet')->count());
+    }
+
+    #[Test]
+    public function a_ham_reply_posts_normally()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'false')]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::query()->orderByDesc('id')->first();
+
+        $this->assertFalse((bool) $post->is_spam);
+        $this->assertTrue((bool) $post->is_approved);
+        $this->assertSame(0, $post->flags()->count());
+    }
+
+    #[Test]
+    public function the_check_carries_the_accuracy_data_points()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'false')]);
+
+        $this->reply('The reply body.');
+
+        $params = $this->lastCheckParams();
+
+        $this->assertSame('reply', $params['comment_type']);
+        $this->assertStringContainsString('The reply body.', $params['comment_content']);
+        $this->assertSame('UTF-8', $params['blog_charset']);
+        $this->assertArrayHasKey('blog_lang', $params);
+        $this->assertStringContainsString('/d/1', $params['permalink']);
+        $this->assertSame('normal', $params['comment_author']);
+    }
+
+    #[Test]
+    public function a_spam_first_post_folds_the_title_into_the_content()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'true')]);
+
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'title' => 'Cheap watches here',
+                            'content' => 'Buy now, best prices.',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $params = $this->lastCheckParams();
+
+        $this->assertSame('forum-post', $params['comment_type']);
+        $this->assertStringContainsString('Cheap watches here', $params['comment_content']);
+        $this->assertStringContainsString('Buy now, best prices.', $params['comment_content']);
+
+        $discussion = Discussion::query()->orderByDesc('id')->first();
+
+        $this->assertFalse((bool) $discussion->is_approved);
+    }
+
+    #[Test]
+    public function an_unreachable_akismet_fails_open_and_the_post_saves()
+    {
+        FakeAkismetProvider::reset([
+            new ConnectException('Connection refused', new Request('POST', 'comment-check')),
+        ]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::query()->orderByDesc('id')->first();
+
+        $this->assertFalse((bool) $post->is_spam);
+        $this->assertTrue((bool) $post->is_approved);
+    }
+
+    #[Test]
+    public function an_invalid_key_response_fails_open_instead_of_passing_silently_as_ham()
+    {
+        FakeAkismetProvider::reset([
+            new Response(200, ['X-akismet-debug-help' => 'Missing required field: api_key.'], 'invalid'),
+        ]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertTrue((bool) Post::query()->orderByDesc('id')->first()->is_approved);
+    }
+
+    #[Test]
+    public function editing_spam_into_an_approved_post_is_rechecked_and_flagged()
+    {
+        // The original check passed; spam arrives via the edit.
+        FakeAkismetProvider::reset([new Response(200, [], 'true')]);
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => ['attributes' => ['content' => 'Actually, cheap watches here.']],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $params = $this->lastCheckParams();
+
+        $this->assertSame('edit', $params['recheck_reason']);
+
+        $post = Post::query()->find(1);
+
+        $this->assertTrue((bool) $post->is_spam);
+        $this->assertFalse((bool) $post->is_approved);
+        $this->assertSame(1, $post->flags()->where('type', 'akismet')->count());
+    }
+
+    #[Test]
+    public function editing_without_changing_content_is_not_rechecked()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'true')]);
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/posts/1', [
+                'authenticatedAs' => 2,
+                'json' => [
+                    'data' => ['attributes' => ['content' => 'first post']],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEmpty(FakeAkismetProvider::$history, 'Unchanged content must not be sent to Akismet.');
+    }
+
+    #[Test]
+    public function blatant_spam_is_deleted_outright_when_the_setting_is_on()
+    {
+        $this->setting('flarum-akismet.delete_blatant_spam', '1');
+
+        FakeAkismetProvider::reset([
+            new Response(200, ['X-akismet-pro-tip' => 'discard'], 'true'),
+            // The Hidden event then submits spam feedback; body is ignored.
+            new Response(200, [], 'Thanks for making the web a better place.'),
+        ]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::query()->orderByDesc('id')->first();
+
+        $this->assertNotNull($post->hidden_at);
+        $this->assertSame(0, $post->flags()->count());
+    }
+
+    #[Test]
+    public function users_with_the_bypass_permission_are_not_checked()
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'bypassAkismet', 'group_id' => 3],
+            ],
+        ]);
+
+        FakeAkismetProvider::reset([new Response(200, [], 'true')]);
+
+        $response = $this->reply();
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEmpty(FakeAkismetProvider::$history, 'Bypassing users must not be sent to Akismet.');
+    }
+}

--- a/extensions/akismet/tests/integration/VerifyKeySettingTest.php
+++ b/extensions/akismet/tests/integration/VerifyKeySettingTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Tests\integration;
+
+use Flarum\Akismet\Tests\fixtures\FakeAkismetProvider;
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A submitted API key is checked against Akismet's verify-key endpoint before
+ * being saved: a typo'd key used to be accepted silently, leaving the forum
+ * unprotected with nothing to show for it.
+ */
+class VerifyKeySettingTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-flags', 'flarum-approval', 'flarum-akismet');
+
+        $this->extend(
+            (new Extend\ServiceProvider())->register(FakeAkismetProvider::class)
+        );
+
+        FakeAkismetProvider::reset();
+
+        $this->prepareDatabase([
+            User::class => [$this->normalUser()],
+        ]);
+    }
+
+    private function saveKey(?string $key): int
+    {
+        return $this->send(
+            $this->request('POST', '/api/settings', [
+                'authenticatedAs' => 1,
+                'json' => ['flarum-akismet.api_key' => $key],
+            ])
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function a_valid_key_saves()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'valid')]);
+
+        $this->assertSame(204, $this->saveKey('a-good-key'));
+
+        // The candidate key, not the configured one, must have been verified.
+        parse_str((string) FakeAkismetProvider::$history[0]['request']->getBody(), $params);
+        $this->assertSame('a-good-key', $params['api_key']);
+        $this->assertStringContainsString('verify-key', (string) FakeAkismetProvider::$history[0]['request']->getUri());
+    }
+
+    #[Test]
+    public function an_invalid_key_is_rejected_with_a_validation_error()
+    {
+        FakeAkismetProvider::reset([new Response(200, [], 'invalid')]);
+
+        $this->assertSame(422, $this->saveKey('a-typoed-key'));
+    }
+
+    #[Test]
+    public function clearing_the_key_is_not_verified()
+    {
+        FakeAkismetProvider::reset();
+
+        $this->assertSame(204, $this->saveKey(''));
+        $this->assertEmpty(FakeAkismetProvider::$history);
+    }
+
+    #[Test]
+    public function an_unreachable_akismet_does_not_block_saving()
+    {
+        FakeAkismetProvider::reset([
+            new ConnectException('Connection refused', new Request('POST', 'verify-key')),
+        ]);
+
+        $this->assertSame(204, $this->saveKey('unverifiable-key'));
+    }
+}

--- a/extensions/akismet/tests/unit/AkismetTest.php
+++ b/extensions/akismet/tests/unit/AkismetTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Akismet\Tests\unit;
+
+use Flarum\Akismet\Akismet;
+use Flarum\Akismet\AkismetUnexpectedResponseException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AkismetTest extends TestCase
+{
+    /** @var array<int, array{request: Request, options: array}> */
+    private array $history = [];
+
+    private function akismet(array $responses, string $apiKey = 'test-key', bool $debug = false): Akismet
+    {
+        $this->history = [];
+
+        $mock = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($this->history));
+
+        return new Akismet(
+            $apiKey,
+            'https://forum.example.com',
+            '2.0.0',
+            '1.0.0',
+            $debug,
+            new Client(['handler' => $stack])
+        );
+    }
+
+    private function lastRequest(): Request
+    {
+        return $this->history[count($this->history) - 1]['request'];
+    }
+
+    private function lastRequestParams(): array
+    {
+        parse_str((string) $this->lastRequest()->getBody(), $params);
+
+        return $params;
+    }
+
+    #[Test]
+    public function requests_go_to_the_modern_endpoint_with_the_key_as_a_parameter()
+    {
+        // Akismet's current API form: POST to rest.akismet.com with api_key in
+        // the body. The legacy {key}.rest.akismet.com subdomain form leaked the
+        // secret key into DNS lookups and TLS SNI on every request.
+        $this->akismet([new Response(200, [], 'false')])->checkSpam();
+
+        $uri = $this->lastRequest()->getUri();
+
+        $this->assertSame('rest.akismet.com', $uri->getHost());
+        $this->assertSame('/1.1/comment-check', $uri->getPath());
+        $this->assertSame('test-key', $this->lastRequestParams()['api_key']);
+    }
+
+    #[Test]
+    public function the_blog_url_and_user_agent_are_always_sent()
+    {
+        $this->akismet([new Response(200, [], 'false')])->checkSpam();
+
+        $this->assertSame('https://forum.example.com', $this->lastRequestParams()['blog']);
+        $this->assertStringContainsString('Flarum/2.0.0', $this->lastRequest()->getHeaderLine('User-Agent'));
+    }
+
+    #[Test]
+    public function check_spam_reports_spam_and_the_discard_pro_tip()
+    {
+        $result = $this->akismet([
+            new Response(200, ['X-akismet-pro-tip' => 'discard'], 'true'),
+        ])->checkSpam();
+
+        $this->assertTrue($result['isSpam']);
+        $this->assertSame('discard', $result['proTip']);
+    }
+
+    #[Test]
+    public function check_spam_reports_ham()
+    {
+        $result = $this->akismet([new Response(200, [], 'false')])->checkSpam();
+
+        $this->assertFalse($result['isSpam']);
+    }
+
+    #[Test]
+    public function an_unexpected_response_throws_with_the_debug_help()
+    {
+        // A misconfigured key returns literally "invalid" plus a debug header.
+        // The old client compared the body to 'true' and silently treated this
+        // as ham — the forum ran unprotected and nobody ever found out.
+        $this->expectException(AkismetUnexpectedResponseException::class);
+        $this->expectExceptionMessage('Missing required field: api_key.');
+
+        $this->akismet([
+            new Response(200, ['X-akismet-debug-help' => 'Missing required field: api_key.'], 'invalid'),
+        ])->checkSpam();
+    }
+
+    #[Test]
+    public function verify_key_accepts_a_valid_key()
+    {
+        $akismet = $this->akismet([new Response(200, [], 'valid')]);
+
+        $this->assertTrue($akismet->verifyKey());
+        $this->assertSame('/1.1/verify-key', $this->lastRequest()->getUri()->getPath());
+        $this->assertSame('test-key', $this->lastRequestParams()['api_key']);
+    }
+
+    #[Test]
+    public function verify_key_rejects_an_invalid_key()
+    {
+        $this->assertFalse($this->akismet([new Response(200, [], 'invalid')])->verifyKey());
+    }
+
+    #[Test]
+    public function verify_key_can_check_a_candidate_key_before_it_is_saved()
+    {
+        $akismet = $this->akismet([new Response(200, [], 'valid')]);
+
+        $this->assertTrue($akismet->verifyKey('candidate-key'));
+        $this->assertSame('candidate-key', $this->lastRequestParams()['api_key']);
+    }
+
+    #[Test]
+    public function requests_carry_a_timeout_so_a_hanging_akismet_cannot_hang_the_forum()
+    {
+        $this->akismet([new Response(200, [], 'false')])->checkSpam();
+
+        $options = $this->history[0]['options'];
+
+        $this->assertArrayHasKey('timeout', $options);
+        $this->assertLessThanOrEqual(5, $options['timeout']);
+    }
+
+    #[Test]
+    public function network_failures_bubble_as_guzzle_exceptions_for_callers_to_fail_open_on()
+    {
+        $this->expectException(ConnectException::class);
+
+        $this->akismet([
+            new ConnectException('Connection refused', new Request('POST', 'comment-check')),
+        ])->checkSpam();
+    }
+
+    #[Test]
+    public function debug_mode_marks_requests_as_tests()
+    {
+        $this->akismet([new Response(200, [], 'false')], debug: true)->checkSpam();
+
+        $this->assertSame('1', $this->lastRequestParams()['is_test']);
+    }
+
+    #[Test]
+    public function with_param_is_immutable()
+    {
+        $akismet = $this->akismet([new Response(200, [], 'false'), new Response(200, [], 'false')]);
+
+        $akismet->withContent('spam content')->checkSpam();
+        $withoutContent = $this->lastRequestParams();
+
+        $this->assertSame('spam content', $withoutContent['comment_content'] ?? null);
+
+        $akismet->checkSpam();
+
+        $this->assertArrayNotHasKey('comment_content', $this->lastRequestParams(), 'withContent must not mutate the original instance');
+    }
+
+    #[Test]
+    public function is_configured_reflects_the_presence_of_a_key()
+    {
+        $this->assertTrue($this->akismet([])->isConfigured());
+        $this->assertFalse($this->akismet([], apiKey: '')->isConfigured());
+    }
+}


### PR DESCRIPTION
### The audit

A fit-for-purpose review of the akismet extension against Akismet's current API documentation found it functional on the happy path but dated and fragile everywhere else — and shipped with zero tests. This PR is the resulting modernization/hardening pass. Registration (signup) checking was deliberately left out; it changes the extension's scope and deserves its own discussion.

### API currency

- **Modern endpoint form.** Requests now go to `https://rest.akismet.com/1.1/*` with `api_key` as a POST parameter, per current Akismet docs. The legacy `{key}.rest.akismet.com` subdomain form also leaked the **secret key into DNS lookups and TLS SNI** on every request.
- **`verify-key` on save.** The admin's API key is checked against Akismet when saved: a typo'd key is now a 422 with an explanatory message instead of a silently unprotected forum. If Akismet is unreachable at save time, the save goes through with a logged warning — verification never blocks the admin.

### Robustness — fail open, always

- Previously any Guzzle failure propagated out of the `Saving` listener: **an Akismet outage failed every post save with a 500**. Checks now carry a 3s timeout and fail open with an identifiable log line.
- The literal `invalid` response a misconfigured key produces was compared against `'true'` and silently treated as ham — the forum ran unprotected with nothing to show for it. It now raises `AkismetUnexpectedResponseException` carrying `X-akismet-debug-help`, is logged, and fails open.
- Posts created outside a browser request (console, queue, integrations) crashed on the unguarded `$_SERVER['HTTP_USER_AGENT']`. Request headers are now only sent when they exist.
- The spam/ham feedback listeners are best-effort: an outage never breaks the moderation action that triggered them.

### Detection accuracy

Akismet's docs: *"Performance can drop dramatically if you choose to exclude data points."*

- Sends `permalink`, `blog_lang` and `blog_charset` alongside the existing fields.
- **Folds the discussion title into first-post content** — spam often lives in the title, and Akismet has no separate title field.
- **Rechecks edited posts** with `recheck_reason=edit` (only when content actually changed) — previously an innocuous post could be edited into spam without ever being rechecked; the old code carried a TODO for exactly this.
- First-post detection no longer relies on `$post->number`, which isn't assigned yet at `Saving` time for new posts.

### Tests (extension previously had none)

- **Unit** (13): the client over a Guzzle MockHandler — endpoint form, key placement, timeout, spam/ham/pro-tip parsing, unexpected-response exception with debug help, verify-key including candidate keys, immutability.
- **Integration** (14): a scripted fake Akismet provider drives the full flows — flagging + unapproval, blatant-spam discard (and its feedback submission), fail-open on outage *and* on `invalid`, edit recheck (asserting `recheck_reason=edit` on the wire), unchanged-content edits not rechecked, title folding for first posts, accuracy params on the wire, bypass permission short-circuiting before any HTTP.

Written red first: against the old code the unit suite fails 11/13, and the old listener 500s the fail-open case and never sends the edit recheck. PHPStan clean; both suites green.