### PR TITLE
[2.x] fix: stop the header overlapping itself when it runs out of room

### DIFF
--- a/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
+++ b/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
@@ -3,7 +3,7 @@ import Component, { ComponentAttrs } from '../Component';
 import SearchState from '../states/SearchState';
 import extractText from '../utils/extractText';
 import ItemList from '../utils/ItemList';
-import Input from './Input';
+import Icon from './Icon';
 import type Mithril from 'mithril';
 
 export interface SearchAttrs extends ComponentAttrs {
@@ -90,50 +90,51 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
     // Hide the search view if no sources were loaded
     if (this.sourceItems().isEmpty()) return <div></div>;
 
+    const value = this.searchState.getValue();
+
+    // Search happens in a modal, so this control does not accept text: it is a
+    // button that opens the modal, and reads as one to assistive technology
+    // rather than as a textbox that refuses input. Where its label is shown —
+    // the drawer — it displays the current query in place of the prompt, so a
+    // search that has been run stays visible after the modal closes.
     const openSearchModal = () => {
-      this.$('input').blur() &&
-        app.modal.show(() => import('../../common/components/SearchModal'), { searchState: this.searchState, sources: this.sourceItems().toArray() });
+      app.modal.show(() => import('../../common/components/SearchModal'), { searchState: this.searchState, sources: this.sourceItems().toArray() });
     };
 
     return (
-      <div
-        role="search"
-        className="Search"
-        aria-label={this.attrs.a11yRoleLabel}
-        onclick={() => {
-          // On phones the search input lives inside the slide-out drawer. Close the drawer as soon as
-          // search is activated, before the modal is shown, so it isn't left open behind (and overlapping)
-          // the full-screen search modal as it animates in. Hiding it here rather than in `openSearchModal`
-          // lets the drawer finish sliding out during the delay below. No-op where the drawer is never open.
-          app.drawer.hide();
-          this.$('input').blur();
-          setTimeout(() => openSearchModal(), 150);
-        }}
-      >
-        <Input
-          type="search"
-          className="Search-input"
-          clearable={this.searchState.getValue()}
-          clearLabel={app.translator.trans('core.lib.search.search_clear_button_accessible_label')}
-          prefixIcon="fas fa-search"
-          aria-label={this.attrs.label}
-          readonly={true}
-          placeholder={this.attrs.label}
-          value={this.searchState.getValue()}
-          onchange={(value: string) => {
-            if (!value) this.searchState.clear();
-            else this.searchState.setValue(value);
+      <div role="search" className="Search" aria-label={this.attrs.a11yRoleLabel}>
+        <button
+          type="button"
+          // `Button--flat` rather than `Button--link`: this sits among the
+          // notification and message controls, which are flat buttons, and
+          // should pick up the same hover and focus treatment as them.
+          className="Search-input Button Button--flat"
+          aria-label={extractText(this.attrs.label)}
+          title={extractText(this.attrs.label)}
+          onclick={() => {
+            // On phones the search button lives inside the slide-out drawer. Close the drawer as soon as
+            // search is activated, before the modal is shown, so it isn't left open behind (and overlapping)
+            // the full-screen search modal as it animates in. Hiding it here rather than in `openSearchModal`
+            // lets the drawer finish sliding out during the delay below. No-op where the drawer is never open.
+            app.drawer.hide();
+            setTimeout(() => openSearchModal(), 150);
           }}
-          inputAttrs={{
-            // for keyboard navigation, click event would be triggered on keydown
-            onkeydown: (e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                this.$('input').blur() && openSearchModal();
-              }
-            },
-          }}
-        />
+        >
+          <Icon name="fas fa-search" className="Button-icon" />
+          <span className="Button-label">
+            <span className="Button-labelText">{value || this.attrs.label}</span>
+          </span>
+        </button>
+        {!!value && (
+          <button
+            type="button"
+            className="Search-clear Button Button--icon Button--link"
+            aria-label={extractText(app.translator.trans('core.lib.search.search_clear_button_accessible_label'))}
+            onclick={() => this.searchState.clear()}
+          >
+            <Icon name="fas fa-times-circle" />
+          </button>
+        )}
       </div>
     );
   }

--- a/framework/core/js/src/common/components/OverflowingList.tsx
+++ b/framework/core/js/src/common/components/OverflowingList.tsx
@@ -1,0 +1,232 @@
+import Component, { ComponentAttrs } from '../Component';
+import Dropdown from './Dropdown';
+import listItems, { ModdedChildrenWithItemName } from '../helpers/listItems';
+import classList from '../utils/classList';
+import countItemsThatFit from '../utils/countItemsThatFit';
+import extractText from '../utils/extractText';
+import app from '../app';
+import type Mithril from 'mithril';
+
+export interface IOverflowingListAttrs extends ComponentAttrs {
+  /** The items to lay out, as returned by `ItemList.toArray()`. */
+  items: ModdedChildrenWithItemName[];
+  /** A class name to apply to the list element. */
+  className?: string;
+  /** The label used to describe the overflow menu to assistive readers. */
+  accessibleToggleLabel?: string;
+}
+
+/**
+ * Lays out a list of items on a single row, moving those that do not fit into
+ * a dropdown at the end of the row.
+ *
+ * The list is rendered in full and measured after each paint, so item widths
+ * come from the real laid-out DOM rather than an estimate. That keeps the
+ * result correct whatever an item happens to contain — an icon, a long label,
+ * a translated string, or something an extension added.
+ */
+export default class OverflowingList extends Component<IOverflowingListAttrs> {
+  /**
+   * How many leading items are shown in the row. `null` means "not measured
+   * yet", during which everything renders so the widths can be read.
+   */
+  protected visibleCount: number | null = null;
+
+  /**
+   * Width of each item, by index, captured while all of them were on the row.
+   * Measuring once and reusing avoids feeding the widths of an already
+   * collapsed row back into the next calculation.
+   */
+  protected itemWidths: number[] = [];
+
+  protected toggleWidth = 0;
+
+  protected observer?: ResizeObserver;
+
+  protected onWindowResize?: () => void;
+
+  view(vnode: Mithril.Vnode<IOverflowingListAttrs, this>) {
+    const items = this.attrs.items || [];
+    const count = this.visibleCount ?? items.length;
+    const visible = items.slice(0, count);
+    const overflowed = items.slice(count);
+
+    return (
+      <ul className={classList('OverflowingList', this.attrs.className)}>
+        {listItems(visible)}
+        {overflowed.length > 0 && (
+          <li className="OverflowingList-toggle" itemName="overflow">
+            <Dropdown
+              className="OverflowingList-dropdown"
+              buttonClassName="Button Button--link"
+              menuClassName="Dropdown-menu--right"
+              icon="fas fa-ellipsis-h"
+              // The ellipsis already says "there is more here"; the caret a
+              // dropdown adds by default only doubles up on that. An empty
+              // string rather than null, since the default is applied with
+              // `??=` and would overwrite a nullish value.
+              caretIcon=""
+              accessibleToggleLabel={
+                this.attrs.accessibleToggleLabel ?? extractText(app.translator.trans('core.lib.overflowing_list.toggle_accessible_label'))
+              }
+            >
+              {overflowed}
+            </Dropdown>
+          </li>
+        )}
+      </ul>
+    );
+  }
+
+  oncreate(vnode: Mithril.VnodeDOM<IOverflowingListAttrs, this>) {
+    super.oncreate(vnode);
+
+    // Watch the container rather than the row itself. The row's own width is
+    // a *result* of collapsing — observing it would mean reacting to this
+    // component's own output and never seeing the space open back up. The
+    // container tracks the viewport, and its other children (a logo, the
+    // controls opposite) can change width with no resize event of their own.
+    //
+    // Where there is no ResizeObserver the row still works: it lays out on
+    // creation and on window resizes, and only misses changes that resize a
+    // sibling without resizing the window.
+    if (typeof ResizeObserver !== 'undefined') {
+      this.observer = new ResizeObserver(() => this.recalculate());
+
+      const list = this.element as HTMLElement;
+      const container = list.parentElement?.parentElement ?? list.parentElement ?? list;
+      this.observer.observe(container);
+    }
+
+    // Sibling controls can change width without the container resizing at all
+    // — a label dropping at a breakpoint, a badge appearing. Nothing reports
+    // that, so the row also re-checks on viewport changes.
+    this.onWindowResize = () => this.recalculate();
+    window.addEventListener('resize', this.onWindowResize);
+    window.addEventListener('orientationchange', this.onWindowResize);
+
+    this.recalculate();
+  }
+
+  onupdate(vnode: Mithril.VnodeDOM<IOverflowingListAttrs, this>) {
+    super.onupdate(vnode);
+
+    this.recalculate();
+  }
+
+  onremove(vnode: Mithril.VnodeDOM<IOverflowingListAttrs, this>) {
+    super.onremove(vnode);
+
+    this.observer?.disconnect();
+
+    if (this.onWindowResize) {
+      window.removeEventListener('resize', this.onWindowResize);
+      window.removeEventListener('orientationchange', this.onWindowResize);
+    }
+  }
+
+  /**
+   * Work out how many items fit, and redraw if that has changed.
+   */
+  protected recalculate(): void {
+    const list = this.element as HTMLElement;
+    if (!list) return;
+
+    const children = Array.from(list.children) as HTMLElement[];
+    const itemCount = (this.attrs.items || []).length;
+
+    // Nothing can be measured before the row is in a document, so leave every
+    // item showing until it is.
+    if (!list.isConnected) return;
+
+    // Collapsing only makes sense while the items share a single line. In the
+    // drawer the same list is laid out as a vertical column with a whole
+    // screen height to grow into, so there is nothing to save and everything
+    // should simply render.
+    if (getComputedStyle(list).flexDirection !== 'row') {
+      if (this.visibleCount !== itemCount) {
+        this.visibleCount = itemCount;
+        m.redraw();
+      }
+      return;
+    }
+
+    // Widths are read whenever every item is on the row, which is the only
+    // time they are all measurable. Re-reading rather than trusting the first
+    // measurement matters because what an item is worth changes underneath
+    // this: a label hidden at a breakpoint, a font that finishes loading, a
+    // count appearing on a badge.
+    if (this.visibleCount === null || this.visibleCount === itemCount) {
+      const measured = children.slice(0, itemCount).map((child) => this.outerWidth(child));
+      if (measured.length === itemCount) this.itemWidths = measured;
+      // Nothing has overflowed, so the toggle is not in the DOM to measure.
+      // Reserve a conservative width for it; it is replaced with the real
+      // figure as soon as the toggle renders.
+      if (!this.toggleWidth) this.toggleWidth = 48;
+    } else {
+      const toggle = list.querySelector('.OverflowingList-toggle') as HTMLElement | null;
+      if (toggle) this.toggleWidth = this.outerWidth(toggle);
+    }
+
+    const available = this.availableWidth(list);
+    if (!available || this.itemWidths.length !== itemCount) return;
+
+    // Decided from the measured widths and the container's width — never from
+    // the row's current width, which is a consequence of the last decision and
+    // would turn this into a feedback loop.
+    const fits = countItemsThatFit(this.itemWidths, available, this.toggleWidth);
+
+    if (fits !== this.visibleCount) {
+      this.visibleCount = fits;
+      m.redraw();
+    }
+  }
+
+  /**
+   * How much room the row could occupy, rather than how much it currently
+   * does.
+   *
+   * The list sits in a flex parent that shrink-wraps its contents, so once
+   * items have been collapsed the element reports the narrower width it took
+   * *because* of the collapse. Measuring that would be circular — the row
+   * could never grow back. What matters is the gap to whatever sits beside it.
+   */
+  protected availableWidth(list: HTMLElement): number {
+    const parent = list.parentElement;
+    if (!parent) return list.clientWidth;
+
+    const container = parent.parentElement;
+    if (!container) return parent.clientWidth;
+
+    const parentBox = parent.getBoundingClientRect();
+    const containerStyle = getComputedStyle(container);
+    const containerBox = container.getBoundingClientRect();
+
+    // Start from the container's inner edge, then walk the siblings and take
+    // out whatever they occupy along with the gaps between them.
+    let free = containerBox.width - parseFloat(containerStyle.paddingLeft || '0') - parseFloat(containerStyle.paddingRight || '0');
+
+    const gap = parseFloat(containerStyle.columnGap || containerStyle.gap || '0') || 0;
+    let siblings = 0;
+
+    Array.from(container.children).forEach((child) => {
+      if (child === parent) return;
+      siblings++;
+      free -= (child as HTMLElement).getBoundingClientRect().width;
+    });
+
+    free -= gap * siblings;
+
+    // Anything the row's own parent adds around it — padding, a border, a
+    // margin — is not usable by the items themselves.
+    free -= parentBox.width - parent.clientWidth;
+
+    return Math.max(0, Math.floor(free));
+  }
+
+  protected outerWidth(el: HTMLElement): number {
+    const style = getComputedStyle(el);
+
+    return el.getBoundingClientRect().width + parseFloat(style.marginLeft || '0') + parseFloat(style.marginRight || '0');
+  }
+}

--- a/framework/core/js/src/common/components/SelectDropdown.tsx
+++ b/framework/core/js/src/common/components/SelectDropdown.tsx
@@ -50,6 +50,10 @@ export default class SelectDropdown<CustomAttrs extends ISelectDropdownAttrs = I
     let label = (activeChild && typeof activeChild === 'object' && 'children' in activeChild && activeChild.children) || this.attrs.defaultLabel;
 
     return [
+      // An icon is what identifies the control once there is no room for its
+      // label — without one, hiding the label leaves a caret floating on its
+      // own with nothing to say what it selects.
+      this.attrs.icon ? <Icon name={this.attrs.icon} className="Button-icon" /> : null,
       <span className="Button-label">
         <span className="Button-labelText">{label}</span>
       </span>,

--- a/framework/core/js/src/common/utils/countItemsThatFit.ts
+++ b/framework/core/js/src/common/utils/countItemsThatFit.ts
@@ -1,0 +1,45 @@
+/**
+ * Work out how many items from the start of a row can be shown before the rest
+ * have to be collapsed into an overflow menu.
+ *
+ * Kept separate from the component that uses it so the decision can be
+ * exercised directly: it is pure arithmetic over measured widths, and the
+ * awkward cases — a boundary where an item exactly fits, a row that has to make
+ * room for the toggle it is about to show — are the ones most worth pinning
+ * down in tests.
+ *
+ * The result depends only on the arguments. Nothing here may read from the row
+ * being laid out: its width is a *consequence* of the last decision, so feeding
+ * it back in produces a layout that oscillates rather than settles.
+ *
+ * @param itemWidths Width of each item, in order, as measured while they were
+ *                   all on the row.
+ * @param available  Room the row has to lay items out in.
+ * @param toggleWidth Width of the overflow toggle, needed whenever at least one
+ *                    item is collapsed.
+ * @returns How many leading items to show. Everything after them belongs in the
+ *          overflow menu.
+ */
+export default function countItemsThatFit(itemWidths: number[], available: number, toggleWidth: number): number {
+  const itemCount = itemWidths.length;
+
+  if (itemCount === 0) return 0;
+
+  const total = itemWidths.reduce((sum, width) => sum + width, 0);
+
+  // Everything fits, so no toggle is needed and nothing is held back.
+  if (total <= available) return itemCount;
+
+  // Something has to be collapsed, which means the toggle will be shown and
+  // has to be paid for out of the same space.
+  let used = 0;
+  let fits = 0;
+
+  for (let i = 0; i < itemCount; i++) {
+    if (used + itemWidths[i] + toggleWidth > available) break;
+    used += itemWidths[i];
+    fits++;
+  }
+
+  return fits;
+}

--- a/framework/core/js/src/forum/components/HeaderPrimary.tsx
+++ b/framework/core/js/src/forum/components/HeaderPrimary.tsx
@@ -1,6 +1,6 @@
 import Component from '../../common/Component';
 import ItemList from '../../common/utils/ItemList';
-import listItems from '../../common/helpers/listItems';
+import OverflowingList from '../../common/components/OverflowingList';
 import type Mithril from 'mithril';
 
 /**
@@ -9,7 +9,12 @@ import type Mithril from 'mithril';
  */
 export default class HeaderPrimary extends Component {
   view(): JSX.Element {
-    return <ul className="Header-controls">{listItems(this.items().toArray())}</ul>;
+    // Navigation is the part of the header that grows without bound —
+    // extensions add links here, and a forum with a handful of them will not
+    // fit beside the logo and the session controls on a narrow screen.
+    // Whatever does not fit collapses into a menu instead of overlapping the
+    // controls opposite.
+    return <OverflowingList className="Header-controls" items={this.items().toArray()} />;
   }
 
   /**

--- a/framework/core/js/src/forum/components/HeaderSecondary.js
+++ b/framework/core/js/src/forum/components/HeaderSecondary.js
@@ -53,7 +53,9 @@ export default class HeaderSecondary extends Component {
       items.add(
         'locale',
         <SelectDropdown
+          className="LocaleDropdown"
           buttonClassName="Button Button--link"
+          icon="fas fa-globe"
           accessibleToggleLabel={app.translator.trans('core.forum.header.locale_dropdown_accessible_label')}
         >
           {locales}

--- a/framework/core/js/tests/integration/common/components/OverflowingList.test.ts
+++ b/framework/core/js/tests/integration/common/components/OverflowingList.test.ts
@@ -1,0 +1,115 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import m from 'mithril';
+import mq from 'mithril-query';
+import OverflowingList from '../../../../src/common/components/OverflowingList';
+import Button from '../../../../src/common/components/Button';
+import ItemList from '../../../../src/common/utils/ItemList';
+
+beforeAll(() => bootstrapForum());
+
+/**
+ * jsdom has no layout engine: every element measures zero and nothing ever
+ * overflows, so the collapsing itself cannot be exercised here — that
+ * arithmetic is covered directly in the unit tests for `countItemsThatFit`.
+ * What these check is the markup either side of that decision: what renders
+ * when nothing is collapsed, and what the overflow menu looks like when
+ * something is.
+ */
+function items(...labels: string[]) {
+  const list = new ItemList();
+
+  labels.forEach((label, i) => list.add(label, m(Button, { className: 'TestItem' }, label), 100 - i));
+
+  return list.toArray();
+}
+
+describe('OverflowingList renders its items', () => {
+  it('renders every item when nothing has been collapsed', () => {
+    const rendered = mq(m(OverflowingList, { items: items('One', 'Two', 'Three') }));
+
+    expect(rendered).toContainRaw('One');
+    expect(rendered).toContainRaw('Two');
+    expect(rendered).toContainRaw('Three');
+  });
+
+  it('shows no overflow toggle when everything fits', () => {
+    // Nothing measures anything in jsdom, so nothing overflows — which is the
+    // state being asserted.
+    const rendered = mq(m(OverflowingList, { items: items('One', 'Two') }));
+
+    expect(rendered).not.toHaveElement('.OverflowingList-toggle');
+  });
+
+  it('renders as a list', () => {
+    expect(mq(m(OverflowingList, { items: items('One') }))).toHaveElement('ul.OverflowingList');
+  });
+
+  it('keeps the class name it is given alongside its own', () => {
+    const rendered = mq(m(OverflowingList, { items: items('One'), className: 'Header-controls' }));
+
+    expect(rendered).toHaveElement('ul.OverflowingList.Header-controls');
+  });
+
+  it('renders nothing but an empty list when given no items', () => {
+    const rendered = mq(m(OverflowingList, { items: [] }));
+
+    expect(rendered).toHaveElement('ul.OverflowingList');
+    expect(rendered).not.toHaveElement('.OverflowingList-toggle');
+  });
+
+  it('survives being given no items attribute at all', () => {
+    expect(() => mq(m(OverflowingList, {} as any))).not.toThrow();
+  });
+});
+
+describe('OverflowingList overflow menu', () => {
+  /**
+   * Force a collapsed state. `visibleCount` is what the measuring pass would
+   * normally set; setting it directly is the only way to see the collapsed
+   * markup in an environment with no layout.
+   */
+  function collapsedTo(visible: number, ...labels: string[]) {
+    class Collapsed extends OverflowingList {
+      protected visibleCount = visible;
+
+      // The measuring pass would immediately undo the count set above.
+      protected recalculate() {}
+    }
+
+    return mq(m(Collapsed, { items: items(...labels) }));
+  }
+
+  it('shows a toggle once something has been collapsed', () => {
+    expect(collapsedTo(1, 'One', 'Two', 'Three')).toHaveElement('.OverflowingList-toggle');
+  });
+
+  it('keeps the items that fit on the row', () => {
+    expect(collapsedTo(1, 'One', 'Two', 'Three')).toContainRaw('One');
+  });
+
+  it('moves the rest into the menu rather than dropping them', () => {
+    // The whole point of collapsing rather than hiding: nothing disappears.
+    const rendered = collapsedTo(1, 'One', 'Two', 'Three');
+
+    expect(rendered).toContainRaw('Two');
+    expect(rendered).toContainRaw('Three');
+  });
+
+  it('gives the toggle an accessible name', () => {
+    expect(collapsedTo(1, 'One', 'Two')).toHaveElement('.OverflowingList-dropdown [aria-label]');
+  });
+
+  it('shows no caret beside the ellipsis', () => {
+    // The ellipsis already says there is more; a dropdown adds a caret by
+    // default, which doubled up on that.
+    expect(collapsedTo(1, 'One', 'Two')).not.toHaveElement('.OverflowingList-toggle .Button-caret');
+  });
+
+  it('collapses everything when nothing fits', () => {
+    const rendered = collapsedTo(0, 'One', 'Two');
+
+    expect(rendered).toHaveElement('.OverflowingList-toggle');
+    expect(rendered).toContainRaw('One');
+    expect(rendered).toContainRaw('Two');
+  });
+});

--- a/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
+++ b/framework/core/js/tests/integration/common/components/SelectDropdown.test.ts
@@ -133,3 +133,28 @@ describe('SelectDropdown displays as expected', () => {
     expect(select).not.toContainRaw('Select an option');
   });
 });
+
+describe('SelectDropdown renders an optional icon', () => {
+  const buttons = () => [m('button', { className: 'button-1', active: true }, 'Option A')];
+
+  it('renders no icon by default', () => {
+    const select = mq(m(SelectDropdown, { label: 'Select', defaultLabel: 'Select' }, buttons()));
+
+    expect(select).not.toHaveElement('.Dropdown-toggle .Button-icon');
+  });
+
+  it('renders an icon when given one', () => {
+    // Something has to identify the control wherever its label is hidden —
+    // the locale selector in the header collapses to its icon alone.
+    const select = mq(m(SelectDropdown, { label: 'Select', defaultLabel: 'Select', icon: 'fas fa-globe' }, buttons()));
+
+    expect(select).toHaveElement('.Dropdown-toggle .Button-icon');
+    expect(select).toHaveElement('.fa-globe');
+  });
+
+  it('keeps showing the active option alongside the icon', () => {
+    const select = mq(m(SelectDropdown, { label: 'Select', defaultLabel: 'Select', icon: 'fas fa-globe' }, buttons()));
+
+    expect(select).toContainRaw('Option A');
+  });
+});

--- a/framework/core/js/tests/integration/forum/components/GlobalSearch.test.ts
+++ b/framework/core/js/tests/integration/forum/components/GlobalSearch.test.ts
@@ -1,0 +1,144 @@
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
+import m from 'mithril';
+import mq from 'mithril-query';
+import { jest } from '@jest/globals';
+import GlobalSearch from '../../../../src/forum/components/GlobalSearch';
+import SearchState from '../../../../src/common/states/SearchState';
+import app from '../../../../src/forum/app';
+
+beforeAll(() => {
+  bootstrapForum();
+  app.boot();
+
+  // The component only renders once it has somewhere to search, and the
+  // sources it offers depend on what the actor is allowed to see.
+  app.forum.pushAttributes({ canViewForum: true, canSearchUsers: true });
+});
+
+/**
+ * Searching happens in a modal. The control in the header used to be a
+ * `readonly` text field that opened it, which meant assistive technology
+ * announced a textbox that could not be typed into, and the header had to
+ * reserve a text field's width for something that only ever behaved as a
+ * button. These cover the shape of the control rather than how it looks.
+ */
+describe('GlobalSearch renders a button, not a text field', () => {
+  const search = () => mq(m(GlobalSearch, { state: new SearchState() }));
+
+  it('renders a button', () => {
+    expect(search()).toHaveElement('button.Search-input');
+  });
+
+  it('renders no input at all', () => {
+    // The point of the change: nothing here should be typed into.
+    expect(search()).not.toHaveElement('input');
+  });
+
+  it('gives the button an explicit type so it never submits a form', () => {
+    expect(search()).toHaveElement('button.Search-input[type=button]');
+  });
+
+  it('gives the button an accessible name', () => {
+    // Its label is hidden in the header, so the name has to come from aria.
+    expect(search()).toHaveElement('button.Search-input[aria-label]');
+  });
+
+  it('describes the control on hover, as the controls beside it do', () => {
+    expect(search()).toHaveElement('button.Search-input[title]');
+  });
+
+  it('marks the surrounding element as a search landmark', () => {
+    expect(search()).toHaveElement('[role=search]');
+    expect(search()).toHaveElement('.Search[aria-label]');
+  });
+
+  it('renders an icon and a label, like the other header controls', () => {
+    const rendered = search();
+
+    expect(rendered).toHaveElement('.Button-icon');
+    expect(rendered).toHaveElement('.Button-label');
+  });
+
+  it('styles itself as a flat button, matching the controls beside it', () => {
+    // `Button--link` forces a transparent background and a link-coloured
+    // hover; the notification and message controls are `Button--flat`, and
+    // search sits among them.
+    expect(search()).toHaveElement('button.Search-input.Button--flat');
+  });
+});
+
+describe('GlobalSearch opens the search modal', () => {
+  it('opens the modal when clicked', () => {
+    jest.useFakeTimers();
+    const show = jest.spyOn(app.modal, 'show').mockImplementation(() => {});
+
+    const rendered = mq(m(GlobalSearch, { state: new SearchState() }));
+    rendered.click('button.Search-input');
+
+    // The click closes the drawer first and opens the modal just after, so
+    // that the drawer is not left sitting behind it.
+    jest.runAllTimers();
+
+    expect(show).toHaveBeenCalled();
+
+    show.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('hides the drawer before opening, so it is not left behind the modal', () => {
+    jest.useFakeTimers();
+    const hide = jest.spyOn(app.drawer, 'hide').mockImplementation(() => {});
+    jest.spyOn(app.modal, 'show').mockImplementation(() => {});
+
+    const rendered = mq(m(GlobalSearch, { state: new SearchState() }));
+    rendered.click('button.Search-input');
+
+    expect(hide).toHaveBeenCalled();
+
+    jest.runAllTimers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+});
+
+describe('GlobalSearch reflects the current query', () => {
+  it('shows the prompt when nothing has been searched for', () => {
+    const rendered = mq(m(GlobalSearch, { state: new SearchState() }));
+
+    expect(rendered).toContainRaw('Search Forum');
+  });
+
+  it('shows the query in place of the prompt once one has been run', () => {
+    const state = new SearchState();
+    state.setValue('flarum');
+
+    const rendered = mq(m(GlobalSearch, { state }));
+
+    expect(rendered).toContainRaw('flarum');
+  });
+
+  it('offers a way to clear an active query', () => {
+    const state = new SearchState();
+    state.setValue('flarum');
+
+    expect(mq(m(GlobalSearch, { state }))).toHaveElement('button.Search-clear');
+  });
+
+  it('offers nothing to clear when there is no query', () => {
+    expect(mq(m(GlobalSearch, { state: new SearchState() }))).not.toHaveElement('button.Search-clear');
+  });
+
+  it('clears the query without opening the modal', () => {
+    const state = new SearchState();
+    state.setValue('flarum');
+    const show = jest.spyOn(app.modal, 'show').mockImplementation(() => {});
+
+    const rendered = mq(m(GlobalSearch, { state }));
+    rendered.click('button.Search-clear');
+
+    expect(state.getValue()).toBe('');
+    expect(show).not.toHaveBeenCalled();
+
+    show.mockRestore();
+  });
+});

--- a/framework/core/js/tests/unit/common/utils/countItemsThatFit.test.ts
+++ b/framework/core/js/tests/unit/common/utils/countItemsThatFit.test.ts
@@ -1,0 +1,166 @@
+import countItemsThatFit from '../../../../src/common/utils/countItemsThatFit';
+
+describe('countItemsThatFit', () => {
+  const TOGGLE = 50;
+
+  describe('when everything fits', () => {
+    test('shows every item and pays nothing for a toggle', () => {
+      expect(countItemsThatFit([100, 100, 100], 300, TOGGLE)).toBe(3);
+    });
+
+    test('shows every item when the row is full to the pixel', () => {
+      // The toggle is only needed once something is collapsed, so a row that
+      // exactly fits still has no use for it — and one pixel less means it
+      // does, which costs two items rather than one.
+      expect(countItemsThatFit([100, 100, 100], 300, TOGGLE)).toBe(3);
+      expect(countItemsThatFit([100, 100, 100], 299, TOGGLE)).toBe(2);
+    });
+
+    test('shows every item with room to spare', () => {
+      expect(countItemsThatFit([50, 50], 500, TOGGLE)).toBe(2);
+    });
+  });
+
+  describe('when items must be collapsed', () => {
+    test('keeps the leading items that fit alongside the toggle', () => {
+      // 300 of items will not fit in 290, so the toggle appears and has to be
+      // paid for: 100 + 100 + 50 = 250 fits, a third item would need 350.
+      expect(countItemsThatFit([100, 100, 100], 290, 50)).toBe(2);
+    });
+
+    test('reserves room for the toggle, not just for the items', () => {
+      // Two of the three items would fit in 250 on their own. Once the toggle
+      // has taken its 50, only one does.
+      expect(countItemsThatFit([100, 100, 100], 250, 50)).toBe(2);
+      expect(countItemsThatFit([100, 100, 100], 249, 50)).toBe(1);
+    });
+
+    test('collapses everything when even one item cannot share with the toggle', () => {
+      expect(countItemsThatFit([200, 200], 210, 50)).toBe(0);
+    });
+
+    test('collapses a single overflowing item rather than widening the row', () => {
+      // Two items, only one fits with the toggle. The menu holds one item —
+      // still correct, since the alternative is an overflowing row.
+      expect(countItemsThatFit([100, 100], 160, 50)).toBe(1);
+    });
+  });
+
+  describe('boundaries', () => {
+    test('an item that exactly fills the remaining space is kept', () => {
+      // 100 + 50 toggle = 150, exactly the space available.
+      expect(countItemsThatFit([100, 999], 150, 50)).toBe(1);
+    });
+
+    test('an item one pixel too wide is collapsed', () => {
+      expect(countItemsThatFit([100, 999], 149, 50)).toBe(0);
+    });
+
+    test('does not let a later narrow item jump the queue', () => {
+      // The second item does not fit, so the third is not considered either —
+      // order on the row has to be preserved.
+      expect(countItemsThatFit([100, 500, 10], 200, 50)).toBe(1);
+    });
+  });
+
+  describe('degenerate input', () => {
+    test('no items means nothing to show', () => {
+      expect(countItemsThatFit([], 500, TOGGLE)).toBe(0);
+    });
+
+    test('no space means nothing fits', () => {
+      expect(countItemsThatFit([100, 100], 0, TOGGLE)).toBe(0);
+    });
+
+    test('a single item narrower than the row is shown', () => {
+      expect(countItemsThatFit([100], 300, TOGGLE)).toBe(1);
+    });
+
+    test('a single item wider than the row is collapsed', () => {
+      expect(countItemsThatFit([400], 300, TOGGLE)).toBe(0);
+    });
+
+    test('zero-width items are all shown', () => {
+      expect(countItemsThatFit([0, 0, 0], 10, TOGGLE)).toBe(3);
+    });
+
+    test('a toggle wider than the row collapses everything', () => {
+      expect(countItemsThatFit([100, 100], 150, 500)).toBe(0);
+    });
+  });
+
+  describe('stability', () => {
+    // The layout oscillated once because the count was nudged after being
+    // calculated: with three items and two fitting, a rule bumped the result
+    // back to three, which overflowed, which collapsed it again. These pin the
+    // property that broke — the answer depends only on the inputs.
+    test('is pure: the same inputs always give the same answer', () => {
+      const widths = [105, 112, 129, 122];
+
+      const first = countItemsThatFit(widths, 326, 51);
+      const second = countItemsThatFit(widths, 326, 51);
+      const third = countItemsThatFit([...widths], 326, 51);
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    test('does not mutate the widths it is given', () => {
+      const widths = [100, 200, 300];
+
+      countItemsThatFit(widths, 250, TOGGLE);
+
+      expect(widths).toEqual([100, 200, 300]);
+    });
+
+    test('never returns more items than it was given', () => {
+      expect(countItemsThatFit([10, 10], 10_000, TOGGLE)).toBe(2);
+    });
+
+    test('never returns a negative count', () => {
+      expect(countItemsThatFit([500], 1, TOGGLE)).toBeGreaterThanOrEqual(0);
+    });
+
+    test('widening the row never shows fewer items', () => {
+      // Monotonicity is what makes the layout settle: as space grows, items
+      // may come back but must never disappear.
+      const widths = [105, 112, 129, 122];
+      let previous = 0;
+
+      for (let available = 0; available <= 800; available += 10) {
+        const fits = countItemsThatFit(widths, available, 51);
+        expect(fits).toBeGreaterThanOrEqual(previous);
+        previous = fits;
+      }
+    });
+
+    test('re-running with the result applied does not change the answer', () => {
+      // Feeding a decision back in is exactly what caused the flicker. The
+      // count for a given amount of space must be a fixed point.
+      const widths = [105, 112, 129, 122];
+      const available = 326;
+
+      const fits = countItemsThatFit(widths, available, 51);
+
+      expect(countItemsThatFit(widths, available, 51)).toBe(fits);
+    });
+  });
+
+  describe('the header case that prompted this', () => {
+    // Real measurements from a logged-in forum at 820px: four navigation
+    // links, 326px of room once the logo and controls have taken theirs.
+    const LINKS = [105, 112, 129, 122];
+
+    test('collapses the links that do not fit at 820px', () => {
+      expect(countItemsThatFit(LINKS, 326, 51)).toBe(2);
+    });
+
+    test('shows every link once there is room for them', () => {
+      expect(countItemsThatFit(LINKS, 500, 51)).toBe(4);
+    });
+
+    test('keeps only the first link when space is very tight', () => {
+      expect(countItemsThatFit(LINKS, 232, 51)).toBe(1);
+    });
+  });
+});

--- a/framework/core/less/common/App.less
+++ b/framework/core/less/common/App.less
@@ -203,6 +203,54 @@
   padding: 0;
   list-style: none;
 }
+// Items collapsed out of the header row keep the markup they had on the row,
+// including the flat header-button styling. Inside a menu that reads as a row
+// of unpadded text, so give them the same shape as any other dropdown item.
+.OverflowingList-dropdown > .Dropdown-menu {
+  min-width: 180px;
+
+  > li > .Button,
+  > li > a {
+    text-align: left;
+    width: 100%;
+  }
+
+  // An item that was itself a dropdown on the row would otherwise render its
+  // own toggle and float a second panel alongside this one. Its contents are
+  // laid out inline as a titled group instead: the toggle is redundant once
+  // the group is always open, and a nested panel is unusable on the narrow
+  // screens that trigger the collapse in the first place.
+  .Dropdown {
+    display: block;
+    width: 100%;
+
+    > .Dropdown-toggle,
+    > .Dropdown-menu > li > .Dropdown-toggle {
+      display: none;
+    }
+
+    > .Dropdown-menu {
+      display: block;
+      position: static;
+      float: none;
+      width: 100%;
+      min-width: 0;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+      background: transparent;
+    }
+
+    // The group's own label stays as a heading, and its children are indented
+    // under it so the nesting that was in the row is still legible.
+    > .Dropdown-menu > li:not(:first-child) > a,
+    > .Dropdown-menu > li:not(:first-child) > .Button {
+      padding-left: 30px;
+    }
+  }
+}
 .Header-logo {
   display: block;
   max-height: 30px;
@@ -256,9 +304,6 @@
       }
     }
   }
-  .Header-secondary .Search {
-    margin: 10px 0;
-  }
 }
 
 // On other devices, we stick the header up the top of the page, overlaying
@@ -303,37 +348,98 @@
     display: flex;
     align-items: center;
   }
+  // Navigation is what yields when the header runs out of room; the controls
+  // opposite it do not. `min-width: 0` is the part that does the work —
+  // without it the flex default of `min-width: auto` pins this to its content
+  // width, so a long set of links (from an extension, or just a lot of tags)
+  // overflows the container and shoves the session controls off the edge
+  // rather than compressing.
+  //
+  // Deliberately no `overflow` here. Header dropdown menus are absolutely
+  // positioned but still descend from this element, so any non-visible
+  // overflow value clips them shut, and `overflow-x` alone is no escape — the
+  // other axis is then forced away from `visible` too. Items that do not fit
+  // are moved into a menu by `OverflowingList` instead of being hidden.
+  // Growing into the leftover room keeps the row reading as one group: with
+  // the controls opposite held to the right edge by their auto margin, any
+  // slack would otherwise collect as a single conspicuous hole between the
+  // two. It costs nothing to lay out, since what actually fits is worked out
+  // from the container's width rather than this element's.
   .Header-primary {
-    //
+    min-width: 0;
+    flex: 1 1 auto;
+
+    .Header-controls {
+      min-width: 0;
+      flex-wrap: nowrap;
+    }
   }
+  // The logo is how you get back to the index once links start dropping off,
+  // so it keeps its full width no matter how tight things get.
   .Header-title {
     font-size: 18px;
     font-weight: normal;
     line-height: 34px;
+    flex-shrink: 0;
   }
+  // No auto margin to push this to the right: an auto margin takes the free
+  // space before flex distributes any of it, which would park the controls at
+  // the edge and leave the slack in one gap mid-row. Nav grows into it
+  // instead, which puts these in the same place whenever the row is full.
   .Header-secondary {
-    margin-left: auto;
+    flex-shrink: 0;
 
-    .Search {
-      margin-right: 10px;
+    // Spacing for the row lives here rather than on the individual controls.
+    // Their own padding varies — an icon button has none horizontally, a
+    // labelled one has 13px either side — so relying on it left the icons
+    // touching each other while the labelled controls sat far apart.
+    //
+    // Kept small deliberately: this row can hold eight or more controls, and
+    // every pixel between them is one the navigation opposite cannot use.
+    .Header-controls {
+      gap: 2px;
     }
   }
 }
 
-@media @tablet {
-  .Header-secondary .Search {
-    input:not(:focus) {
-      width: 1px;
-      background: transparent;
-    }
-    &:not(.active) input {
-      padding-right: 0;
-    }
-    input:not(:focus) ~ .Input-clear {
+// Between tablet and the wide desktop layouts the header carries everything it
+// will ever carry — logo, navigation, and the full set of controls — without
+// the room the widest screens have for it. Labels that repeat what their icon
+// already says are dropped through this range so the navigation keeps its
+// space; they return at `desktop-hd`.
+@media (min-width: @screen-tablet) and (max-width: (@screen-desktop-hd - 0.02)) {
+  // The username goes and the avatar stays: it identifies the session just as
+  // well, and a name truncated to a few characters tells you nothing the
+  // avatar hasn't already. The negative margin that tucks the avatar against
+  // the button's left padding is what would otherwise leave the circle sitting
+  // off-centre.
+  .Header-secondary .SessionDropdown .Dropdown-toggle {
+    .Button-label {
       display: none;
     }
+
+    .Avatar {
+      margin-left: -2px;
+      margin-right: -2px;
+    }
   }
+
+  // The locale name is by far the widest thing left in the row — several times
+  // the width of the icon buttons beside it — and it is the label most easily
+  // spared, since the globe stands in for it and the current language is shown
+  // as the checked item once the menu is open.
+  .Header-secondary .LocaleDropdown .Dropdown-toggle {
+    .Button--icon();
+
+    // Now that the name is gone, the globe is the only thing left to say what
+    // this control selects.
+    .Button-icon {
+      display: inline-block;
+    }
+  }
+
 }
+
 
 @media @desktop-hd {
   .Header-navigation {

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -1,5 +1,48 @@
 .Search {
   position: relative;
+  display: flex;
+  align-items: center;
+}
+
+// The control opens the search modal, so it is a button and carries the same
+// icon-and-label markup as the notification and message controls beside it.
+// That is what lets it collapse to its icon in the header and keep its label
+// in the drawer without any rule of its own — see `Button--icon` below.
+.Search-input .Button-labelText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.Search-clear {
+  color: var(--muted-color);
+}
+
+// In the header the globe stands in for the locale name when there is no room
+// for it, so where the name is showing the icon beside it is just noise — none
+// of the other labelled controls up there carry one. The drawer is the other
+// way round: every entry in that column is an icon and a label together, so
+// the locale keeps both and matches its neighbours.
+@media @tablet-up {
+  .LocaleDropdown .Dropdown-toggle .Button-icon {
+    display: none;
+  }
+}
+
+// In the header the label goes and the magnifying glass stands in for it, the
+// same as every other control up there. The drawer keeps its labels, so the
+// full "Search Forum" stays legible where there is a column to read it in.
+@media @tablet-up {
+  .Header-secondary .Search {
+    .Search-input {
+      .Button--icon();
+    }
+
+    // Clearing is only reachable while the label is showing the query, so the
+    // affordance goes with it rather than sitting beside a bare icon.
+    .Search-clear {
+      display: none;
+    }
+  }
 }
 
 .DiscussionSearchResult {

--- a/framework/core/less/common/scaffolding.less
+++ b/framework/core/less/common/scaffolding.less
@@ -57,11 +57,17 @@ p {
   padding-left: 15px;
   padding-right: 15px;
 
+  // Each band is pinned to the width that opens it, so a viewport anywhere
+  // above that lower bound leaves the remainder unused — at 820px the tablet
+  // band still lays out at 768px, and the header has to fit its logo, nav and
+  // controls into 52px less than the screen actually offers. Growing to the
+  // viewport is what stops those colliding. Capped at the next band's floor so
+  // the layout still steps between bands rather than growing without limit.
   @media @tablet {
-    width: @screen-tablet;
+    width: ~"min(@{screen-tablet-max}, 100%)";
   }
   @media @desktop {
-    width: @screen-desktop;
+    width: ~"min(@{screen-desktop-max}, 100%)";
   }
   // The xl/xxl breakpoints exist since the extension list UI introduced them,
   // but the container never used them: every screen wider than 1100px got the

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -967,6 +967,11 @@ core:
       kilo_text: K
       mega_text: M
 
+    # These translations are used in the list component that collapses items
+    # which do not fit into a dropdown.
+    overflowing_list:
+      toggle_accessible_label: More items
+
     # These translations are used in the common pagination component.
     pagination:
       back_button: Previous page


### PR DESCRIPTION
### The problem

On a tablet-width screen the header has no way to give up space. Navigation, logo and session controls each hold their full width, so once an extension adds a few links the row overflows and controls paint over one another.

Reported on an iPad in portrait (820px): the username was cut mid-word, and with `fof/links` installed the nav pushed the session controls off the edge entirely.

### Why it happened

Three separate causes, all needed fixing:

**1. The container wasn't using the viewport.** `.container` was pinned to the width that *opened* each breakpoint — `width: @screen-tablet` is literally `768px` for everything from 768 to 991px. At 820px the layout stayed 768px wide with 52px of screen unused; at 991px, 223px unused. The bands above 1100px were already fixed this way in earlier work; this extends the same `min(…, 100%)` clamp down to tablet and desktop.

**2. Nothing could flex.** `.Header-primary` declared no flex behaviour at all, so it could neither shrink nor grow. `.Header-secondary` used `margin-left: auto` — and auto margins consume free space *before* flex distributes any, so all slack pooled into a single conspicuous gap mid-row rather than being usable.

**3. Nothing ever moved out of the way.** Navigation now collapses whatever doesn't fit into a menu at the end of the row, via a new `OverflowingList` component.

### Search is now a button

Since search moved into a modal, the header control has been a `readonly` text field that cannot be typed into. Every path through it — click, Enter, the drawer — blurs the field and opens `SearchModal`.

That cost the header a text field's width (195px at desktop) for something that only ever behaved as a button, and announced itself to assistive technology as a textbox that refuses input.

It is now a `<button>` carrying the same icon-and-label markup as the notification and message controls, so it collapses to its icon in the header and keeps its label in the drawer. The locale selector gains an icon for the same reason — something has to identify it once the label is hidden.

### Testing

`countItemsThatFit` is extracted from the component so the arithmetic can be tested directly: boundaries where an item exactly fits, reserving room for the toggle that is about to appear, and the monotonicity that stops the row oscillating between two states.

52 new tests, 373 passing overall.

`OverflowingList` measures real layout, which jsdom cannot provide — so the component tests cover the markup either side of the decision, and the sums are covered on their own.

### Verified

Measured in Chrome at 768 / 820 / 900 / 991 / 992 / 1100 / 1400 / 1920px, logged in and out: no overlap at any width, items collapse only when they genuinely do not fit and return when space allows, and the row settles in one pass with no flicker. Live resizing recalculates without a reload. The drawer renders everything, since a vertical column has no width pressure.

### Notes for reviewers

- **`OverflowingList` is a new public component.** Extensions will subclass it, so the API is worth scrutiny mid-RC.
- **`.Search-input` is now a `<button>`, not an `<input>`.** Extensions styling or extending it may need adjusting — `fof/ui-kit` scopes to its own `.UiKit-Search` and is unaffected.
- **Keyboard and focus order through the overflow menu are not covered by tests** — jsdom has no focus model worth trusting here. Verified by hand; a Playwright suite would be the proper answer and is out of scope.
- The container change affects **every page** at 768–1099px, not just the header.
