### PR TITLE
[2.x] chore: raise the Symfony floor to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,16 +168,16 @@
         "pusher/pusher-php-server": "^7.2",
         "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
-        "symfony/config": "^7.0",
-        "symfony/console": "^7.0",
-        "symfony/event-dispatcher": "^7.0",
-        "symfony/http-client": "^7.0",
-        "symfony/mailgun-mailer": "^7.0",
-        "symfony/mime": "^7.0",
+        "symfony/config": "^7.4",
+        "symfony/console": "^7.4",
+        "symfony/event-dispatcher": "^7.4",
+        "symfony/http-client": "^7.4",
+        "symfony/mailgun-mailer": "^7.4",
+        "symfony/mime": "^7.4",
         "symfony/polyfill-intl-messageformatter": "^1.27",
-        "symfony/postmark-mailer": "^7.0",
-        "symfony/translation": "^7.0",
-        "symfony/yaml": "^7.0",
+        "symfony/postmark-mailer": "^7.4",
+        "symfony/translation": "^7.4",
+        "symfony/yaml": "^7.4",
         "wikimedia/less.php": "^5.3"
     },
     "require-dev": {
@@ -186,7 +186,7 @@
         "mockery/mockery": "^1.5",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^12.5.22",
-        "symfony/var-dumper": "^7.0"
+        "symfony/var-dumper": "^7.4"
     },
     "config": {
         "sort-packages": true

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -82,22 +82,22 @@
         "psr/http-server-middleware": "^1.0.2",
         "psy/psysh": "^0.12",
         "s9e/text-formatter": "^2.13",
-        "symfony/config": "^7.0",
-        "symfony/console": "^7.0",
-        "symfony/event-dispatcher": "^7.0",
-        "symfony/http-client": "^7.0",
-        "symfony/mailgun-mailer": "^7.0",
-        "symfony/mime": "^7.0",
+        "symfony/config": "^7.4",
+        "symfony/console": "^7.4",
+        "symfony/event-dispatcher": "^7.4",
+        "symfony/http-client": "^7.4",
+        "symfony/mailgun-mailer": "^7.4",
+        "symfony/mime": "^7.4",
         "symfony/polyfill-intl-messageformatter": "^1.27",
-        "symfony/postmark-mailer": "^7.0",
-        "symfony/translation": "^7.0",
+        "symfony/postmark-mailer": "^7.4",
+        "symfony/translation": "^7.4",
         "symfony/translation-contracts": "^2.5",
-        "symfony/yaml": "^7.0",
+        "symfony/yaml": "^7.4",
         "wikimedia/less.php": "^5.3"
     },
     "require-dev": {
         "flarum/testing": "^2.0",
-        "symfony/var-dumper": "^7.0"
+        "symfony/var-dumper": "^7.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The Symfony constraints read `^7.0`, which permits 7.0 through 7.3 — all end of life. A fresh install resolves 7.4 regardless, so this only rules out versions nobody should be getting.

7.4 is the current LTS. It was released alongside 8.0 with the same feature set and is maintained in step with it, so there is nothing to account for between 7.0 and 7.4. `composer update` on these reports **"Nothing to modify in lock file"** — they were all already resolving to 7.4.x.

20 constraints, 10 in each of the root and core files. Left at their own version lines: `polyfill-intl-messageformatter` (`^1.27`) and `translation-contracts` (`^2.5`).

### Why not `^7.4 || ^8.0`

Laravel 13 allows both, so it is a fair question. Two things stop us following:

Symfony 8 requires PHP 8.4, and our floor is 8.3 — so a widened constraint resolves to a different Symfony major depending on the host.

More importantly it would break extensions, with no opt-in and no warning. Checked against a real `symfony/console` 8.1.2 install:

| pattern | result on Symfony 8 |
|---|---|
| `implements OutputInterface` directly | **fatal at class load** — `isSilent()` is a new interface method |
| `extends ProgressIndicator`, overriding `finish()` | **fatal** — new `$finishedIndicator` argument |
| `extends Output` / `ConsoleOutput` / `BufferedOutput` | fine, `isSilent()` inherited |
| *calling* `$indicator->finish('done')` | fine, the new argument is optional |

Extensions do implement `OutputInterface` and subclass `ProgressIndicator`, and those are load-time fatals rather than deprecations — a dead `php flarum` command, not a log line. The author has done nothing wrong; their code is valid against the major we currently declare.

That makes a Symfony 8 bump a breaking change for the ecosystem, so it belongs in a major with an upgrade note telling authors to extend `Output` rather than implement the interface. Worth noting several Symfony 8 packages are already installed transitively today (`mailer`, `http-kernel`, `finder`, `filesystem`…) via Laravel's own `^7.4 || ^8.0` constraints — that is fine, since Symfony sanctions those cross-major pairs in its own metadata, and none of them is a base class extensions build on. `symfony/console` is the one that matters.

Verified on PHP 8.5.9: core unit 402/402, console integration 20/20, `composer validate` clean.
