### PR TITLE
[2.x] fix: revision webfont URLs so a font upgrade cannot serve from stale caches

### DIFF
--- a/framework/core/src/Frontend/Assets.php
+++ b/framework/core/src/Frontend/Assets.php
@@ -158,6 +158,7 @@ class Assets
 
         if ($this->lessImportDirs) {
             $compiler->setImportDirs($this->lessImportDirs);
+            $compiler->setFontsDir($this->fontsDir());
         }
 
         if ($this->lessImportOverrides) {
@@ -171,6 +172,26 @@ class Assets
         $compiler->setCustomFunctions($this->customFunctions);
 
         return $compiler;
+    }
+
+    /**
+     * Where the webfonts referenced by the compiled CSS live on disk, so their
+     * URLs can be revisioned. Font URLs are written relative to the stylesheet
+     * that imports them (`../webfonts/…`), so the fonts sit beside each LESS
+     * import directory — that is the same directory the assets publisher copies
+     * into `assets/fonts`.
+     */
+    protected function fontsDir(): ?string
+    {
+        foreach (array_keys($this->lessImportDirs ?? []) as $dir) {
+            $candidate = dirname($dir).'/webfonts';
+
+            if (is_dir($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     protected function makeJsDirectoryCompiler(string $string): JsDirectoryCompiler

--- a/framework/core/src/Frontend/Compiler/LessCompiler.php
+++ b/framework/core/src/Frontend/Compiler/LessCompiler.php
@@ -24,10 +24,20 @@ class LessCompiler extends RevisionCompiler
     protected array $customFunctions = [];
     protected ?Collection $lessImportOverrides = null;
     protected ?Collection $fileSourceOverrides = null;
+    protected ?string $fontsDir = null;
 
     public function getCacheDir(): string
     {
         return $this->cacheDir;
+    }
+
+    /**
+     * The directory holding the webfonts that get published to `assets/fonts`.
+     * Used to revision the font URLs emitted into the compiled CSS.
+     */
+    public function setFontsDir(?string $fontsDir): void
+    {
+        $this->fontsDir = $fontsDir;
     }
 
     public function setCacheDir(string $cacheDir): void
@@ -137,9 +147,69 @@ class LessCompiler extends RevisionCompiler
         }
     }
 
+    /**
+     * Point font URLs at the published `assets/fonts` directory, and stamp each
+     * with a revision derived from the font file itself.
+     *
+     * The stylesheet is already cache-busted (`forum.css?v=<rev>`), but the font
+     * URLs inside it were not. On a FontAwesome major upgrade every browser
+     * therefore picked up the new CSS immediately while continuing to serve the
+     * *previous* font file from cache — same filename, same URL, long max-age.
+     * The new CSS asks for codepoints the old font doesn't contain, so every
+     * icon rendered as a placeholder box until that cache entry happened to
+     * expire. Revisioning the URL means a changed font is always a new URL, for
+     * browser and CDN caches alike.
+     *
+     * Because the asset revision is a hash of this compiled output, a font
+     * change also moves the stylesheet's own revision — so connected clients get
+     * the usual "reload for the new version" prompt without any extra wiring.
+     */
     protected function finalize(string $parsedCss): string
     {
-        return str_replace('url("../webfonts/', 'url("./fonts/', $parsedCss);
+        return preg_replace_callback(
+            '~url\("\.\./webfonts/([^"?#]+)([^"]*)"\)~',
+            function (array $matches): string {
+                [, $file, $suffix] = $matches;
+
+                $revision = $this->fontRevision($file);
+
+                // Preserve any existing query/fragment (e.g. `#iefix`), and
+                // don't add a second `?` if one is already there.
+                if ($revision !== null) {
+                    $suffix .= (str_contains($suffix, '?') ? '&' : '?')."v=$revision";
+                }
+
+                return 'url("./fonts/'.$file.$suffix.'")';
+            },
+            $parsedCss
+        ) ?? $parsedCss;
+    }
+
+    /**
+     * A short hash of a webfont's contents, or null when it can't be read —
+     * fonts are published separately, so a compile must never fail just because
+     * the directory isn't there yet.
+     */
+    protected function fontRevision(string $file): ?string
+    {
+        if ($this->fontsDir === null) {
+            return null;
+        }
+
+        // Defend the filesystem read against anything unexpected in the URL.
+        if (basename($file) !== $file) {
+            return null;
+        }
+
+        $path = $this->fontsDir.'/'.$file;
+
+        if (! file_exists($path)) {
+            return null;
+        }
+
+        $hash = @hash_file('xxh128', $path);
+
+        return $hash === false ? null : $hash;
     }
 
     /**

--- a/framework/core/tests/unit/Frontend/Compiler/LessFontUrlTest.php
+++ b/framework/core/tests/unit/Frontend/Compiler/LessFontUrlTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\unit\Frontend\Compiler;
+
+use Flarum\Frontend\Compiler\FileVersioner;
+use Flarum\Frontend\Compiler\LessCompiler;
+use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The stylesheet is cache-busted (`forum.css?v=<rev>`), but the font URLs
+ * inside it were not: `url("./fonts/fa-solid-900.woff2")`, served with a long
+ * max-age. On a FontAwesome major upgrade every browser therefore picked up
+ * the new CSS immediately while continuing to serve the *old* font file from
+ * cache under the unchanged URL. The new CSS asks for codepoints that don't
+ * exist in the old font, so every icon rendered as a placeholder box until the
+ * font cache happened to expire.
+ *
+ * Font URLs must therefore carry a revision derived from the font files
+ * themselves, so that changing a font always changes its URL.
+ */
+class LessFontUrlTest extends TestCase
+{
+    private string $tmpDir;
+    private string $fontsDir;
+
+    /** @var array<string, string> */
+    private array $written = [];
+
+    /** @var array<string, string|null> */
+    private array $manifest = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tmpDir = sys_get_temp_dir().'/flarum-lessfonts-'.uniqid();
+        $this->fontsDir = $this->tmpDir.'/webfonts';
+
+        @mkdir($this->tmpDir.'/cache', 0777, true);
+        @mkdir($this->fontsDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir.'/{,*/}*', GLOB_BRACE) ?: [] as $path) {
+            is_dir($path) ? @rmdir($path) : @unlink($path);
+        }
+        @rmdir($this->tmpDir);
+
+        parent::tearDown();
+    }
+
+    private function font(string $name, string $content): void
+    {
+        file_put_contents($this->fontsDir.'/'.$name, $content);
+    }
+
+    private function assetsDir(): Cloud
+    {
+        $assetsDir = m::mock(Cloud::class);
+        $assetsDir->shouldReceive('put')->andReturnUsing(function ($file, $content) {
+            $this->written[$file] = $content;
+
+            return true;
+        });
+        $assetsDir->shouldReceive('exists')->andReturnUsing(fn ($file) => isset($this->written[$file]));
+        $assetsDir->shouldReceive('url')->andReturnUsing(fn ($file) => '/assets/'.$file);
+
+        return $assetsDir;
+    }
+
+    private function versioner(): FileVersioner
+    {
+        $manifestFs = m::mock(Filesystem::class);
+        $manifestFs->shouldReceive('exists')->with(FileVersioner::REV_MANIFEST)->andReturnUsing(fn () => $this->manifest !== []);
+        $manifestFs->shouldReceive('get')->with(FileVersioner::REV_MANIFEST)->andReturnUsing(fn () => json_encode($this->manifest));
+        $manifestFs->shouldReceive('put')->with(FileVersioner::REV_MANIFEST, m::type('string'))
+            ->andReturnUsing(function ($_, $json) {
+                $this->manifest = json_decode($json, true);
+
+                return true;
+            });
+
+        return new FileVersioner($manifestFs);
+    }
+
+    /**
+     * Compile a stylesheet whose source references the webfonts the way
+     * FontAwesome's own CSS does, and return the compiled output.
+     */
+    private function compile(string $less = '@font-face { font-family: "Test"; src: url("../webfonts/fa-solid-900.woff2"); }'): string
+    {
+        $source = $this->tmpDir.'/source-'.uniqid().'.less';
+        file_put_contents($source, $less);
+
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->andReturn(null);
+        $settings->shouldReceive('delete')->andReturnNull();
+
+        $compiler = new LessCompiler(
+            $this->assetsDir(),
+            'forum.css',
+            $settings,
+            $this->versioner()
+        );
+
+        $compiler->setCacheDir($this->tmpDir.'/cache');
+        $compiler->setFontsDir($this->fontsDir);
+        $compiler->addSources(function (SourceCollector $sources) use ($source) {
+            $sources->addFile($source);
+        });
+        $compiler->commit(true);
+
+        return $this->written['forum.css'] ?? '';
+    }
+
+    private function fontUrls(string $css): array
+    {
+        preg_match_all('/url\("([^"]+\.woff2[^"]*)"\)/', $css, $matches);
+
+        return $matches[1];
+    }
+
+    #[Test]
+    public function font_urls_are_rewritten_to_the_published_fonts_directory()
+    {
+        $this->font('fa-solid-900.woff2', 'FA7-SOLID');
+
+        $urls = $this->fontUrls($this->compile());
+
+        $this->assertNotEmpty($urls, 'The compiled CSS must still reference the font.');
+        $this->assertStringStartsWith('./fonts/fa-solid-900.woff2', $urls[0]);
+    }
+
+    #[Test]
+    public function font_urls_carry_a_revision()
+    {
+        $this->font('fa-solid-900.woff2', 'FA7-SOLID');
+
+        $urls = $this->fontUrls($this->compile());
+
+        $this->assertMatchesRegularExpression(
+            '~^\./fonts/fa-solid-900\.woff2\?v=[a-f0-9]+$~',
+            $urls[0],
+            'Without a revision in the URL, a cached font from a previous FontAwesome version is served against the new CSS.'
+        );
+    }
+
+    #[Test]
+    public function the_revision_changes_when_the_font_file_changes()
+    {
+        $this->font('fa-solid-900.woff2', 'FA5-SOLID');
+        $before = $this->fontUrls($this->compile())[0];
+
+        // The FontAwesome upgrade: same filename, different bytes.
+        $this->font('fa-solid-900.woff2', 'FA7-SOLID');
+        $after = $this->fontUrls($this->compile())[0];
+
+        $this->assertNotSame($before, $after, 'A changed font must produce a different URL, or caches keep the old file.');
+    }
+
+    #[Test]
+    public function the_revision_is_stable_when_nothing_changes()
+    {
+        $this->font('fa-solid-900.woff2', 'FA7-SOLID');
+
+        $this->assertSame(
+            $this->fontUrls($this->compile())[0],
+            $this->fontUrls($this->compile())[0],
+            'Recompiling unchanged input must not churn font URLs and needlessly bust client caches.'
+        );
+    }
+
+    #[Test]
+    public function unrelated_css_changes_do_not_change_the_font_revision()
+    {
+        $this->font('fa-solid-900.woff2', 'FA7-SOLID');
+
+        $base = '@font-face { font-family: "Test"; src: url("../webfonts/fa-solid-900.woff2"); }';
+
+        $before = $this->fontUrls($this->compile($base))[0];
+        $after = $this->fontUrls($this->compile($base.' .a { color: red; }'))[0];
+
+        $this->assertSame($before, $after, 'The font revision must track the font files, not the stylesheet.');
+    }
+
+    #[Test]
+    public function compilation_still_succeeds_when_the_fonts_directory_is_missing()
+    {
+        // Fonts are published separately; a compile must never hard-fail just
+        // because the directory isn't there (e.g. before assets:publish).
+        $urls = $this->fontUrls($this->compile());
+
+        $this->assertNotEmpty($urls);
+        $this->assertStringStartsWith('./fonts/fa-solid-900.woff2', $urls[0]);
+    }
+}


### PR DESCRIPTION
### The report

Users across several installs were seeing **every** FontAwesome icon render as a placeholder box — on both locally-hosted and Kit installs, and only for *some* users on any given forum. Reports skewed heavily towards iPad.

### Root cause

The stylesheet is cache-busted (`forum.css?v=<rev>`). The font URLs *inside* it were not:

```css
src: url("./fonts/fa-solid-900.woff2");   /* served with a long max-age */
```

So on the FontAwesome 5 → 7 upgrade:

1. `forum.css` got a new `?v=` token, so **every browser refetched the CSS immediately**. It now asks for family `"Font Awesome 7 Free"` and FA7 codepoints.
2. `fa-solid-900.woff2` kept the **same URL**, so any browser holding the FA5 file served it from cache.

New CSS + old font = codepoints that don't exist in the loaded font = every icon a placeholder box. FA7's `@font-face` is woff2-only with `font-display: block`, so there's no fallback format.

That accounts for every part of the report:

- **Only some users** — only those whose browser had cached the font before the upgrade.
- **Reported across several installs** — the FontAwesome CSS is compiled into the bundle in every mode ("Always include FontAwesome LESS import paths"), so the local `@font-face` rules are present regardless of the configured source. See the Kit note below.
- **iPad-heavy** — iOS Safari's font cache is persistent and those users rarely hard-reload; desktop users hit Cmd-Shift-R, self-fix and never report. A reporting artifact, not an iPad bug.
- **Trickling in** — each client self-heals whenever its cache entry expires (I saw 4h on one install, 30 days on another).

I verified on two affected installs that the server side was entirely healthy: correct FA 7.3.1 fonts byte-identical to vendor, correct `font/woff2` MIME type, correct CSS. The breakage is purely stale client/CDN caches.

This is a latent bug rather than a regression — it bites on any FontAwesome major upgrade.

### The fix

`LessCompiler::finalize()` previously did a blind `str_replace` of `url("../webfonts/` → `url("./fonts/`. It now rewrites each font URL individually and appends a hash of that font file's contents, so changed bytes always mean a new URL — for browser and CDN caches alike.

- The revision is derived from the **font files**, not the stylesheet, so unrelated CSS edits don't churn font URLs (covered by a test).
- Existing query/fragment parts (e.g. `#iefix`) are preserved.
- A font that can't be read falls back to an unversioned URL: fonts are published separately, so compiling must never hard-fail before `assets:publish` has run.
- The fonts directory is derived from the existing LESS import dirs — font URLs are written relative to the importing stylesheet, so the fonts sit beside it, which is the same directory the publisher copies into `assets/fonts`. Nothing new to configure.

**Scope**: this addresses the locally-hosted font path, which is where the bug lives. Kit installs load their fonts from `kit.fontawesome.com` via `@font-face` rules the Kit's JS injects after our compiled CSS; those URLs are outside this rewrite's reach and are versioned by the Kit URL itself. The compiled local `@font-face` still exists on a Kit install as a fallback and is revisioned by this change, but Kit-mode breakage was never confirmed in the reports — only the local path was. Font *preloading* was already correctly gated to local-only mode.

**Works for every hosting shape**: the rewrite happens inside the CSS at compile time, so it holds wherever the assets dir points (local, S3, CDN). I confirmed empirically on a CDN-backed install that the query string is part of the cache key — the versioned URL returns `cf-cache-status: DYNAMIC` while the bare URL is a `HIT` — and `?v=` is already the convention core uses for `forum.css` itself.

**Feeds the reload prompt for free**: the asset revision is a hash of the compiled output (#4857), so a font change moves the stylesheet's revision, which moves the assets-revision token connected clients compare against. No extra wiring.

### Tests

Six unit tests in `LessFontUrlTest`: URLs still point at the published fonts dir, URLs carry a revision, the revision changes when the font bytes change, it's stable across recompiles of unchanged input, unrelated CSS changes don't move it, and compilation survives a missing fonts directory.

Proven red first — the two tests encoding the bug fail against the old `finalize()`, while the four guarding existing behaviour pass in both directions. Core unit suite 402/402.

Also verified end-to-end on a live install: each font now emits its own hash (`fa-solid-900.woff2?v=9fe5ae71…`), the versioned URL serves correctly (200, `font/woff2`, 119048 bytes), and `forum.css`'s revision moved as expected.

### Note for affected users

This fixes the problem from the next asset rebuild onward — the new URLs bypass stale cache entries immediately. Users broken *right now* on an un-upgraded install are still fixed by a hard reload.

