### PR TITLE
[2.x] chore: require the sourcemap release carrying the 8.5 deprecation fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "axy/sourcemap": "^1.1",
+        "axy/sourcemap": "^1.1.1",
         "bitworking/mimeparse": "^2.3",
         "composer/composer": "^2.7",
         "dflydev/fig-cookies": "^3.0",

--- a/framework/core/composer.json
+++ b/framework/core/composer.json
@@ -37,7 +37,7 @@
     },
     "require": {
         "php": "^8.3",
-        "axy/sourcemap": "^1.1",
+        "axy/sourcemap": "^1.1.1",
         "bitworking/mimeparse": "^2.3",
         "dflydev/fig-cookies": "^3.0",
         "doctrine/dbal": "^3.6",


### PR DESCRIPTION
Closes #4894.

`axy/sourcemap` 1.1.1 was released today, carrying the fix from [axypro/sourcemap#13](https://github.com/axypro/sourcemap/pull/13): the two guards in `Line::concat()` read an array before checking the index is not null, so PHP 8.5 reports a deprecation once per mapped position — hundreds of lines per request while compiling assets on a debug install.

```php
// before
if ((isset($mSources[$fi])) && ($fi !== null)) {

// after
if (($fi !== null) && (isset($mSources[$fi]))) {
```

### This changes nothing mechanically

`^1.1` already resolves to 1.1.1, so any install resolving fresh picks it up without this. The bump is here to be explicit: the version we need is 1.1.1, not merely whatever 1.x happens to resolve to.

Worth being clear that it does **not** unblock anything — 1.1.0 works, it is just noisy on 8.5 — so this is a statement of intent rather than a compatibility fix.

### Verified

On PHP 8.5.9, running `JsCompiler`'s own assembly (`new SourceMap()` → `concat($mapFile, $line)` per source):

| | 1.1.0 | 1.1.1 |
|---|---|---|
| `Using null as an array offset` | 3 notices | **none** |
| mappings output | `AAAA,SAASA,IAAIC;;…` | **identical** |

Core unit suite green: 405 tests.

### Still noisy, separately

The other deprecations that surface alongside these come from `axy/errors` (5) and `axy/codecs-base64vlq` (2) — implicitly-nullable `$previous` parameters. Different packages, different reports; not addressed here.
