### PR TITLE
[2.x] fix: recognise a finished scheduler run without a removed Symfony method

### DIFF
--- a/framework/core/src/Console/ConsoleServiceProvider.php
+++ b/framework/core/src/Console/ConsoleServiceProvider.php
@@ -98,10 +98,14 @@ class ConsoleServiceProvider extends AbstractServiceProvider
         }
 
         $events->listen(CommandFinished::class, function (CommandFinished $event) use ($container) {
-            $command = $event->command;
             $cache = $container->make(CacheRepository::class);
 
-            if ($command === ScheduleRunCommand::getDefaultName()) {
+            // `CommandFinished` reports the name the command was invoked as, so
+            // this compares against the name Laravel gives `ScheduleRunCommand`
+            // in its `#[AsCommand]` attribute. It used to read that name back
+            // through `Command::getDefaultName()`, which Symfony has since
+            // removed in favour of the attribute.
+            if ($event->command === 'schedule:run') {
                 $cache->forever('flarum:schedule:last_run', Carbon::now());
             }
         });

--- a/framework/core/tests/integration/console/ScheduleRunTest.php
+++ b/framework/core/tests/integration/console/ScheduleRunTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Tests\integration\console;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Scheduling\ScheduleRunCommand;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ScheduleRunTest extends ConsoleTestCase
+{
+    private function cache(): CacheRepository
+    {
+        return $this->app()->getContainer()->make(CacheRepository::class);
+    }
+
+    /**
+     * The admin info screen reports when the scheduler last ran, from a cache
+     * key a `CommandFinished` listener writes. The listener recognises the run
+     * by the name the event carries, so if the two ever disagree the key is
+     * never written and the forum reports that the scheduler has never run.
+     *
+     * `Flarum\Console\Server` dispatches that event with the command's own
+     * `getName()`, which is what this feeds in. The name used to be read back
+     * through `Command::getDefaultName()`, removed in Symfony 8.
+     */
+    #[Test]
+    public function the_scheduler_finishing_records_when_it_last_ran(): void
+    {
+        $this->app();
+
+        $this->cache()->forget('flarum:schedule:last_run');
+
+        $name = (new ScheduleRunCommand())->getName();
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(
+            new CommandFinished($name, new ArrayInput([]), new BufferedOutput(), 0)
+        );
+
+        $this->assertNotNull(
+            $this->cache()->get('flarum:schedule:last_run'),
+            "A finished '$name' did not record flarum:schedule:last_run."
+        );
+    }
+
+    /**
+     * Any other command finishing must leave the timestamp alone, or the info
+     * screen would report a scheduler run whenever anything at all was run.
+     */
+    #[Test]
+    public function another_command_finishing_does_not_record_a_scheduler_run(): void
+    {
+        $this->app();
+
+        $this->cache()->forget('flarum:schedule:last_run');
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(
+            new CommandFinished('cache:clear', new ArrayInput([]), new BufferedOutput(), 0)
+        );
+
+        $this->assertNull($this->cache()->get('flarum:schedule:last_run'));
+    }
+
+    /**
+     * The listener matches on a literal, and the name is Laravel's to change.
+     * Reading it back from the `#[AsCommand]` attribute keeps the two honest —
+     * and that attribute is the only way to ask, now that Symfony 8 has removed
+     * `Command::getDefaultName()`.
+     */
+    #[Test]
+    public function the_scheduler_is_still_named_what_the_listener_expects(): void
+    {
+        $attributes = (new \ReflectionClass(ScheduleRunCommand::class))->getAttributes(AsCommand::class);
+
+        $this->assertNotEmpty($attributes, 'ScheduleRunCommand no longer declares an #[AsCommand] attribute.');
+        $this->assertSame('schedule:run', $attributes[0]->newInstance()->name);
+        $this->assertSame('schedule:run', (new ScheduleRunCommand())->getName());
+    }
+}


### PR DESCRIPTION
The listener that records when the scheduler last ran compared the finished command against `ScheduleRunCommand::getDefaultName()`:

```php
if ($command === ScheduleRunCommand::getDefaultName()) {
```

Symfony deprecated that static in favour of the `#[AsCommand]` attribute and has now removed it, so on Symfony 8 the call is a fatal — and it is reached whenever *any* command finishes, since the listener runs for all of them.

We are not on Symfony 8 yet (`symfony/console` resolves to 7.4), so nothing is broken today. It surfaced while checking what a wider constraint would cost.

It was also asking the wrong question. [`Flarum\Console\Server`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Console/Server.php) dispatches `CommandFinished` with the command's own `getName()`:

```php
new CommandFinished($event->getCommand()->getName(), ...)
```

so the value being compared was never the static's return value — reading it back through `getDefaultName()` was an indirect way of writing a constant. Laravel declares the name in `#[AsCommand(name: 'schedule:run')]`, and its `$signature` and `getName()` both agree with it.

### Tests

There were none for this, and a mismatch fails quietly — the timestamp is simply never written, and the admin info screen reports that the scheduler has never run. Three added:

- a finished `schedule:run` records `flarum:schedule:last_run`
- another command finishing leaves it alone
- the name the listener matches is still the one Laravel declares, read back from the attribute

I checked they fail if the name is wrong, rather than just passing.

Verified on PHP 8.5.9: 3 tests / 5 assertions green, console integration suite 20/20, core unit 402/402.
