### PR TITLE
[2.x] fix: keep a saved falsy setting in settings modals too

### DIFF
--- a/framework/core/js/src/admin/components/SettingsModal.tsx
+++ b/framework/core/js/src/admin/components/SettingsModal.tsx
@@ -38,7 +38,12 @@ export default abstract class SettingsModal<CustomAttrs extends ISettingsModalAt
   }
 
   setting(key: string, fallback: string = ''): Stream<SettingValue> {
-    this.settings[key] = this.settings[key] || Stream(app.data.settings[key] || fallback);
+    // `??`, not `||`: settings live in a string column, so a saved `false`
+    // arrives as an empty string. Falling back on falsiness discarded it and
+    // reseeded the default, which meant a setting whose default is truthy could
+    // never be switched off — it came back on with every reload. Only the
+    // absence of a saved value should reach for the fallback.
+    this.settings[key] = this.settings[key] || Stream(app.data.settings[key] ?? fallback);
 
     return this.settings[key];
   }

--- a/framework/core/js/tests/integration/admin/components/AdminPageSetting.test.ts
+++ b/framework/core/js/tests/integration/admin/components/AdminPageSetting.test.ts
@@ -1,5 +1,6 @@
 import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
 import AdminPage from '../../../../src/admin/components/AdminPage';
+import SettingsModal from '../../../../src/admin/components/SettingsModal';
 import { app } from '../../../../src/admin';
 
 beforeAll(() => bootstrapAdmin());
@@ -8,12 +9,17 @@ beforeAll(() => bootstrapAdmin());
  * `setting(key, fallback)` seeds a stream from the saved value, falling back to
  * the given default when there is nothing saved.
  *
- * Settings are stored in a string column, so a saved `false` comes back as `''`
- * and a saved `0` as `'0'` — both falsy in JavaScript. Choosing the fallback on
- * falsiness therefore discarded values an administrator had deliberately saved,
- * and a setting whose default is truthy could never be turned off: it reverted
- * on every reload (flarum/framework#4781). Only the *absence* of a saved value
- * should reach for the default.
+ * Settings are stored in a string column, so a saved `false` comes back as an
+ * empty string — the one value a setting can hold that JavaScript reads as
+ * absent. Choosing the fallback on falsiness therefore discarded a value the
+ * administrator had deliberately saved, and a setting whose default is truthy
+ * could never be turned off: it reverted on every reload
+ * (flarum/framework#4781). Only the *absence* of a saved value should reach for
+ * the default.
+ *
+ * Two classes expose this, and both are public API: `AdminPage` for settings
+ * pages, and `SettingsModal` for settings modals. They are covered together
+ * because the bug was fixed in the first while surviving in the second.
  */
 describe('AdminPage.setting()', () => {
   class TestPage extends AdminPage {
@@ -63,5 +69,50 @@ describe('AdminPage.setting()', () => {
    */
   test('a saved "0" is kept', () => {
     expect(seeded('0', '10')).toBe('0');
+  });
+});
+
+/**
+ * The same contract, on the class settings *modals* are built from. `flarum/audit`
+ * and core's own custom header, footer and CSS modals all extend it, and it is
+ * part of the public API extensions import as
+ * `flarum/admin/components/SettingsModal`.
+ */
+describe('SettingsModal.setting()', () => {
+  class TestModal extends SettingsModal {
+    title() {
+      return 'Test';
+    }
+
+    form() {
+      return null;
+    }
+  }
+
+  const seeded = (saved: string | undefined, fallback: string): unknown => {
+    const key = 'test.modal.setting';
+
+    if (saved === undefined) {
+      delete app.data.settings[key];
+    } else {
+      app.data.settings[key] = saved;
+    }
+
+    const modal = new TestModal();
+    (modal as any).settings = {};
+
+    return modal.setting(key, fallback)();
+  };
+
+  test('a saved value is used', () => {
+    expect(seeded('1', '')).toBe('1');
+  });
+
+  test('the fallback is used when nothing is saved', () => {
+    expect(seeded(undefined, 'the-default')).toBe('the-default');
+  });
+
+  test('a saved empty string is kept rather than falling back', () => {
+    expect(seeded('', '1')).toBe('');
   });
 });


### PR DESCRIPTION
Follow-up to #4782, which fixed this in `AdminPage` while the identical line in `SettingsModal` survived. Same defect, different file — context in #4781.

```ts
// AdminPage.tsx — fixed by #4782
this.settings[key] = this.settings[key] || Stream<string>(app.data.settings[key] ?? fallback);

// SettingsModal.tsx — this PR
this.settings[key] = this.settings[key] || Stream(app.data.settings[key] ?? fallback);
```

Settings live in a string column, so a saved `false` arrives as an empty string. Choosing the fallback on falsiness discarded it and reseeded the default, which meant a boolean setting whose default is truthy could not be switched off — it came back on with every reload.

### Why it matters

`SettingsModal` is public API — extensions import it as `flarum/admin/components/SettingsModal`. Current consumers:

- core: `EditCustomHeaderModal`, `EditCustomFooterModal`, `EditCustomCssModal`
- `flarum/audit`: `LimitedSettingsModal`

### Tests

The existing `AdminPageSetting.test.ts` (added in #4782) now covers **both** classes side by side rather than only the one the original issue named — which is what would have caught this the first time round. Seven tests: four for `AdminPage`, three for `SettingsModal`.

I checked the new `SettingsModal` empty-string test fails without this change.

Its docblock is also corrected. It claimed a saved `'0'` was discarded too, but the *string* `'0'` is truthy in JavaScript — only the number is falsy. The empty string is the only value a setting can hold that JavaScript reads as absent.

All integration suites green: 50 suites, 169 tests. `check-typings` clean.

### Testing by hand

Awkward to demonstrate in core, since none of the three core modals has a boolean setting with a truthy default — the visible effect there is nil. It reproduces through an extension that puts such a setting in a modal. The test coverage is the real assurance here.
