### PR TITLE
[2.x] fix: let gambit suggestions wrap instead of running off the dropdown

### DIFF
--- a/framework/core/less/common/Dropdown.less
+++ b/framework/core/less/common/Dropdown.less
@@ -56,6 +56,17 @@
         align-items: flex-start;
       }
 
+      // Gambit rows document the query syntax rather than naming a command, and
+      // the value of `is:` is every boolean gambit joined together — it grows
+      // with each extension that registers one, so there is no width at which
+      // ellipsising it stays useful. Declared here to override the single-line
+      // defaults above at equal specificity.
+      &.GambitsAutocomplete-gambit {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+      }
+
       &.disabled {
         opacity: 0.4;
         background: none !important;
@@ -247,22 +258,37 @@
 .GambitsAutocomplete {
   &-gambit {
     display: flex;
-    align-items: center;
+    // A wrapped value makes the row taller than one line, so the actions align
+    // to the first line rather than to the middle of the whole row.
+    align-items: flex-start;
 
     > button {
       flex-grow: 1;
+      // Without this the button refuses to shrink below the intrinsic width of
+      // its text, so a long value pushes the row out of the dropdown instead of
+      // wrapping inside it.
+      min-width: 0;
       cursor: pointer;
       gap: 4px;
       display: flex;
-      align-items: center;
+      flex-wrap: wrap;
+      align-items: baseline;
+      text-align: start;
       padding: 8px 15px;
       margin: -8px 0 -8px -15px;
     }
     &-key {
       font-weight: bold;
+      // The key is the label the row is identified by, so it keeps its line
+      // and the value wraps around it.
+      flex-shrink: 0;
     }
     &-value {
       color: var(--control-color);
+      // See the note above: wrap rather than overflow, and break a single
+      // over-long token rather than let it escape the panel.
+      min-width: 0;
+      overflow-wrap: break-word;
     }
     &-actions {
       flex-shrink: 0;


### PR DESCRIPTION
The `is:` row in the search modal was cut off mid-word:

```
is: hidden, unread, following, ignoring, sticky, locked, private, blog, trending, bo…
```

`.Dropdown-menu > li > a, > button, > span` sets `white-space: nowrap`, `overflow: hidden` and `text-overflow: ellipsis`. That is right for a menu of commands, but the gambit rows document the query syntax, and the value against `is:` is every boolean gambit joined into one string — it grows with each extension that registers one, so no width makes truncation useful. Any forum with a few extensions installed hits it.

## What changed

The reset is declared **inside the block it overrides**, next to the other `&.` modifiers. That placement is the substance of the fix rather than tidiness: the generic selector matches on two classes and two elements, so the same declarations written against `.GambitsAutocomplete-gambit` alone lose the cascade and do nothing at all. Compiled output confirms the override resolves to `.Dropdown-menu > li > span.GambitsAutocomplete-gambit`, winning on specificity and source order.

Wrapping then needs the flex containers to permit it:

- `min-width: 0` on the button — a flex item will not shrink below its text’s intrinsic width without it, so the row pushed out of the panel rather than wrapping inside it
- `flex-wrap: wrap` so the key and value can occupy separate lines
- `flex-shrink: 0` on the key, which is the label the row is identified by and keeps its line
- `overflow-wrap: break-word` on the value, so a single over-long token breaks rather than escaping the panel
- alignment moves from `center` to `flex-start` / `baseline`, because a row can now be taller than one line and the add/negate buttons should sit on the first line rather than against the middle of a wrapped block

## Notes

Only `.GambitsAutocomplete-gambit` is affected; every other dropdown item keeps the single-line ellipsis behaviour.

Surfaced while looking at a raw translation key in that list (FriendsOfFlarum/gamification#167), but the clipping is independent of it and predates it — the shortened label just moves the cutoff rather than removing it.

Verified by compiling `less/common/Dropdown.less` with `less.php` and reading the emitted CSS, and in the browser.