### PR TITLE
[2.x] fix: clamp the desktop container widths to the available space

### DIFF
--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -68,14 +68,20 @@ p {
   // same fixed width, wasting half the viewport on modern displays. The widths
   // are CSS custom properties (see root.less) so themes can retune each band
   // without re-declaring the media queries.
+  //
+  // A band's width is not tied to the breakpoint that opens it, and a theme can
+  // set it to anything, so each is clamped to the viewport: a width wider than
+  // the band's own lower bound would otherwise overflow (body hides the overflow
+  // and auto margins cannot go negative, so the layout silently clips off-centre
+  // rather than scrolling).
   @media @desktop-hd {
-    width: var(--container-hd);
+    width: ~"min(var(--container-hd), 100%)";
   }
   @media @desktop-xl {
-    width: var(--container-xl);
+    width: ~"min(var(--container-xl), 100%)";
   }
   @media @desktop-xxl {
-    width: var(--container-xxl);
+    width: ~"min(var(--container-xxl), 100%)";
   }
 }
 


### PR DESCRIPTION
The desktop band widths introduced in #4869 are not tied to the breakpoints that open them. `@screen-desktop-hd` is `1100px`, but the hd band sets `width: var(--container-hd)`, which is `1200px`. So every viewport from 1100px to 1199px gets a container up to 100px wider than the screen.

This does not surface as a horizontal scrollbar, which is why it slipped through. `body` has `overflow-x: hidden`, and `margin-left/right: auto` cannot resolve to a negative value, so the container is pinned to the left and its right edge is silently clipped — the layout stops being centred and part of the header runs off-screen. Reproduce by sizing a window to ~1150px wide on any page where the discussion list pane is not pinned.

(The pinned-pane path escapes it by accident: `DiscussionListPane.less` already sets `.container { max-width: 100% }` in that case.)

### Changes proposed in this pull request:

Each desktop band is now clamped to the space actually available:

```less
@media @desktop-hd  { width: ~"min(var(--container-hd), 100%)"; }
@media @desktop-xl  { width: ~"min(var(--container-xl), 100%)"; }
@media @desktop-xxl { width: ~"min(var(--container-xxl), 100%)"; }
```

The hd band goes fluid between 1100px and 1199px and pins to 1200px from 1200px up, which is what #4869 intended. The xl and xxl bands are not broken today (1300px at a 1600px bound, 1600px at a 2000px bound), but they get the same guard because the widths are custom properties — a theme retuning `--container-xl` from `:root` could reintroduce the identical mismatch, and core has no way to catch that.

`100%` rather than `100vw`: `body` has `overflow-y: scroll`, so `100vw` would include the scrollbar gutter and stay ~15px too wide. `100%` also does the right thing when the pane is pinned, where the containing block is already narrowed by `margin-left: var(--pane-width)` — the clamp then means "the space left over", matching the existing override.

### Reviewer notes

The existing `max-width: 100%` in `DiscussionListPane.less` is now redundant but harmless, so I left it rather than widen the diff.
