### PR TITLE
[2.x] fix: hold icons blank rather than wrong while a Kit or CDN font loads

### DIFF
--- a/framework/core/js/src/common/Application.tsx
+++ b/framework/core/js/src/common/Application.tsx
@@ -387,9 +387,43 @@ export default class Application {
 
     this.registerConnectivityListeners();
 
+    this.watchIconFonts();
+
     this.initialRoute = window.location.href;
 
     caughtInitializationErrors.forEach((handler) => handler());
+  }
+
+  /**
+   * When the icons come from a Kit or CDN, they hold a blank placeholder font
+   * until the remote stylesheet arrives. The backend wires a rescue — rebinding
+   * the icons to the bundled fonts — to `onerror` on the remote tags, but some
+   * failures never produce an error event: a kit script that loads fine while
+   * its own stylesheet request is blocked, or a connection that hangs rather
+   * than dying. This watchdog covers those. Firing by mistake is harmless: the
+   * remote faces are declared later than the rescued ones whenever they do turn
+   * up, so the icons simply upgrade in place.
+   */
+  protected watchIconFonts(): void {
+    const rescue = (window as any).flarumRescueIconFonts;
+
+    // Only defined by the backend when the icons are remote.
+    if (typeof rescue !== 'function') return;
+
+    setTimeout(() => {
+      // An SVG kit registers no fonts at all — its presence shows in the DOM.
+      if (document.querySelector('svg.svg-inline--fa')) return;
+
+      // The compiled CSS declares three FontAwesome faces of its own (two
+      // blank, one brands). Anything beyond those means a remote stylesheet
+      // arrived and there is nothing to rescue.
+      let faces = 0;
+      document.fonts.forEach((font) => {
+        if (font.family.replace(/['"]/g, '').startsWith('Font Awesome')) faces++;
+      });
+
+      if (faces <= 3) rescue();
+    }, 5000);
   }
 
   public beforeMount(callback: () => void) {

--- a/framework/core/less/common/Iconography.less
+++ b/framework/core/less/common/Iconography.less
@@ -1,7 +1,32 @@
+// Which glyph each icon is, and how icons size, stack and spin. This names no
+// font and is the same whichever source supplies one, so it is always needed —
+// without it an icon has nothing to draw.
 @import (inline) "fontawesome.css";
+
+// Brands bind their own family rather than the classic one, so they never
+// compete with a remote source's fonts and stay in unconditionally.
 @import (inline) "brands.css";
-@import (inline) "regular.css";
-@import (inline) "solid.css";
+
+// The classic-family binding. For local icons this is the bundled Free font.
+// For a Kit or CDN it is a blank font instead: the glyph definitions above
+// resolve their font through a chain ending in a hardcoded
+// 'Font Awesome 7 Free', and binding that name to the real Free files while a
+// Kit or Pro CDN is on its way means every icon resolves twice — first against
+// the bundled font (wrong glyphs, or placeholder boxes under a forced style),
+// then again when the remote stylesheet lands. The blank font occupies the
+// same name with glyphs that draw nothing, so icons hold their space and stay
+// empty until the remote fonts arrive; the remote stylesheet's own faces are
+// declared later and take precedence from there. See fa-blank.css.
+//
+// `@fa-bundled-fonts` comes from FontAwesome::needsBundledFonts().
+.fa-classic-font-faces() when (@fa-bundled-fonts = true) {
+  @import (inline) "regular.css";
+  @import (inline) "solid.css";
+}
+.fa-classic-font-faces() when (@fa-bundled-fonts = false) {
+  @import (inline) "fa-blank.css";
+}
+.fa-classic-font-faces();
 
 // FontAwesome 7 (and its Kit JS) sets `display: var(--fa-display, inline-block)` on
 // .fas/.far/.fab etc. When a Kit is loaded its dynamically-injected stylesheet lands

--- a/framework/core/less/common/fa-blank.css
+++ b/framework/core/less/common/fa-blank.css
@@ -1,0 +1,50 @@
+/*!
+ * A blank stand-in for the bundled FontAwesome fonts, used when the real icons
+ * come from a Kit or CDN.
+ *
+ * The icon glyph definitions resolve their font through a chain that ends in a
+ * hardcoded 'Font Awesome 7 Free'. When the bundled Free fonts are compiled in
+ * alongside a Kit or Pro CDN, every icon is resolved twice — first against the
+ * bundled font, then again when the remote stylesheet lands — and readers see
+ * that second pass as the icons flickering (or, under a forced style, as
+ * placeholder boxes, since Free lacks most non-solid glyphs). Naming a font
+ * that does not exist is no better: the browser falls through to the default
+ * font, which draws each icon's private-use codepoint as a visible box.
+ *
+ * So the name resolves to this: a real font that draws nothing. Every
+ * FontAwesome codepoint (U+E000-F8FF and U+F0000-FFFFD) maps to a single empty
+ * glyph with a 0.9em advance, so icons hold their space and paint no pixels
+ * until the remote font arrives. The remote stylesheet declares later
+ * same-descriptor faces, which take precedence, so the handover needs no
+ * further machinery.
+ *
+ * The payload is 312 bytes and should never need rebuilding — its only inputs
+ * are the private use ranges, which Unicode fixes, and the advance width. To
+ * reproduce it with fontTools:
+ *
+ *   - FontBuilder(1000, isTTF=True), glyph order [".notdef", "blank"]
+ *   - both glyphs empty, horizontal metrics (900, 0) for each
+ *   - hhea ascent 800, descent -200; name family "Flarum FA Blank"
+ *   - a format 13 cmap subtable (3, 10) mapping every codepoint in
+ *     U+E000-F8FF and U+F0000-FFFFD to "blank", plus a format 4 subtable
+ *     (3, 1) holding one token entry
+ *   - assign the cmap table before setupOS2(), which asserts on its absence
+ *   - give ".notdef" a degenerate zero-area contour rather than no outline at
+ *     all: a truly empty glyf table is a zero-length table, which OTS rejects
+ *     as malformed and the browser then refuses the font outright
+ *   - flavor = "woff2", save, base64
+ */
+@font-face {
+  font-family: "Font Awesome 7 Free";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("data:font/woff2;base64,d09GMgABAAAAAAE4AAoAAAAAAqgAAADwAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAAXAoQMgE2AiQDBgsGAAQgBXgHLBsRAiCeA27bRM1ncM78PDmDmIhdn37F8/V73bm7L9QmmS8ZX11pWsUKEC5GRjEIWZq6TTSVpfpyuqHIghjcRQ5vgP/6y5nBA6mT41OLPAAsyywQjCMrwAgTyG1s6nJoJ+g0a6vueTYzUBxgwE0Dlmqga3qyAABMoLTgSNvAuWHCMKSJhucQAdvgDFAs8RFiF7v/vwgoMBAUGjBAqAQgCC8OX9duX+t+h7ctPgqAViCM6XNjIRNJz0FQSkABAGC4FBC7CCirdrWMdXHqpEzKjvNnMSvg9qbbrktdozmhVAI8M3BP6Lmm7ShCqVMoUrM1AAAA") format("woff2");
+}
+@font-face {
+  font-family: "Font Awesome 7 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url("data:font/woff2;base64,d09GMgABAAAAAAE4AAoAAAAAAqgAAADwAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAAXAoQMgE2AiQDBgsGAAQgBXgHLBsRAiCeA27bRM1ncM78PDmDmIhdn37F8/V73bm7L9QmmS8ZX11pWsUKEC5GRjEIWZq6TTSVpfpyuqHIghjcRQ5vgP/6y5nBA6mT41OLPAAsyywQjCMrwAgTyG1s6nJoJ+g0a6vueTYzUBxgwE0Dlmqga3qyAABMoLTgSNvAuWHCMKSJhucQAdvgDFAs8RFiF7v/vwgoMBAUGjBAqAQgCC8OX9duX+t+h7ctPgqAViCM6XNjIRNJz0FQSkABAGC4FBC7CCirdrWMdXHqpEzKjvNnMSvg9qbbrktdozmhVAI8M3BP6Lmm7ShCqVMoUrM1AAAA") format("woff2");
+}

--- a/framework/core/src/Foundation/FontAwesome.php
+++ b/framework/core/src/Foundation/FontAwesome.php
@@ -66,6 +66,35 @@ class FontAwesome
         return $this->source() === self::SOURCE_LOCAL;
     }
 
+    /**
+     * Whether the bundled font files are what the icons will actually be drawn
+     * from.
+     *
+     * This is not quite the same question as `useLocalFonts()`. A forum can name
+     * a CDN or a Kit and give no URL for it, in which case that source cannot
+     * deliver anything and the bundled fonts are all there is. Treating such a
+     * forum as remote would leave it with no icons at all, rather than with
+     * icons that arrive late.
+     */
+    public function needsBundledFonts(): bool
+    {
+        if ($this->useLocalFonts()) {
+            return true;
+        }
+
+        if ($this->useCdn()) {
+            return $this->cdnUrl() === null;
+        }
+
+        if ($this->useKit()) {
+            return $this->kitUrl() === null;
+        }
+
+        // An unrecognised source names nothing we can load, so the bundled
+        // fonts remain the only ones available.
+        return true;
+    }
+
     public function useCdn(): bool
     {
         return $this->source() === self::SOURCE_CDN;

--- a/framework/core/src/Frontend/FrontendServiceProvider.php
+++ b/framework/core/src/Frontend/FrontendServiceProvider.php
@@ -111,6 +111,32 @@ class FrontendServiceProvider extends AbstractServiceProvider
                     /** @var FontAwesome $fontAwesome */
                     $fontAwesome = $container->make(FontAwesome::class);
 
+                    if (! $fontAwesome->needsBundledFonts()) {
+                        // When the icons come from a Kit or CDN, the compiled CSS binds
+                        // their font name to a blank placeholder until the remote
+                        // stylesheet arrives (see less/common/Iconography.less). If it
+                        // never arrives — an adblocker eating the kit, a dead CDN — the
+                        // icons would stay blank, so this rescue rebinds the name to the
+                        // bundled Free fonts: visible glyphs, even if not the ones the
+                        // forum paid for. Wired to `onerror` on the tags below, and to a
+                        // watchdog in the frontend for failures that produce no error
+                        // event, like a kit script that loads but whose stylesheet
+                        // request is blocked. Declared before them so it exists whenever
+                        // they fire.
+                        $filesystem = $container->make('filesystem')->disk('flarum-assets');
+
+                        $faces = '';
+                        foreach (['fa-regular-400' => 400, 'fa-solid-900' => 900] as $file => $weight) {
+                            $faces .= '@font-face{font-family:"Font Awesome 7 Free";font-style:normal;font-weight:'.$weight.';font-display:block;'
+                                .'src:url("'.$filesystem->url('fonts/'.$file.'.woff2').'") format("woff2")}';
+                        }
+
+                        $document->head[] = '<script>window.flarumRescueIconFonts=function(){var f=window.flarumRescueIconFonts;if(f.done)return;f.done=true;'
+                            .'var s=document.createElement("style");s.textContent='.json_encode($faces).';document.head.appendChild(s)};</script>';
+                    }
+
+                    $rescue = ' onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()"';
+
                     if ($fontAwesome->useCdn()) {
                         $cdnUrl = $fontAwesome->cdnUrl();
                         if (! empty($cdnUrl)) {
@@ -127,7 +153,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                             // rendered by the SPA, so a browser with scripting off has no icon
                             // elements on the page for this stylesheet to style. The fallback
                             // only ever bought such a browser an extra request.
-                            $document->head[] = '<link rel="preload" href="'.e($cdnUrl).'" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">';
+                            $document->head[] = '<link rel="preload" href="'.e($cdnUrl).'" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'"'.$rescue.'>';
                         }
                     } elseif ($fontAwesome->useKit()) {
                         $kitUrl = $fontAwesome->kitUrl();
@@ -141,7 +167,7 @@ class FrontendServiceProvider extends AbstractServiceProvider
                             // Defer Kit JS — it has no dependencies and nothing depends on it
                             // executing synchronously; defer keeps it out of the critical path
                             // while preserving execution order relative to other deferred scripts.
-                            $document->head[] = '<script src="'.e($kitUrl).'" crossorigin="anonymous" defer></script>';
+                            $document->head[] = '<script src="'.e($kitUrl).'" crossorigin="anonymous" defer'.$rescue.'></script>';
                         }
                     }
 
@@ -249,7 +275,15 @@ class FrontendServiceProvider extends AbstractServiceProvider
         $this->container->singleton(
             'flarum.less.custom_variables',
             function (Container $container) {
-                return [];
+                return [
+                    // Whether the compiled CSS binds the icon font name to the
+                    // bundled Free files, or to a blank placeholder that a Kit or
+                    // CDN replaces when its stylesheet lands. See
+                    // less/common/Iconography.less for the whole story.
+                    'fa-bundled-fonts' => function () use ($container) {
+                        return $container->make(FontAwesome::class)->needsBundledFonts() ? 'true' : 'false';
+                    },
+                ];
             }
         );
 

--- a/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
+++ b/framework/core/tests/integration/frontend/FontAwesomeLoadingTest.php
@@ -67,16 +67,16 @@ class FontAwesomeLoadingTest extends TestCase
         $body = $response->getBody()->getContents();
 
         // Should load CDN CSS asynchronously (preload + onload swap)
-        $this->assertStringContainsString('<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">', $body);
+        $this->assertStringContainsString('<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'" onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()">', $body);
 
         // No `<noscript>` counterpart. Icons are rendered by the SPA, so with
         // scripting off the page contains no icon elements for a stylesheet to
         // style — the fallback only ever cost a request.
         $this->assertStringNotContainsString('<noscript><link rel="stylesheet"', $body);
 
-        // Should not contain local font preloads
-        $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
-        $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
+        // Should not preload the local fonts. (Their filenames do appear in the
+        // rescue payload, which rebinds to them if the remote source fails.)
+        $this->assertStringNotContainsString('as="font"', $body);
     }
 
     #[Test]
@@ -92,11 +92,11 @@ class FontAwesomeLoadingTest extends TestCase
         $body = $response->getBody()->getContents();
 
         // Should load Kit JS deferred (not blocking)
-        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/abc123xyz.js" crossorigin="anonymous" defer></script>', $body);
+        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/abc123xyz.js" crossorigin="anonymous" defer onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()"></script>', $body);
 
-        // Should not contain local font preloads
-        $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
-        $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
+        // Should not preload the local fonts. (Their filenames do appear in the
+        // rescue payload, which rebinds to them if the remote source fails.)
+        $this->assertStringNotContainsString('as="font"', $body);
     }
 
     // Note: Config override tests are handled in unit tests for FontAwesome service
@@ -164,14 +164,14 @@ class FontAwesomeLoadingTest extends TestCase
         $body = $response->getBody()->getContents();
 
         // Should load config CDN CSS asynchronously (preload + onload swap)
-        $this->assertStringContainsString('<link rel="preload" href="https://config.example.com/fontawesome.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'">', $body);
+        $this->assertStringContainsString('<link rel="preload" href="https://config.example.com/fontawesome.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=\'stylesheet\'" onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()">', $body);
 
         // No `<noscript>` counterpart — see the CDN test above.
         $this->assertStringNotContainsString('<noscript><link rel="stylesheet"', $body);
 
-        // Should not contain local font preloads
-        $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
-        $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
+        // Should not preload the local fonts. (Their filenames do appear in the
+        // rescue payload, which rebinds to them if the remote source fails.)
+        $this->assertStringNotContainsString('as="font"', $body);
     }
 
     #[Test]
@@ -194,14 +194,14 @@ class FontAwesomeLoadingTest extends TestCase
         $body = $response->getBody()->getContents();
 
         // Should use config Kit URL with crossorigin attribute, deferred
-        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/config123.js" crossorigin="anonymous" defer></script>', $body);
+        $this->assertStringContainsString('<script src="https://kit.fontawesome.com/config123.js" crossorigin="anonymous" defer onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()"></script>', $body);
 
         // Should not contain database CDN URL
         $this->assertStringNotContainsString('database.example.com', $body);
 
-        // Should not contain local font preloads
-        $this->assertStringNotContainsString('fa-solid-900.woff2', $body);
-        $this->assertStringNotContainsString('fa-regular-400.woff2', $body);
+        // Should not preload the local fonts. (Their filenames do appear in the
+        // rescue payload, which rebinds to them if the remote source fails.)
+        $this->assertStringNotContainsString('as="font"', $body);
     }
 
     #[Test]

--- a/framework/core/tests/integration/frontend/FontAwesomeStylesheetTest.php
+++ b/framework/core/tests/integration/frontend/FontAwesomeStylesheetTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\frontend;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Which FontAwesome fonts the compiled stylesheet binds.
+ *
+ * The icon glyph definitions resolve their font through a chain that ends in a
+ * hardcoded 'Font Awesome 7 Free'. Local icons bind that name to the bundled
+ * font files. When the icons come from a Kit or CDN instead, binding the
+ * bundled files means every icon resolves twice — first against them, then
+ * again when the remote stylesheet lands — which readers see as the icons
+ * flickering. And leaving the name unbound is worse: the browser falls through
+ * to the default font and draws each icon's codepoint as a visible box.
+ *
+ * So remote sources bind the name to a blank font instead — a real font whose
+ * glyphs draw nothing — and the remote stylesheet takes the name over when it
+ * arrives, because same-descriptor faces declared later win.
+ */
+class FontAwesomeStylesheetTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /**
+     * The blank font travels as an inlined data URI, so its presence in the
+     * compiled CSS is unmistakable.
+     */
+    private const BLANK_FONT = 'data:font/woff2;base64,';
+
+    /**
+     * The bundled Free files, referenced only by the real bindings.
+     */
+    private const BUNDLED_REGULAR = 'fa-regular-400.woff2';
+    private const BUNDLED_SOLID = 'fa-solid-900.woff2';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * The compiled forum stylesheet.
+     */
+    private function css(): string
+    {
+        // Boot and render, so the asset is compiled the way a real request
+        // compiles it rather than through a hand-assembled compiler.
+        $this->send($this->request('GET', '/'));
+
+        $assets = $this->app()->getContainer()->make('flarum.assets.forum');
+        $compiler = $assets->makeCss();
+        $compiler->commit(true);
+
+        $filesystem = $this->app()->getContainer()->make('filesystem')->disk('flarum-assets');
+
+        return $filesystem->get($compiler->getFilename());
+    }
+
+    private function configureSource(string $source, ?string $forcedStyle): void
+    {
+        $this->setting('fontawesome_source', $source);
+        $this->setting('fontawesome_cdn_url', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css');
+        $this->setting('fontawesome_kit_url', 'https://kit.fontawesome.com/0000000000.js');
+
+        if ($forcedStyle !== null) {
+            $this->setting('fontawesome_forced_style', $forcedStyle);
+        }
+    }
+
+    /**
+     * source, forced style, whether the bundled fonts should be bound.
+     *
+     * @return array<string, array{string, string|null, bool}>
+     */
+    public static function sources(): array
+    {
+        return [
+            'local, no forced style' => ['local', null, true],
+            'local, forced regular' => ['local', 'fa-regular', true],
+            'cdn, no forced style' => ['cdn', null, false],
+            'cdn, forced regular' => ['cdn', 'fa-regular', false],
+            'kit, no forced style' => ['kit', null, false],
+            'kit, forced regular' => ['kit', 'fa-regular', false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('sources')]
+    public function the_classic_binding_matches_the_source(string $source, ?string $forcedStyle, bool $bundled): void
+    {
+        $this->configureSource($source, $forcedStyle);
+
+        $css = $this->css();
+
+        if ($bundled) {
+            $this->assertStringContainsString(self::BUNDLED_REGULAR, $css);
+            $this->assertStringContainsString(self::BUNDLED_SOLID, $css);
+            $this->assertStringNotContainsString(self::BLANK_FONT, $css, 'Local icons must draw immediately, not wait behind a placeholder.');
+        } else {
+            $this->assertStringContainsString(self::BLANK_FONT, $css, 'Without the placeholder, remote icons first paint in the bundled font and repaint when the remote one lands.');
+            $this->assertStringNotContainsString(self::BUNDLED_REGULAR, $css, 'Binding the bundled fonts alongside a remote source is what makes every icon resolve twice.');
+            $this->assertStringNotContainsString(self::BUNDLED_SOLID, $css);
+        }
+    }
+
+    /**
+     * The same cases, for assertions that hold whichever binding is chosen.
+     *
+     * @return array<string, array{string, string|null}>
+     */
+    public static function sourcesAlone(): array
+    {
+        return array_map(fn (array $case) => [$case[0], $case[1]], self::sources());
+    }
+
+    /**
+     * The glyph definitions say *which* character an icon is; they name no font
+     * and are needed whichever source supplies one.
+     */
+    #[Test]
+    #[DataProvider('sourcesAlone')]
+    public function glyph_definitions_are_compiled_in_for_every_source(string $source, ?string $forcedStyle): void
+    {
+        $this->configureSource($source, $forcedStyle);
+
+        $css = $this->css();
+
+        $this->assertStringContainsString('.fa-gavel', $css);
+        $this->assertStringContainsString('.fa-house', $css);
+    }
+
+    /**
+     * Brands bind their own family, so they neither collide with a remote
+     * source's fonts nor need a placeholder.
+     */
+    #[Test]
+    #[DataProvider('sourcesAlone')]
+    public function brands_are_compiled_in_for_every_source(string $source, ?string $forcedStyle): void
+    {
+        $this->configureSource($source, $forcedStyle);
+
+        $this->assertStringContainsString('fa-brands-400.woff2', $this->css());
+    }
+
+    /**
+     * An empty URL means the source cannot actually deliver anything, so the
+     * bundled fonts have to stay: a placeholder would leave such a forum with
+     * no icons at all rather than with icons that arrive late.
+     */
+    #[Test]
+    public function a_kit_with_no_url_keeps_the_bundled_fonts(): void
+    {
+        $this->setting('fontawesome_source', 'kit');
+        $this->setting('fontawesome_kit_url', '');
+
+        $css = $this->css();
+
+        $this->assertStringContainsString(self::BUNDLED_REGULAR, $css);
+        $this->assertStringNotContainsString(self::BLANK_FONT, $css);
+    }
+
+    #[Test]
+    public function a_cdn_with_no_url_keeps_the_bundled_fonts(): void
+    {
+        $this->setting('fontawesome_source', 'cdn');
+        $this->setting('fontawesome_cdn_url', '');
+
+        $css = $this->css();
+
+        $this->assertStringContainsString(self::BUNDLED_REGULAR, $css);
+        $this->assertStringNotContainsString(self::BLANK_FONT, $css);
+    }
+
+    /**
+     * If the remote source never delivers — a blocked kit, a dead CDN — the
+     * placeholder must not be the end of the story. The page carries a rescue
+     * that rebinds the icons to the bundled fonts, wired to the remote tags'
+     * error events and to a frontend watchdog for failures that produce none.
+     */
+    #[Test]
+    public function remote_sources_carry_the_rescue(): void
+    {
+        $this->setting('fontawesome_source', 'kit');
+        $this->setting('fontawesome_kit_url', 'https://kit.fontawesome.com/0000000000.js');
+
+        $body = $this->send($this->request('GET', '/'))->getBody()->getContents();
+
+        $this->assertStringContainsString('window.flarumRescueIconFonts=function()', $body);
+        $this->assertStringContainsString(self::BUNDLED_REGULAR, $body, 'The rescue must know where the bundled fonts live.');
+        $this->assertStringContainsString('defer onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()"', $body);
+    }
+
+    #[Test]
+    public function the_cdn_stylesheet_carries_the_rescue_too(): void
+    {
+        $this->setting('fontawesome_source', 'cdn');
+        $this->setting('fontawesome_cdn_url', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css');
+
+        $body = $this->send($this->request('GET', '/'))->getBody()->getContents();
+
+        $this->assertStringContainsString('window.flarumRescueIconFonts=function()', $body);
+        $this->assertStringContainsString('onerror="window.flarumRescueIconFonts&&window.flarumRescueIconFonts()">', $body);
+    }
+
+    /**
+     * Local icons cannot fail to arrive, so they get no rescue machinery.
+     */
+    #[Test]
+    public function local_icons_carry_no_rescue(): void
+    {
+        $body = $this->send($this->request('GET', '/'))->getBody()->getContents();
+
+        $this->assertStringNotContainsString('flarumRescueIconFonts', $body);
+    }
+}


### PR DESCRIPTION
Fixes the icon flicker reported at https://discuss.flarum.org/d/39532/84 — icons appear, then get replaced "section by section" once the FontAwesome Kit finishes loading.

## Cause

The icon glyph definitions resolve their font through a chain that ends in a hardcoded literal:

```css
--_fa-family: var(--fa-family, var(--fa-style-family, 'Font Awesome 7 Free'));
```

Core compiles the bundled Free stylesheets in whichever source a forum has configured, and those bind that name to the local font files at `:root`. A Kit or Pro CDN rebinds the same name from a stylesheet that can only arrive later, so every icon on the page is resolved twice — once against the bundled font, then again when the remote one lands. That second pass is the flicker.

Measured on a Kit forum, sampling from before first paint:

| | t | computed `font-family` | what a reader sees |
| --- | --- | --- | --- |
| 1 | ~66ms | `system-ui` | no icons yet |
| 2 | ~180–290ms | `Font Awesome 7 Free` | icons appear, many as empty boxes |
| 3 | ~300ms+ | `Font Awesome 7 Pro` | icons correct |

The forced icon style makes stage 2 worse but does not cause it — the double resolution happens with no forced style too, it just looks like a weight change rather than empty boxes. Free ships a few hundred regular-style glyphs against Pro's several thousand, so under `fa-regular` most icons at stage 2 have nothing to draw.

## Change

When the icons come from a Kit or CDN, the bundled Free bindings are withheld and the name is bound to a blank font instead: 312 bytes, inlined as a data URI, every FontAwesome codepoint mapped to an empty glyph with a 0.9em advance. Icons hold their space and paint nothing until the remote fonts arrive, and the remote stylesheet takes the name over on its own, because same-descriptor faces declared later win. Local forums compile exactly what they did before.

Two things that look like alternatives but are not:

- **Leaving the name unbound.** An unresolvable family falls through to the default font, which draws each icon's private-use codepoint as a visible replacement box — worse than a wrong glyph, and it is what `document.fonts.check()` reports as usable.
- **Hiding the glyph** with a transparent colour, zero font size, clip or transform. None of those are undone by anything a Kit sends, so the icons never come back. A Kit replaces the *font*; the font is the only lever that self-releases.

`FontAwesome::needsBundledFonts()` also treats a source with no URL as local. A forum can select a Kit or CDN and leave the URL empty; that source can deliver nothing, so withholding the bundled fonts would leave it with no icons at all rather than icons that arrive late.

## When the remote source never arrives

An adblocker eating `kit.fontawesome.com` is common enough that a placeholder cannot be the end of the story. The page carries a rescue that rebinds the name to the bundled Free files, wired to `onerror` on the Kit script and CDN link, and to a watchdog in `Application` for failures that fire no error event — a Kit script that loads while its own stylesheet host is blocked being the realistic case. A rescue that fires by mistake is harmless: the remote faces are declared later whenever they do turn up, so the icons upgrade in place.

Degraded icons are solid-style Free rather than the forum's chosen style. Visible and wrong beats invisible.

## Verified

Driven in a browser against a dev forum, measuring painted pixels and glyph advance widths rather than `font-family` strings, with the LESS cache cleared between each cell (`assets:publish` does not recompile it):

| source | forced style | fonts actually painted | |
| --- | --- | --- | --- |
| kit (webfont) | none / `fa-regular` | Pro only | fixed |
| kit (SVG) | none / `fa-regular` | none — blank, then SVG | fixed |
| cdn (Free) | none / `fa-regular` | Free only | unchanged |
| local | none | Free only, immediately | unchanged |
| kit / cdn, no URL | none | Free only, immediately | falls back |
| kit blocked | `fa-regular` | Free at ~+300ms via `onerror` | rescued |
| kit loads, CSS host blocked | `fa-regular` | Free at ~+5.2s via watchdog | rescued |

The Kit case also passes on Firefox and WebKit, and the "later same-descriptor face wins" behaviour the handover depends on is consistent across all three engines. A run against unmodified `2.x` confirms the local path is unchanged.

Treat every timing above as indicative only. They come from a debug-mode forum with opcache off and an unminified 1.7 MB `forum.js`, on a fast connection to a datacentre — so the SPA boots later than it would in production while the remote fetches land sooner. The ordering the fix depends on is what matters, and that holds regardless: the bundled font can only ever be bound before the remote one arrives.

Tests cover the source × forced-style matrix by asserting what reaches the compiled stylesheet, plus the rescue markup and `needsBundledFonts()`. 439 pass across `tests/unit` and `tests/integration/frontend`; 149 JS unit tests unaffected.
