### PR TITLE
[2.x] fix: drop the dead FontAwesome noscript fallback, and say what forcing a style costs

### DIFF
--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -57,7 +57,7 @@ core:
         kit_url_label: Kit URL
         kit_url_help: Your FontAwesome Kit script URL (from kit.fontawesome.com)
         forced_style_label: Forced Icon Style
-        forced_style_help: "Force every icon to a particular FontAwesome style, e.g. \"fa-duotone fa-light\" or \"fa-regular\". Replaces the style declared by core and extensions (brand icons are never changed). The style must be available in your icon source — most styles require FontAwesome Pro. Leave empty to disable."
+        forced_style_help: "Force every icon to a particular FontAwesome style, e.g. \"fa-duotone fa-light\" or \"fa-regular\". Replaces the style declared by core and extensions (brand icons are never changed). Your icon source has to be able to supply the style: the bundled icons are FontAwesome Free, which only covers a few hundred icons outside the solid style, so forcing anything else on them leaves most icons blank. Every style is available with a FontAwesome Pro CDN or Kit. Leave empty to disable."
         config_override:
           label: Config Override
           help: FontAwesome settings are currently set in your config.php file and cannot be changed here.

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -122,10 +122,12 @@ class FrontendServiceProvider extends AbstractServiceProvider
                             }
                             // Load asynchronously — FA icons are only rendered after JS boots the
                             // SPA, so there is no FOUC risk from deferring this stylesheet.
-                            // The <noscript> fallback covers JS-disabled browsers.
-                            $escaped = e($cdnUrl);
-                            $document->head[] = '<link rel="preload" href="'.$escaped.'" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">'
-                                .'<noscript><link rel="stylesheet" href="'.$escaped.'" crossorigin="anonymous"></noscript>';
+                            //
+                            // Deliberately without a <noscript> counterpart: the icons are
+                            // rendered by the SPA, so a browser with scripting off has no icon
+                            // elements on the page for this stylesheet to style. The fallback
+                            // only ever bought such a browser an extra request.
+                            $document->head[] = '<link rel="preload" href="'.e($cdnUrl).'" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">';
                         }
                     } elseif ($fontAwesome->useKit()) {
                         $kitUrl = $fontAwesome->kitUrl();

--- a/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
+++ b/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
@@ -69,8 +69,10 @@ class FontAwesomeLoadingTest extends TestCase
         // Should load CDN CSS asynchronously (preload + onload swap)
         $this->assertStringContainsString('<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">', $body);
 
-        // Should include noscript fallback
-        $this->assertStringContainsString('<noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous"></noscript>', $body);
+        // No `<noscript>` counterpart. Icons are rendered by the SPA, so with
+        // scripting off the page contains no icon elements for a stylesheet to
+        // style — the fallback only ever cost a request.
+        $this->assertStringNotContainsString('<noscript><link rel="stylesheet"', $body);
 
         // Should not contain local font preloads
         $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
@@ -164,8 +166,8 @@ class FontAwesomeLoadingTest extends TestCase
         // Should load config CDN CSS asynchronously (preload + onload swap)
         $this->assertStringContainsString('<link rel="preload" href="https://config.example.com/fontawesome.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">', $body);
 
-        // Should include noscript fallback
-        $this->assertStringContainsString('<noscript><link rel="stylesheet" href="https://config.example.com/fontawesome.css" crossorigin="anonymous"></noscript>', $body);
+        // No `<noscript>` counterpart — see the CDN test above.
+        $this->assertStringNotContainsString('<noscript><link rel="stylesheet"', $body);
 
         // Should not contain local font preloads
         $this->assertStringNotContainsString('fa-solid-900.woff2', $body);


### PR DESCRIPTION
Two small corrections to the FontAwesome settings. Both came out of looking into the icon flicker reported at https://discuss.flarum.org/d/39532/84, but neither addresses it — see the note at the end.

## The `<noscript>` copy of the CDN stylesheet

The CDN branch emitted its stylesheet twice: once as an async `preload`, and once inside `<noscript>` on the reasoning that this covered browsers with scripting turned off.

It covers nothing. The icons are rendered by the SPA, so with scripting off the page has no icon elements on it at all — checked against a real page load with JS disabled, which gives **0** `<i class="icon">` elements and **0** `fa-*` classes. What such a browser does get is `<noscript id="flarum-content">`, a plain list of discussion links with no icons in it. A stylesheet that styles icons therefore has nothing to style, and the fallback only ever bought that browser an extra request.

The `preload` + `onload` swap is unchanged, so browsers with scripting still load it exactly as before.

## The forced icon style help text

The setting lets an admin force every icon to a given style, and its help text noted that "most styles require FontAwesome Pro". That understates what happens when the style is not available.

The bundled icons are FontAwesome Free, which ships a few hundred regular-style glyphs against Pro's several thousand. Forcing `fa-regular` on a forum using the bundled icons therefore leaves most icons **blank**, not subtly different. Measured by comparing glyph advance widths against the loaded font: `fa-house` resolves, while `fa-gavel`, `fa-bars`, `fa-check`, `fa-sort`, `fa-bolt` and `fa-magnifying-glass` all come back at notdef width.

The setting still permits it — a forum may want a style its source covers in part — but the help text now says what it costs.

## Not the flicker

This PR started as an attempt to fix the flicker itself, by withholding the bundled Free stylesheets when the icons come from a Kit or CDN. That does remove one of the two passes, but it cannot remove the other: FontAwesome's own glyph definitions end their font chain in a hardcoded `'Font Awesome 7 Free'`, and there is no way to defuse that from CSS. Substituting a family that cannot resolve makes the browser fall through to the default font, which draws the private-use codepoint as its own replacement box — a visible `[x]` placeholder, which is worse than a wrong glyph. Every way of hiding that box is permanent, because a Kit replaces the *font* and has no reason to touch a colour or a size, so the icons never come back.

Confirmed the hard way on a dev forum: that approach left 0 of 90 non-brand icons visible.

So the flicker is not fixable by gating which stylesheets are compiled in, and the attempt has been dropped from this branch. It needs approaching from latency instead — the window is around 80ms on a webfont Kit purely because the Kit's stylesheet arrives late. Being planned separately.