### PR TITLE
[2.x] fix: retry a realtime push whose connection was interrupted

### DIFF
--- a/extensions/realtime/src/Websocket/PusherClientFactory.php
+++ b/extensions/realtime/src/Websocket/PusherClientFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Websocket;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * The HTTP client the Pusher SDK uses to reach our own websocket server.
+ *
+ * Left to itself the SDK builds `new Client(['timeout' => n])` and nothing more,
+ * so a push that fails in transit fails outright. That matters here because the
+ * server on the other end is ours and is restarted on every deployment — which
+ * is also when `BroadcastAssetsRevisionJob` runs, to tell browsers the assets
+ * changed. A push caught in that window died with `cURL error 56: Recv failure:
+ * Connection reset by peer`, and the realtime queue runs `tries: 1`, so it
+ * failed permanently.
+ *
+ * The SDK's own guard does not help: it catches `ConnectException`, and a
+ * mid-response reset is a `RequestException` — siblings under
+ * `TransferException`, not parent and child.
+ *
+ * So the transport retries briefly. A websocket process comes back in far less
+ * time than the delays below, and these payloads are small enough that repeating
+ * one costs nothing worth counting.
+ */
+class PusherClientFactory
+{
+    /**
+     * Attempts after the first. Two is enough to cross a process restart without
+     * holding a queue worker while a server that is genuinely down stays down.
+     */
+    public const RETRIES = 2;
+
+    /**
+     * Build the client.
+     *
+     * @param int $timeout seconds, from the extension's own settings
+     * @param callable|null $handler transport to use instead of the default, for tests
+     * @param callable|null $delay milliseconds to wait before attempt $n, for tests
+     */
+    public static function make(int $timeout, ?callable $handler = null, ?callable $delay = null): Client
+    {
+        $stack = $handler ? HandlerStack::create($handler) : HandlerStack::create();
+
+        $stack->push(Middleware::retry(
+            self::decider(),
+            $delay ?? self::delay()
+        ));
+
+        return new Client([
+            'timeout' => $timeout,
+            'handler' => $stack,
+        ]);
+    }
+
+    /**
+     * Retry only where the request never got an answer. A response — including a
+     * rejection such as an auth signature that does not verify — is the server
+     * answering, and repeating it would be told the same thing again.
+     */
+    private static function decider(): callable
+    {
+        return function (
+            int $retries,
+            RequestInterface $request,
+            ?ResponseInterface $response = null,
+            ?\Throwable $exception = null
+        ): bool {
+            if ($retries >= self::RETRIES) {
+                return false;
+            }
+
+            return $response === null && $exception instanceof TransferException;
+        };
+    }
+
+    /**
+     * Short, growing waits: long enough for a restarting process to bind its
+     * socket again, short enough not to stall the queue.
+     */
+    private static function delay(): callable
+    {
+        return fn (int $retries): int => 100 * $retries;
+    }
+}

--- a/extensions/realtime/src/WebsocketProvider.php
+++ b/extensions/realtime/src/WebsocketProvider.php
@@ -15,6 +15,7 @@ use Flarum\Realtime\Push\RealtimeRegistry;
 use Flarum\Realtime\Websocket\Api\PresenceChannelAuthorizer;
 use Flarum\Realtime\Websocket\Channel\Manager;
 use Flarum\Realtime\Websocket\IndexTypingPresence;
+use Flarum\Realtime\Websocket\PusherClientFactory;
 use Flarum\Realtime\Websocket\Settings;
 use Flarum\Realtime\Websocket\TypingIdentity;
 use Illuminate\Contracts\Container\Container;
@@ -48,6 +49,11 @@ class WebsocketProvider extends AbstractServiceProvider
                     'debug' => $config->inDebugMode(),
                     'timeout' => $settings->phpClientTimeout
                 ],
+                // Given no client the SDK builds one carrying only a timeout, so
+                // a push interrupted in transit fails outright. The server on the
+                // other end is ours and restarts on deployment, so brief retries
+                // are the difference between a lost push and a failed job.
+                PusherClientFactory::make($settings->phpClientTimeout),
             );
 
             $pusher->setLogger($container->make(LoggerInterface::class));

--- a/extensions/realtime/tests/unit/Websocket/PusherClientRetryTest.php
+++ b/extensions/realtime/tests/unit/Websocket/PusherClientRetryTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Realtime\Tests\unit\Websocket;
+
+use Flarum\Realtime\Websocket\PusherClientFactory;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The HTTP client the Pusher SDK uses to reach our own websocket server.
+ *
+ * Every push goes over this connection, and the server is restarted on every
+ * deployment — which is also exactly when `BroadcastAssetsRevisionJob` fires, to
+ * tell browsers the assets changed. A push caught mid-restart died with
+ * `cURL error 56: Recv failure: Connection reset by peer` and, on a queue
+ * configured `tries: 1`, failed permanently.
+ *
+ * The SDK builds its own client when none is given — `new Client(['timeout' => n])`
+ * and nothing else, so no retry. It also only guards against `ConnectException`,
+ * which a mid-response reset is not: `RequestException` and `ConnectException`
+ * are siblings under `TransferException`, not parent and child. So a reset
+ * escaped the SDK's own handling entirely.
+ */
+class PusherClientRetryTest extends TestCase
+{
+    private function request(): Request
+    {
+        return new Request('POST', 'http://localhost:8443/apps/1/events');
+    }
+
+    /**
+     * @param mixed[] $queue responses and/or exceptions the transport will yield
+     * @return array{0: \GuzzleHttp\Client, 1: MockHandler}
+     */
+    private function client(array $queue): array
+    {
+        $mock = new MockHandler($queue);
+
+        // No sleeping in tests: the factory's delay is exercised separately.
+        return [PusherClientFactory::make(3, $mock, fn () => 0), $mock];
+    }
+
+    /**
+     * The reported failure: a connection reset partway through the response.
+     */
+    #[Test]
+    public function it_retries_a_connection_reset_and_succeeds(): void
+    {
+        [$client] = $this->client([
+            new RequestException('cURL error 56: Recv failure: Connection reset by peer', $this->request()),
+            new Response(200, [], '{}'),
+        ]);
+
+        $response = $client->post('http://localhost:8443/apps/1/events');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * The websocket server refusing the connection outright — the same restart
+     * window, caught a moment earlier. `ConnectException` does not extend
+     * `RequestException`, so a decider written for one misses the other.
+     */
+    #[Test]
+    public function it_retries_a_refused_connection_and_succeeds(): void
+    {
+        [$client] = $this->client([
+            new ConnectException('cURL error 7: Failed to connect to localhost port 8443', $this->request()),
+            new Response(200, [], '{}'),
+        ]);
+
+        $response = $client->post('http://localhost:8443/apps/1/events');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Retrying is bounded. A server that stays down must surface, not spin —
+     * the caller decides whether an undeliverable push is worth failing over.
+     */
+    #[Test]
+    public function it_gives_up_once_the_attempts_are_exhausted(): void
+    {
+        [$client, $mock] = $this->client([
+            new ConnectException('cURL error 7', $this->request()),
+            new ConnectException('cURL error 7', $this->request()),
+            new ConnectException('cURL error 7', $this->request()),
+            new ConnectException('cURL error 7', $this->request()),
+        ]);
+
+        $this->expectException(ConnectException::class);
+
+        try {
+            $client->post('http://localhost:8443/apps/1/events');
+        } finally {
+            // One original attempt plus the retries, and no more.
+            $this->assertLessThanOrEqual(3, 4 - $mock->count(), 'Retried more times than intended.');
+        }
+    }
+
+    /**
+     * A 4xx is the server answering, not failing to answer. Retrying it would
+     * repeat a request that will be rejected identically — an auth signature
+     * that does not verify, say.
+     */
+    #[Test]
+    public function it_does_not_retry_a_rejected_request(): void
+    {
+        [$client, $mock] = $this->client([
+            new Response(401, [], 'invalid signature'),
+            new Response(200, [], '{}'),
+        ]);
+
+        $response = $client->post('http://localhost:8443/apps/1/events', ['http_errors' => false]);
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame(1, $mock->count(), 'A rejected request must not be retried.');
+    }
+
+    /**
+     * A successful push costs no extra attempts.
+     */
+    #[Test]
+    public function it_does_not_retry_a_successful_request(): void
+    {
+        [$client, $mock] = $this->client([
+            new Response(200, [], '{}'),
+            new Response(200, [], '{}'),
+        ]);
+
+        $client->post('http://localhost:8443/apps/1/events');
+
+        $this->assertSame(1, $mock->count(), 'A successful request must not be retried.');
+    }
+}


### PR DESCRIPTION
Seen on discuss.flarum.org during a deployment:

```
Flarum\Realtime\Push\Jobs\BroadcastAssetsRevisionJob — Queue realtime · failed

GuzzleHttp\Exception\RequestException: cURL error 56: Recv failure: Connection
reset by peer for http://localhost:8443/apps/1/events
  #15 BroadcastAssetsRevisionJob.php(33): Pusher\Pusher->trigger('public', 'assetsRevision', …)
```

The job POSTs to our **own** websocket server, which is restarted on every deployment — and a deployment is precisely when this job fires, since recompiled assets are what it announces. So the push races the restart of the thing carrying it, and with `tries: 1` on the realtime queue a lost connection is a permanent failure.

### Why nothing caught it

Realtime passes the Pusher SDK no client, so the SDK builds one itself:

```php
$this->client = new \GuzzleHttp\Client(['timeout' => $this->settings['timeout']]);
```

A timeout and nothing else — no retry.

The SDK does guard its own request, but only against `ConnectException`:

```php
} catch (ConnectException $e) {
    throw new ApiErrorException($e->getMessage());
}
```

A mid-response reset is a `RequestException`, and **`ConnectException` does not extend `RequestException`** — they are siblings under `TransferException`. So the reset went straight past the SDK's handling and surfaced raw in the worker, which is what the trace shows.

### The change

A new `PusherClientFactory` builds the client the SDK would otherwise build for itself, plus `Middleware::retry`:

- retries when `$response === null && $exception instanceof TransferException` — i.e. the request got no answer, covering both a reset and a refused connection
- 2 retries, ~100ms and ~200ms apart. A websocket process rebinds in far less than that, and these payloads are small
- a **response** is never retried, however unwelcome: an auth signature that does not verify would be rejected identically next time

Bound in the container rather than the job, so it applies to every realtime push and to any extension resolving `Pusher::class` — not only the job whose failures made it visible.

`timeout` is untouched. The realtime queue's short timeout is a deliberate shedding mechanism: a push worth more than a few seconds is not worth delivering.

### Tests

Five, driving the handler stack directly:

- a connection reset is retried, then succeeds — fails without this change
- a refused connection is retried, then succeeds — fails without this change
- retrying is bounded, and a server that stays down surfaces
- a 401 is **not** retried
- a success is **not** retried

The last three are the guards that stop this becoming "retry anything". I confirmed the first two fail with the decider disabled.

Realtime unit suite green: 46 tests.

### Still worth doing separately

This narrows the window; it does not close it. If the websocket server is down for a whole deployment, retries only postpone the same failure. Two follow-ups, deliberately not bundled here:

1. `tries: 2` on fof/horizon's realtime profile, so one requeue covers a server still down after the HTTP attempts are spent. `emails` already does this for the same reason.
2. Treating a genuinely unreachable server as a no-op rather than a failure — the asset revision reaches clients via the `X-Flarum-Assets-Revision` response header regardless. That has to catch connectivity exceptions only and never `\Throwable`, which is how a worker OOM stayed hidden here once before.
