### PR TITLE
[2.x] chore: use the upstream sourcemap package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
+        "axy/sourcemap": "^1.1",
         "bitworking/mimeparse": "^2.3",
         "composer/composer": "^2.7",
         "dflydev/fig-cookies": "^3.0",
@@ -167,7 +168,6 @@
         "pusher/pusher-php-server": "^7.2",
         "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
-        "sycho/sourcemap": "^2.0.0",
         "symfony/config": "^7.0",
         "symfony/console": "^7.0",
         "symfony/event-dispatcher": "^7.0",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -37,6 +37,7 @@
     },
     "require": {
         "php": "^8.3",
+        "axy/sourcemap": "^1.1",
         "bitworking/mimeparse": "^2.3",
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6",
@@ -81,7 +82,6 @@
         "psr/http-server-middleware": "^1.0.2",
         "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
-        "sycho/sourcemap": "^2.0.0",
         "symfony/config": "^7.0",
         "symfony/console": "^7.0",
         "symfony/event-dispatcher": "^7.0",


### PR DESCRIPTION
`sycho/sourcemap` is a fork of [`axy/sourcemap`](https://github.com/axypro/sourcemap) made in 2022. Its only substantive change was relaxing the PHP floor from 8.1 to 7.3 for Flarum 1.x, and it pulled forks of that package's two dependencies along for the same reason.

2.x requires PHP 8.3, so the concession no longer applies. Upstream has resumed releasing (1.1.0, March 2026); the forks have had nothing since 2022.

## What differs

I diffed all three packages with comments and whitespace stripped. Upstream is ahead by exactly one thing: parameters that were implicitly nullable are now declared `?Type`, which PHP 8.4 deprecates. `axy/sourcemap` has converted five of these that the fork had not; its two dependencies are byte-identical to their forks and have converted none.

Everything else is noise — a moved docblock, one string-concatenation style line in `axy/errors`, and files relocated from the repository root into `src/` in `axy/codecs-base64vlq`. No behavioural drift in any of the three.

The PSR-4 namespace is unchanged at `axy\sourcemap\`, so `JsCompiler` is untouched and no other code has to change.

## Lock

```
- Removing  sycho/sourcemap (2.0.0), sycho/errors (3.0.0), sycho/codecs-base64vlq (2.0.0)
- Upgrading axy/backtrace (2.0.0 => 3.0.1)
- Locking   axy/sourcemap (1.1.0), axy/errors (3.0.1), axy/codecs-base64vlq (2.0.1)
```

`axy/backtrace` moves because it was only in the tree at 2.0.0 to satisfy `sycho/errors`, which pinned it to `~2.0.0`.

The constraint reads as a downgrade (`^2.0.0` → `^1.1`) because the fork bumped its major version and upstream never did.

## Verified

- `JsCompiler`'s sourcemap assembly — `new SourceMap()`, then `concat($mapFile, $line)` per source — produces byte-identical mappings before and after.
- Core unit suite passes, 402/402. The 24 PHPUnit notices are pre-existing and unchanged in count.
- Implicitly-nullable signatures in the sourcemap package: 12 → 7.

Correcting a figure given earlier in this description's history: I first reported that as "4 → 0" across the whole chain. That was measured with a pattern that only matched a nullable parameter in final position, so every `Exception $previous = null, $thrower = null` was missed. The dependencies are unchanged by this swap — `errors` stays at 20 and `codecs-base64vlq` at 3, identical to their forks — and those live in separate repositories. The maintenance case for the swap is unaffected; the number was overstated.

## What this does not fix

The `Using null as an array offset is deprecated` notices emitted while compiling assets on PHP 8.5 are still present, now reported from `axy/sourcemap/src/parsing/Line.php:495`. Upstream reproduces them identically:

```php
if ((isset($mSources[$fi])) && ($fi !== null)) {
```

`isset()` evaluates the null offset before `$fi !== null` is ever tested, so the null check is unreachable. Reordering the operands silences it with identical output, verified on 8.5.9. That belongs upstream, and I'm filing it there — tracked in #4894.

