### PR TITLE
[2.x] fix: run the caller's `ondismiss` when an alert is dismissed

### DIFF
--- a/framework/core/js/src/common/components/AlertManager.tsx
+++ b/framework/core/js/src/common/components/AlertManager.tsx
@@ -28,9 +28,20 @@ export default class AlertManager<CustomAttrs extends IAlertManagerAttrs = IAler
             const alert = activeAlerts[key];
             const urgent = alert.attrs.type === 'error';
 
+            // Dismissing has to remove the alert from the list, which is the
+            // manager's bookkeeping and not the caller's to replace. Whatever
+            // the caller passed runs as well: an extension may need to know its
+            // alert was dismissed — to remember the reader declined, say — and
+            // overwriting `ondismiss` outright is why it never heard about it.
+            const ondismiss = (...args: unknown[]) => {
+              (alert.attrs.ondismiss as ((...args: unknown[]) => void) | undefined)?.(...args);
+
+              this.state.dismiss(key);
+            };
+
             return (
               <div className="AlertManager-alert" role="alert" aria-live={urgent ? 'assertive' : 'polite'}>
-                <alert.componentClass {...alert.attrs} ondismiss={this.state.dismiss.bind(this.state, key)}>
+                <alert.componentClass {...alert.attrs} ondismiss={ondismiss}>
                   {alert.children}
                 </alert.componentClass>
               </div>

--- a/framework/core/js/tests/integration/common/AlertManager.test.ts
+++ b/framework/core/js/tests/integration/common/AlertManager.test.ts
@@ -25,6 +25,45 @@ describe('AlertManager', () => {
     expect(manager).not.toContainRaw('Hello, world!');
   });
 
+  /**
+   * The manager needs its own dismiss handler on every alert, so that the
+   * dismiss button removes the alert from the list. Passing one used to mean the
+   * caller's own `ondismiss` was dropped, so an extension could not learn that
+   * its alert had been dismissed — flarum/pwa relies on exactly that to remember
+   * the reader declined, and without it re-asked on every page load.
+   */
+  test('dismissing an alert runs the callback the caller gave', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    const ondismiss = jest.fn();
+
+    app.alerts.show({ type: 'success', dismissible: true, ondismiss }, 'Hello, world!');
+
+    manager.redraw();
+
+    manager.click('.Alert-dismiss');
+
+    expect(ondismiss).toHaveBeenCalled();
+  });
+
+  /**
+   * ...and the alert must still go away. The manager's own bookkeeping is not
+   * the caller's to replace.
+   */
+  test('dismissing an alert still removes it when the caller supplies a callback', () => {
+    const manager = mq(AlertManager, { state: app.alerts });
+
+    app.alerts.show({ type: 'success', dismissible: true, ondismiss: () => {} }, 'Goodbye, world!');
+
+    manager.redraw();
+    expect(manager).toContainRaw('Goodbye, world!');
+
+    manager.click('.Alert-dismiss');
+
+    manager.redraw();
+    expect(manager).not.toContainRaw('Goodbye, world!');
+  });
+
   test('can clear all alerts', () => {
     const manager = mq(AlertManager, { state: app.alerts });
 


### PR DESCRIPTION
Fixes #4837.

`AlertManager` spread each alert's attrs and then overwrote `ondismiss` with its own dismiss handler:

```tsx
<alert.componentClass {...alert.attrs} ondismiss={this.state.dismiss.bind(this.state, key)}>
```

So a callback passed to `app.alerts.show()` was silently discarded, and an extension had no way to learn its alert had been dismissed. flarum/pwa relies on exactly that to remember the reader declined the push-notification prompt, so it re-asked on every page load.

The handler now composes — the caller's callback runs, then the alert is dismissed:

```tsx
const ondismiss = (...args: unknown[]) => {
  (alert.attrs.ondismiss as ((...args: unknown[]) => void) | undefined)?.(...args);

  this.state.dismiss(key);
};
```

Removing the alert from the list stays the manager's responsibility rather than something a caller replaces by passing `ondismiss`.

### Tests

Two, added to the existing `AlertManager.test.ts`:

- **the caller's callback runs on dismiss** — fails without this change; I checked by reverting it.
- **the alert still goes away when a callback is supplied** — passes before *and* after, deliberately. It guards against the naive version of this fix, which is to hand `ondismiss` straight through and lose the dismissal.

Whole common integration suite green: 32 suites, 98 tests. `check-typings` clean.

### To try it

```js
app.alerts.show({ dismissible: true, ondismiss: () => alert('dismissed') }, 'test');
```

Clicking the dismiss button should fire the callback and remove the alert.

### 1.x

The same line is unchanged on 1.x, so the bug is real there too. Not fixing it there — 1.x is critical-fixes-only and this doesn't meet that bar.
