### PR TITLE
[2.x] fix: show and let people cancel an active search from the header

### DIFF
--- a/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
+++ b/framework/core/js/src/common/components/AbstractGlobalSearch.tsx
@@ -3,6 +3,7 @@ import Component, { ComponentAttrs } from '../Component';
 import SearchState from '../states/SearchState';
 import extractText from '../utils/extractText';
 import ItemList from '../utils/ItemList';
+import classList from '../utils/classList';
 import Icon from './Icon';
 import type Mithril from 'mithril';
 
@@ -102,15 +103,19 @@ export default abstract class AbstractGlobalSearch<T extends SearchAttrs = Searc
     };
 
     return (
-      <div role="search" className="Search" aria-label={this.attrs.a11yRoleLabel}>
+      <div role="search" className={classList('Search', { 'Search--active': !!value })} aria-label={this.attrs.a11yRoleLabel}>
         <button
           type="button"
           // `Button--flat` rather than `Button--link`: this sits among the
           // notification and message controls, which are flat buttons, and
           // should pick up the same hover and focus treatment as them.
           className="Search-input Button Button--flat"
-          aria-label={extractText(this.attrs.label)}
-          title={extractText(this.attrs.label)}
+          aria-label={
+            value
+              ? extractText(app.translator.trans('core.lib.search.search_active_button_accessible_label', { query: value }))
+              : extractText(this.attrs.label)
+          }
+          title={value || extractText(this.attrs.label)}
           onclick={() => {
             // On phones the search button lives inside the slide-out drawer. Close the drawer as soon as
             // search is activated, before the modal is shown, so it isn't left open behind (and overlapping)

--- a/framework/core/js/src/common/components/OverflowingList.tsx
+++ b/framework/core/js/src/common/components/OverflowingList.tsx
@@ -140,11 +140,20 @@ export default class OverflowingList extends Component<IOverflowingListAttrs> {
     if (!list.isConnected) return;
 
     // Collapsing only makes sense while the items share a single line. In the
-    // drawer the same list is laid out as a vertical column with a whole
-    // screen height to grow into, so there is nothing to save and everything
-    // should simply render.
-    if (getComputedStyle(list).flexDirection !== 'row') {
-      if (this.visibleCount !== itemCount) {
+    // drawer the same list is laid out as a stack of block-level entries with a
+    // whole screen height to grow into, so there is nothing to save and
+    // everything should simply render.
+    //
+    // What decides that is whether the list lays its items out in a row at all,
+    // which means the display type: `flex-direction` is reported as `row` on
+    // everything, flex container or not, so it cannot answer this on its own.
+    const style = getComputedStyle(list);
+    const laysOutInARow = (style.display === 'flex' || style.display === 'inline-flex') && style.flexDirection.startsWith('row');
+
+    // A hidden row measures zero, and zero available space would collapse
+    // every item. Leave the count alone until it can be measured for real.
+    if (!laysOutInARow || !list.clientWidth) {
+      if (!laysOutInARow && this.visibleCount !== itemCount) {
         this.visibleCount = itemCount;
         m.redraw();
       }

--- a/framework/core/js/src/common/components/OverflowingList.tsx
+++ b/framework/core/js/src/common/components/OverflowingList.tsx
@@ -94,8 +94,20 @@ export default class OverflowingList extends Component<IOverflowingListAttrs> {
       this.observer = new ResizeObserver(() => this.recalculate());
 
       const list = this.element as HTMLElement;
-      const container = list.parentElement?.parentElement ?? list.parentElement ?? list;
+      const row = list.parentElement;
+      const container = row?.parentElement ?? row ?? list;
       this.observer.observe(container);
+
+      // The siblings are watched as well as the container holding them. They
+      // take their space from the same line this row does and can change size
+      // without the container changing at all — a search control growing to
+      // show an active query, a badge appearing on a button — and the room
+      // they give back is room this row should be able to use again.
+      if (row) {
+        Array.from(container.children).forEach((child) => {
+          if (child !== row) this.observer!.observe(child);
+        });
+      }
     }
 
     // Sibling controls can change width without the container resizing at all

--- a/framework/core/less/common/Search.less
+++ b/framework/core/less/common/Search.less
@@ -43,6 +43,35 @@
       display: none;
     }
   }
+
+  // An active search is different: the results being shown are filtered, and
+  // the header is the only place that says so once the modal has been closed.
+  // Hiding the query here would leave someone looking at a filtered page with
+  // nothing to explain it and no way back, so the control takes the room it
+  // needs to show what was searched for and to undo it.
+  .Header-secondary .Search--active {
+    .Search-input {
+      width: auto;
+      max-width: 180px;
+      padding: 8px 13px;
+      color: var(--header-color);
+
+      .Button-label {
+        display: flex;
+      }
+    }
+
+    .Search-clear {
+      display: flex;
+      color: var(--header-color);
+    }
+  }
+}
+
+// The accent marks the control as doing something to the page, matching how the
+// notification bell colours its icon when there is something to attend to.
+.Search--active .Search-input .Button-icon {
+  color: var(--header-color);
 }
 
 .DiscussionSearchResult {

--- a/framework/core/locale/core.yml
+++ b/framework/core/locale/core.yml
@@ -991,6 +991,7 @@ core:
       options_heading: Search options
       placeholder: Search...
       preview_heading: Search preview
+      search_active_button_accessible_label: "Change search: {query}"
       search_clear_button_accessible_label: Clear search query
 
     # These translations are used by search sources.


### PR DESCRIPTION
Follow-up to #4906, which turned the header search into a button — an active search's query and its clear button were both hidden at header widths, leaving a filtered page with nothing to explain it and no way back outside the modal. Also fixes the drawer collapsing its links into an overflow menu.