### PR TITLE
[2.x] fix(tags): wrap the selected tags in the tag-selection setting

### DIFF
--- a/extensions/tags/less/admin.less
+++ b/extensions/tags/less/admin.less
@@ -2,6 +2,7 @@
 
 @import "admin/TagsPage";
 @import "admin/EditTagModal";
+@import "admin/SelectTagsSettingComponent";
 
 .Dropdown--restrictByTag .Dropdown-menu {
   max-height: 400px;

--- a/extensions/tags/less/admin/SelectTagsSettingComponent.less
+++ b/extensions/tags/less/admin/SelectTagsSettingComponent.less
@@ -1,0 +1,17 @@
+// The selected tags are rendered inside the button that opens the tag picker.
+// A button does not wrap its contents, so a setting holding more than a handful
+// of tags ran the labels off the edge of the settings panel instead of flowing
+// onto a second line.
+.SelectTagsSettingComponent {
+  .Button {
+    height: auto;
+    white-space: normal;
+    text-align: left;
+  }
+
+  .TagsLabel {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+}


### PR DESCRIPTION
### The problem

`SelectTagsSettingComponent` renders the selected tags inside the button that opens the picker. A button neither wraps its contents nor grows to fit them, so a setting holding more than a handful of tags runs its labels off the edge of the settings panel in a single line rather than flowing onto multiple rows.

Found while adding this setting type to an extension on a forum with 33 tags.

### The fix

Wrap the labels, and let the button grow to fit them:

```less
.SelectTagsSettingComponent {
  .Button {
    height: auto;
    white-space: normal;
    text-align: left;
  }

  .TagsLabel {
    display: flex;
    flex-wrap: wrap;
    gap: 4px;
  }
}
```

`height: auto` matters alongside the wrapping — a fixed-height button clips the extra rows once the labels do wrap.

### Why it belongs here

Nothing shipped any styling for this component, so every consumer meets the same overflow. fof/best-answer already carries a workaround for it, but scoped inside its own settings-page wrapper, so it fixes only that page and leaves the problem in place for anyone else using `flarum-tags.select-tags`. Putting it in the component's own stylesheet covers all of them.

### Verified

On a forum with 33 tags, with fof/best-answer disabled so its workaround could not mask the result, and after a full asset rebuild — the compiled `admin.css` carries these rules and the labels wrap within the panel.