### PR TITLE
[2.x] fix: tell assistive technology which dropdown option is selected

### DIFF
--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -56,4 +56,29 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
       this.attrs.caretIcon ? <Icon name={this.attrs.caretIcon} className="Button-caret" /> : null,
     ];
   }
+
+  /**
+   * Which option is in effect is otherwise conveyed only by a class on the item
+   * and by the toggle button borrowing that option's label — neither of which a
+   * screen reader announces while moving through the menu.
+   *
+   * `aria-current` rather than `aria-selected`: the latter is only valid on
+   * roles this menu does not claim, and claiming them would mean implementing
+   * the whole listbox keyboard contract. Unselected items are left without the
+   * attribute rather than given `"false"`, since only one item can be current
+   * and the absence says as much.
+   */
+  getMenu(items: Mithril.Vnode<any, any>[]): Mithril.Vnode<any, any> {
+    items.forEach((item) => {
+      // Each item arrives wrapped in the list element `listItems` built around
+      // it, so the option itself is the wrapper's child.
+      const option = (Array.isArray(item?.children) ? item.children[0] : item?.children) as Mithril.Children;
+
+      if (isActive(option)) {
+        item.attrs = { ...item.attrs, 'aria-current': 'true' };
+      }
+    });
+
+    return super.getMenu(items);
+  }
 }

--- a/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
+++ b/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
@@ -30,6 +30,87 @@ describe('SelectDropdown displays as expected', () => {
     expect(select).toContainRaw('Option C');
   });
 
+  /**
+   * Which option is selected is shown visually by a class on the item, and by
+   * the toggle button taking that option's label. Neither reaches a screen
+   * reader, so the menu read as an undifferentiated list of options with no
+   * indication of which one was in effect (flarum/framework#3362).
+   *
+   * `aria-current` is used rather than `aria-selected`, which is only valid on
+   * roles this menu does not claim (`option`, `tab`, `row`, `gridcell`,
+   * `treeitem`). Giving it those roles would mean honouring the whole listbox
+   * keyboard contract; `aria-current` is valid anywhere and says what is meant —
+   * the current item within a set.
+   */
+  it('marks the selected option for assistive technology', () => {
+    const buttons = [
+      m('button', { className: 'button-1', active: false }, 'Option A'),
+      m('button', { className: 'button-2', active: true }, 'Option B'),
+      m('button', { className: 'button-3', active: false }, 'Option C'),
+    ];
+
+    const select = mq(
+      m(
+        SelectDropdown,
+        {
+          label: 'Select the option',
+          defaultLabel: 'Select an option',
+        },
+        buttons
+      )
+    );
+
+    const current = select.rootEl.querySelectorAll('[aria-current="true"]');
+
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toContain('Option B');
+  });
+
+  /**
+   * Mithril omits an attribute set to `false` entirely, so the unselected items
+   * must not be given `aria-current` at all rather than `aria-current="false"`.
+   */
+  it('does not mark unselected options', () => {
+    const buttons = [
+      m('button', { className: 'button-1', active: false }, 'Option A'),
+      m('button', { className: 'button-2', active: true }, 'Option B'),
+    ];
+
+    const select = mq(
+      m(
+        SelectDropdown,
+        {
+          label: 'Select the option',
+          defaultLabel: 'Select an option',
+        },
+        buttons
+      )
+    );
+
+    // Every item carrying the attribute at all is the selected one.
+    expect(select.rootEl.querySelectorAll('[aria-current]')).toHaveLength(1);
+  });
+
+  /**
+   * A menu with nothing selected must not claim a current item.
+   */
+  it('marks nothing when no option is selected', () => {
+    const buttons = [m('button', { className: 'button-1' }, 'Option A'), m('button', { className: 'button-2' }, 'Option B')];
+
+    const select = mq(
+      m(
+        SelectDropdown,
+        {
+          label: 'Select the option',
+          defaultLabel: 'Select an option',
+        },
+        buttons
+      )
+    );
+
+    expect(select.rootEl.querySelectorAll('[aria-current]')).toHaveLength(0);
+  });
+
   it('uses active button as label', () => {
     const buttons = [
       m('button', { className: 'button-1', active: false }, 'Option A'),


### PR DESCRIPTION
Fixes #3362.

A `SelectDropdown` shows which option is in effect two ways — a class on the item, and the toggle button borrowing that option's label. Neither reaches a screen reader, so moving through the menu announces an undifferentiated list of options with no indication of which one is active.

The selected item now carries `aria-current="true"`.

### Why `aria-current` and not `aria-selected`

The issue asks for `aria-selected`, but that attribute is only valid on elements with role `option`, `tab`, `row`, `gridcell` or `treeitem`. The menu is a plain `<ul>` of `<li>` wrapping buttons:

```tsx
getMenu(items) {
  return <ul className={'Dropdown-menu dropdown-menu ' + this.attrs.menuClassName}>{items}</ul>;
}
```

with no role declared in `Dropdown`, `SelectDropdown` or `Select`. Adding `aria-selected` there would be ignored by assistive tech at best, and flagged as invalid by axe/Lighthouse at worst.

Giving the menu `role="listbox"` and its items `role="option"` would make it valid, but that is a contract — it commits us to arrow-key navigation and `aria-activedescendant`, which is a much bigger piece of work and belongs with #3361 and the rest of the keyboard-navigation issues. `aria-current` is valid on any element and states what is actually meant: the current item within a set.

Unselected items are left without the attribute rather than given `"false"`. Only one item can be current, so the absence carries the meaning — and Mithril omits an attribute set to `false` regardless.

### Scoping

The tidier place would have been `listItems`, which already works out which item is active and adds the `active` class. It is scoped to `SelectDropdown` instead because that helper wraps *every* list in Flarum, and the only component implementing `isActive` is `LinkButton` — which is route-based. Nav items are genuinely navigation and want `aria-current="page"`, so marking them `"true"` would be wrong.

### Tests

Three added to the existing `SelectDropdown.test.ts`:

- **the selected option is marked** — exactly one `[aria-current="true"]`, and it is the right one
- **unselected options are not marked** — guards against applying it to everything
- **nothing is marked when no option is selected** — passes before this change as well as after; it is the guard against over-application

I checked the first two fail without the change rather than assuming it.

All integration suites green: 49 suites, 162 tests. `check-typings` clean.

### To try it

Open a select dropdown — the sort dropdown on the discussion index is the clearest — and inspect the menu. The current option's `<li>` should carry `aria-current="true"` and the others should have no such attribute.
